### PR TITLE
Fix user permission changes not reflected until re-login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ## Unreleased
 
+- Fix user permission changes not reflected until re-login: backend signals stale JWT via `X-Refresh-Token` header, frontend auto-refreshes session ([#126](https://github.com/xescugc/qid/pull/126))
 - Add users and teams with role-based access control, refactor HTTP transport from go-kit to direct handlers ([#124](https://github.com/xescugc/qid/pull/124))

--- a/integration/qid_test.go
+++ b/integration/qid_test.go
@@ -3,14 +3,17 @@ package integration_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"image"
 	"image/png"
+	"net/http"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/tebeka/selenium"
+	thttp "github.com/xescugc/qid/qid/transport/http"
 )
 
 func TestQID(t *testing.T) {
@@ -761,6 +764,63 @@ job "gen" {
 				return len(builds) > initialCount
 			}, 5*time.Second)
 		})
+	})
+	t.Run("RefreshToken", func(t *testing.T) {
+		// Pepito is still logged in as a non-admin member of "main".
+		// We promote pepito to team admin via a direct HTTP call (as admin),
+		// then navigate in the browser. The next Backbone.sync fetch should
+		// detect the stale JWT via the X-Refresh-Token header, auto-refresh
+		// the session, and pepito should now see admin controls.
+
+		// Step 1: Get admin JWT via HTTP
+		loginBody, _ := json.Marshal(thttp.UserLoginRequest{
+			Username: "admin",
+			Password: "admin123",
+		})
+		loginReq, err := http.NewRequest(http.MethodPost, qidURL+"/login.json", bytes.NewReader(loginBody))
+		require.NoError(t, err)
+		loginResp, err := http.DefaultClient.Do(loginReq)
+		require.NoError(t, err)
+		defer loginResp.Body.Close()
+		require.Equal(t, http.StatusOK, loginResp.StatusCode)
+		var lr thttp.UserLoginResponse
+		json.NewDecoder(loginResp.Body).Decode(&lr)
+		require.Empty(t, lr.Err)
+		adminJWT := lr.Data.JWT
+
+		// Step 2: Promote pepito to admin on "main" team via HTTP
+		updateBody, _ := json.Marshal(thttp.UpdateTeamMemberRequest{Admin: true})
+		updateReq, err := http.NewRequest(http.MethodPut, qidURL+"/teams/main/members/pepito.json", bytes.NewReader(updateBody))
+		require.NoError(t, err)
+		updateReq.Header.Set("Authorization", "Bearer "+adminJWT)
+		updateResp, err := http.DefaultClient.Do(updateReq)
+		require.NoError(t, err)
+		defer updateResp.Body.Close()
+		require.Equal(t, http.StatusOK, updateResp.StatusCode)
+
+		// Step 3: Navigate to teams list — this triggers a Backbone.sync fetch
+		// which will detect the stale JWT and auto-refresh the session
+		err = wd.Get(qidURL + "/")
+		require.NoError(t, err)
+
+		waitFor(t, wd, eqText(selenium.ByCSSSelector, "#breadcrumb", "Teams"), 5*time.Second)
+
+		// Step 4: Navigate to pipelines — give the refresh a moment to complete
+		// The first fetch triggered the refresh. Navigate again to see the updated UI.
+		pipelines, err := wd.FindElement(selenium.ByCSSSelector, "#pipelines")
+		require.NoError(t, err)
+		err = pipelines.Click()
+		require.NoError(t, err)
+
+		waitFor(t, wd, eqText(selenium.ByCSSSelector, "#breadcrumb", "Teams\nMain\nPipelines"), 5*time.Second)
+
+		// Step 5: Pepito should now see the "New" pipeline button (admin control)
+		// The first navigation triggered the token refresh asynchronously.
+		// We may need to navigate once more for the refreshed session to take effect.
+		waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+			_, err := wd.FindElement(selenium.ByCSSSelector, "#pipelines-new")
+			return err == nil
+		}, 5*time.Second)
 	})
 }
 

--- a/qid/mock/service.go
+++ b/qid/mock/service.go
@@ -372,6 +372,22 @@ func (mr *ServiceMockRecorder) ListUsers(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUsers", reflect.TypeOf((*Service)(nil).ListUsers), ctx)
 }
 
