### PR TITLE
Add ordered plan execution and put step (#169, #72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add ordered plan execution and `put` step support: jobs now execute `get`, `task`, and `put` steps in the order they appear in HCL, enabling CD workflows like build→push→deploy. The `put` step invokes `resource_type.push` to push content to resources ([#169](https://github.com/xescugc/pikoci/issues/169), [#72](https://github.com/xescugc/pikoci/issues/72))
 - Redesign UI with PICO-8 color palette, Plus Jakarta Sans / JetBrains Mono fonts, dark mode toggle, improved pipeline graph styling, and modernized layout for all views ([#133](https://github.com/xescugc/pikoci/issues/133))
 - CLI auto-refreshes stale JWT when backend returns `X-Refresh-Token` header, persisting the new token to disk ([#130](https://github.com/xescugc/pikoci/issues/130))
 - Fix entity still shown in collection when backend creation fails: add Unit of Work (transaction) pattern for multi-step DB operations and `wait: true` to frontend `collection.create()` calls ([#123](https://github.com/xescugc/pikoci/issues/123))

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -353,7 +353,9 @@ When a Job has a `get` to a resource, the `resource.pull` is run before the `job
 
 #### `push`
 
-NOT YET IMPLEMENTED. But will be used to push new content to the Resource Type
+The `label` is the [`runner`](#runner)
+
+When a Job has a `put` step for a resource, the `resource_type.push` is run. Resource-level params are available with the `$param_*` prefix (same as `check` and `pull`). Put-step params use the `$put_*` prefix (e.g. `$put_tag`).
 
 #### Example
 
@@ -419,7 +421,7 @@ resource "git" "my_repo" {
 
 ### Job
 
-Jobs are where the user actions happen. Jobs define a set of tasks that are run in groups: first all the `get` steps and then all the `task` steps.
+Jobs are where the user actions happen. Jobs define a **plan** — an ordered sequence of `get`, `task`, and `put` steps that are executed in the order they appear in the HCL configuration. This allows interleaving steps for CD workflows (e.g., build → push → deploy).
 
 #### `get`
 
@@ -473,6 +475,28 @@ Runs when the Job succeeds
 The `label` is the [`runner`](#runner)
 
 Runs when the Job fails
+
+##### `ensure`
+
+The `label` is the [`runner`](#runner)
+
+Runs always
+
+#### `put`
+
+Put steps push content to a resource. The labels must match a `resource` definition: the first label is the resource type and the second is the resource name. Any additional attributes inside the `put` block are passed as parameters to the `resource_type.push` runner.
+
+##### `on_success`
+
+The `label` is the [`runner`](#runner)
+
+Runs when the put step succeeds
+
+##### `on_failure`
+
+The `label` is the [`runner`](#runner)
+
+Runs when the put step fails
 
 ##### `ensure`
 
@@ -539,6 +563,25 @@ job "test" {
   }
   ensure "exec" {
     path = "ls"
+  }
+}
+```
+
+A CD pipeline with interleaved get/task/put steps:
+
+```hcl
+job "deploy" {
+  get "git" "my_repo" {
+    trigger = true
+  }
+  task "build" {
+    run "docker" {
+      image = "golang:1.25"
+      cmd = "make build"
+    }
+  }
+  put "git" "my_repo" {
+    tag = "latest"
   }
 }
 ```

--- a/pikoci/build/build.go
+++ b/pikoci/build/build.go
@@ -15,8 +15,7 @@ const (
 // Build represents a run of a Job
 type Build struct {
 	ID     uint32 `json:"id"`
-	Get    []Step `json:"get"`
-	Task   []Step `json:"task"`
+	Steps  []Step `json:"steps"`
 	Status Status `json:"status"`
 	Error  string `json:"error"`
 	// Job are the general logs printed at the end
@@ -27,6 +26,7 @@ type Build struct {
 }
 
 type Step struct {
+	Type      string        `json:"type"`
 	Name      string        `json:"name"`
 	VersionID uint32        `json:"version_id"`
 	Logs      string        `json:"logs"`

--- a/pikoci/helper.go
+++ b/pikoci/helper.go
@@ -8,11 +8,72 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsimple"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/xescugc/pikoci/pikoci/job"
 	"github.com/xescugc/pikoci/pikoci/pipeline"
+	"github.com/xescugc/pikoci/pikoci/resource"
+	"github.com/xescugc/pikoci/pikoci/restype"
+	"github.com/xescugc/pikoci/pikoci/runner"
 	"github.com/xescugc/pikoci/pikoci/utils"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
 )
+
+// hclGetStep is the HCL-decoded get step with per-step hooks.
+type hclGetStep struct {
+	Type    string   `json:"type" hcl:"type,label"`
+	Name    string   `json:"name" hcl:"name,label"`
+	Passed  []string `json:"passed" hcl:"passed,optional"`
+	Trigger bool     `json:"trigger" hcl:"trigger,optional"`
+
+	OnSuccess []utils.RunnerCommand `json:"on_success" hcl:"on_success,block"`
+	OnFailure []utils.RunnerCommand `json:"on_failure" hcl:"on_failure,block"`
+	Ensure    []utils.RunnerCommand `json:"ensure" hcl:"ensure,block"`
+}
+
+// hclTaskStep is the HCL-decoded task step with per-step hooks.
+type hclTaskStep struct {
+	Name string              `json:"name" hcl:"name,label"`
+	Run  utils.RunnerCommand `json:"run" hcl:"run,block"`
+
+	OnSuccess []utils.RunnerCommand `json:"on_success" hcl:"on_success,block"`
+	OnFailure []utils.RunnerCommand `json:"on_failure" hcl:"on_failure,block"`
+	Ensure    []utils.RunnerCommand `json:"ensure" hcl:"ensure,block"`
+}
+
+// hclPutStep is the HCL-decoded put step.
+type hclPutStep struct {
+	Type string `hcl:"type,label"`
+	Name string `hcl:"name,label"`
+
+	OnSuccess []utils.RunnerCommand `hcl:"on_success,block"`
+	OnFailure []utils.RunnerCommand `hcl:"on_failure,block"`
+	Ensure    []utils.RunnerCommand `hcl:"ensure,block"`
+
+	Params map[string]string `hcl:",remain"`
+}
+
+// hclJob is the intermediate HCL-decoded job with separate get/task/put arrays.
+type hclJob struct {
+	Name string       `hcl:"name,label"`
+	Get  []hclGetStep `hcl:"get,block"`
+	Task []hclTaskStep `hcl:"task,block"`
+	Put  []hclPutStep `hcl:"put,block"`
+
+	OnSuccess []utils.RunnerCommand `hcl:"on_success,block"`
+	OnFailure []utils.RunnerCommand `hcl:"on_failure,block"`
+	Ensure    []utils.RunnerCommand `hcl:"ensure,block"`
+}
+
+// hclPipeline is the intermediate HCL-decoded pipeline.
+type hclPipeline struct {
+	Name          string                 `json:"name"`
+	Jobs          []hclJob               `hcl:"job,block"`
+	Resources     []resource.Resource    `hcl:"resource,block"`
+	ResourceTypes []restype.ResourceType `hcl:"resource_type,block"`
+	Runners       []runner.Runner        `hcl:"runner,block"`
+	Remain        hcl.Body               `hcl:",remain"`
+}
 
 func (q *PikoCI) readPipeline(ctx context.Context, rpp []byte, vars map[string]interface{}) (*pipeline.Pipeline, error) {
 	ectx := &hcl.EvalContext{
@@ -99,16 +160,127 @@ func (q *PikoCI) readPipeline(ctx context.Context, rpp []byte, vars map[string]i
 		},
 	}
 
-	var pp pipeline.Pipeline
-	err = hclsimple.Decode("pipeline.hcl", rpp, ectx, &pp)
+	var hp hclPipeline
+	err = hclsimple.Decode("pipeline.hcl", rpp, ectx, &hp)
 	if err != nil {
 		for _, e := range err.(hcl.Diagnostics).Errs() {
 			spew.Dump(e)
 		}
 		return nil, fmt.Errorf("failed to Decode Pipeline config: %w", err)
 	}
+
+	// Parse the raw HCL to determine block ordering within each job.
+	jobPlans, err := parseJobPlans(rpp, hp.Jobs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse job plans: %w", err)
+	}
+
+	pp := pipeline.Pipeline{
+		Resources:     hp.Resources,
+		ResourceTypes: hp.ResourceTypes,
+		Runners:       hp.Runners,
+	}
+
+	for _, hj := range hp.Jobs {
+		j := job.Job{
+			Name:      hj.Name,
+			Plan:      jobPlans[hj.Name],
+			OnSuccess: hj.OnSuccess,
+			OnFailure: hj.OnFailure,
+			Ensure:    hj.Ensure,
+		}
+		pp.Jobs = append(pp.Jobs, j)
+	}
+
 	for i, r := range pp.Resources {
 		pp.Resources[i].Canonical = utils.ResourceCanonical(r.Type, r.Name)
 	}
 	return &pp, nil
+}
+
+// parseJobPlans walks the raw HCL AST to extract get/task/put blocks in source
+// order for each job, then builds ordered PlanStep slices using the decoded data.
+func parseJobPlans(rpp []byte, hclJobs []hclJob) (map[string][]job.PlanStep, error) {
+	file, diags := hclsyntax.ParseConfig(rpp, "pipeline.hcl", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	body := file.Body.(*hclsyntax.Body)
+	result := make(map[string][]job.PlanStep)
+
+	jobIndex := 0
+	for _, block := range body.Blocks {
+		if block.Type != "job" {
+			continue
+		}
+		if jobIndex >= len(hclJobs) {
+			break
+		}
+		hj := hclJobs[jobIndex]
+		jobIndex++
+
+		var plan []job.PlanStep
+		getIdx, taskIdx, putIdx := 0, 0, 0
+
+		for _, innerBlock := range block.Body.Blocks {
+			switch innerBlock.Type {
+			case "get":
+				if getIdx >= len(hj.Get) {
+					continue
+				}
+				g := hj.Get[getIdx]
+				getIdx++
+				plan = append(plan, job.PlanStep{
+					Type: job.StepTypeGet,
+					Get: &job.GetStep{
+						Type:    g.Type,
+						Name:    g.Name,
+						Passed:  g.Passed,
+						Trigger: g.Trigger,
+					},
+					OnSuccess: g.OnSuccess,
+					OnFailure: g.OnFailure,
+					Ensure:    g.Ensure,
+				})
+			case "task":
+				if taskIdx >= len(hj.Task) {
+					continue
+				}
+				t := hj.Task[taskIdx]
+				taskIdx++
+				plan = append(plan, job.PlanStep{
+					Type: job.StepTypeTask,
+					Task: &job.TaskStep{
+						Name: t.Name,
+						Run:  t.Run,
+					},
+					OnSuccess: t.OnSuccess,
+					OnFailure: t.OnFailure,
+					Ensure:    t.Ensure,
+				})
+			case "put":
+				if putIdx >= len(hj.Put) {
+					continue
+				}
+				p := hj.Put[putIdx]
+				putIdx++
+				plan = append(plan, job.PlanStep{
+					Type: job.StepTypePut,
+					Put: &job.PutStep{
+						Type:   p.Type,
+						Name:   p.Name,
+						Params: p.Params,
+					},
+					OnSuccess: p.OnSuccess,
+					OnFailure: p.OnFailure,
+					Ensure:    p.Ensure,
+				})
+			}
+		}
+
+		result[hj.Name] = plan
+	}
+
+	return result, nil
 }

--- a/pikoci/job/job.go
+++ b/pikoci/job/job.go
@@ -2,15 +2,54 @@ package job
 
 import "github.com/xescugc/pikoci/pikoci/utils"
 
+type StepType string
+
+const (
+	StepTypeGet  StepType = "get"
+	StepTypeTask StepType = "task"
+	StepTypePut  StepType = "put"
+)
+
 type Job struct {
-	ID   uint32     `json:"id"`
-	Name string     `json:"name" hcl:"name,label"`
-	Get  []GetStep  `json:"gets" hcl:"get,block"`
-	Task []TaskStep `json:"tasks" hcl:"task,block"`
+	ID   uint32 `json:"id"`
+	Name string `json:"name" hcl:"name,label"`
+	Plan []PlanStep `json:"plan"`
 
 	OnSuccess []utils.RunnerCommand `json:"on_success" hcl:"on_success,block"`
 	OnFailure []utils.RunnerCommand `json:"on_failure" hcl:"on_failure,block"`
 	Ensure    []utils.RunnerCommand `json:"ensure" hcl:"ensure,block"`
+}
+
+// GetSteps returns all get steps from the plan in order.
+func (j *Job) GetSteps() []GetStep {
+	var steps []GetStep
+	for _, p := range j.Plan {
+		if p.Type == StepTypeGet && p.Get != nil {
+			steps = append(steps, *p.Get)
+		}
+	}
+	return steps
+}
+
+// PlanGetSteps returns all PlanSteps that are get steps.
+func (j *Job) PlanGetSteps() []PlanStep {
+	var steps []PlanStep
+	for _, p := range j.Plan {
+		if p.Type == StepTypeGet {
+			steps = append(steps, p)
+		}
+	}
+	return steps
+}
+
+type PlanStep struct {
+	Type      StepType              `json:"type"`
+	Get       *GetStep              `json:"get,omitempty"`
+	Task      *TaskStep             `json:"task,omitempty"`
+	Put       *PutStep              `json:"put,omitempty"`
+	OnSuccess []utils.RunnerCommand `json:"on_success,omitempty"`
+	OnFailure []utils.RunnerCommand `json:"on_failure,omitempty"`
+	Ensure    []utils.RunnerCommand `json:"ensure,omitempty"`
 }
 
 type GetStep struct {
@@ -18,10 +57,6 @@ type GetStep struct {
 	Name    string   `json:"name" hcl:"name,label"`
 	Passed  []string `json:"passed" hcl:"passed,optional"`
 	Trigger bool     `json:"trigger" hcl:"trigger,optional"`
-
-	OnSuccess []utils.RunnerCommand `json:"on_success" hcl:"on_success,block"`
-	OnFailure []utils.RunnerCommand `json:"on_failure" hcl:"on_failure,block"`
-	Ensure    []utils.RunnerCommand `json:"ensure" hcl:"ensure,block"`
 }
 
 func (g *GetStep) ResourceCanonical() string {
@@ -31,8 +66,14 @@ func (g *GetStep) ResourceCanonical() string {
 type TaskStep struct {
 	Name string              `json:"name" hcl:"name,label"`
 	Run  utils.RunnerCommand `json:"run" hcl:"run,block"`
+}
 
-	OnSuccess []utils.RunnerCommand `json:"on_success" hcl:"on_success,block"`
-	OnFailure []utils.RunnerCommand `json:"on_failure" hcl:"on_failure,block"`
-	Ensure    []utils.RunnerCommand `json:"ensure" hcl:"ensure,block"`
+type PutStep struct {
+	Type   string            `json:"type"`
+	Name   string            `json:"name"`
+	Params map[string]string `json:"params,omitempty"`
+}
+
+func (p *PutStep) ResourceCanonical() string {
+	return utils.ResourceCanonical(p.Type, p.Name)
 }

--- a/pikoci/job/job_test.go
+++ b/pikoci/job/job_test.go
@@ -1,10 +1,13 @@
 package job_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/xescugc/pikoci/pikoci/job"
+	"github.com/xescugc/pikoci/pikoci/utils"
 )
 
 func TestGetStep_ResourceCanonical(t *testing.T) {
@@ -13,4 +16,98 @@ func TestGetStep_ResourceCanonical(t *testing.T) {
 
 	g = &job.GetStep{Type: "cron", Name: "timer"}
 	assert.Equal(t, "cron.timer", g.ResourceCanonical())
+}
+
+func TestPutStep_ResourceCanonical(t *testing.T) {
+	p := &job.PutStep{Type: "git", Name: "my-repo"}
+	assert.Equal(t, "git.my-repo", p.ResourceCanonical())
+
+	p = &job.PutStep{Type: "docker", Name: "image"}
+	assert.Equal(t, "docker.image", p.ResourceCanonical())
+}
+
+func TestJob_GetSteps(t *testing.T) {
+	j := job.Job{
+		Name: "test",
+		Plan: []job.PlanStep{
+			{Type: job.StepTypeGet, Get: &job.GetStep{Type: "git", Name: "repo"}},
+			{Type: job.StepTypeTask, Task: &job.TaskStep{Name: "build"}},
+			{Type: job.StepTypeGet, Get: &job.GetStep{Type: "cron", Name: "timer"}},
+			{Type: job.StepTypePut, Put: &job.PutStep{Type: "git", Name: "repo"}},
+		},
+	}
+
+	gets := j.GetSteps()
+	require.Len(t, gets, 2)
+	assert.Equal(t, "repo", gets[0].Name)
+	assert.Equal(t, "timer", gets[1].Name)
+}
+
+func TestJob_GetSteps_Empty(t *testing.T) {
+	j := job.Job{Name: "empty"}
+	gets := j.GetSteps()
+	assert.Nil(t, gets)
+}
+
+func TestJob_PlanGetSteps(t *testing.T) {
+	j := job.Job{
+		Name: "test",
+		Plan: []job.PlanStep{
+			{Type: job.StepTypeGet, Get: &job.GetStep{Type: "git", Name: "repo"}},
+			{Type: job.StepTypeTask, Task: &job.TaskStep{Name: "build"}},
+			{Type: job.StepTypeGet, Get: &job.GetStep{Type: "cron", Name: "timer"}},
+		},
+	}
+
+	planGets := j.PlanGetSteps()
+	require.Len(t, planGets, 2)
+	assert.Equal(t, job.StepTypeGet, planGets[0].Type)
+	assert.Equal(t, job.StepTypeGet, planGets[1].Type)
+}
+
+func TestPlanStep_JSONMarshalUnmarshal(t *testing.T) {
+	original := []job.PlanStep{
+		{
+			Type: job.StepTypeGet,
+			Get:  &job.GetStep{Type: "git", Name: "repo", Trigger: true},
+		},
+		{
+			Type: job.StepTypeTask,
+			Task: &job.TaskStep{
+				Name: "build",
+				Run:  utils.RunnerCommand{Runner: "exec", Params: map[string]string{"path": "echo"}},
+			},
+		},
+		{
+			Type: job.StepTypePut,
+			Put:  &job.PutStep{Type: "docker", Name: "image", Params: map[string]string{"tag": "latest"}},
+			OnSuccess: []utils.RunnerCommand{
+				{Runner: "exec", Params: map[string]string{"path": "echo", "args": "done"}},
+			},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded []job.PlanStep
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	require.Len(t, decoded, 3)
+	assert.Equal(t, job.StepTypeGet, decoded[0].Type)
+	assert.NotNil(t, decoded[0].Get)
+	assert.Nil(t, decoded[0].Task)
+	assert.Nil(t, decoded[0].Put)
+	assert.Equal(t, "repo", decoded[0].Get.Name)
+	assert.True(t, decoded[0].Get.Trigger)
+
+	assert.Equal(t, job.StepTypeTask, decoded[1].Type)
+	assert.NotNil(t, decoded[1].Task)
+	assert.Equal(t, "build", decoded[1].Task.Name)
+
+	assert.Equal(t, job.StepTypePut, decoded[2].Type)
+	assert.NotNil(t, decoded[2].Put)
+	assert.Equal(t, "latest", decoded[2].Put.Params["tag"])
+	require.Len(t, decoded[2].OnSuccess, 1)
 }

--- a/pikoci/mysql/build.go
+++ b/pikoci/mysql/build.go
@@ -23,8 +23,7 @@ func NewBuildRepository(db sqlr.Querier) *BuildRepository {
 
 type dbBuild struct {
 	ID        sql.NullInt64
-	Get       sql.NullString
-	Task      sql.NullString
+	Steps     sql.NullString
 	Job       sql.NullString
 	Status    sql.NullString
 	Error     sql.NullString
@@ -33,12 +32,10 @@ type dbBuild struct {
 }
 
 func newDBBuild(b build.Build) dbBuild {
-	g, _ := json.Marshal(b.Get)
-	t, _ := json.Marshal(b.Task)
+	s, _ := json.Marshal(b.Steps)
 	j, _ := json.Marshal(b.Job)
 	return dbBuild{
-		Get:       toNullString(string(g)),
-		Task:      toNullString(string(t)),
+		Steps:     toNullString(string(s)),
 		Job:       toNullString(string(j)),
 		Status:    toNullString(b.Status.String()),
 		Error:     toNullString(b.Error),
@@ -57,8 +54,7 @@ func (dbb *dbBuild) toDomainEntity() *build.Build {
 		Duration:  time.Duration(dbb.Duration.Int64),
 	}
 
-	_ = json.Unmarshal([]byte(dbb.Get.String), &b.Get)
-	_ = json.Unmarshal([]byte(dbb.Task.String), &b.Task)
+	_ = json.Unmarshal([]byte(dbb.Steps.String), &b.Steps)
 	_ = json.Unmarshal([]byte(dbb.Job.String), &b.Job)
 
 	return b
@@ -67,8 +63,8 @@ func (dbb *dbBuild) toDomainEntity() *build.Build {
 func (r *BuildRepository) Create(ctx context.Context, tc, pn, jn string, b build.Build) (uint32, error) {
 	dbb := newDBBuild(b)
 	res, err := r.querier.ExecContext(ctx, `
-		INSERT INTO builds( get, task, job, status, error, started_at, duration, job_id)
-		VALUES (?, ?, ?, ?, ?, ?, ?,
+		INSERT INTO builds(steps, job, status, error, started_at, duration, job_id)
+		VALUES (?, ?, ?, ?, ?, ?,
 			-- job_id
 			(
 				SELECT j.id
@@ -78,7 +74,7 @@ func (r *BuildRepository) Create(ctx context.Context, tc, pn, jn string, b build
 				JOIN teams AS t
 					ON p.team_id = t.id
 				WHERE t.canonical = ? AND p.name = ? AND j.name = ?
-			))`, dbb.Get, dbb.Task, dbb.Job, dbb.Status, dbb.Error, dbb.StartedAt, dbb.Duration, tc, pn, jn)
+			))`, dbb.Steps, dbb.Job, dbb.Status, dbb.Error, dbb.StartedAt, dbb.Duration, tc, pn, jn)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -93,7 +89,7 @@ func (r *BuildRepository) Create(ctx context.Context, tc, pn, jn string, b build
 
 func (r *BuildRepository) Find(ctx context.Context, tc, pn, jn string, bID uint32) (*build.Build, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT b.id, b.get, b.task, b.job, b.status, b.error, b.started_at, b.duration
+		SELECT b.id, b.steps, b.job, b.status, b.error, b.started_at, b.duration
 		FROM builds AS b
 		JOIN jobs AS j
 			ON b.job_id = j.id
@@ -114,7 +110,7 @@ func (r *BuildRepository) Find(ctx context.Context, tc, pn, jn string, bID uint3
 
 func (r *BuildRepository) Filter(ctx context.Context, tc, pn, jn string) ([]*build.Build, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT b.id, b.get, b.task, b.job, b.status, b.error, b.started_at, b.duration
+		SELECT b.id, b.steps, b.job, b.status, b.error, b.started_at, b.duration
 		FROM builds AS b
 		JOIN jobs AS j
 			ON b.job_id = j.id
@@ -140,7 +136,7 @@ func (r *BuildRepository) Update(ctx context.Context, tc, pn, jn string, bID uin
 	dbb := newDBBuild(b)
 	res, err := r.querier.ExecContext(ctx, `
 		UPDATE builds AS b
-		SET get = ?, task = ?, job = ?, status = ?, error = ?, started_at = ?, duration = ?
+		SET steps = ?, job = ?, status = ?, error = ?, started_at = ?, duration = ?
 		FROM (
 			SELECT b.id
 			FROM builds AS b
@@ -153,7 +149,7 @@ func (r *BuildRepository) Update(ctx context.Context, tc, pn, jn string, bID uin
 			WHERE t.canonical = ? AND p.name = ? AND j.name = ? AND b.id = ?
 		) AS bb
 		WHERE bb.id = b.id
-	`, dbb.Get, dbb.Task, dbb.Job, dbb.Status, dbb.Error, dbb.StartedAt, dbb.Duration, tc, pn, jn, bID, bID)
+	`, dbb.Steps, dbb.Job, dbb.Status, dbb.Error, dbb.StartedAt, dbb.Duration, tc, pn, jn, bID, bID)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -199,8 +195,7 @@ func scanBuild(s sqlr.Scanner) (*build.Build, error) {
 
 	err := s.Scan(
 		&b.ID,
-		&b.Get,
-		&b.Task,
+		&b.Steps,
 		&b.Job,
 		&b.Status,
 		&b.Error,

--- a/pikoci/mysql/job.go
+++ b/pikoci/mysql/job.go
@@ -23,23 +23,20 @@ func NewJobRepository(db sqlr.Querier) *JobRepository {
 type dbJob struct {
 	ID        sql.NullInt64
 	Name      sql.NullString
-	Get       sql.NullString
-	Task      sql.NullString
+	Plan      sql.NullString
 	OnSuccess sql.NullString
 	OnFailure sql.NullString
 	Ensure    sql.NullString
 }
 
 func newDBJob(p job.Job) dbJob {
-	g, _ := json.Marshal(p.Get)
-	t, _ := json.Marshal(p.Task)
+	pl, _ := json.Marshal(p.Plan)
 	s, _ := json.Marshal(p.OnSuccess)
 	f, _ := json.Marshal(p.OnFailure)
 	e, _ := json.Marshal(p.Ensure)
 	return dbJob{
 		Name:      toNullString(p.Name),
-		Get:       toNullString(string(g)),
-		Task:      toNullString(string(t)),
+		Plan:      toNullString(string(pl)),
 		OnSuccess: toNullString(string(s)),
 		OnFailure: toNullString(string(f)),
 		Ensure:    toNullString(string(e)),
@@ -52,8 +49,7 @@ func (dbp *dbJob) toDomainEntity() *job.Job {
 		Name: dbp.Name.String,
 	}
 
-	_ = json.Unmarshal([]byte(dbp.Get.String), &j.Get)
-	_ = json.Unmarshal([]byte(dbp.Task.String), &j.Task)
+	_ = json.Unmarshal([]byte(dbp.Plan.String), &j.Plan)
 	_ = json.Unmarshal([]byte(dbp.OnSuccess.String), &j.OnSuccess)
 	_ = json.Unmarshal([]byte(dbp.OnFailure.String), &j.OnFailure)
 	_ = json.Unmarshal([]byte(dbp.Ensure.String), &j.Ensure)
@@ -64,8 +60,8 @@ func (dbp *dbJob) toDomainEntity() *job.Job {
 func (r *JobRepository) Create(ctx context.Context, tc, pn string, j job.Job) (uint32, error) {
 	dbj := newDBJob(j)
 	res, err := r.querier.ExecContext(ctx, `
-		INSERT INTO jobs(name, get, task, on_success, on_failure, ensure, pipeline_id)
-		VALUES (?, ?, ?, ?, ?, ?,
+		INSERT INTO jobs(name, plan, on_success, on_failure, ensure, pipeline_id)
+		VALUES (?, ?, ?, ?, ?,
 			-- pipeline_id
 			(
 				SELECT p.id
@@ -73,7 +69,7 @@ func (r *JobRepository) Create(ctx context.Context, tc, pn string, j job.Job) (u
 				JOIN teams AS t
 					ON p.team_id = t.id
 				WHERE t.canonical = ? AND p.name = ?
-			))`, dbj.Name, dbj.Get, dbj.Task, dbj.OnSuccess, dbj.OnFailure, dbj.Ensure, tc, pn)
+			))`, dbj.Name, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.Ensure, tc, pn)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -90,7 +86,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 	dbj := newDBJob(j)
 	res, err := r.querier.ExecContext(ctx, `
 		UPDATE jobs AS j
-		SET name = ?, get = ?, task = ?, on_success = ?, on_failure = ?, ensure = ?
+		SET name = ?, plan = ?, on_success = ?, on_failure = ?, ensure = ?
 		FROM (
 			SELECT j.id
 			FROM jobs AS j
@@ -101,7 +97,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 			WHERE t.canonical = ? AND p.name = ? AND j.name = ?
 		) AS jj
 		WHERE jj.id = j.id
-	`, dbj.Name, dbj.Get, dbj.Task, dbj.OnSuccess, dbj.OnFailure, dbj.Ensure, tc, pn, jn)
+	`, dbj.Name, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.Ensure, tc, pn, jn)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -116,7 +112,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 
 func (r *JobRepository) Find(ctx context.Context, tc, pn, jn string) (*job.Job, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT j.id, j.name, j.get, j.task, j.on_success, j.on_failure, j.ensure
+		SELECT j.id, j.name, j.plan, j.on_success, j.on_failure, j.ensure
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -135,7 +131,7 @@ func (r *JobRepository) Find(ctx context.Context, tc, pn, jn string) (*job.Job, 
 
 func (r *JobRepository) Filter(ctx context.Context, tc, pn string) ([]*job.Job, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT j.id, j.name, j.get, j.task, j.on_success, j.on_failure, j.ensure
+		SELECT j.id, j.name, j.plan, j.on_success, j.on_failure, j.ensure
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -187,8 +183,7 @@ func scanJob(s sqlr.Scanner) (*job.Job, error) {
 	err := s.Scan(
 		&j.ID,
 		&j.Name,
-		&j.Get,
-		&j.Task,
+		&j.Plan,
 		&j.OnSuccess,
 		&j.OnFailure,
 		&j.Ensure,

--- a/pikoci/mysql/migrate/migrations/V9OrderedPlan.go
+++ b/pikoci/mysql/migrate/migrations/V9OrderedPlan.go
@@ -1,0 +1,12 @@
+package migrations
+
+// V9OrderedPlan adds plan column to jobs and steps column to builds,
+// replacing the separate get/task columns. Old columns are kept for
+// backwards compatibility during the transition.
+var V9OrderedPlan = Migration{
+	Name: "OrderedPlan",
+	SQL: `
+		ALTER TABLE jobs ADD plan TEXT;
+		ALTER TABLE builds ADD steps TEXT;
+	`,
+}

--- a/pikoci/mysql/migrate/migrations/migrations.go
+++ b/pikoci/mysql/migrate/migrations/migrations.go
@@ -12,7 +12,7 @@ type Migration struct {
 // in compilation time if some order is wrong
 // if it where to have more than one person working
 // on it
-var Migrations = [9]Migration{
+var Migrations = [10]Migration{
 	V0Initial,
 	V1ResourceCheckInterval,
 	V2JobsAndBuilds,
@@ -22,4 +22,5 @@ var Migrations = [9]Migration{
 	V6ResourceVersion,
 	V7InputsToParams,
 	V8UsersAdnTeams,
+	V9OrderedPlan,
 }

--- a/pikoci/mysql/pipeline.go
+++ b/pikoci/mysql/pipeline.go
@@ -152,7 +152,7 @@ func (r *PipelineRepository) Delete(ctx context.Context, tc, pn string) error {
 const pipelineQuery = `
 	SELECT
 		p.id, p.name, p.raw,
-		j.id, j.name, j.get, j.task, j.on_success, j.on_failure, j.ensure,
+		j.id, j.name, j.plan, j.on_success, j.on_failure, j.ensure,
 		r.id, r.name, r.type, r.canonical, r.params, r.check_interval, r.cron_id, r.logs, r.last_check,
 		rt.id, rt.name, rt.` + "`check`" + `, rt.pull, rt.push, rt.params,
 		ru.id, ru.name, ru.run
@@ -187,7 +187,7 @@ func scanPipelines(rows *sql.Rows) ([]*pipeline.Pipeline, error) {
 
 		err := rows.Scan(
 			&pp.ID, &pp.Name, &pp.Raw,
-			&j.ID, &j.Name, &j.Get, &j.Task, &j.OnSuccess, &j.OnFailure, &j.Ensure,
+			&j.ID, &j.Name, &j.Plan, &j.OnSuccess, &j.OnFailure, &j.Ensure,
 			&r.ID, &r.Name, &r.Type, &r.Canonical, &r.Params, &r.CheckInterval, &r.CronID, &r.Logs, &r.LastCheck,
 			&rt.ID, &rt.Name, &rt.Check, &rt.Pull, &rt.Push, &rt.Params,
 			&ru.ID, &ru.Name, &ru.Run,

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -485,7 +485,8 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 		if err != nil {
 			return nil, fmt.Errorf("failed to add node to Graph: %w", err)
 		}
-		for _, g := range j.Get {
+		// Draw resource→job edges for get steps without passed constraints
+		for _, g := range j.GetSteps() {
 			if len(g.Passed) == 0 {
 				rCan := fmt.Sprintf(`"%s.%s"`, g.Type, g.Name)
 				opt := make(map[string]string)
@@ -500,11 +501,23 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 				}
 			}
 		}
+		// Draw job→resource edges for put steps
+		for _, ps := range j.Plan {
+			if ps.Type == "put" && ps.Put != nil {
+				rCan := fmt.Sprintf(`"%s.%s"`, ps.Put.Type, ps.Put.Name)
+				err = graph.AddEdge(j.Name, rCan, false, map[string]string{
+					string(gographviz.Style): "solid",
+				})
+				if err != nil {
+					return nil, fmt.Errorf("failed to add edge to Graph: %w", err)
+				}
+			}
+		}
 	}
 
 	// Now we print all the jobs interconnections depending on resources
 	for _, j := range pp.Jobs {
-		for _, g := range j.Get {
+		for _, g := range j.GetSteps() {
 			if len(g.Passed) != 0 {
 				for _, p := range g.Passed {
 					nn := fmt.Sprintf(`"%s-%s-%s"`, p, g.Name, j.Name)

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -92,3 +92,115 @@ func TestDeletePipeline_InvalidCanonical(t *testing.T) {
 	err = s.S.DeletePipeline(ctx, "main", "INVALID")
 	require.Error(t, err)
 }
+
+func TestCreatePipeline_OrderedPlanWithPut(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+resource_type "git" {
+  params = ["url"]
+  check "exec" {
+    path = "echo"
+    args = "check"
+  }
+  pull "exec" {
+    path = "echo"
+    args = "pull"
+  }
+  push "exec" {
+    path = "echo"
+    args = "push"
+  }
+}
+
+resource "git" "repo" {
+  params {
+    url = "http://example.com"
+  }
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+  params {}
+}
+
+job "deploy" {
+  get "cron" "timer" {
+    trigger = true
+  }
+  task "build" {
+    run "exec" {
+      path = "echo"
+      args = "building"
+    }
+  }
+  put "git" "repo" {
+    tag = "latest"
+  }
+}
+`)
+
+	// Expect all the create calls
+	s.Pipelines.EXPECT().Create(ctx, "main", gomock.Any()).Return(uint32(1), nil)
+	s.Jobs.EXPECT().Create(ctx, "main", "test-pipeline", gomock.Any()).DoAndReturn(
+		func(ctx context.Context, tc, pn string, j job.Job) (uint32, error) {
+			// Verify the plan is ordered: get, task, put
+			require.Len(t, j.Plan, 3)
+			assert.Equal(t, job.StepTypeGet, j.Plan[0].Type)
+			assert.Equal(t, "timer", j.Plan[0].Get.Name)
+			assert.Equal(t, job.StepTypeTask, j.Plan[1].Type)
+			assert.Equal(t, "build", j.Plan[1].Task.Name)
+			assert.Equal(t, job.StepTypePut, j.Plan[2].Type)
+			assert.Equal(t, "repo", j.Plan[2].Put.Name)
+			assert.Equal(t, "latest", j.Plan[2].Put.Params["tag"])
+			return uint32(1), nil
+		})
+	s.ResourceTypes.EXPECT().Create(ctx, "main", "test-pipeline", gomock.Any()).Return(uint32(1), nil)
+	s.Resources.EXPECT().Create(ctx, "main", "test-pipeline", gomock.Any()).Return(uint32(1), nil).Times(2)
+	s.Pipelines.EXPECT().Find(ctx, "main", "test-pipeline").Return(&pipeline.Pipeline{ID: 1, Name: "test-pipeline"}, nil)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "test-pipeline", hclConfig, nil)
+	require.NoError(t, err)
+}
+
+func TestCreatePipeline_BackwardsCompat_GetThenTask(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+  params {}
+}
+
+job "test" {
+  get "cron" "timer" {
+    trigger = true
+  }
+  task "echo" {
+    run "exec" {
+      path = "echo"
+      args = "hello"
+    }
+  }
+}
+`)
+
+	s.Pipelines.EXPECT().Create(ctx, "main", gomock.Any()).Return(uint32(1), nil)
+	s.Jobs.EXPECT().Create(ctx, "main", "compat-pipeline", gomock.Any()).DoAndReturn(
+		func(ctx context.Context, tc, pn string, j job.Job) (uint32, error) {
+			// Verify backwards compat: get before task
+			require.Len(t, j.Plan, 2)
+			assert.Equal(t, job.StepTypeGet, j.Plan[0].Type)
+			assert.Equal(t, job.StepTypeTask, j.Plan[1].Type)
+			return uint32(1), nil
+		})
+	s.Resources.EXPECT().Create(ctx, "main", "compat-pipeline", gomock.Any()).Return(uint32(1), nil)
+	s.Pipelines.EXPECT().Find(ctx, "main", "compat-pipeline").Return(&pipeline.Pipeline{ID: 1, Name: "compat-pipeline"}, nil)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "compat-pipeline", hclConfig, nil)
+	require.NoError(t, err)
+}

--- a/pikoci/testdata/put.hcl
+++ b/pikoci/testdata/put.hcl
@@ -1,0 +1,45 @@
+resource_type "git" {
+  params = [
+    "url",
+    "name",
+  ]
+  check "exec" {
+    path = "/bin/sh"
+    args = "-ec 'echo [{\"ref\":\"abc\"}]'"
+  }
+  pull "exec" {
+    path = "/bin/sh"
+    args = "-ec 'echo pulling'"
+  }
+  push "exec" {
+    path = "/bin/sh"
+    args = "-ec 'echo pushing'"
+  }
+}
+
+resource "git" "repo" {
+  params {
+    url = "http://example.com"
+    name = "repo"
+  }
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 10s"
+  params {}
+}
+
+job "build-and-push" {
+  get "cron" "timer" {
+    trigger = true
+  }
+  task "build" {
+    run "exec" {
+      path = "echo"
+      args = "building"
+    }
+  }
+  put "git" "repo" {
+    tag = "latest"
+  }
+}

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -377,39 +377,24 @@
             <span class="piko-badge piko-badge-started">Running</span>
           <% } %>
         </div>
-        <% _.each(get || [], function(g, i) { %>
-          <div class="piko-step-row">
-            <div class="piko-step-row-header" onclick="this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'block' : 'none'">
-              <span><span class="piko-step-label">get</span> <%- g.name %> <span style="color:var(--text-muted);">(<%- g.duration %>)</span></span>
-              <% if (status === "succeeded" || g.logs) { %>
-                <span class="piko-badge piko-badge-succeeded">ok</span>
-              <% } %>
-            </div>
-            <div class="piko-step-row-body" style="display:none;">
-<pre>
-<%- g.logs %>
-</pre>
-            </div>
-          </div>
-        <% }) %>
-        <% var _task = task || []; %>
+        <% var _steps = steps || []; %>
         <% var _job = job || []; %>
-        <% var lastTask = _task.length > 0 ? _task[_task.length-1] : null; %>
-        <% _.each(_task, function(t, i) { %>
+        <% var lastStep = _steps.length > 0 ? _steps[_steps.length-1] : null; %>
+        <% _.each(_steps, function(s, i) { %>
           <div class="piko-step-row">
             <div class="piko-step-row-header" onclick="this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'block' : 'none'">
-              <span><span class="piko-step-label">task</span> <%- t.name %> <span style="color:var(--text-muted);">(<%- t.duration %>)</span></span>
-              <% if (status === "failed" && t === lastTask && _job.length === 0) { %>
+              <span><span class="piko-step-label"><%- s.type || "step" %></span> <%- s.name %> <span style="color:var(--text-muted);">(<%- s.duration %>)</span></span>
+              <% if (status === "failed" && s === lastStep && _job.length === 0) { %>
                 <span class="piko-badge piko-badge-failed">fail</span>
-              <% } else if (status === "started" && t === lastTask && _job.length === 0) { %>
+              <% } else if (status === "started" && s === lastStep && _job.length === 0) { %>
                 <span class="piko-badge piko-badge-started">running</span>
-              <% } else if (t.logs) { %>
+              <% } else if (s.logs) { %>
                 <span class="piko-badge piko-badge-succeeded">ok</span>
               <% } %>
             </div>
             <div class="piko-step-row-body" style="display:none;">
 <pre>
-<%- t.logs %>
+<%- s.logs %>
 </pre>
             </div>
           </div>
@@ -796,11 +781,8 @@
             if (data.duration  !== 0) {
               data.duration = durationToString(data.duration)
             }
-            _.each(data.get, function(g, i) {
-              data.get[i].duration = durationToString(g.duration)
-            })
-            _.each(data.task, function(t, i) {
-              data.task[i].duration = durationToString(t.duration)
+            _.each(data.steps, function(s, i) {
+              data.steps[i].duration = durationToString(s.duration)
             })
             _.each(data.job, function(j, i) {
               data.job[i].duration = durationToString(j.duration)

--- a/worker/service.go
+++ b/worker/service.go
@@ -34,7 +34,7 @@ type Service interface {
 
 type Worker struct {
 	topic        queue.Topic
-	pikoci        pikoci.Service
+	pikoci       pikoci.Service
 	subscription queue.Subscription
 
 	logger *slog.Logger
@@ -42,7 +42,7 @@ type Worker struct {
 
 func New(s pikoci.Service, t queue.Topic, ss queue.Subscription, l *slog.Logger) *Worker {
 	return &Worker{
-		pikoci:        s,
+		pikoci:       s,
 		topic:        t,
 		subscription: ss,
 		logger:       l,
@@ -103,13 +103,12 @@ func (w *Worker) processMessage(ctx context.Context, m queue.Body, cwd string) {
 	}
 }
 
-// processJob handles executing a job: creates a build, runs get/task steps,
+// processJob handles executing a job: creates a build, runs the plan steps,
 // runs hooks, and triggers downstream jobs.
 func (w *Worker) processJob(ctx context.Context, m queue.Body, cwd string, pp *pipeline.Pipeline) {
 	b := build.Build{
 		Status:    build.Started,
-		Get:       []build.Step{},
-		Task:      []build.Step{},
+		Steps:     []build.Step{},
 		StartedAt: time.Now(),
 	}
 	nb, err := w.pikoci.CreateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, b)
@@ -129,16 +128,14 @@ func (w *Worker) processJob(ctx context.Context, m queue.Body, cwd string, pp *p
 		return
 	}
 
-	failed := w.runGetSteps(ctx, m, &b, cwd, pp, j)
-	if !failed {
-		failed = w.runTaskSteps(ctx, m, &b, cwd, pp, j)
-	}
+	failed := w.runPlan(ctx, m, &b, cwd, pp, j)
 
 	if !failed {
 		b.Status = build.Succeeded
 		if err := w.updateBuild(ctx, m, b); err != nil {
 			return
 		}
+		w.triggerDownstreamJobs(ctx, m, &b, pp, j)
 		w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.OnSuccess, "on_success")
 	} else {
 		w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.OnFailure, "on_failure")
@@ -149,7 +146,11 @@ func (w *Worker) processJob(ctx context.Context, m queue.Body, cwd string, pp *p
 // checkPassedConstraints verifies that all jobs in the "passed" list have a
 // successful latest build. If not, the build is deleted and false is returned.
 func (w *Worker) checkPassedConstraints(ctx context.Context, m queue.Body, b *build.Build, j *job.Job) bool {
-	for _, g := range j.Get {
+	for _, ps := range j.Plan {
+		if ps.Type != job.StepTypeGet || ps.Get == nil {
+			continue
+		}
+		g := ps.Get
 		for _, p := range g.Passed {
 			builds, err := w.pikoci.ListJobBuilds(ctx, m.TeamCanonical, m.PipelineName, p)
 			if err != nil {
@@ -173,52 +174,162 @@ func (w *Worker) checkPassedConstraints(ctx context.Context, m queue.Body, b *bu
 	return true
 }
 
-// runGetSteps runs all "get" steps (resource pulls) for a job.
-// Returns true if the job failed during get steps.
-func (w *Worker) runGetSteps(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, j *job.Job) bool {
-	for _, g := range j.Get {
-		r, ok := pp.Resource(utils.ResourceCanonical(g.Type, g.Name))
-		if !ok {
-			continue
+// runPlan runs all plan steps (get/task/put) in order.
+// Returns true if the job failed during plan execution.
+func (w *Worker) runPlan(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, j *job.Job) bool {
+	for _, ps := range j.Plan {
+		switch ps.Type {
+		case job.StepTypeGet:
+			if ps.Get == nil {
+				continue
+			}
+			if w.runGetStep(ctx, m, b, cwd, pp, *ps.Get, ps) {
+				return true
+			}
+		case job.StepTypeTask:
+			if ps.Task == nil {
+				continue
+			}
+			if w.runTaskStep(ctx, m, b, cwd, pp, *ps.Task, ps) {
+				return true
+			}
+		case job.StepTypePut:
+			if ps.Put == nil {
+				continue
+			}
+			if w.runPutStep(ctx, m, b, cwd, pp, *ps.Put, ps) {
+				return true
+			}
 		}
-		rt, ok := pp.ResourceType(g.Type)
-		if !ok {
-			continue
-		}
-
-		params := w.buildPullParams(ctx, m, b, rt, r, g)
-		if params == nil {
-			return true // error already handled
-		}
-
-		ru, ok := pp.Runner(rt.Pull.Runner)
-		if !ok {
-			continue
-		}
-
-		out, d, err := w.runRunner(ctx, ru, cwd, params)
-		if err != nil {
-			b.Get = append(b.Get, build.Step{Name: g.Name, Logs: out, Duration: d})
-			b.Status = build.Failed
-			w.failBuild(ctx, m, *b, nil)
-			w.logger.Error("failed to run get step", "step", g.Name, "error", err)
-			w.runHooks(ctx, m, b, &b.Get, cwd, pp, g.Name, g.OnFailure, "on_failure")
-			w.runHooks(ctx, m, b, &b.Get, cwd, pp, g.Name, g.Ensure, "ensure")
-			return true
-		}
-
-		b.Get = append(b.Get, build.Step{
-			Name:      g.Name,
-			VersionID: m.VersionID,
-			Logs:      out,
-			Duration:  d,
-		})
-		if err := w.updateBuild(ctx, m, *b); err != nil {
-			return true
-		}
-		w.runHooks(ctx, m, b, &b.Get, cwd, pp, g.Name, g.OnSuccess, "on_success")
-		w.runHooks(ctx, m, b, &b.Get, cwd, pp, g.Name, g.Ensure, "ensure")
 	}
+	return false
+}
+
+// runGetStep runs a single get step (resource pull).
+// Returns true if the step failed.
+func (w *Worker) runGetStep(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, g job.GetStep, ps job.PlanStep) bool {
+	r, ok := pp.Resource(utils.ResourceCanonical(g.Type, g.Name))
+	if !ok {
+		return false
+	}
+	rt, ok := pp.ResourceType(g.Type)
+	if !ok {
+		return false
+	}
+
+	params := w.buildPullParams(ctx, m, b, rt, r, g)
+	if params == nil {
+		return true
+	}
+
+	ru, ok := pp.Runner(rt.Pull.Runner)
+	if !ok {
+		return false
+	}
+
+	out, d, err := w.runRunner(ctx, ru, cwd, params)
+	if err != nil {
+		b.Steps = append(b.Steps, build.Step{Type: "get", Name: g.Name, Logs: out, Duration: d})
+		b.Status = build.Failed
+		w.failBuild(ctx, m, *b, nil)
+		w.logger.Error("failed to run get step", "step", g.Name, "error", err)
+		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, g.Name, ps.OnFailure, "on_failure")
+		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, g.Name, ps.Ensure, "ensure")
+		return true
+	}
+
+	b.Steps = append(b.Steps, build.Step{
+		Type:      "get",
+		Name:      g.Name,
+		VersionID: m.VersionID,
+		Logs:      out,
+		Duration:  d,
+	})
+	if err := w.updateBuild(ctx, m, *b); err != nil {
+		return true
+	}
+	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, g.Name, ps.OnSuccess, "on_success")
+	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, g.Name, ps.Ensure, "ensure")
+	return false
+}
+
+// runTaskStep runs a single task step.
+// Returns true if the step failed.
+func (w *Worker) runTaskStep(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, t job.TaskStep, ps job.PlanStep) bool {
+	ru, ok := pp.Runner(t.Run.Runner)
+	if !ok {
+		return false
+	}
+
+	out, d, err := w.runRunner(ctx, ru, cwd, t.Run.Params)
+	if err != nil {
+		b.Steps = append(b.Steps, build.Step{Type: "task", Name: t.Name, Logs: out, Duration: d})
+		b.Status = build.Failed
+		w.failBuild(ctx, m, *b, nil)
+		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.OnFailure, "on_failure")
+		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.Ensure, "ensure")
+		return true
+	}
+
+	b.Steps = append(b.Steps, build.Step{Type: "task", Name: t.Name, Logs: out, Duration: d})
+	if err := w.updateBuild(ctx, m, *b); err != nil {
+		return true
+	}
+	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.OnSuccess, "on_success")
+	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.Ensure, "ensure")
+	return false
+}
+
+// runPutStep runs a single put step (resource push).
+// Returns true if the step failed.
+func (w *Worker) runPutStep(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, p job.PutStep, ps job.PlanStep) bool {
+	rCan := utils.ResourceCanonical(p.Type, p.Name)
+	r, ok := pp.Resource(rCan)
+	if !ok {
+		return false
+	}
+	rt, ok := pp.ResourceType(p.Type)
+	if !ok {
+		return false
+	}
+
+	params := rt.Push.Params
+	if params == nil {
+		params = make(map[string]string)
+	}
+	// Add resource-level params
+	for k, v := range r.Params.Params {
+		if slices.Contains(rt.Params, k) {
+			params["param_"+k] = v
+		}
+	}
+	// Add put-step-level params with put_ prefix
+	for k, v := range p.Params {
+		params["put_"+k] = v
+	}
+
+	ru, ok := pp.Runner(rt.Push.Runner)
+	if !ok {
+		return false
+	}
+
+	out, d, err := w.runRunner(ctx, ru, cwd, params)
+	if err != nil {
+		b.Steps = append(b.Steps, build.Step{Type: "put", Name: p.Name, Logs: out, Duration: d})
+		b.Status = build.Failed
+		w.failBuild(ctx, m, *b, nil)
+		w.logger.Error("failed to run put step", "step", p.Name, "error", err)
+		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, p.Name, ps.OnFailure, "on_failure")
+		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, p.Name, ps.Ensure, "ensure")
+		return true
+	}
+
+	b.Steps = append(b.Steps, build.Step{Type: "put", Name: p.Name, Logs: out, Duration: d})
+	if err := w.updateBuild(ctx, m, *b); err != nil {
+		return true
+	}
+	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, p.Name, ps.OnSuccess, "on_success")
+	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, p.Name, ps.Ensure, "ensure")
 	return false
 }
 
@@ -271,43 +382,15 @@ func (w *Worker) buildPullParams(ctx context.Context, m queue.Body, b *build.Bui
 	return params
 }
 
-// runTaskSteps runs all "task" steps for a job and triggers downstream jobs on success.
-// Returns true if the job failed during task steps.
-func (w *Worker) runTaskSteps(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, j *job.Job) bool {
-	for _, t := range j.Task {
-		ru, ok := pp.Runner(t.Run.Runner)
-		if !ok {
-			continue
-		}
-
-		out, d, err := w.runRunner(ctx, ru, cwd, t.Run.Params)
-		if err != nil {
-			b.Task = append(b.Task, build.Step{Name: t.Name, Logs: out, Duration: d})
-			b.Status = build.Failed
-			w.failBuild(ctx, m, *b, nil)
-			w.runHooks(ctx, m, b, &b.Task, cwd, pp, t.Name, t.OnFailure, "on_failure")
-			w.runHooks(ctx, m, b, &b.Task, cwd, pp, t.Name, t.Ensure, "ensure")
-			return true
-		}
-
-		b.Task = append(b.Task, build.Step{Name: t.Name, Logs: out, Duration: d})
-		if err := w.updateBuild(ctx, m, *b); err != nil {
-			return true
-		}
-		w.runHooks(ctx, m, b, &b.Task, cwd, pp, t.Name, t.OnSuccess, "on_success")
-		w.runHooks(ctx, m, b, &b.Task, cwd, pp, t.Name, t.Ensure, "ensure")
-
-		// Trigger downstream jobs that depend on this job via "passed"
-		w.triggerDownstreamJobs(ctx, m, b, pp, j)
-	}
-	return false
-}
-
 // triggerDownstreamJobs finds jobs that depend on the current job via "passed"
 // and triggers them.
 func (w *Worker) triggerDownstreamJobs(ctx context.Context, m queue.Body, b *build.Build, pp *pipeline.Pipeline, j *job.Job) {
 	for _, nj := range pp.Jobs {
-		for _, g := range nj.Get {
+		for _, ps := range nj.Plan {
+			if ps.Type != job.StepTypeGet || ps.Get == nil {
+				continue
+			}
+			g := ps.Get
 			if slices.Contains(g.Passed, j.Name) && g.Trigger {
 				qb := queue.Body{
 					TeamCanonical:     m.TeamCanonical,
@@ -349,7 +432,7 @@ func (w *Worker) runHooks(ctx context.Context, m queue.Body, b *build.Build, ste
 			}
 		}
 
-		*steps = append(*steps, build.Step{Name: name, Logs: out, Duration: d})
+		*steps = append(*steps, build.Step{Type: "hook", Name: name, Logs: out, Duration: d})
 		if err := w.updateBuild(ctx, m, *b); err != nil {
 			return
 		}
@@ -439,7 +522,11 @@ func (w *Worker) processResourceCheck(ctx context.Context, m queue.Body, cwd str
 // triggerResourceJobs triggers jobs that depend on a resource via "get" with trigger=true.
 func (w *Worker) triggerResourceJobs(ctx context.Context, m queue.Body, pp *pipeline.Pipeline, r resource.Resource, cv *resource.Version) {
 	for _, j := range pp.Jobs {
-		for _, g := range j.Get {
+		for _, ps := range j.Plan {
+			if ps.Type != job.StepTypeGet || ps.Get == nil {
+				continue
+			}
+			g := ps.Get
 			// If Passed is not 0 it means is waiting for another job
 			// and this trigger is only for resources
 			if g.Name == r.Name && g.Type == r.Type && g.Trigger && len(g.Passed) == 0 {

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -29,7 +29,7 @@ func newTestWorker(ctrl *gomock.Controller) (*Worker, *mock.Service, *mock.Topic
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
 	w := &Worker{
-		pikoci:        svc,
+		pikoci: svc,
 		topic:  topic,
 		logger: logger,
 	}
@@ -44,21 +44,21 @@ func testPipeline() *pipeline.Pipeline {
 			{
 				ID:   1,
 				Name: "test-job",
-				Get: []job.GetStep{
+				Plan: []job.PlanStep{
 					{
-						Type:    "cron",
-						Name:    "my-cron",
-						Trigger: true,
+						Type: job.StepTypeGet,
+						Get:  &job.GetStep{Type: "cron", Name: "my-cron", Trigger: true},
 					},
-				},
-				Task: []job.TaskStep{
 					{
-						Name: "echo",
-						Run: utils.RunnerCommand{
-							Runner: "exec",
-							Params: map[string]string{
-								"path": "echo",
-								"args": "hello",
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "echo",
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Params: map[string]string{
+									"path": "echo",
+									"args": "hello",
+								},
 							},
 						},
 					},
@@ -122,14 +122,17 @@ func TestProcessJob_Success_TaskOnly(t *testing.T) {
 			{
 				ID:   1,
 				Name: "echo-job",
-				Task: []job.TaskStep{
+				Plan: []job.PlanStep{
 					{
-						Name: "echo",
-						Run: utils.RunnerCommand{
-							Runner: "exec",
-							Params: map[string]string{
-								"path": "echo",
-								"args": "hello",
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "echo",
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Params: map[string]string{
+									"path": "echo",
+									"args": "hello",
+								},
 							},
 						},
 					},
@@ -172,13 +175,17 @@ func TestProcessJob_Success_WithGetAndTask(t *testing.T) {
 			{
 				ID:   1,
 				Name: "test-job",
-				Get: []job.GetStep{
-					{Type: "cron", Name: "my-cron", Trigger: true},
-				},
-				Task: []job.TaskStep{
+				Plan: []job.PlanStep{
 					{
-						Name: "echo",
-						Run:  utils.RunnerCommand{Runner: "exec", Params: map[string]string{"path": "echo", "args": "hello"}},
+						Type: job.StepTypeGet,
+						Get:  &job.GetStep{Type: "cron", Name: "my-cron", Trigger: true},
+					},
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "echo",
+							Run:  utils.RunnerCommand{Runner: "exec", Params: map[string]string{"path": "echo", "args": "hello"}},
+						},
 					},
 				},
 			},
@@ -235,12 +242,15 @@ func TestProcessJob_FailedPassedConstraint_NoBuilds(t *testing.T) {
 			{
 				ID:   2,
 				Name: "downstream-job",
-				Get: []job.GetStep{
+				Plan: []job.PlanStep{
 					{
-						Type:    "cron",
-						Name:    "my-cron",
-						Passed:  []string{"upstream-job"},
-						Trigger: true,
+						Type: job.StepTypeGet,
+						Get: &job.GetStep{
+							Type:    "cron",
+							Name:    "my-cron",
+							Passed:  []string{"upstream-job"},
+							Trigger: true,
+						},
 					},
 				},
 			},
@@ -284,12 +294,15 @@ func TestProcessJob_FailedPassedConstraint_NotSucceeded(t *testing.T) {
 			{
 				ID:   2,
 				Name: "downstream-job",
-				Get: []job.GetStep{
+				Plan: []job.PlanStep{
 					{
-						Type:    "cron",
-						Name:    "my-cron",
-						Passed:  []string{"upstream-job"},
-						Trigger: true,
+						Type: job.StepTypeGet,
+						Get: &job.GetStep{
+							Type:    "cron",
+							Name:    "my-cron",
+							Passed:  []string{"upstream-job"},
+							Trigger: true,
+						},
 					},
 				},
 			},
@@ -334,14 +347,17 @@ func TestProcessJob_TaskFailure_RunsHooks(t *testing.T) {
 			{
 				ID:   1,
 				Name: "failing-job",
-				Task: []job.TaskStep{
+				Plan: []job.PlanStep{
 					{
-						Name: "will-fail",
-						Run: utils.RunnerCommand{
-							Runner: "exec",
-							Params: map[string]string{
-								"path": "false", // exits with code 1
-								"args": "",
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "will-fail",
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Params: map[string]string{
+									"path": "false", // exits with code 1
+									"args": "",
+								},
 							},
 						},
 						OnFailure: []utils.RunnerCommand{
@@ -421,14 +437,17 @@ func TestProcessJob_TriggersDownstream(t *testing.T) {
 			{
 				ID:   1,
 				Name: "upstream-job",
-				Task: []job.TaskStep{
+				Plan: []job.PlanStep{
 					{
-						Name: "echo",
-						Run: utils.RunnerCommand{
-							Runner: "exec",
-							Params: map[string]string{
-								"path": "echo",
-								"args": "hello",
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "echo",
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Params: map[string]string{
+									"path": "echo",
+									"args": "hello",
+								},
 							},
 						},
 					},
@@ -437,12 +456,15 @@ func TestProcessJob_TriggersDownstream(t *testing.T) {
 			{
 				ID:   2,
 				Name: "downstream-job",
-				Get: []job.GetStep{
+				Plan: []job.PlanStep{
 					{
-						Type:    "cron",
-						Name:    "my-cron",
-						Passed:  []string{"upstream-job"},
-						Trigger: true,
+						Type: job.StepTypeGet,
+						Get: &job.GetStep{
+							Type:    "cron",
+							Name:    "my-cron",
+							Passed:  []string{"upstream-job"},
+							Trigger: true,
+						},
 					},
 				},
 			},
@@ -503,7 +525,12 @@ func TestProcessResourceCheck_NewVersions(t *testing.T) {
 			{
 				ID:   1,
 				Name: "test-job",
-				Get:  []job.GetStep{{Type: "cron", Name: "my-cron", Trigger: true}},
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeGet,
+						Get:  &job.GetStep{Type: "cron", Name: "my-cron", Trigger: true},
+					},
+				},
 			},
 		},
 		Resources: []resource.Resource{
@@ -562,11 +589,14 @@ func TestCheckPassedConstraints_AllPassed(t *testing.T) {
 	b := build.Build{ID: 50}
 	j := &job.Job{
 		Name: "downstream-job",
-		Get: []job.GetStep{
+		Plan: []job.PlanStep{
 			{
-				Type:   "cron",
-				Name:   "my-cron",
-				Passed: []string{"job-a", "job-b"},
+				Type: job.StepTypeGet,
+				Get: &job.GetStep{
+					Type:   "cron",
+					Name:   "my-cron",
+					Passed: []string{"job-a", "job-b"},
+				},
 			},
 		},
 	}
@@ -694,7 +724,7 @@ func TestProcessMessage_JobDispatch(t *testing.T) {
 	svc.EXPECT().CreateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, gomock.Any()).
 		Return(&build.Build{ID: 1}, nil)
 
-	// GetPipelineJob — no tasks, no gets
+	// GetPipelineJob — no plan steps
 	svc.EXPECT().GetPipelineJob(ctx, m.TeamCanonical, m.PipelineName, m.JobName).
 		Return(&job.Job{Name: "test-job"}, nil)
 
@@ -807,6 +837,151 @@ func TestBuildPullParams_NoVersions_Fails(t *testing.T) {
 
 	params := w.buildPullParams(ctx, m, &b, rt, r, g)
 	assert.Nil(t, params)
+}
+
+func TestProcessJob_PutStep_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical: "main",
+		PipelineName:  "test-pipeline",
+		JobName:       "deploy-job",
+	}
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "deploy-job",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "build",
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Params: map[string]string{"path": "echo", "args": "building"},
+							},
+						},
+					},
+					{
+						Type: job.StepTypePut,
+						Put: &job.PutStep{
+							Type:   "git",
+							Name:   "repo",
+							Params: map[string]string{"tag": "latest"},
+						},
+					},
+				},
+			},
+		},
+		Resources: []resource.Resource{
+			{ID: 1, Name: "repo", Type: "git", Canonical: "git.repo", Params: resource.Params{Params: map[string]string{"url": "http://example.com"}}},
+		},
+		ResourceTypes: []restype.ResourceType{
+			{
+				ID: 1, Name: "git",
+				Params: []string{"url"},
+				Push: utils.RunnerCommand{
+					Runner: "exec",
+					Params: map[string]string{"path": "echo", "args": "pushing"},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().CreateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, gomock.Any()).
+		Return(&build.Build{ID: 80}, nil)
+	svc.EXPECT().GetPipelineJob(ctx, m.TeamCanonical, m.PipelineName, m.JobName).
+		Return(&pp.Jobs[0], nil)
+
+	// UpdateJobBuild: after task step + after put step + after marking succeeded
+	svc.EXPECT().UpdateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, uint32(80), gomock.Any()).
+		Return(nil).Times(3)
+
+	w.processJob(ctx, m, cwd, pp)
+}
+
+func TestProcessJob_OrderedPlan_GetTaskPut(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical: "main",
+		PipelineName:  "test-pipeline",
+		JobName:       "ordered-job",
+		VersionID:     1,
+	}
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "ordered-job",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeGet,
+						Get:  &job.GetStep{Type: "cron", Name: "my-cron", Trigger: true},
+					},
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "build",
+							Run:  utils.RunnerCommand{Runner: "exec", Params: map[string]string{"path": "echo", "args": "building"}},
+						},
+					},
+					{
+						Type: job.StepTypePut,
+						Put:  &job.PutStep{Type: "git", Name: "repo"},
+					},
+				},
+			},
+		},
+		Resources: []resource.Resource{
+			{ID: 1, Name: "my-cron", Type: "cron", Canonical: "cron.my-cron"},
+			{ID: 2, Name: "repo", Type: "git", Canonical: "git.repo"},
+		},
+		ResourceTypes: []restype.ResourceType{
+			{
+				ID: 1, Name: "cron",
+				Pull: utils.RunnerCommand{Runner: "exec", Params: map[string]string{"path": "echo", "args": "pulling"}},
+			},
+			{
+				ID: 2, Name: "git",
+				Push: utils.RunnerCommand{Runner: "exec", Params: map[string]string{"path": "echo", "args": "pushing"}},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().CreateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, gomock.Any()).
+		Return(&build.Build{ID: 90}, nil)
+	svc.EXPECT().GetPipelineJob(ctx, m.TeamCanonical, m.PipelineName, m.JobName).
+		Return(&pp.Jobs[0], nil)
+	svc.EXPECT().ListResourceVersions(ctx, m.TeamCanonical, m.PipelineName, "cron.my-cron").
+		Return([]*resource.Version{
+			{ID: 1, Version: map[string]interface{}{"date": "now"}},
+		}, nil)
+
+	// UpdateJobBuild: after get + after task + after put + after success = 4
+	svc.EXPECT().UpdateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, uint32(90), gomock.Any()).
+		Return(nil).Times(4)
+
+	w.processJob(ctx, m, cwd, pp)
 }
 
 // Silence the unused import warnings


### PR DESCRIPTION
## Summary
- Replace separate `Get`/`Task` arrays with single ordered `Plan []PlanStep` on jobs and `Steps []Step` on builds
- Add `put` step type that invokes `resource_type.push` to push content to resources
- Parse HCL blocks in source order using `hclsyntax`, preserving interleaved get/task/put execution order
- Add V9 DB migration, update pipeline graph with put-step edges, update frontend template

Closes #169
Closes #72

## Test plan
- [x] `go build ./...` compiles
- [x] `go test ./...` all tests pass
- [x] `go tool staticcheck ./...` no new warnings
- [ ] Manual: create pipeline with interleaved get/task/put, verify execution order
- [ ] Manual: verify existing get-then-task pipelines still work