### PR TITLE
worker: Now the running jobs have a UUID folder as context

### DIFF
--- a/qid/job/job.go
+++ b/qid/job/job.go
@@ -21,5 +21,5 @@ type TaskStep struct {
 
 type RunCommand struct {
 	Path string   `json:"path" hcl:"path"`
-	Args []string `json:"args" hcl:"args"`
+	Args []string `json:"args" hcl:"args,optional"`
 }

--- a/qid/testdata/pipeline.hcl
+++ b/qid/testdata/pipeline.hcl
@@ -8,8 +8,6 @@ resource_type "git" {
     args = [
       "-ec",
       <<-EOT
-        cd /
-        rm -rf $NAME
         git clone --quiet $URL $NAME
         cd $NAME
         if [[ -n $LAST_VERSION_HASH ]]; then
@@ -25,8 +23,6 @@ resource_type "git" {
     args = [
       "-ec",
       <<-EOT
-        cd /
-        rm -rf $NAME
         git clone $URL $NAME
         cd $NAME
         git checkout $VERSION_HASH

--- a/qid/transport/http/templates/views/layouts/index.tmpl
+++ b/qid/transport/http/templates/views/layouts/index.tmpl
@@ -85,7 +85,9 @@
           </div>
         </div>
       </div>
-      <div id="graphviz"></div>
+      <div class="row">
+        <div id="graphviz"></div>
+      </div>
     </script>
 
     <script type="text/template" id="pipeline-graph-view">


### PR DESCRIPTION
So they do not share any context with other jobs but you can still go out of it

Closes #46 