+// RefreshToken mocks base method.
+func (m *Service) RefreshToken(ctx context.Context, un string) (*user.WithMemberships, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RefreshToken", ctx, un)
+	ret0, _ := ret[0].(*user.WithMemberships)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// RefreshToken indicates an expected call of RefreshToken.
+func (mr *ServiceMockRecorder) RefreshToken(ctx, un any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshToken", reflect.TypeOf((*Service)(nil).RefreshToken), ctx, un)
+}
+
 // TriggerPipelineJob mocks base method.
 func (m *Service) TriggerPipelineJob(ctx context.Context, tc, pn, jn string) error {
 	m.ctrl.T.Helper()

--- a/qid/service.go
+++ b/qid/service.go
@@ -21,6 +21,7 @@ import (
 
 type Service interface {
 	UserLogin(ctx context.Context, un, pass string) (*user.WithMemberships, string, error)
+	RefreshToken(ctx context.Context, un string) (*user.WithMemberships, string, error)
 
 	GetUser(ctx context.Context, un string) (*user.WithMemberships, error)
 	CreateUser(ctx context.Context, u user.User, isHash bool) (*user.User, error)

--- a/qid/transport/http/authorization.go
+++ b/qid/transport/http/authorization.go
@@ -11,7 +11,8 @@ type authorizationFn func(ctx context.Context, s qid.Service, un, tc string) err
 
 var (
 	routeAuthorization = map[RouteName]authorizationFn{
-		UserLogin: nothing,
+		UserLogin:    nothing,
+		RefreshToken: nothing,
 
 		CreateUser: admin,
 		ListUsers:  admin,

--- a/qid/transport/http/client/client.go
+++ b/qid/transport/http/client/client.go
@@ -60,6 +60,21 @@ func (cl *Client) UserLogin(ctx context.Context, un, pass string) (*user.WithMem
 	return resp.Data.User, resp.Data.JWT, nil
 }
 
+func (cl *Client) RefreshToken(ctx context.Context, un string) (*user.WithMemberships, string, error) {
+	var resp thttp.RefreshTokenResponse
+
+	err := cl.Request(ctx, http.MethodPost, fmt.Sprintf("%s/refresh-token", cl.url), nil, &resp)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to make request: %w", err)
+	}
+
+	if resp.Err != "" {
+		return nil, "", fmt.Errorf("error from request: %s", resp.Err)
+	}
+
+	return resp.Data.User, resp.Data.JWT, nil
+}
+
 func (cl *Client) GetUser(ctx context.Context, un string) (*user.WithMemberships, error) {
 	// No server-side endpoint for GetUser; it's only used internally for authorization
 	return nil, fmt.Errorf("GetUser is not exposed via HTTP")

--- a/qid/transport/http/handler.go
+++ b/qid/transport/http/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/xescugc/qid/qid"
 	"github.com/xescugc/qid/qid/transport/http/assets"
 	"github.com/xescugc/qid/qid/transport/http/templates"
+	"github.com/xescugc/qid/qid/user"
 )
 
 const (
@@ -114,6 +115,14 @@ func Handler(s qid.Service, ts []byte, l *slog.Logger) http.Handler {
 					encodeError("Authentication required", rw)
 					return
 				}
+
+				// Check if JWT claims are stale compared to DB
+				if un != "" {
+					um, err := s.GetUser(rr.Context(), un)
+					if err == nil && membershipsDiffer(userClaim, um) {
+						rw.Header().Set("X-Refresh-Token", "true")
+					}
+				}
 			}
 
 			h.ServeHTTP(rw, rr)
@@ -142,6 +151,8 @@ func Handler(s qid.Service, ts []byte, l *slog.Logger) http.Handler {
 	api := jsonr.PathPrefix("/").Subrouter()
 
 	api.Use(auth)
+
+	api.Methods(http.MethodPost).Path("/refresh-token").Name(RefreshToken.String()).Handler(refreshToken(s))
 
 	api.Methods(http.MethodGet).Path("/users").Name(ListUsers.String()).Handler(listUsers(s))
 	api.Methods(http.MethodPost).Path("/users").Name(CreateUser.String()).Handler(createUser(s))
@@ -216,6 +227,43 @@ func (r ErrorResponse) Error() string {
 
 type Errorer interface {
 	Error() string
+}
+
+func membershipsDiffer(jwtUser map[string]interface{}, dbUser *user.WithMemberships) bool {
+	jwtAdmin, _ := jwtUser["admin"].(bool)
+	if jwtAdmin != dbUser.Admin {
+		return true
+	}
+
+	jwtMemberships, _ := jwtUser["memberships"].([]interface{})
+	if len(jwtMemberships) != len(dbUser.Memberships) {
+		return true
+	}
+
+	dbSet := make(map[string]bool, len(dbUser.Memberships))
+	for _, m := range dbUser.Memberships {
+		key := m.TeamCanonical
+		if m.Admin {
+			key += ":admin"
+		}
+		dbSet[key] = true
+	}
+	for _, jm := range jwtMemberships {
+		m, ok := jm.(map[string]interface{})
+		if !ok {
+			return true
+		}
+		tc, _ := m["team_canonical"].(string)
+		a, _ := m["admin"].(bool)
+		key := tc
+		if a {
+			key += ":admin"
+		}
+		if !dbSet[key] {
+			return true
+		}
+	}
+	return false
 }
 
 func encodeResponse(r interface{}, w http.ResponseWriter) {

--- a/qid/transport/http/handler_test.go
+++ b/qid/transport/http/handler_test.go
@@ -2,11 +2,17 @@ package http
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xescugc/qid/qid/mock"
+	"github.com/xescugc/qid/qid/user"
+	"go.uber.org/mock/gomock"
 )
 
 func TestEncodeResponse_WithError(t *testing.T) {
@@ -48,3 +54,230 @@ func TestErrorResponse_Error(t *testing.T) {
 	e = ErrorResponse{Err: ""}
 	assert.Equal(t, "", e.Error())
 }
+
+func TestMembershipsDiffer(t *testing.T) {
+	tests := []struct {
+		name     string
+		jwtUser  map[string]interface{}
+		dbUser   *user.WithMemberships
+		expected bool
+	}{
+		{
+			name: "identical",
+			jwtUser: map[string]interface{}{
+				"admin": false,
+				"memberships": []interface{}{
+					map[string]interface{}{"team_canonical": "main", "admin": false},
+				},
+			},
+			dbUser: &user.WithMemberships{
+				User:        user.User{Admin: false},
+				Memberships: []user.Member{{TeamCanonical: "main", Admin: false}},
+			},
+			expected: false,
+		},
+		{
+			name: "admin flag changed",
+			jwtUser: map[string]interface{}{
+				"admin":       false,
+				"memberships": []interface{}{},
+			},
+			dbUser: &user.WithMemberships{
+				User: user.User{Admin: true},
+			},
+			expected: true,
+		},
+		{
+			name: "new membership added",
+			jwtUser: map[string]interface{}{
+				"admin":       false,
+				"memberships": []interface{}{},
+			},
+			dbUser: &user.WithMemberships{
+				User:        user.User{Admin: false},
+				Memberships: []user.Member{{TeamCanonical: "main", Admin: false}},
+			},
+			expected: true,
+		},
+		{
+			name: "membership removed",
+			jwtUser: map[string]interface{}{
+				"admin": false,
+				"memberships": []interface{}{
+					map[string]interface{}{"team_canonical": "main", "admin": false},
+				},
+			},
+			dbUser: &user.WithMemberships{
+				User: user.User{Admin: false},
+			},
+			expected: true,
+		},
+		{
+			name: "membership admin changed",
+			jwtUser: map[string]interface{}{
+				"admin": false,
+				"memberships": []interface{}{
+					map[string]interface{}{"team_canonical": "main", "admin": false},
+				},
+			},
+			dbUser: &user.WithMemberships{
+				User:        user.User{Admin: false},
+				Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := membershipsDiffer(tt.jwtUser, tt.dbUser)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func signJWT(t *testing.T, secret []byte, um *user.WithMemberships) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"user": um,
+	})
+	s, err := token.SignedString(secret)
+	require.NoError(t, err)
+	return s
+}
+
+func TestRefreshTokenEndpoint(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	handler := Handler(s, secret, logger)
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	um := &user.WithMemberships{
+		User:        user.User{Username: "pepito"},
+		Memberships: []user.Member{},
+	}
+	jwtToken := signJWT(t, secret, um)
+
+	updatedUM := &user.WithMemberships{
+		User:        user.User{Username: "pepito"},
+		Memberships: []user.Member{{TeamCanonical: "main", Admin: false}},
+	}
+
+	// Stale-check in middleware calls GetUser; RefreshToken is the handler
+	s.EXPECT().GetUser(gomock.Any(), "pepito").Return(updatedUM, nil)
+	s.EXPECT().RefreshToken(gomock.Any(), "pepito").Return(updatedUM, signJWT(t, secret, updatedUM), nil)
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/refresh-token.json", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+jwtToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var refreshResp RefreshTokenResponse
+	err = json.NewDecoder(resp.Body).Decode(&refreshResp)
+	require.NoError(t, err)
+	assert.Empty(t, refreshResp.Err)
+	assert.NotEmpty(t, refreshResp.Data.JWT)
+	assert.Equal(t, "pepito", refreshResp.Data.User.Username)
+	assert.Len(t, refreshResp.Data.User.Memberships, 1)
+}
+
+func TestXRefreshTokenHeader(t *testing.T) {
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	t.Run("header set when memberships differ", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		s := mock.NewService(ctrl)
+		handler := Handler(s, secret, logger)
+		server := httptest.NewServer(handler)
+		defer server.Close()
+
+		um := &user.WithMemberships{
+			User:        user.User{Username: "pepito"},
+			Memberships: []user.Member{},
+		}
+		jwtToken := signJWT(t, secret, um)
+
+		updatedUM := &user.WithMemberships{
+			User:        user.User{Username: "pepito"},
+			Memberships: []user.Member{{TeamCanonical: "main", Admin: false}},
+		}
+
+		// member() authz calls GetUser, then middleware stale-check calls GetUser again
+		s.EXPECT().GetUser(gomock.Any(), "pepito").Return(updatedUM, nil).Times(2)
+		s.EXPECT().ListTeams(gomock.Any(), "pepito").Return(nil, nil)
+
+		req, err := http.NewRequest(http.MethodGet, server.URL+"/teams.json", nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+jwtToken)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+
+		assert.Equal(t, "true", resp.Header.Get("X-Refresh-Token"))
+	})
+
+	t.Run("header not set when memberships match", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		s := mock.NewService(ctrl)
+		handler := Handler(s, secret, logger)
+		server := httptest.NewServer(handler)
+		defer server.Close()
+
+		um := &user.WithMemberships{
+			User:        user.User{Username: "pepito"},
+			Memberships: []user.Member{{TeamCanonical: "main", Admin: false}},
+		}
+		jwtToken := signJWT(t, secret, um)
+
+		s.EXPECT().GetUser(gomock.Any(), "pepito").Return(um, nil).Times(2)
+		s.EXPECT().ListTeams(gomock.Any(), "pepito").Return(nil, nil)
+
+		req, err := http.NewRequest(http.MethodGet, server.URL+"/teams.json", nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+jwtToken)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+
+		assert.Empty(t, resp.Header.Get("X-Refresh-Token"))
+	})
+
+	t.Run("header not set for worker tokens", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		s := mock.NewService(ctrl)
+		handler := Handler(s, secret, logger)
+		server := httptest.NewServer(handler)
+		defer server.Close()
+
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+			"is_from_worker": true,
+		})
+		workerJWT, err := token.SignedString(secret)
+		require.NoError(t, err)
+
+		// Workers skip authz and stale-check; the handler itself will fail
+		// because there's no username in context, but the important thing
+		// is that X-Refresh-Token is NOT set.
+		req, err := http.NewRequest(http.MethodGet, server.URL+"/teams.json", nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+workerJWT)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+
+		assert.Empty(t, resp.Header.Get("X-Refresh-Token"))
+	})
+}
+

--- a/qid/transport/http/route_names.go
+++ b/qid/transport/http/route_names.go
@@ -6,6 +6,7 @@ type RouteName int
 
 const (
 	UserLogin RouteName = iota
+	RefreshToken
 
 	CreateUser
 	ListUsers

--- a/qid/transport/http/route_names_string.go
+++ b/qid/transport/http/route_names_string.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _RouteNameName = "user_logincreate_userlist_userscreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildupdate_job_builddelete_job_buildlist_job_buildsget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versions"
+const _RouteNameName = "user_loginrefresh_tokencreate_userlist_userscreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildupdate_job_builddelete_job_buildlist_job_buildsget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versions"
 
-var _RouteNameIndex = [...]uint16{0, 10, 21, 31, 42, 52, 60, 71, 82, 100, 118, 136, 151, 166, 178, 193, 207, 225, 246, 266, 282, 298, 314, 330, 345, 366, 390, 415, 438, 460}
+var _RouteNameIndex = [...]uint16{0, 10, 23, 34, 44, 55, 65, 73, 84, 95, 113, 131, 149, 164, 179, 191, 206, 220, 238, 259, 279, 295, 311, 327, 343, 358, 379, 403, 428, 451, 473}
 
-const _RouteNameLowerName = "user_logincreate_userlist_userscreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildupdate_job_builddelete_job_buildlist_job_buildsget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versions"
+const _RouteNameLowerName = "user_loginrefresh_tokencreate_userlist_userscreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildupdate_job_builddelete_job_buildlist_job_buildsget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versions"
 
 func (i RouteName) String() string {
 	if i < 0 || i >= RouteName(len(_RouteNameIndex)-1) {
@@ -25,129 +25,133 @@ func (i RouteName) String() string {
 func _RouteNameNoOp() {
 	var x [1]struct{}
 	_ = x[UserLogin-(0)]
-	_ = x[CreateUser-(1)]
-	_ = x[ListUsers-(2)]
-	_ = x[CreateTeam-(3)]
-	_ = x[ListTeams-(4)]
-	_ = x[GetTeam-(5)]
-	_ = x[UpdateTeam-(6)]
-	_ = x[DeleteTeam-(7)]
-	_ = x[CreateTeamMember-(8)]
-	_ = x[UpdateTeamMember-(9)]
-	_ = x[DeleteTeamMember-(10)]
-	_ = x[CreatePipeline-(11)]
-	_ = x[UpdatePipeline-(12)]
-	_ = x[GetPipeline-(13)]
-	_ = x[DeletePipeline-(14)]
-	_ = x[ListPipelines-(15)]
-	_ = x[GetPipelineImage-(16)]
-	_ = x[CreatePipelineImage-(17)]
-	_ = x[TriggerPipelineJob-(18)]
-	_ = x[GetPipelineJob-(19)]
-	_ = x[CreateJobBuild-(20)]
-	_ = x[UpdateJobBuild-(21)]
-	_ = x[DeleteJobBuild-(22)]
-	_ = x[ListJobBuilds-(23)]
-	_ = x[GetPipelineResource-(24)]
-	_ = x[UpdatePipelineResource-(25)]
-	_ = x[TriggerPipelineResource-(26)]
-	_ = x[CreateResourceVersion-(27)]
-	_ = x[ListResourceVersions-(28)]
+	_ = x[RefreshToken-(1)]
+	_ = x[CreateUser-(2)]
+	_ = x[ListUsers-(3)]
+	_ = x[CreateTeam-(4)]
+	_ = x[ListTeams-(5)]
+	_ = x[GetTeam-(6)]
+	_ = x[UpdateTeam-(7)]
+	_ = x[DeleteTeam-(8)]
+	_ = x[CreateTeamMember-(9)]
+	_ = x[UpdateTeamMember-(10)]
+	_ = x[DeleteTeamMember-(11)]
+	_ = x[CreatePipeline-(12)]
+	_ = x[UpdatePipeline-(13)]
+	_ = x[GetPipeline-(14)]
+	_ = x[DeletePipeline-(15)]
+	_ = x[ListPipelines-(16)]
+	_ = x[GetPipelineImage-(17)]
+	_ = x[CreatePipelineImage-(18)]
+	_ = x[TriggerPipelineJob-(19)]
+	_ = x[GetPipelineJob-(20)]
+	_ = x[CreateJobBuild-(21)]
+	_ = x[UpdateJobBuild-(22)]
+	_ = x[DeleteJobBuild-(23)]
+	_ = x[ListJobBuilds-(24)]
+	_ = x[GetPipelineResource-(25)]
+	_ = x[UpdatePipelineResource-(26)]
+	_ = x[TriggerPipelineResource-(27)]
+	_ = x[CreateResourceVersion-(28)]
+	_ = x[ListResourceVersions-(29)]
 }
 
-var _RouteNameValues = []RouteName{UserLogin, CreateUser, ListUsers, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, GetPipelineJob, CreateJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions}
+var _RouteNameValues = []RouteName{UserLogin, RefreshToken, CreateUser, ListUsers, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, GetPipelineJob, CreateJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions}
 
 var _RouteNameNameToValueMap = map[string]RouteName{
 	_RouteNameName[0:10]:         UserLogin,
 	_RouteNameLowerName[0:10]:    UserLogin,
-	_RouteNameName[10:21]:        CreateUser,
-	_RouteNameLowerName[10:21]:   CreateUser,
-	_RouteNameName[21:31]:        ListUsers,
-	_RouteNameLowerName[21:31]:   ListUsers,
-	_RouteNameName[31:42]:        CreateTeam,
-	_RouteNameLowerName[31:42]:   CreateTeam,
-	_RouteNameName[42:52]:        ListTeams,
-	_RouteNameLowerName[42:52]:   ListTeams,
-	_RouteNameName[52:60]:        GetTeam,
-	_RouteNameLowerName[52:60]:   GetTeam,
-	_RouteNameName[60:71]:        UpdateTeam,
-	_RouteNameLowerName[60:71]:   UpdateTeam,
-	_RouteNameName[71:82]:        DeleteTeam,
-	_RouteNameLowerName[71:82]:   DeleteTeam,
-	_RouteNameName[82:100]:       CreateTeamMember,
-	_RouteNameLowerName[82:100]:  CreateTeamMember,
-	_RouteNameName[100:118]:      UpdateTeamMember,
-	_RouteNameLowerName[100:118]: UpdateTeamMember,
-	_RouteNameName[118:136]:      DeleteTeamMember,
-	_RouteNameLowerName[118:136]: DeleteTeamMember,
-	_RouteNameName[136:151]:      CreatePipeline,
-	_RouteNameLowerName[136:151]: CreatePipeline,
-	_RouteNameName[151:166]:      UpdatePipeline,
-	_RouteNameLowerName[151:166]: UpdatePipeline,
-	_RouteNameName[166:178]:      GetPipeline,
-	_RouteNameLowerName[166:178]: GetPipeline,
-	_RouteNameName[178:193]:      DeletePipeline,
-	_RouteNameLowerName[178:193]: DeletePipeline,
-	_RouteNameName[193:207]:      ListPipelines,
-	_RouteNameLowerName[193:207]: ListPipelines,
-	_RouteNameName[207:225]:      GetPipelineImage,
-	_RouteNameLowerName[207:225]: GetPipelineImage,
-	_RouteNameName[225:246]:      CreatePipelineImage,
-	_RouteNameLowerName[225:246]: CreatePipelineImage,
-	_RouteNameName[246:266]:      TriggerPipelineJob,
-	_RouteNameLowerName[246:266]: TriggerPipelineJob,
-	_RouteNameName[266:282]:      GetPipelineJob,
-	_RouteNameLowerName[266:282]: GetPipelineJob,
-	_RouteNameName[282:298]:      CreateJobBuild,
-	_RouteNameLowerName[282:298]: CreateJobBuild,
-	_RouteNameName[298:314]:      UpdateJobBuild,
-	_RouteNameLowerName[298:314]: UpdateJobBuild,
-	_RouteNameName[314:330]:      DeleteJobBuild,
-	_RouteNameLowerName[314:330]: DeleteJobBuild,
-	_RouteNameName[330:345]:      ListJobBuilds,
-	_RouteNameLowerName[330:345]: ListJobBuilds,
-	_RouteNameName[345:366]:      GetPipelineResource,
-	_RouteNameLowerName[345:366]: GetPipelineResource,
-	_RouteNameName[366:390]:      UpdatePipelineResource,
-	_RouteNameLowerName[366:390]: UpdatePipelineResource,
-	_RouteNameName[390:415]:      TriggerPipelineResource,
-	_RouteNameLowerName[390:415]: TriggerPipelineResource,
-	_RouteNameName[415:438]:      CreateResourceVersion,
-	_RouteNameLowerName[415:438]: CreateResourceVersion,
-	_RouteNameName[438:460]:      ListResourceVersions,
-	_RouteNameLowerName[438:460]: ListResourceVersions,
+	_RouteNameName[10:23]:        RefreshToken,
+	_RouteNameLowerName[10:23]:   RefreshToken,
+	_RouteNameName[23:34]:        CreateUser,
+	_RouteNameLowerName[23:34]:   CreateUser,
+	_RouteNameName[34:44]:        ListUsers,
+	_RouteNameLowerName[34:44]:   ListUsers,
+	_RouteNameName[44:55]:        CreateTeam,
+	_RouteNameLowerName[44:55]:   CreateTeam,
+	_RouteNameName[55:65]:        ListTeams,
+	_RouteNameLowerName[55:65]:   ListTeams,
+	_RouteNameName[65:73]:        GetTeam,
+	_RouteNameLowerName[65:73]:   GetTeam,
+	_RouteNameName[73:84]:        UpdateTeam,
+	_RouteNameLowerName[73:84]:   UpdateTeam,
+	_RouteNameName[84:95]:        DeleteTeam,
+	_RouteNameLowerName[84:95]:   DeleteTeam,
+	_RouteNameName[95:113]:       CreateTeamMember,
+	_RouteNameLowerName[95:113]:  CreateTeamMember,
+	_RouteNameName[113:131]:      UpdateTeamMember,
+	_RouteNameLowerName[113:131]: UpdateTeamMember,
+	_RouteNameName[131:149]:      DeleteTeamMember,
+	_RouteNameLowerName[131:149]: DeleteTeamMember,
+	_RouteNameName[149:164]:      CreatePipeline,
+	_RouteNameLowerName[149:164]: CreatePipeline,
+	_RouteNameName[164:179]:      UpdatePipeline,
+	_RouteNameLowerName[164:179]: UpdatePipeline,
+	_RouteNameName[179:191]:      GetPipeline,
+	_RouteNameLowerName[179:191]: GetPipeline,
+	_RouteNameName[191:206]:      DeletePipeline,
+	_RouteNameLowerName[191:206]: DeletePipeline,
+	_RouteNameName[206:220]:      ListPipelines,
+	_RouteNameLowerName[206:220]: ListPipelines,
+	_RouteNameName[220:238]:      GetPipelineImage,
+	_RouteNameLowerName[220:238]: GetPipelineImage,
+	_RouteNameName[238:259]:      CreatePipelineImage,
+	_RouteNameLowerName[238:259]: CreatePipelineImage,
+	_RouteNameName[259:279]:      TriggerPipelineJob,
+	_RouteNameLowerName[259:279]: TriggerPipelineJob,
+	_RouteNameName[279:295]:      GetPipelineJob,
+	_RouteNameLowerName[279:295]: GetPipelineJob,
+	_RouteNameName[295:311]:      CreateJobBuild,
+	_RouteNameLowerName[295:311]: CreateJobBuild,
+	_RouteNameName[311:327]:      UpdateJobBuild,
+	_RouteNameLowerName[311:327]: UpdateJobBuild,
+	_RouteNameName[327:343]:      DeleteJobBuild,
+	_RouteNameLowerName[327:343]: DeleteJobBuild,
+	_RouteNameName[343:358]:      ListJobBuilds,
+	_RouteNameLowerName[343:358]: ListJobBuilds,
+	_RouteNameName[358:379]:      GetPipelineResource,
+	_RouteNameLowerName[358:379]: GetPipelineResource,
+	_RouteNameName[379:403]:      UpdatePipelineResource,
+	_RouteNameLowerName[379:403]: UpdatePipelineResource,
+	_RouteNameName[403:428]:      TriggerPipelineResource,
+	_RouteNameLowerName[403:428]: TriggerPipelineResource,
+	_RouteNameName[428:451]:      CreateResourceVersion,
+	_RouteNameLowerName[428:451]: CreateResourceVersion,
+	_RouteNameName[451:473]:      ListResourceVersions,
+	_RouteNameLowerName[451:473]: ListResourceVersions,
 }
 
 var _RouteNameNames = []string{
 	_RouteNameName[0:10],
-	_RouteNameName[10:21],
-	_RouteNameName[21:31],
-	_RouteNameName[31:42],
-	_RouteNameName[42:52],
-	_RouteNameName[52:60],
-	_RouteNameName[60:71],
-	_RouteNameName[71:82],
-	_RouteNameName[82:100],
-	_RouteNameName[100:118],
-	_RouteNameName[118:136],
-	_RouteNameName[136:151],
-	_RouteNameName[151:166],
-	_RouteNameName[166:178],
-	_RouteNameName[178:193],
-	_RouteNameName[193:207],
-	_RouteNameName[207:225],
-	_RouteNameName[225:246],
-	_RouteNameName[246:266],
-	_RouteNameName[266:282],
-	_RouteNameName[282:298],
-	_RouteNameName[298:314],
-	_RouteNameName[314:330],
-	_RouteNameName[330:345],
-	_RouteNameName[345:366],
-	_RouteNameName[366:390],
-	_RouteNameName[390:415],
-	_RouteNameName[415:438],
-	_RouteNameName[438:460],
+	_RouteNameName[10:23],
+	_RouteNameName[23:34],
+	_RouteNameName[34:44],
+	_RouteNameName[44:55],
+	_RouteNameName[55:65],
+	_RouteNameName[65:73],
+	_RouteNameName[73:84],
+	_RouteNameName[84:95],
+	_RouteNameName[95:113],
+	_RouteNameName[113:131],
+	_RouteNameName[131:149],
+	_RouteNameName[149:164],
+	_RouteNameName[164:179],
+	_RouteNameName[179:191],
+	_RouteNameName[191:206],
+	_RouteNameName[206:220],
+	_RouteNameName[220:238],
+	_RouteNameName[238:259],
+	_RouteNameName[259:279],
+	_RouteNameName[279:295],
+	_RouteNameName[295:311],
+	_RouteNameName[311:327],
+	_RouteNameName[327:343],
+	_RouteNameName[343:358],
+	_RouteNameName[358:379],
+	_RouteNameName[379:403],
+	_RouteNameName[403:428],
+	_RouteNameName[428:451],
+	_RouteNameName[451:473],
 }
 
 // RouteNameString retrieves an enum value from the enum constants string name.

--- a/qid/transport/http/templates/views/layouts/index.tmpl
+++ b/qid/transport/http/templates/views/layouts/index.tmpl
@@ -1766,9 +1766,25 @@
           }
         }
         var optSuccess = options.success
-        options.success = function(response){
+        options.success = function(response, textStatus, jqXHR){
           if (!options.isInterval) {
             app.apiError.clear()
+          }
+          if (jqXHR && jqXHR.getResponseHeader('X-Refresh-Token') === 'true') {
+            $.ajax({
+              url: '/refresh-token.json',
+              type: 'POST',
+              headers: {
+                'Authorization': 'Bearer ' + app.session.get("jwt"),
+                'Content-Type': 'application/json',
+              },
+              success: function(resp) {
+                if (resp.data && resp.data.jwt) {
+                  app.session.set({jwt: resp.data.jwt, user: resp.data.user});
+                  window.localStorage.setItem(userSessionKey, JSON.stringify(app.session.toJSON()));
+                }
+              },
+            });
           }
           if (optSuccess) {
             optSuccess(response)

--- a/qid/transport/http/users.go
+++ b/qid/transport/http/users.go
@@ -56,6 +56,47 @@ func userLogin(s qid.Service) http.HandlerFunc {
 	}
 }
 
+type RefreshTokenResponse struct {
+	Err  string `json:"error,omitempty"`
+	Data struct {
+		User *user.WithMemberships `json:"user,omitempty"`
+		JWT  string                `json:"jwt,omitempty"`
+	} `json:"data,omitempty"`
+}
+
+func (r RefreshTokenResponse) Error() string {
+	return r.Err
+}
+
+func refreshToken(s qid.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		un, _ := ctx.Value(UsernameContextKey).(string)
+		if un == "" {
+			encodeResponse(RefreshTokenResponse{Err: "missing username"}, w)
+			return
+		}
+
+		u, jwt, err := s.RefreshToken(ctx, un)
+		var errs string
+		if err != nil {
+			errs = err.Error()
+		}
+
+		resp := RefreshTokenResponse{
+			Data: struct {
+				User *user.WithMemberships `json:"user,omitempty"`
+				JWT  string                `json:"jwt,omitempty"`
+			}{
+				User: u,
+				JWT:  jwt,
+			},
+			Err: errs,
+		}
+		encodeResponse(resp, w)
+	}
+}
+
 type ListUsersResponse struct {
 	Err   string       `json:"error,omitempty"`
 	Users []*user.User `json:"data,omitempty"`

--- a/qid/users.go
+++ b/qid/users.go
@@ -35,6 +35,26 @@ func (q *Qid) UserLogin(ctx context.Context, un, pass string) (*user.WithMembers
 	return um, tokenString, nil
 }
 
+func (q *Qid) RefreshToken(ctx context.Context, un string) (*user.WithMemberships, string, error) {
+	if !utils.ValidateCanonical(un) {
+		return nil, "", fmt.Errorf("invalid Username format %q", un)
+	}
+	um, err := q.Users.FindWithMemberships(ctx, un)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to Find User: %w", err)
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"user": um,
+	})
+	tokenString, err := token.SignedString(q.JWTSecret)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to sign token: %w", err)
+	}
+
+	return um, tokenString, nil
+}
+
 func (q *Qid) GetUser(ctx context.Context, un string) (*user.WithMemberships, error) {
 	if !utils.ValidateCanonical(un) {
 		return nil, fmt.Errorf("invalid Username format %q", un)


### PR DESCRIPTION
## Summary

Fixes #126. When a user's permissions change (promoted to team admin, removed from team, etc.), the frontend UI now reflects the changes without requiring re-login.

- **Backend**: Auth middleware compares JWT membership claims against fresh DB data on each request. If they differ, sets `X-Refresh-Token: true` response header (zero overhead when unchanged)
- **New endpoint**: `POST /refresh-token` — validates old JWT, fetches fresh memberships, issues new JWT
- **Frontend**: `Backbone.sync` wrapper detects the `X-Refresh-Token` header and automatically calls `/refresh-token` to update `app.session` and `localStorage`

## Test plan

- [x] `TestMembershipsDiffer` — unit tests for JWT vs DB comparison logic
- [x] `TestRefreshTokenEndpoint` — endpoint returns new JWT with updated memberships
- [x] `TestXRefreshTokenHeader` — header set when stale, absent when fresh, absent for workers
- [x] Selenium integration test: promote pepito to admin via HTTP, navigate in browser, verify admin controls appear without re-login
- [x] All existing tests pass (`make test`, `make lint`)