### PR TITLE
CLI auto-refresh stale JWT via X-Refresh-Token header (#130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- CLI auto-refreshes stale JWT when backend returns `X-Refresh-Token` header, persisting the new token to disk ([#130](https://github.com/xescugc/qid/issues/130))
 - Fix entity still shown in collection when backend creation fails: add Unit of Work (transaction) pattern for multi-step DB operations and `wait: true` to frontend `collection.create()` calls ([#123](https://github.com/xescugc/qid/issues/123))
 - Fix user permission changes not reflected until re-login: backend signals stale JWT via `X-Refresh-Token` header, frontend auto-refreshes session ([#126](https://github.com/xescugc/qid/pull/126))
 - Add users and teams with role-based access control, refactor HTTP transport from go-kit to direct handlers ([#124](https://github.com/xescugc/qid/pull/124))

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -94,7 +94,7 @@ var (
 							&cli.StringFlag{Name: "vars", Aliases: []string{"v"}, Usage: "Path to the Pipeline var file (JSON)", TakesFile: true},
 						},
 						Action: func(ctx context.Context, cmd *cli.Command) error {
-							c, err := client.New(cmd.String("url"), cmd.String("jwt"))
+							c, err := newClientWithConfig(cmd.String("url"), cmd.String("jwt"))
 							if err != nil {
 								return fmt.Errorf("failed to initialize client with url %q: %w", cmd.String("url"), err)
 							}
@@ -141,7 +141,7 @@ var (
 							&cli.StringFlag{Name: "vars", Aliases: []string{"v"}, Usage: "Path to the Pipeline var file (JSON)", TakesFile: true},
 						},
 						Action: func(ctx context.Context, cmd *cli.Command) error {
-							c, err := client.New(cmd.String("url"), cmd.String("jwt"))
+							c, err := newClientWithConfig(cmd.String("url"), cmd.String("jwt"))
 							if err != nil {
 								return fmt.Errorf("failed to initialize client with url %q: %w", cmd.String("url"), err)
 							}
@@ -152,7 +152,7 @@ var (
 						Name:  "list",
 						Usage: "Lists the QID Pipelines",
 						Action: func(ctx context.Context, cmd *cli.Command) error {
-							c, err := client.New(cmd.String("url"), cmd.String("jwt"))
+							c, err := newClientWithConfig(cmd.String("url"), cmd.String("jwt"))
 							if err != nil {
 								return fmt.Errorf("failed to initialize client with url %q: %w", cmd.String("url"), err)
 							}
@@ -174,7 +174,7 @@ var (
 							&cli.StringFlag{Name: "name", Aliases: []string{"n", "pn"}, Usage: "Name of the Pipeline", Required: true},
 						},
 						Action: func(ctx context.Context, cmd *cli.Command) error {
-							c, err := client.New(cmd.String("url"), cmd.String("jwt"))
+							c, err := newClientWithConfig(cmd.String("url"), cmd.String("jwt"))
 							if err != nil {
 								return fmt.Errorf("failed to initialize client with url %q: %w", cmd.String("url"), err)
 							}
@@ -196,7 +196,7 @@ var (
 							&cli.StringFlag{Name: "name", Aliases: []string{"n", "pn"}, Usage: "Name of the Pipeline", Required: true},
 						},
 						Action: func(ctx context.Context, cmd *cli.Command) error {
-							c, err := client.New(cmd.String("url"), cmd.String("jwt"))
+							c, err := newClientWithConfig(cmd.String("url"), cmd.String("jwt"))
 							if err != nil {
 								return fmt.Errorf("failed to initialize client with url %q: %w", cmd.String("url"), err)
 							}
@@ -226,7 +226,7 @@ var (
 							&cli.StringFlag{Name: "job-name", Aliases: []string{"n", "jn"}, Usage: "Name of the Job", Required: true},
 						},
 						Action: func(ctx context.Context, cmd *cli.Command) error {
-							c, err := client.New(cmd.String("url"), cmd.String("jwt"))
+							c, err := newClientWithConfig(cmd.String("url"), cmd.String("jwt"))
 							if err != nil {
 								return fmt.Errorf("failed to initialize client with url %q: %w", cmd.String("url"), err)
 							}
@@ -248,7 +248,7 @@ var (
 							&cli.StringFlag{Name: "job-name", Aliases: []string{"n", "jn"}, Usage: "Name of the Job", Required: true},
 						},
 						Action: func(ctx context.Context, cmd *cli.Command) error {
-							c, err := client.New(cmd.String("url"), cmd.String("jwt"))
+							c, err := newClientWithConfig(cmd.String("url"), cmd.String("jwt"))
 							if err != nil {
 								return fmt.Errorf("failed to initialize client with url %q: %w", cmd.String("url"), err)
 							}
@@ -266,6 +266,18 @@ var (
 		},
 	}
 )
+
+func newClientWithConfig(url, jwt string) (*client.Client, error) {
+	c, err := client.New(url, jwt)
+	if err != nil {
+		return nil, err
+	}
+	configFilePath, err := xdg.ConfigFile(configAuthenticationPath)
+	if err == nil {
+		c.SetConfigPath(configFilePath)
+	}
+	return c, nil
+}
 
 func createPipeline(ctx context.Context, svc qid.Service, tc, name, config, vars string) error {
 

--- a/qid/transport/http/client/client.go
+++ b/qid/transport/http/client/client.go
@@ -17,8 +17,9 @@ import (
 )
 
 type Client struct {
-	url string
-	jwt string
+	url        string
+	jwt        string
+	configPath string
 }
 
 // New returns a new HTTP Client for QID
@@ -40,6 +41,12 @@ func New(host, jwt string) (*Client, error) {
 	}
 
 	return cl, nil
+}
+
+// SetConfigPath sets the path where the JWT will be persisted on refresh.
+// When empty (default), JWT refresh will not be written to disk.
+func (cl *Client) SetConfigPath(path string) {
+	cl.configPath = path
 }
 
 func (cl *Client) UserLogin(ctx context.Context, un, pass string) (*user.WithMemberships, string, error) {

--- a/qid/transport/http/client/client_test.go
+++ b/qid/transport/http/client/client_test.go
@@ -1,13 +1,603 @@
 package client_test
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
 	"testing"
 
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/xescugc/qid/qid"
+	"github.com/xescugc/qid/qid/build"
+	"github.com/xescugc/qid/qid/job"
+	"github.com/xescugc/qid/qid/pipeline"
+	"github.com/xescugc/qid/qid/resource"
+	"github.com/xescugc/qid/qid/team"
+	thttp "github.com/xescugc/qid/qid/transport/http"
 	"github.com/xescugc/qid/qid/transport/http/client"
+	"github.com/xescugc/qid/qid/user"
 )
 
 func Test_IsQID_Service(t *testing.T) {
 	assert.Implements(t, (*qid.Service)(nil), new(client.Client))
+}
+
+func jsonHandler(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(v)
+}
+
+func TestUserLogin(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/login", func(w http.ResponseWriter, req *http.Request) {
+		var lr thttp.UserLoginRequest
+		json.NewDecoder(req.Body).Decode(&lr)
+		resp := thttp.UserLoginResponse{}
+		resp.Data.User = &user.WithMemberships{User: user.User{Username: lr.Username}}
+		resp.Data.JWT = "test-jwt-token"
+		jsonHandler(w, resp)
+	}).Methods("POST")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "")
+	require.NoError(t, err)
+
+	u, jwt, err := c.UserLogin(context.Background(), "alice", "pass")
+	require.NoError(t, err)
+	assert.Equal(t, "alice", u.Username)
+	assert.Equal(t, "test-jwt-token", jwt)
+}
+
+func TestRefreshToken(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/refresh-token", func(w http.ResponseWriter, req *http.Request) {
+		resp := thttp.RefreshTokenResponse{}
+		resp.Data.User = &user.WithMemberships{User: user.User{Username: "bob"}}
+		resp.Data.JWT = "new-jwt"
+		jsonHandler(w, resp)
+	}).Methods("POST")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "old-jwt")
+	require.NoError(t, err)
+
+	u, jwt, err := c.RefreshToken(context.Background(), "bob")
+	require.NoError(t, err)
+	assert.Equal(t, "bob", u.Username)
+	assert.Equal(t, "new-jwt", jwt)
+}
+
+func TestCreateUser(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/users", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.CreateUserResponse{User: &user.User{Username: "newuser"}})
+	}).Methods("POST")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	u, err := c.CreateUser(context.Background(), user.User{Username: "newuser", Password: "pass"}, false)
+	require.NoError(t, err)
+	assert.Equal(t, "newuser", u.Username)
+}
+
+func TestListUsers(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/users", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.ListUsersResponse{Users: []*user.User{{Username: "a"}, {Username: "b"}}})
+	}).Methods("GET")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	users, err := c.ListUsers(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, users, 2)
+}
+
+func TestCreateTeam(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.CreateTeamResponse{Team: &team.WithMembers{Team: team.Team{Name: "myteam"}}})
+	}).Methods("POST")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	tm, err := c.CreateTeam(context.Background(), "user", team.Team{Name: "myteam"})
+	require.NoError(t, err)
+	assert.Equal(t, "myteam", tm.Name)
+}
+
+func TestListTeams(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.ListTeamsResponse{Teams: []*team.WithMembers{{Team: team.Team{Name: "t1"}}}})
+	}).Methods("GET")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	teams, err := c.ListTeams(context.Background(), "user")
+	require.NoError(t, err)
+	assert.Len(t, teams, 1)
+}
+
+func TestGetTeam(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}", func(w http.ResponseWriter, req *http.Request) {
+		tc := mux.Vars(req)["tc"]
+		jsonHandler(w, thttp.GetTeamResponse{Team: &team.WithMembers{Team: team.Team{Name: tc}}})
+	}).Methods("GET")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	tm, err := c.GetTeam(context.Background(), "myteam")
+	require.NoError(t, err)
+	assert.Equal(t, "myteam", tm.Name)
+}
+
+func TestUpdateTeam(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.UpdateTeamResponse{Team: &team.WithMembers{Team: team.Team{Name: "updated"}}})
+	}).Methods("PUT")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	tm, err := c.UpdateTeam(context.Background(), "old", team.Team{Name: "updated"})
+	require.NoError(t, err)
+	assert.Equal(t, "updated", tm.Name)
+}
+
+func TestDeleteTeam(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.DeleteTeamResponse{})
+	}).Methods("DELETE")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	err = c.DeleteTeam(context.Background(), "myteam")
+	require.NoError(t, err)
+}
+
+func TestCreateTeamMember(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/members", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.CreateTeamMemberResponse{Member: &team.Member{User: user.User{Username: "alice"}}})
+	}).Methods("POST")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	m, err := c.CreateTeamMember(context.Background(), "myteam", team.Member{User: user.User{Username: "alice"}})
+	require.NoError(t, err)
+	assert.Equal(t, "alice", m.User.Username)
+}
+
+func TestUpdateTeamMember(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/members/{mu}", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.UpdateTeamMemberResponse{Member: &team.Member{Admin: true, User: user.User{Username: "alice"}}})
+	}).Methods("PUT")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	m, err := c.UpdateTeamMember(context.Background(), "myteam", "alice", team.Member{Admin: true})
+	require.NoError(t, err)
+	assert.True(t, m.Admin)
+}
+
+func TestDeleteTeamMember(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/members/{mu}", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.DeleteTeamMemberResponse{})
+	}).Methods("DELETE")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	err = c.DeleteTeamMember(context.Background(), "myteam", "alice")
+	require.NoError(t, err)
+}
+
+func TestCreatePipeline(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.CreatePipelineResponse{Pipeline: &pipeline.Pipeline{Name: "mypipe"}})
+	}).Methods("POST")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	p, err := c.CreatePipeline(context.Background(), "team", "mypipe", []byte("config"), nil)
+	require.NoError(t, err)
+	assert.Equal(t, "mypipe", p.Name)
+}
+
+func TestUpdatePipeline(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/{pn}", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.UpdatePipelineResponse{Pipeline: &pipeline.Pipeline{Name: "mypipe"}})
+	}).Methods("PUT")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	p, err := c.UpdatePipeline(context.Background(), "team", "mypipe", []byte("config"), nil)
+	require.NoError(t, err)
+	assert.Equal(t, "mypipe", p.Name)
+}
+
+func TestGetPipeline(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/{pn}", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.GetPipelineResponse{Pipeline: &pipeline.Pipeline{Name: mux.Vars(req)["pn"]}})
+	}).Methods("GET")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	p, err := c.GetPipeline(context.Background(), "team", "mypipe")
+	require.NoError(t, err)
+	assert.Equal(t, "mypipe", p.Name)
+}
+
+func TestListPipelines(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.ListPipelinesResponse{Pipelines: []*pipeline.Pipeline{{Name: "p1"}, {Name: "p2"}}})
+	}).Methods("GET")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	pps, err := c.ListPipelines(context.Background(), "team")
+	require.NoError(t, err)
+	assert.Len(t, pps, 2)
+}
+
+func TestDeletePipeline(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/{pn}", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.DeletePipelineResponse{})
+	}).Methods("DELETE")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	err = c.DeletePipeline(context.Background(), "team", "mypipe")
+	require.NoError(t, err)
+}
+
+func TestGetPipelineImage(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/{pn}/image.{format}", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.GetPipelineImageResponse{Image: "svg-data"})
+	}).Methods("GET")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	img, err := c.GetPipelineImage(context.Background(), "team", "mypipe", "svg")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("svg-data"), img)
+}
+
+func TestCreatePipelineImage(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/image.{format}", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.CreatePipelineImageResponse{Image: "png-data"})
+	}).Methods("POST")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	img, err := c.CreatePipelineImage(context.Background(), "team", []byte("config"), nil, "png")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("png-data"), img)
+}
+
+func TestTriggerPipelineJob(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/{pn}/jobs/{jn}/trigger", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.TriggerPipelineJobResponse{})
+	}).Methods("POST")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	err = c.TriggerPipelineJob(context.Background(), "team", "pipe", "job1")
+	require.NoError(t, err)
+}
+
+func TestGetPipelineJob(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/{pn}/jobs/{jn}", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.GetPipelineJobResponse{Job: &job.Job{Name: mux.Vars(req)["jn"]}})
+	}).Methods("GET")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	j, err := c.GetPipelineJob(context.Background(), "team", "pipe", "job1")
+	require.NoError(t, err)
+	assert.Equal(t, "job1", j.Name)
+}
+
+func TestCreateJobBuild(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/{pn}/jobs/{jn}/builds", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.CreateJobBuildResponse{Build: &build.Build{ID: 1}})
+	}).Methods("POST")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	b, err := c.CreateJobBuild(context.Background(), "team", "pipe", "job1", build.Build{})
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), b.ID)
+}
+
+func TestUpdateJobBuild(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/{pn}/jobs/{jn}/builds/{bid}", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.UpdateJobBuildResponse{})
+	}).Methods("PUT")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	err = c.UpdateJobBuild(context.Background(), "team", "pipe", "job1", 1, build.Build{})
+	require.NoError(t, err)
+}
+
+func TestDeleteJobBuild(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/{pn}/jobs/{jn}/builds/{bid}", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.DeleteJobBuildResponse{})
+	}).Methods("DELETE")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	err = c.DeleteJobBuild(context.Background(), "team", "pipe", "job1", 1)
+	require.NoError(t, err)
+}
+
+func TestListJobBuilds(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/{pn}/jobs/{jn}/builds", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.ListJobBuildsResponse{Builds: []*build.Build{{ID: 1}, {ID: 2}}})
+	}).Methods("GET")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	builds, err := c.ListJobBuilds(context.Background(), "team", "pipe", "job1")
+	require.NoError(t, err)
+	assert.Len(t, builds, 2)
+}
+
+func TestCreateResourceVersion(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/{pn}/resources/{rCan}/versions", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.CreateResourceVersionResponse{Version: &resource.Version{ID: 1}})
+	}).Methods("POST")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	v, err := c.CreateResourceVersion(context.Background(), "team", "pipe", "res1", resource.Version{})
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), v.ID)
+}
+
+func TestListResourceVersions(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/{pn}/resources/{rCan}/versions", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.ListResourceVersionsResponse{Versions: []*resource.Version{{ID: 1}}})
+	}).Methods("GET")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	versions, err := c.ListResourceVersions(context.Background(), "team", "pipe", "res1")
+	require.NoError(t, err)
+	assert.Len(t, versions, 1)
+}
+
+func TestGetPipelineResource(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/{pn}/resources/{rCan}", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.GetPipelineResourceResponse{Resource: &resource.Resource{Name: "res1"}})
+	}).Methods("GET")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	res, err := c.GetPipelineResource(context.Background(), "team", "pipe", "res1")
+	require.NoError(t, err)
+	assert.Equal(t, "res1", res.Name)
+}
+
+func TestUpdatePipelineResource(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/{pn}/resources/{rCan}", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.UpdatePipelineResourceResponse{})
+	}).Methods("PUT")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	err = c.UpdatePipelineResource(context.Background(), "team", "pipe", "res1", resource.Resource{})
+	require.NoError(t, err)
+}
+
+func TestTriggerPipelineResource(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/{pn}/resources/{rCan}", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.TriggerPipelineResourceResponse{})
+	}).Methods("POST")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	err = c.TriggerPipelineResource(context.Background(), "team", "pipe", "res1")
+	require.NoError(t, err)
+}
+
+func TestRequestError(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams", func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(thttp.ErrorResponse{Err: "forbidden"})
+	}).Methods("GET")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	_, err = c.ListTeams(context.Background(), "user")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forbidden")
+}
+
+func TestRequest_RefreshToken(t *testing.T) {
+	var refreshCalled atomic.Int32
+
+	r := mux.NewRouter()
+	r.HandleFunc("/teams", func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("X-Refresh-Token", "true")
+		jsonHandler(w, thttp.ListTeamsResponse{Teams: []*team.WithMembers{{Team: team.Team{Name: "t1"}}}})
+	}).Methods("GET")
+	r.HandleFunc("/refresh-token", func(w http.ResponseWriter, req *http.Request) {
+		refreshCalled.Add(1)
+		resp := thttp.RefreshTokenResponse{}
+		resp.Data.User = &user.WithMemberships{User: user.User{Username: "alice"}}
+		resp.Data.JWT = "refreshed-jwt"
+		jsonHandler(w, resp)
+	}).Methods("POST")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "authentication")
+
+	c, err := client.New(ts.URL, "old-jwt")
+	require.NoError(t, err)
+	c.SetConfigPath(configPath)
+
+	teams, err := c.ListTeams(context.Background(), "user")
+	require.NoError(t, err)
+	assert.Len(t, teams, 1)
+
+	assert.Equal(t, int32(1), refreshCalled.Load())
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, "refreshed-jwt", string(data))
+}
+
+func TestRequest_NoRefreshToken(t *testing.T) {
+	var refreshCalled atomic.Int32
+
+	r := mux.NewRouter()
+	r.HandleFunc("/teams", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.ListTeamsResponse{Teams: []*team.WithMembers{{Team: team.Team{Name: "t1"}}}})
+	}).Methods("GET")
+	r.HandleFunc("/refresh-token", func(w http.ResponseWriter, req *http.Request) {
+		refreshCalled.Add(1)
+		resp := thttp.RefreshTokenResponse{}
+		resp.Data.JWT = "new-jwt"
+		jsonHandler(w, resp)
+	}).Methods("POST")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "authentication")
+
+	c, err := client.New(ts.URL, "original-jwt")
+	require.NoError(t, err)
+	c.SetConfigPath(configPath)
+
+	teams, err := c.ListTeams(context.Background(), "user")
+	require.NoError(t, err)
+	assert.Len(t, teams, 1)
+
+	assert.Equal(t, int32(0), refreshCalled.Load())
+
+	_, err = os.ReadFile(configPath)
+	assert.True(t, os.IsNotExist(err))
 }

