### PR TITLE
Fix entity still added to collection on failed creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,6 @@
 
 ## Unreleased
 
+- Fix entity still shown in collection when backend creation fails: add Unit of Work (transaction) pattern for multi-step DB operations and `wait: true` to frontend `collection.create()` calls ([#123](https://github.com/xescugc/qid/issues/123))
 - Fix user permission changes not reflected until re-login: backend signals stale JWT via `X-Refresh-Token` header, frontend auto-refreshes session ([#126](https://github.com/xescugc/qid/pull/126))
 - Add users and teams with role-based access control, refactor HTTP transport from go-kit to direct handlers ([#124](https://github.com/xescugc/qid/pull/124))

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/xescugc/qid/qid/mysql"
 	"github.com/xescugc/qid/qid/mysql/migrate"
 	tshttp "github.com/xescugc/qid/qid/transport/http"
+	"github.com/xescugc/qid/qid/unitwork"
 	"github.com/xescugc/qid/qid/user"
 	"gocloud.dev/pubsub"
 
@@ -161,8 +162,10 @@ var (
 			br := mysql.NewBuildRepository(querier)
 			rur := mysql.NewRunnerRepository(querier)
 
+			suow := unitwork.NewStartUnitOfWork(db)
+
 			logger.Info("initializing service")
-			var svc = qid.New(ctx, topic, ur, tr, ppr, jr, rr, rt, br, rur, cfg.JWTSecret, logger)
+			var svc = qid.New(ctx, topic, ur, tr, ppr, jr, rr, rt, br, rur, suow, cfg.JWTSecret, logger)
 			logger.Info("initialized service")
 
 			logger.Info("initializing http handlers")

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/xescugc/qid/qid/mysql/migrate"
 	"github.com/xescugc/qid/qid/queue"
 	tshttp "github.com/xescugc/qid/qid/transport/http"
+	"github.com/xescugc/qid/qid/unitwork"
 	"github.com/xescugc/qid/qid/user"
 	"github.com/xescugc/qid/worker"
 	"gocloud.dev/pubsub"
@@ -58,7 +59,8 @@ func runTests(m *testing.M) int {
 	rt := mysql.NewResourceTypeRepository(db)
 	br := mysql.NewBuildRepository(db)
 	rur := mysql.NewRunnerRepository(db)
-	var svc = qid.New(ctx, topic, ur, tr, ppr, jr, rr, rt, br, rur, jwtSecret, logger)
+	suow := unitwork.NewStartUnitOfWork(db)
+	var svc = qid.New(ctx, topic, ur, tr, ppr, jr, rr, rt, br, rur, suow, jwtSecret, logger)
 	var handler = tshttp.Handler(svc, jwtSecret, logger.With("component", "HTTP"))
 	server := httptest.NewServer(handler)
 	qidURL = server.URL

--- a/qid/helper_test.go
+++ b/qid/helper_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/xescugc/qid/qid"
 	"github.com/xescugc/qid/qid/mock"
+	"github.com/xescugc/qid/qid/unitwork"
 	"go.uber.org/mock/gomock"
 )
 
@@ -33,6 +34,17 @@ func newService(ctrl *gomock.Controller) MockService {
 	rur := mock.NewRunnerRepository(ctrl)
 	t := mock.NewTopic(ctrl)
 
+	suow := unitwork.NewNoopStartUnitOfWork(unitwork.Repositories{
+		UsersRepo:         ur,
+		TeamsRepo:         tr,
+		PipelinesRepo:     pr,
+		JobsRepo:          jr,
+		ResourcesRepo:     rr,
+		ResourceTypesRepo: rtr,
+		BuildsRepo:        br,
+		RunnersRepo:       rur,
+	})
+
 	return MockService{
 		Topic:         t,
 		Users:         ur,
@@ -44,6 +56,6 @@ func newService(ctrl *gomock.Controller) MockService {
 		Builds:        br,
 		Runners:       rur,
 
-		S: qid.New(context.TODO(), t, ur, tr, pr, jr, rr, rtr, br, rur, []byte("test-secret"), nil),
+		S: qid.New(context.TODO(), t, ur, tr, pr, jr, rr, rtr, br, rur, suow, []byte("test-secret"), nil),
 	}
 }

--- a/qid/pipelines.go
+++ b/qid/pipelines.go
@@ -14,6 +14,7 @@ import (
 	"github.com/xescugc/qid/qid/pipeline"
 	"github.com/xescugc/qid/qid/queue"
 	"github.com/xescugc/qid/qid/resource"
+	"github.com/xescugc/qid/qid/unitwork"
 	"github.com/xescugc/qid/qid/utils"
 	"gocloud.dev/pubsub"
 )
@@ -63,64 +64,77 @@ func (q *Qid) CreatePipeline(ctx context.Context, tc, pn string, rpp []byte, var
 	pp.Name = pn
 	pp.Raw = rpp
 
-	_, err = q.Pipelines.Create(ctx, tc, *pp)
+	var cronEntries []cron.EntryID
+	var cp *pipeline.Pipeline
+	err = q.StartUoW(ctx, func(uow unitwork.UnitOfWork) error {
+		_, err := uow.Pipelines().Create(ctx, tc, *pp)
+		if err != nil {
+			return fmt.Errorf("failed to create Pipeline %q: %w", pn, err)
+		}
+
+		for _, j := range pp.Jobs {
+			if !utils.ValidateCanonical(j.Name) {
+				return fmt.Errorf("invalid Job Name format %q", j.Name)
+			}
+			_, err = uow.Jobs().Create(ctx, tc, pn, j)
+			if err != nil {
+				return fmt.Errorf("failed to create Job %q: %w", j.Name, err)
+			}
+		}
+
+		for _, rt := range pp.ResourceTypes {
+			if !utils.ValidateCanonical(rt.Name) {
+				return fmt.Errorf("invalid ResourceType Name format %q", rt.Name)
+			}
+			_, err = uow.ResourceTypes().Create(ctx, tc, pn, rt)
+			if err != nil {
+				return fmt.Errorf("failed to create ResourceType %q: %w", rt.Name, err)
+			}
+		}
+
+		for _, r := range pp.Resources {
+			if !utils.ValidateCanonical(r.Name) {
+				return fmt.Errorf("invalid Resource Name format %q", r.Name)
+			}
+			spec := r.CheckInterval
+			if spec == "" {
+				spec = "@every 1m"
+			}
+			eid, err := q.cron.AddFunc(spec, q.newCronResourceFunc(tc, pp.Name, r.Canonical))
+			if err != nil {
+				return fmt.Errorf("failed to add Cron Func %q: %w", r.Name, err)
+			}
+			cronEntries = append(cronEntries, eid)
+			r.CronID = uint64(eid)
+			_, err = uow.Resources().Create(ctx, tc, pn, r)
+			if err != nil {
+				q.cron.Remove(eid)
+				return fmt.Errorf("failed to create Resource %q: %w", r.Name, err)
+			}
+		}
+
+		for _, ru := range pp.Runners {
+			if !utils.ValidateCanonical(ru.Name) {
+				return fmt.Errorf("invalid Runner Name format %q", ru.Name)
+			}
+			_, err = uow.Runners().Create(ctx, tc, pn, ru)
+			if err != nil {
+				return fmt.Errorf("failed to create Runner %q: %w", ru.Name, err)
+			}
+		}
+
+		cp, err = uow.Pipelines().Find(ctx, tc, pn)
+		if err != nil {
+			return fmt.Errorf("failed to get Pipeline: %w", err)
+		}
+		return nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Pipeline %q: %w", pn, err)
-	}
-
-	for _, j := range pp.Jobs {
-		if !utils.ValidateCanonical(j.Name) {
-			return nil, fmt.Errorf("invalid Job Name format %q", j.Name)
-		}
-		_, err = q.Jobs.Create(ctx, tc, pn, j)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create Job %q: %w", j.Name, err)
-		}
-	}
-
-	for _, rt := range pp.ResourceTypes {
-		if !utils.ValidateCanonical(rt.Name) {
-			return nil, fmt.Errorf("invalid ResourceType Name format %q", rt.Name)
-		}
-		_, err = q.ResourceTypes.Create(ctx, tc, pn, rt)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create ResourceType %q: %w", rt.Name, err)
-		}
-	}
-
-	for _, r := range pp.Resources {
-		if !utils.ValidateCanonical(r.Name) {
-			return nil, fmt.Errorf("invalid Resource Name format %q", r.Name)
-		}
-		spec := r.CheckInterval
-		if spec == "" {
-			spec = "@every 1m"
-		}
-		eid, err := q.cron.AddFunc(spec, q.newCronResourceFunc(tc, pp.Name, r.Canonical))
-		if err != nil {
-			return nil, fmt.Errorf("failed to add Cron Func %q: %w", r.Name, err)
-		}
-		r.CronID = uint64(eid)
-		_, err = q.Resources.Create(ctx, tc, pn, r)
-		if err != nil {
+		// Clean up any cron entries that were added
+		for _, eid := range cronEntries {
 			q.cron.Remove(eid)
-			return nil, fmt.Errorf("failed to create Resource %q: %w", r.Name, err)
 		}
-	}
-
-	for _, ru := range pp.Runners {
-		if !utils.ValidateCanonical(ru.Name) {
-			return nil, fmt.Errorf("invalid Runner Name format %q", ru.Name)
-		}
-		_, err = q.Runners.Create(ctx, tc, pn, ru)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create Runner %q: %w", ru.Name, err)
-		}
-	}
-
-	cp, err := q.GetPipeline(ctx, tc, pn)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get Pipeline: %w", err)
+		return nil, err
 	}
 	return cp, nil
 }
@@ -140,149 +154,160 @@ func (q *Qid) UpdatePipeline(ctx context.Context, tc, pn string, rpp []byte, var
 	pp.Name = pn
 	pp.Raw = rpp
 
-	err = q.Pipelines.Update(ctx, tc, pn, *pp)
-
-	dbpp, err := q.GetPipeline(ctx, tc, pn)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get Pipeline %q: %w", pn, err)
-	}
-
-	dbjbs := make(map[string]struct{})
-	for _, j := range dbpp.Jobs {
-		dbjbs[j.Name] = struct{}{}
-	}
-	for _, j := range pp.Jobs {
-		if !utils.ValidateCanonical(j.Name) {
-			return nil, fmt.Errorf("invalid Job Name format %q", j.Name)
-		}
-		if _, ok := dbjbs[j.Name]; ok {
-			delete(dbjbs, j.Name)
-			err = q.Jobs.Update(ctx, tc, pn, j.Name, j)
-			if err != nil {
-				return nil, fmt.Errorf("failed to update Job %q: %w", j.Name, err)
-			}
-		} else {
-			_, err = q.Jobs.Create(ctx, tc, pn, j)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create Job %q: %w", j.Name, err)
-			}
-		}
-	}
-	for jn := range dbjbs {
-		err = q.Jobs.Delete(ctx, tc, pn, jn)
+	var up *pipeline.Pipeline
+	err = q.StartUoW(ctx, func(uow unitwork.UnitOfWork) error {
+		err := uow.Pipelines().Update(ctx, tc, pn, *pp)
 		if err != nil {
-			return nil, fmt.Errorf("failed to delete Job %q: %w", jn, err)
+			return fmt.Errorf("failed to update Pipeline %q: %w", pn, err)
 		}
-	}
 
-	dbrts := make(map[string]struct{})
-	for _, rt := range dbpp.ResourceTypes {
-		dbrts[rt.Name] = struct{}{}
-	}
-	for _, rt := range pp.ResourceTypes {
-		if !utils.ValidateCanonical(rt.Name) {
-			return nil, fmt.Errorf("invalid ResourceType Name format %q", rt.Name)
-		}
-		if _, ok := dbrts[rt.Name]; ok {
-			delete(dbrts, rt.Name)
-			err = q.ResourceTypes.Update(ctx, tc, pn, rt.Name, rt)
-			if err != nil {
-				return nil, fmt.Errorf("failed to update ResourceType %q: %w", rt.Name, err)
-			}
-		} else {
-			_, err = q.ResourceTypes.Create(ctx, tc, pn, rt)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create ResourceType %q: %w", rt.Name, err)
-			}
-		}
-	}
-	for rt := range dbrts {
-		err = q.ResourceTypes.Delete(ctx, tc, pn, rt)
+		dbpp, err := uow.Pipelines().Find(ctx, tc, pn)
 		if err != nil {
-			return nil, fmt.Errorf("failed to delete ResourceType %q: %w", rt, err)
+			return fmt.Errorf("failed to get Pipeline %q: %w", pn, err)
 		}
-	}
 
-	dbrs := make(map[string]resource.Resource)
-	for _, r := range dbpp.Resources {
-		dbrs[r.Canonical] = r
-	}
-	for _, r := range pp.Resources {
-		if !utils.ValidateCanonical(r.Name) {
-			return nil, fmt.Errorf("invalid Resource Name format %q", r.Name)
+		dbjbs := make(map[string]struct{})
+		for _, j := range dbpp.Jobs {
+			dbjbs[j.Name] = struct{}{}
 		}
-		if dbr, ok := dbrs[r.Canonical]; ok {
-			delete(dbrs, r.Canonical)
-			if dbr.CheckInterval != r.CheckInterval {
-				q.cron.Remove(cron.EntryID(dbr.CronID))
+		for _, j := range pp.Jobs {
+			if !utils.ValidateCanonical(j.Name) {
+				return fmt.Errorf("invalid Job Name format %q", j.Name)
+			}
+			if _, ok := dbjbs[j.Name]; ok {
+				delete(dbjbs, j.Name)
+				err = uow.Jobs().Update(ctx, tc, pn, j.Name, j)
+				if err != nil {
+					return fmt.Errorf("failed to update Job %q: %w", j.Name, err)
+				}
+			} else {
+				_, err = uow.Jobs().Create(ctx, tc, pn, j)
+				if err != nil {
+					return fmt.Errorf("failed to create Job %q: %w", j.Name, err)
+				}
+			}
+		}
+		for jn := range dbjbs {
+			err = uow.Jobs().Delete(ctx, tc, pn, jn)
+			if err != nil {
+				return fmt.Errorf("failed to delete Job %q: %w", jn, err)
+			}
+		}
+
+		dbrts := make(map[string]struct{})
+		for _, rt := range dbpp.ResourceTypes {
+			dbrts[rt.Name] = struct{}{}
+		}
+		for _, rt := range pp.ResourceTypes {
+			if !utils.ValidateCanonical(rt.Name) {
+				return fmt.Errorf("invalid ResourceType Name format %q", rt.Name)
+			}
+			if _, ok := dbrts[rt.Name]; ok {
+				delete(dbrts, rt.Name)
+				err = uow.ResourceTypes().Update(ctx, tc, pn, rt.Name, rt)
+				if err != nil {
+					return fmt.Errorf("failed to update ResourceType %q: %w", rt.Name, err)
+				}
+			} else {
+				_, err = uow.ResourceTypes().Create(ctx, tc, pn, rt)
+				if err != nil {
+					return fmt.Errorf("failed to create ResourceType %q: %w", rt.Name, err)
+				}
+			}
+		}
+		for rt := range dbrts {
+			err = uow.ResourceTypes().Delete(ctx, tc, pn, rt)
+			if err != nil {
+				return fmt.Errorf("failed to delete ResourceType %q: %w", rt, err)
+			}
+		}
+
+		dbrs := make(map[string]resource.Resource)
+		for _, r := range dbpp.Resources {
+			dbrs[r.Canonical] = r
+		}
+		for _, r := range pp.Resources {
+			if !utils.ValidateCanonical(r.Name) {
+				return fmt.Errorf("invalid Resource Name format %q", r.Name)
+			}
+			if dbr, ok := dbrs[r.Canonical]; ok {
+				delete(dbrs, r.Canonical)
+				if dbr.CheckInterval != r.CheckInterval {
+					q.cron.Remove(cron.EntryID(dbr.CronID))
+					spec := r.CheckInterval
+					if spec == "" {
+						spec = "@every 1m"
+					}
+					eid, err := q.cron.AddFunc(spec, q.newCronResourceFunc(tc, pp.Name, r.Canonical))
+					if err != nil {
+						return fmt.Errorf("failed to add Cron Func %q: %w", r.Canonical, err)
+					}
+					r.CronID = uint64(eid)
+				}
+				err = uow.Resources().Update(ctx, tc, pn, r.Canonical, r)
+				if err != nil {
+					return fmt.Errorf("failed to update Resource %q: %w", r.Canonical, err)
+				}
+			} else {
 				spec := r.CheckInterval
 				if spec == "" {
 					spec = "@every 1m"
 				}
 				eid, err := q.cron.AddFunc(spec, q.newCronResourceFunc(tc, pp.Name, r.Canonical))
 				if err != nil {
-					return nil, fmt.Errorf("failed to add Cron Func %q: %w", r.Canonical, err)
+					return fmt.Errorf("failed to add Cron Func %q: %w", r.Canonical, err)
 				}
 				r.CronID = uint64(eid)
-			}
-			err = q.Resources.Update(ctx, tc, pn, r.Canonical, r)
-			if err != nil {
-				return nil, fmt.Errorf("failed to update Resource %q: %w", r.Canonical, err)
-			}
-		} else {
-			q.cron.Remove(cron.EntryID(dbr.CronID))
-			spec := r.CheckInterval
-			if spec == "" {
-				spec = "@every 1m"
-			}
-			eid, err := q.cron.AddFunc(spec, q.newCronResourceFunc(tc, pp.Name, r.Canonical))
-			if err != nil {
-				return nil, fmt.Errorf("failed to add Cron Func %q: %w", r.Canonical, err)
-			}
-			r.CronID = uint64(eid)
-			_, err = q.Resources.Create(ctx, tc, pn, r)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create Resource %q: %w", r.Canonical, err)
+				_, err = uow.Resources().Create(ctx, tc, pn, r)
+				if err != nil {
+					return fmt.Errorf("failed to create Resource %q: %w", r.Canonical, err)
+				}
 			}
 		}
-	}
-	for rc := range dbrs {
-		err = q.Resources.Delete(ctx, tc, pn, rc)
-		if err != nil {
-			return nil, fmt.Errorf("failed to delete Resource %q: %w", rc, err)
+		for rc := range dbrs {
+			err = uow.Resources().Delete(ctx, tc, pn, rc)
+			if err != nil {
+				return fmt.Errorf("failed to delete Resource %q: %w", rc, err)
+			}
 		}
-	}
 
-	dbru := make(map[string]struct{})
-	for _, ru := range dbpp.Runners {
-		dbru[ru.Name] = struct{}{}
-	}
-	for _, ru := range pp.Runners {
-		if !utils.ValidateCanonical(ru.Name) {
-			return nil, fmt.Errorf("invalid Resource Name format %q", ru.Name)
+		dbru := make(map[string]struct{})
+		for _, ru := range dbpp.Runners {
+			dbru[ru.Name] = struct{}{}
 		}
-		if _, ok := dbru[ru.Name]; ok {
-			delete(dbru, ru.Name)
-			err = q.Runners.Update(ctx, tc, pn, ru.Name, ru)
-			if err != nil {
-				return nil, fmt.Errorf("failed to update Runner %q: %w", ru.Name, err)
+		for _, ru := range pp.Runners {
+			if !utils.ValidateCanonical(ru.Name) {
+				return fmt.Errorf("invalid Resource Name format %q", ru.Name)
 			}
-		} else {
-			_, err = q.Runners.Create(ctx, tc, pn, ru)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create Runner %q: %w", ru.Name, err)
+			if _, ok := dbru[ru.Name]; ok {
+				delete(dbru, ru.Name)
+				err = uow.Runners().Update(ctx, tc, pn, ru.Name, ru)
+				if err != nil {
+					return fmt.Errorf("failed to update Runner %q: %w", ru.Name, err)
+				}
+			} else {
+				_, err = uow.Runners().Create(ctx, tc, pn, ru)
+				if err != nil {
+					return fmt.Errorf("failed to create Runner %q: %w", ru.Name, err)
+				}
 			}
 		}
-	}
-	for run := range dbru {
-		err = q.Runners.Delete(ctx, tc, pn, run)
+		for run := range dbru {
+			err = uow.Runners().Delete(ctx, tc, pn, run)
+			if err != nil {
+				return fmt.Errorf("failed to delete Runner %q: %w", run, err)
+			}
+		}
+
+		up, err = uow.Pipelines().Find(ctx, tc, pn)
 		if err != nil {
-			return nil, fmt.Errorf("failed to delete Runner %q: %w", run, err)
+			return fmt.Errorf("failed to get Pipeline: %w", err)
 		}
-	}
-	up, err := q.GetPipeline(ctx, tc, pn)
+
+		return nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get Pipeline: %w", err)
+		return nil, err
 	}
 
 	return up, nil
@@ -530,20 +555,23 @@ func (q *Qid) DeletePipeline(ctx context.Context, tc, pn string) error {
 	} else if !utils.ValidateCanonical(pn) {
 		return fmt.Errorf("invalid Pipeline Name format %q", pn)
 	}
-	resources, err := q.Resources.Filter(ctx, tc, pn)
-	if err != nil {
-		return fmt.Errorf("failed to get Resources from Pipeline %q: %w", pn, err)
-	}
 
-	// Removes all the Cron Resources
-	for _, res := range resources {
-		q.cron.Remove(cron.EntryID(res.CronID))
-	}
+	return q.StartUoW(ctx, func(uow unitwork.UnitOfWork) error {
+		resources, err := uow.Resources().Filter(ctx, tc, pn)
+		if err != nil {
+			return fmt.Errorf("failed to get Resources from Pipeline %q: %w", pn, err)
+		}
 
-	err = q.Pipelines.Delete(ctx, tc, pn)
-	if err != nil {
-		return fmt.Errorf("failed to delete Pipeline %q: %w", pn, err)
-	}
+		// Removes all the Cron Resources
+		for _, res := range resources {
+			q.cron.Remove(cron.EntryID(res.CronID))
+		}
 
-	return nil
+		err = uow.Pipelines().Delete(ctx, tc, pn)
+		if err != nil {
+			return fmt.Errorf("failed to delete Pipeline %q: %w", pn, err)
+		}
+
+		return nil
+	})
 }

--- a/qid/service.go
+++ b/qid/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/xescugc/qid/qid/restype"
 	"github.com/xescugc/qid/qid/runner"
 	"github.com/xescugc/qid/qid/team"
+	"github.com/xescugc/qid/qid/unitwork"
 	"github.com/xescugc/qid/qid/user"
 
 	"log/slog"
@@ -71,6 +72,7 @@ type Qid struct {
 	ResourceTypes restype.Repository
 	Builds        build.Repository
 	Runners       runner.Repository
+	StartUoW      unitwork.StartUnitOfWork
 	Ctx           context.Context
 
 	JWTSecret []byte
@@ -79,7 +81,7 @@ type Qid struct {
 	logger *slog.Logger
 }
 
-func New(ctx context.Context, t queue.Topic, ur user.Repository, tr team.Repository, pr pipeline.Repository, jr job.Repository, rr resource.Repository, rt restype.Repository, br build.Repository, rur runner.Repository, js []byte, l *slog.Logger) *Qid {
+func New(ctx context.Context, t queue.Topic, ur user.Repository, tr team.Repository, pr pipeline.Repository, jr job.Repository, rr resource.Repository, rt restype.Repository, br build.Repository, rur runner.Repository, suow unitwork.StartUnitOfWork, js []byte, l *slog.Logger) *Qid {
 	q := &Qid{
 		Ctx:           ctx,
 		Topic:         t,
@@ -91,6 +93,7 @@ func New(ctx context.Context, t queue.Topic, ur user.Repository, tr team.Reposit
 		ResourceTypes: rt,
 		Builds:        br,
 		Runners:       rur,
+		StartUoW:      suow,
 		JWTSecret:     js,
 		logger:        l,
 		cron:          cron.New(cron.WithContext(ctx)),

--- a/qid/teams.go
+++ b/qid/teams.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/xescugc/qid/qid/team"
+	"github.com/xescugc/qid/qid/unitwork"
 	"github.com/xescugc/qid/qid/user"
 	"github.com/xescugc/qid/qid/utils"
 )
@@ -18,25 +19,33 @@ func (q *Qid) CreateTeam(ctx context.Context, un string, t team.Team) (*team.Wit
 
 	t.Canonical = utils.Canonicalize(t.Name)
 
-	id, err := q.Teams.Create(ctx, t)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Team: %w", err)
-	}
-	t.ID = id
+	var twm *team.WithMembers
+	err := q.StartUoW(ctx, func(uow unitwork.UnitOfWork) error {
+		id, err := uow.Teams().Create(ctx, t)
+		if err != nil {
+			return fmt.Errorf("failed to create Team: %w", err)
+		}
+		t.ID = id
 
-	err = q.Teams.CreateMember(ctx, t.Canonical, team.Member{
-		Admin: true,
-		User: user.User{
-			Username: un,
-		},
+		err = uow.Teams().CreateMember(ctx, t.Canonical, team.Member{
+			Admin: true,
+			User: user.User{
+				Username: un,
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create Team Member: %w", err)
+		}
+
+		twm, err = uow.Teams().Find(ctx, t.Canonical)
+		if err != nil {
+			return fmt.Errorf("failed to find Team: %w", err)
+		}
+
+		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Team Member: %w", err)
-	}
-
-	twm, err := q.Teams.Find(ctx, t.Canonical)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find Team: %w", err)
+		return nil, err
 	}
 
 	return twm, nil

--- a/qid/transport/http/templates/views/layouts/index.tmpl
+++ b/qid/transport/http/templates/views/layouts/index.tmpl
@@ -975,6 +975,7 @@
           var name = this.$el.find("#name").get(0).value
 
           app.teams.create({name: name}, {
+            wait: true,
             //type: "POST",
             // TODO: Try to find a way to create a model with the idAttribute
             // set with POST
@@ -1262,6 +1263,7 @@
           }
           if (this.model.get("id")){
             this.collection.create({name: name, config: data, vars: vars}, {
+              wait: true,
               url: this.model.url(),
               success: function(m) {
                 app.router.navigate(m.url(), { trigger: true });
@@ -1270,6 +1272,7 @@
           } else {
             var that = this
             this.collection.create({name: name, config: data, vars: vars}, {
+              wait: true,
               type: "POST",
               // TODO: Try to find a way to create a model with the idAttribute
               // set with POST

--- a/qid/unitwork/noop.go
+++ b/qid/unitwork/noop.go
@@ -1,0 +1,36 @@
+package unitwork
+
+import (
+	"context"
+
+	"github.com/xescugc/qid/qid/build"
+	"github.com/xescugc/qid/qid/job"
+	"github.com/xescugc/qid/qid/pipeline"
+	"github.com/xescugc/qid/qid/resource"
+	"github.com/xescugc/qid/qid/restype"
+	"github.com/xescugc/qid/qid/runner"
+	"github.com/xescugc/qid/qid/team"
+	"github.com/xescugc/qid/qid/user"
+)
+
+type noopUnitOfWork struct {
+	repos Repositories
+}
+
+func NewNoopStartUnitOfWork(repos Repositories) StartUnitOfWork {
+	return func(ctx context.Context, uowFn func(uow UnitOfWork) error) error {
+		uow := &noopUnitOfWork{repos: repos}
+		return uowFn(uow)
+	}
+}
+
+func (u *noopUnitOfWork) Users() user.Repository         { return u.repos.UsersRepo }
+func (u *noopUnitOfWork) Teams() team.Repository         { return u.repos.TeamsRepo }
+func (u *noopUnitOfWork) Pipelines() pipeline.Repository { return u.repos.PipelinesRepo }
+func (u *noopUnitOfWork) Jobs() job.Repository           { return u.repos.JobsRepo }
+func (u *noopUnitOfWork) Resources() resource.Repository { return u.repos.ResourcesRepo }
+func (u *noopUnitOfWork) ResourceTypes() restype.Repository {
+	return u.repos.ResourceTypesRepo
+}
+func (u *noopUnitOfWork) Builds() build.Repository   { return u.repos.BuildsRepo }
+func (u *noopUnitOfWork) Runners() runner.Repository { return u.repos.RunnersRepo }

--- a/qid/unitwork/unit_of_work.go
+++ b/qid/unitwork/unit_of_work.go
@@ -1,0 +1,110 @@
+package unitwork
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/xescugc/qid/qid/build"
+	"github.com/xescugc/qid/qid/job"
+	"github.com/xescugc/qid/qid/mysql"
+	"github.com/xescugc/qid/qid/pipeline"
+	"github.com/xescugc/qid/qid/resource"
+	"github.com/xescugc/qid/qid/restype"
+	"github.com/xescugc/qid/qid/runner"
+	"github.com/xescugc/qid/qid/team"
+	"github.com/xescugc/qid/qid/user"
+)
+
+type unitOfWork struct {
+	tx *sql.Tx
+
+	users         user.Repository
+	teams         team.Repository
+	pipelines     pipeline.Repository
+	jobs          job.Repository
+	resources     resource.Repository
+	resourceTypes restype.Repository
+	builds        build.Repository
+	runners       runner.Repository
+}
+
+func NewStartUnitOfWork(db *sql.DB) StartUnitOfWork {
+	return func(ctx context.Context, uowFn func(uow UnitOfWork) error) error {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("failed to begin transaction: %w", err)
+		}
+
+		uow := &unitOfWork{tx: tx}
+
+		if err := uowFn(uow); err != nil {
+			if rbErr := tx.Rollback(); rbErr != nil {
+				return fmt.Errorf("failed to rollback: %w (original error: %w)", rbErr, err)
+			}
+			return err
+		}
+
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("failed to commit transaction: %w", err)
+		}
+
+		return nil
+	}
+}
+
+func (u *unitOfWork) Users() user.Repository {
+	if u.users == nil {
+		u.users = mysql.NewUserRepository(u.tx)
+	}
+	return u.users
+}
+
+func (u *unitOfWork) Teams() team.Repository {
+	if u.teams == nil {
+		u.teams = mysql.NewTeamRepository(u.tx)
+	}
+	return u.teams
+}
+
+func (u *unitOfWork) Pipelines() pipeline.Repository {
+	if u.pipelines == nil {
+		u.pipelines = mysql.NewPipelineRepository(u.tx)
+	}
+	return u.pipelines
+}
+
+func (u *unitOfWork) Jobs() job.Repository {
+	if u.jobs == nil {
+		u.jobs = mysql.NewJobRepository(u.tx)
+	}
+	return u.jobs
+}
+
+func (u *unitOfWork) Resources() resource.Repository {
+	if u.resources == nil {
+		u.resources = mysql.NewResourceRepository(u.tx)
+	}
+	return u.resources
+}
+
+func (u *unitOfWork) ResourceTypes() restype.Repository {
+	if u.resourceTypes == nil {
+		u.resourceTypes = mysql.NewResourceTypeRepository(u.tx)
+	}
+	return u.resourceTypes
+}
+
+func (u *unitOfWork) Builds() build.Repository {
+	if u.builds == nil {
+		u.builds = mysql.NewBuildRepository(u.tx)
+	}
+	return u.builds
+}
+
+func (u *unitOfWork) Runners() runner.Repository {
+	if u.runners == nil {
+		u.runners = mysql.NewRunnerRepository(u.tx)
+	}
+	return u.runners
+}

--- a/qid/unitwork/unitwork.go
+++ b/qid/unitwork/unitwork.go
@@ -1,0 +1,39 @@
+package unitwork
+
+import (
+	"context"
+
+	"github.com/xescugc/qid/qid/build"
+	"github.com/xescugc/qid/qid/job"
+	"github.com/xescugc/qid/qid/pipeline"
+	"github.com/xescugc/qid/qid/resource"
+	"github.com/xescugc/qid/qid/restype"
+	"github.com/xescugc/qid/qid/runner"
+	"github.com/xescugc/qid/qid/team"
+	"github.com/xescugc/qid/qid/user"
+)
+
+type StartUnitOfWork func(ctx context.Context, uowFn func(uow UnitOfWork) error) error
+
+type UnitOfWork interface {
+	Users() user.Repository
+	Teams() team.Repository
+	Pipelines() pipeline.Repository
+	Jobs() job.Repository
+	Resources() resource.Repository
+	ResourceTypes() restype.Repository
+	Builds() build.Repository
+	Runners() runner.Repository
+}
+
+// Repositories holds all repository interfaces, used to construct a noop UoW for testing.
+type Repositories struct {
+	UsersRepo         user.Repository
+	TeamsRepo         team.Repository
+	PipelinesRepo     pipeline.Repository
+	JobsRepo          job.Repository
+	ResourcesRepo     resource.Repository
+	ResourceTypesRepo restype.Repository
+	BuildsRepo        build.Repository
+	RunnersRepo       runner.Repository
+}


### PR DESCRIPTION
Fixes #123

When a Team or Pipeline creation fails on the backend, the entity was still shown in the frontend list. Two root causes fixed:

**Backend**: Multi-step creation (e.g. CreateTeam creates team + member, CreatePipeline creates pipeline + jobs + resources + runners) had no transaction — if a later step failed, earlier inserts remained orphaned. Added a `unitwork` package implementing the Unit of Work pattern (`BeginTx`/`Commit`/`Rollback`). `CreateTeam`, `CreatePipeline`, `UpdatePipeline`, and `DeletePipeline` are now wrapped in transactions.

**Frontend**: `Backbone.collection.create()` was called without `wait: true`, so models were optimistically added before the server responded. Added `wait: true` to team and pipeline creation calls.