### PR TITLE
Replace shellquote splitting with native HCL list args (#201)

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -203,14 +203,14 @@ job "build" {
   task "build" {
     run "exec" {
       path = "make"
-      args = "-C ${var.repo_name} release"
+      args = ["-C", "${var.repo_name}", "release"]
     }
   }
 }
 ```
 
 Will use `exec` when running the task `build`, and all the content of the `run`  will be passed to the `runner` as env variables,
-in this case `$path` and `$args` will be available to be used on the `runner`.
+in this case `$path` will be available to be used on the `runner`. The `$args` placeholder in the runner definition is replaced by the `args` list from the `run` block.
 
 The runner `exec` will be always available to be used (no need to define it) and it looks like:
 
@@ -223,7 +223,7 @@ runner "exec" {
 }
 ```
 
-So to use it you need to pass a `path` and `args` to the block. If you want to pass multiline or separate arguments, here is an example:
+So to use it you need to pass a `path` and `args` to the block. Each element of the `args` list is passed as a single argument:
 
 ```hcl
 job "build" {
@@ -234,17 +234,11 @@ job "build" {
   task "build" {
     run "exec" {
       path = "make"
-      args = <<-EOT
-          '-C'
-          '${var.repo_name}'
-          'release'
-        EOT
+      args = ["-C", "${var.repo_name}", "release"]
     }
   }
 }
 ```
-
-The logic for separating the `args` (as this is just a 1 string with `\n`) is implemented using the [go-shellquote#Split](https://github.com/kballard/go-shellquote) for reference, so using in this case `'arg1' 'arg2'`
 
 #### `run`
 
@@ -256,7 +250,7 @@ The name of or path to the executable to run.
 
 ##### `args`
 
-Arguments to pass to the command.
+A list of arguments to pass to the command. Each element is passed as a single argument (no shell-style splitting).
 
 #### Example
 
@@ -307,7 +301,7 @@ job "my_job" {
   task "echo" {
     run "exec" {
       path = "echo"
-      args = "'IN'"
+      args = ["IN"]
     }
   }
 }

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -203,7 +203,11 @@ job "build" {
   task "build" {
     run "exec" {
       path = "make"
-      args = ["-C", "${var.repo_name}", "release"]
+      args = [
+        "-C",
+        "${var.repo_name}",
+        "release",
+      ]
     }
   }
 }
@@ -234,7 +238,11 @@ job "build" {
   task "build" {
     run "exec" {
       path = "make"
-      args = ["-C", "${var.repo_name}", "release"]
+      args = [
+        "-C",
+        "${var.repo_name}",
+        "release",
+      ]
     }
   }
 }
@@ -301,7 +309,9 @@ job "my_job" {
   task "echo" {
     run "exec" {
       path = "echo"
-      args = ["IN"]
+      args = [
+        "IN",
+      ]
     }
   }
 }
@@ -363,25 +373,29 @@ resource_type "git" {
   ]
   check "exec" {
     path = "/bin/sh"
-    args = <<-EOT
-        '-ec'
-        'git clone --quiet $param_url $param_name
-        cd $param_name
-        if [[ -n $version_ref ]]; then
-          git log $version_ref..HEAD --pretty=format:"%H" | jq -Rsc "(. / \"\n\" | map(select(length>0) | { "ref": . }))"
-        else
-          git log -1 --pretty=format:"%H" | jq -Rsc "(. / \"\n\" | map(select(length>0) | { "ref": . }))"
-        fi'
+    args = [
+      "-ec",
+      <<-EOT
+      git clone --quiet $param_url $param_name
+      cd $param_name
+      if [[ -n $version_ref ]]; then
+        git log $version_ref..HEAD --pretty=format:"%H" | jq -Rsc "(. / \"\n\" | map(select(length>0) | { \"ref\": . }))"
+      else
+        git log -1 --pretty=format:"%H" | jq -Rsc "(. / \"\n\" | map(select(length>0) | { \"ref\": . }))"
+      fi
       EOT
+    ]
   }
   pull "exec" {
     path = "/bin/sh"
-    args = <<-EOT
-        '-ec'
-        'git clone $param_url $param_name
-        cd $param_name
-        git checkout $version_ref'
+    args = [
+      "-ec",
+      <<-EOT
+      git clone $param_url $param_name
+      cd $param_name
+      git checkout $version_ref
       EOT
+    ]
   }
   push "exec" { }
 }
@@ -528,11 +542,11 @@ job "gen" {
   task "gen" {
     run "exec" {
       path = "make"
-      args = <<-EOT
-          '-C'
-          '${var.repo_name}'
-          'gen'
-        EOT
+      args = [
+        "-C",
+        "${var.repo_name}",
+        "gen",
+      ]
     }
     on_success "exec" {
       path = "ls"
@@ -548,11 +562,11 @@ job "test" {
   task "test" {
     run "exec" {
       path = "make"
-      args = <<-EOT
-          '-C'
-          '${var.repo_name}'
-          'test'
-        EOT
+      args = [
+        "-C",
+        "${var.repo_name}",
+        "test",
+      ]
     }
   }
   ensure "exec" {

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/gosimple/slug v1.15.0
 	github.com/hashicorp/hcl/v2 v2.24.0
-	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/knadh/koanf/parsers/json v1.0.0
 	github.com/knadh/koanf/providers/cliflagv3 v1.1.0
 	github.com/knadh/koanf/providers/env/v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,6 @@ github.com/jcmturner/gokrb5/v8 v8.4.4/go.mod h1:1btQEpgT6k+unzCwX1KdWMEwPPkkgBtP
 github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
-github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
-github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=
 github.com/klauspost/compress v1.18.2/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/knadh/koanf/maps v0.1.2 h1:RBfmAW5CnZT+PJ1CVc1QSJKf4Xu9kxfQgYVQSu8hpbo=

--- a/integration/pikoci_test.go
+++ b/integration/pikoci_test.go
@@ -267,7 +267,7 @@ job "gen" {
   task "echo" {
     run "exec" {
       path = "echo"
-      args = "'IN'"
+      args = ["IN"]
     }
   }
 }`)
@@ -313,7 +313,7 @@ job "gen" {
   task "echo" {
     run "exec" {
       path = "echo"
-      args = "'IN'"
+      args = ["IN"]
     }
   }
 }`)
@@ -455,7 +455,7 @@ job "gen" {
   task "echo" {
     run "exec" {
       path = "echo"
-      args = "'IN'"
+      args = ["IN"]
     }
   }
 }`)

--- a/pikoci/job/job_test.go
+++ b/pikoci/job/job_test.go
@@ -82,7 +82,7 @@ func TestPlanStep_JSONMarshalUnmarshal(t *testing.T) {
 			Type: job.StepTypePut,
 			Put:  &job.PutStep{Type: "docker", Name: "image", Params: map[string]string{"tag": "latest"}},
 			OnSuccess: []utils.RunnerCommand{
-				{Runner: "exec", Params: map[string]string{"path": "echo", "args": "done"}},
+				{Runner: "exec", Args: []string{"done"}, Params: map[string]string{"path": "echo"}},
 			},
 		},
 	}

--- a/pikoci/pipeline/pipeline.go
+++ b/pikoci/pipeline/pipeline.go
@@ -42,9 +42,9 @@ func (pp *Pipeline) ResourceType(rtn string) (restype.ResourceType, bool) {
 			Name: "cron",
 			Check: utils.RunnerCommand{
 				Runner: "exec",
+				Args:   []string{"-ec", `echo [{"date":"$(date)"}]`},
 				Params: map[string]string{
 					"path": "/bin/sh",
-					"args": `-ec 'echo [{\"date\":\"$(date)\"}]'`,
 				},
 			},
 		}, true

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -103,15 +103,15 @@ resource_type "git" {
   params = ["url"]
   check "exec" {
     path = "echo"
-    args = "check"
+    args = ["check"]
   }
   pull "exec" {
     path = "echo"
-    args = "pull"
+    args = ["pull"]
   }
   push "exec" {
     path = "echo"
-    args = "push"
+    args = ["push"]
   }
 }
 
@@ -133,7 +133,7 @@ job "deploy" {
   task "build" {
     run "exec" {
       path = "echo"
-      args = "building"
+      args = ["building"]
     }
   }
   put "git" "repo" {
@@ -183,7 +183,7 @@ job "test" {
   task "echo" {
     run "exec" {
       path = "echo"
-      args = "hello"
+      args = ["hello"]
     }
   }
 }

--- a/pikoci/testdata/cron.hcl
+++ b/pikoci/testdata/cron.hcl
@@ -10,7 +10,7 @@ job "gen" {
   task "echo" {
     run "exec" {
       path = "echo"
-      args = "'IN'"
+      args = ["IN"]
     }
   }
 }

--- a/pikoci/testdata/pipeline.hcl
+++ b/pikoci/testdata/pipeline.hcl
@@ -5,25 +5,29 @@ resource_type "git" {
   ]
   check "exec" {
     path = "/bin/sh"
-    args = <<-EOT
-        '-ec'
-        'git clone --quiet $param_url $param_name
-        cd $param_name
-        if [[ -n $version_ref ]]; then
-          git log $version_ref..HEAD --pretty=format:"%H" | jq -Rsc "(. / \"\n\" | map(select(length>0) | { "ref": . }))"
-        else
-          git log -1 --pretty=format:"%H" | jq -Rsc "(. / \"\n\" | map(select(length>0) | { "ref": . }))"
-        fi'
+    args = [
+      "-ec",
+      <<-EOT
+      git clone --quiet $param_url $param_name
+      cd $param_name
+      if [[ -n $version_ref ]]; then
+        git log $version_ref..HEAD --pretty=format:"%H" | jq -Rsc "(. / \"\n\" | map(select(length>0) | { \"ref\": . }))"
+      else
+        git log -1 --pretty=format:"%H" | jq -Rsc "(. / \"\n\" | map(select(length>0) | { \"ref\": . }))"
+      fi
       EOT
+    ]
   }
   pull "exec" {
     path = "/bin/sh"
-    args = <<-EOT
-        '-ec'
-        'git clone $param_url $param_name
-        cd $param_name
-        git checkout $version_ref'
+    args = [
+      "-ec",
+      <<-EOT
+      git clone $param_url $param_name
+      cd $param_name
+      git checkout $version_ref
       EOT
+    ]
   }
   push "exec" { }
 }
@@ -81,7 +85,7 @@ job "build" {
   task "build" {
     run "exec" {
       path = "make"
-      args = "-C ${var.repo_name} release"
+      args = ["-C", "${var.repo_name}", "release"]
     }
   }
 }

--- a/pikoci/testdata/put.hcl
+++ b/pikoci/testdata/put.hcl
@@ -5,15 +5,15 @@ resource_type "git" {
   ]
   check "exec" {
     path = "/bin/sh"
-    args = "-ec 'echo [{\"ref\":\"abc\"}]'"
+    args = ["-ec", "echo [{\\\"ref\\\":\\\"abc\\\"}]"]
   }
   pull "exec" {
     path = "/bin/sh"
-    args = "-ec 'echo pulling'"
+    args = ["-ec", "echo pulling"]
   }
   push "exec" {
     path = "/bin/sh"
-    args = "-ec 'echo pushing'"
+    args = ["-ec", "echo pushing"]
   }
 }
 
@@ -36,7 +36,7 @@ job "build-and-push" {
   task "build" {
     run "exec" {
       path = "echo"
-      args = "building"
+      args = ["building"]
     }
   }
   put "git" "repo" {

--- a/pikoci/testdata/tutorial.hcl
+++ b/pikoci/testdata/tutorial.hcl
@@ -5,25 +5,29 @@ resource_type "git" {
   ]
   check "exec" {
     path = "/bin/sh"
-    args = <<-EOT
-        '-ec'
-        'git clone --quiet $param_url $param_name
-        cd $param_name
-        if [[ -n $version_ref ]]; then
-          git log $version_ref..HEAD --pretty=format:"%H" | jq -Rsc "(. / \"\n\" | map(select(length>0) | { "ref": . }))"
-        else
-          git log -1 --pretty=format:"%H" | jq -Rsc "(. / \"\n\" | map(select(length>0) | { "ref": . }))"
-        fi'
+    args = [
+      "-ec",
+      <<-EOT
+      git clone --quiet $param_url $param_name
+      cd $param_name
+      if [[ -n $version_ref ]]; then
+        git log $version_ref..HEAD --pretty=format:"%H" | jq -Rsc "(. / \"\n\" | map(select(length>0) | { \"ref\": . }))"
+      else
+        git log -1 --pretty=format:"%H" | jq -Rsc "(. / \"\n\" | map(select(length>0) | { \"ref\": . }))"
+      fi
       EOT
+    ]
   }
   pull "exec" {
     path = "/bin/sh"
-    args = <<-EOT
-        '-ec'
-        'git clone $param_url $param_name
-        cd $param_name
-        git checkout $version_ref'
+    args = [
+      "-ec",
+      <<-EOT
+      git clone $param_url $param_name
+      cd $param_name
+      git checkout $version_ref
       EOT
+    ]
   }
   push "exec" { }
 }

--- a/pikoci/utils/run_command.go
+++ b/pikoci/utils/run_command.go
@@ -2,6 +2,7 @@ package utils
 
 type RunnerCommand struct {
 	Runner string            `json:"runner" hcl:"runner,label"`
+	Args   []string          `json:"args" hcl:"args,optional"`
 	Params map[string]string `json:"params" hcl:",remain"`
 }
 

--- a/worker/service.go
+++ b/worker/service.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/adrg/xdg"
 	"github.com/google/uuid"
-	"github.com/kballard/go-shellquote"
 	"github.com/xescugc/pikoci/pikoci"
 	"github.com/xescugc/pikoci/pikoci/build"
 	"github.com/xescugc/pikoci/pikoci/job"
@@ -227,7 +226,12 @@ func (w *Worker) runGetStep(ctx context.Context, m queue.Body, b *build.Build, c
 		return false
 	}
 
-	out, d, err := w.runRunner(ctx, ru, cwd, params)
+	rc := utils.RunnerCommand{
+		Runner: rt.Pull.Runner,
+		Args:   rt.Pull.Args,
+		Params: params,
+	}
+	out, d, err := w.runRunner(ctx, ru, cwd, rc)
 	if err != nil {
 		b.Steps = append(b.Steps, build.Step{Type: "get", Name: g.Name, Logs: out, Duration: d})
 		b.Status = build.Failed
@@ -261,7 +265,7 @@ func (w *Worker) runTaskStep(ctx context.Context, m queue.Body, b *build.Build, 
 		return false
 	}
 
-	out, d, err := w.runRunner(ctx, ru, cwd, t.Run.Params)
+	out, d, err := w.runRunner(ctx, ru, cwd, t.Run)
 	if err != nil {
 		b.Steps = append(b.Steps, build.Step{Type: "task", Name: t.Name, Logs: out, Duration: d})
 		b.Status = build.Failed
@@ -313,7 +317,12 @@ func (w *Worker) runPutStep(ctx context.Context, m queue.Body, b *build.Build, c
 		return false
 	}
 
-	out, d, err := w.runRunner(ctx, ru, cwd, params)
+	rc := utils.RunnerCommand{
+		Runner: rt.Push.Runner,
+		Args:   rt.Push.Args,
+		Params: params,
+	}
+	out, d, err := w.runRunner(ctx, ru, cwd, rc)
 	if err != nil {
 		b.Steps = append(b.Steps, build.Step{Type: "put", Name: p.Name, Logs: out, Duration: d})
 		b.Status = build.Failed
@@ -418,7 +427,7 @@ func (w *Worker) runHooks(ctx context.Context, m queue.Body, b *build.Build, ste
 		if !ok {
 			continue
 		}
-		out, d, _ := w.runRunner(ctx, ru, cwd, h.Params)
+		out, d, _ := w.runRunner(ctx, ru, cwd, h)
 
 		name := hookType
 		if stepName != "" {
@@ -473,7 +482,12 @@ func (w *Worker) processResourceCheck(ctx context.Context, m queue.Body, cwd str
 		return
 	}
 
-	out, _, err := w.runRunner(ctx, ru, cwd, params)
+	rc := utils.RunnerCommand{
+		Runner: rt.Check.Runner,
+		Args:   rt.Check.Args,
+		Params: params,
+	}
+	out, _, err := w.runRunner(ctx, ru, cwd, rc)
 	if err != nil {
 		r.Logs = out
 		if nerr := w.pikoci.UpdatePipelineResource(ctx, m.TeamCanonical, m.PipelineName, r.Canonical, r); nerr != nil {
@@ -574,9 +588,9 @@ func (w *Worker) deleteBuild(ctx context.Context, m queue.Body, b build.Build) {
 	}
 }
 
-func (w *Worker) runRunner(ctx context.Context, ru runner.Runner, cwd string, params map[string]string) (string, time.Duration, error) {
+func (w *Worker) runRunner(ctx context.Context, ru runner.Runner, cwd string, rc utils.RunnerCommand) (string, time.Duration, error) {
 	envs := map[string]string{"WORKDIR": cwd}
-	for k, v := range params {
+	for k, v := range rc.Params {
 		envs[k] = v
 	}
 	envFn := func(p string) string {
@@ -589,16 +603,19 @@ func (w *Worker) runRunner(ctx context.Context, ru runner.Runner, cwd string, pa
 	var args []string
 	var out string
 	for _, a := range ru.Run.Args {
-		ea := os.Expand(a, envFn)
-		if ea == "" {
+		if a == "$args" {
+			for _, ca := range rc.Args {
+				ea := os.Expand(ca, envFn)
+				if ea != "" {
+					args = append(args, ea)
+				}
+			}
 			continue
 		}
-		sea, err := shellquote.Split(ea)
-		if err != nil {
-			out += "\n" + err.Error()
-			return out, time.Duration(1), err
+		ea := os.Expand(a, envFn)
+		if ea != "" {
+			args = append(args, ea)
 		}
-		args = append(args, sea...)
 	}
 
 	cmd := exec.CommandContext(ctx, os.Expand(ru.Run.Path, envFn), args...)

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -55,9 +55,9 @@ func testPipeline() *pipeline.Pipeline {
 							Name: "echo",
 							Run: utils.RunnerCommand{
 								Runner: "exec",
+								Args:   []string{"hello"},
 								Params: map[string]string{
 									"path": "echo",
-									"args": "hello",
 								},
 							},
 						},
@@ -81,9 +81,9 @@ func testPipeline() *pipeline.Pipeline {
 				Params: []string{},
 				Check: utils.RunnerCommand{
 					Runner: "exec",
+					Args:   []string{"-ec", `echo [{"date":"now"}]`},
 					Params: map[string]string{
 						"path": "/bin/sh",
-						"args": `-ec 'echo [{"date":"now"}]'`,
 					},
 				},
 				Pull: utils.RunnerCommand{
@@ -129,9 +129,9 @@ func TestProcessJob_Success_TaskOnly(t *testing.T) {
 							Name: "echo",
 							Run: utils.RunnerCommand{
 								Runner: "exec",
+								Args:   []string{"hello"},
 								Params: map[string]string{
 									"path": "echo",
-									"args": "hello",
 								},
 							},
 						},
@@ -184,7 +184,7 @@ func TestProcessJob_Success_WithGetAndTask(t *testing.T) {
 						Type: job.StepTypeTask,
 						Task: &job.TaskStep{
 							Name: "echo",
-							Run:  utils.RunnerCommand{Runner: "exec", Params: map[string]string{"path": "echo", "args": "hello"}},
+							Run:  utils.RunnerCommand{Runner: "exec", Args: []string{"hello"}, Params: map[string]string{"path": "echo"}},
 						},
 					},
 				},
@@ -198,7 +198,8 @@ func TestProcessJob_Success_WithGetAndTask(t *testing.T) {
 				ID: 1, Name: "cron",
 				Pull: utils.RunnerCommand{
 					Runner: "exec",
-					Params: map[string]string{"path": "echo", "args": "pulling"},
+					Args:   []string{"pulling"},
+					Params: map[string]string{"path": "echo"},
 				},
 			},
 		},
@@ -356,16 +357,15 @@ func TestProcessJob_TaskFailure_RunsHooks(t *testing.T) {
 								Runner: "exec",
 								Params: map[string]string{
 									"path": "false", // exits with code 1
-									"args": "",
 								},
 							},
 						},
 						OnFailure: []utils.RunnerCommand{
 							{
 								Runner: "exec",
+								Args:   []string{"task failed"},
 								Params: map[string]string{
 									"path": "echo",
-									"args": "task failed",
 								},
 							},
 						},
@@ -374,18 +374,18 @@ func TestProcessJob_TaskFailure_RunsHooks(t *testing.T) {
 				OnFailure: []utils.RunnerCommand{
 					{
 						Runner: "exec",
+						Args:   []string{"job failed"},
 						Params: map[string]string{
 							"path": "echo",
-							"args": "job failed",
 						},
 					},
 				},
 				Ensure: []utils.RunnerCommand{
 					{
 						Runner: "exec",
+						Args:   []string{"always runs"},
 						Params: map[string]string{
 							"path": "echo",
-							"args": "always runs",
 						},
 					},
 				},
@@ -444,9 +444,9 @@ func TestProcessJob_TriggersDownstream(t *testing.T) {
 							Name: "echo",
 							Run: utils.RunnerCommand{
 								Runner: "exec",
+								Args:   []string{"hello"},
 								Params: map[string]string{
 									"path": "echo",
-									"args": "hello",
 								},
 							},
 						},
@@ -541,9 +541,9 @@ func TestProcessResourceCheck_NewVersions(t *testing.T) {
 				ID: 1, Name: "cron",
 				Check: utils.RunnerCommand{
 					Runner: "exec",
+					Args:   []string{"-ec", `printf "[{\"date\":\"now\"}]\n"`},
 					Params: map[string]string{
 						"path": "/bin/sh",
-						"args": `-ec 'printf "[{\"date\":\"now\"}]\n"'`,
 					},
 				},
 			},
@@ -631,8 +631,8 @@ func TestRunHooks(t *testing.T) {
 	}
 
 	hooks := []utils.RunnerCommand{
-		{Runner: "exec", Params: map[string]string{"path": "echo", "args": "hook1"}},
-		{Runner: "exec", Params: map[string]string{"path": "echo", "args": "hook2"}},
+		{Runner: "exec", Args: []string{"hook1"}, Params: map[string]string{"path": "echo"}},
+		{Runner: "exec", Args: []string{"hook2"}, Params: map[string]string{"path": "echo"}},
 	}
 
 	// 2 hooks = 2 UpdateJobBuild calls
@@ -663,7 +663,7 @@ func TestRunHooks_SingleHook_NoIndex(t *testing.T) {
 	b := build.Build{ID: 61, Job: []build.Step{}}
 
 	hooks := []utils.RunnerCommand{
-		{Runner: "exec", Params: map[string]string{"path": "echo", "args": "only"}},
+		{Runner: "exec", Args: []string{"only"}, Params: map[string]string{"path": "echo"}},
 	}
 
 	svc.EXPECT().UpdateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, uint32(61), gomock.Any()).
@@ -692,7 +692,7 @@ func TestRunHooks_JobLevel_NoStepName(t *testing.T) {
 	b := build.Build{ID: 62, Job: []build.Step{}}
 
 	hooks := []utils.RunnerCommand{
-		{Runner: "exec", Params: map[string]string{"path": "echo", "args": "job-level"}},
+		{Runner: "exec", Args: []string{"job-level"}, Params: map[string]string{"path": "echo"}},
 	}
 
 	svc.EXPECT().UpdateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, uint32(62), gomock.Any()).
@@ -864,7 +864,8 @@ func TestProcessJob_PutStep_Success(t *testing.T) {
 							Name: "build",
 							Run: utils.RunnerCommand{
 								Runner: "exec",
-								Params: map[string]string{"path": "echo", "args": "building"},
+								Args:   []string{"building"},
+								Params: map[string]string{"path": "echo"},
 							},
 						},
 					},
@@ -888,7 +889,8 @@ func TestProcessJob_PutStep_Success(t *testing.T) {
 				Params: []string{"url"},
 				Push: utils.RunnerCommand{
 					Runner: "exec",
-					Params: map[string]string{"path": "echo", "args": "pushing"},
+					Args:   []string{"pushing"},
+					Params: map[string]string{"path": "echo"},
 				},
 			},
 		},
@@ -938,7 +940,7 @@ func TestProcessJob_OrderedPlan_GetTaskPut(t *testing.T) {
 						Type: job.StepTypeTask,
 						Task: &job.TaskStep{
 							Name: "build",
-							Run:  utils.RunnerCommand{Runner: "exec", Params: map[string]string{"path": "echo", "args": "building"}},
+							Run:  utils.RunnerCommand{Runner: "exec", Args: []string{"building"}, Params: map[string]string{"path": "echo"}},
 						},
 					},
 					{
@@ -955,11 +957,11 @@ func TestProcessJob_OrderedPlan_GetTaskPut(t *testing.T) {
 		ResourceTypes: []restype.ResourceType{
 			{
 				ID: 1, Name: "cron",
-				Pull: utils.RunnerCommand{Runner: "exec", Params: map[string]string{"path": "echo", "args": "pulling"}},
+				Pull: utils.RunnerCommand{Runner: "exec", Args: []string{"pulling"}, Params: map[string]string{"path": "echo"}},
 			},
 			{
 				ID: 2, Name: "git",
-				Push: utils.RunnerCommand{Runner: "exec", Params: map[string]string{"path": "echo", "args": "pushing"}},
+				Push: utils.RunnerCommand{Runner: "exec", Args: []string{"pushing"}, Params: map[string]string{"path": "echo"}},
 			},
 		},
 		Runners: []runner.Runner{


### PR DESCRIPTION
## Summary

- Remove `go-shellquote` dependency; each `args` list element is now passed as a single argument without shell-style parsing
- Add `Args []string` field to `RunnerCommand` and handle `$args` placeholder by splicing the list into runner args
- Update all HCL configs, tests, and docs to use native list syntax for `args`