--- a/qid/transport/http/client/utils.go
+++ b/qid/transport/http/client/utils.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"regexp"
 	"strconv"
 
@@ -48,5 +49,28 @@ func (c *Client) Request(ctx context.Context, method, url string, body, resp int
 		}
 	}
 
+	if hresp.Header.Get("X-Refresh-Token") == "true" {
+		c.refreshToken(ctx)
+	}
+
 	return nil
+}
+
+func (c *Client) refreshToken(ctx context.Context) {
+	var resp thttp.RefreshTokenResponse
+
+	err := c.Request(ctx, http.MethodPost, fmt.Sprintf("%s/refresh-token", c.url), nil, &resp)
+	if err != nil {
+		return
+	}
+
+	if resp.Err != "" || resp.Data.JWT == "" {
+		return
+	}
+
+	c.jwt = resp.Data.JWT
+
+	if c.configPath != "" {
+		_ = os.WriteFile(c.configPath, []byte(c.jwt), 0600)
+	}
 }


### PR DESCRIPTION
## Summary

- CLI now auto-refreshes stale JWTs when the backend returns `X-Refresh-Token: true`, mirroring the frontend behavior
- Refreshed token is persisted to `~/.config/qid/authentication`
- Worker/server internal clients are unaffected

## Test plan

- [x] All 29 client tests pass
- [x] No new lint warnings

Closes #130