### PR TITLE
Add source mechanism, built-ins, and HCL functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,18 @@
 
 ## Unreleased
 
+- Add `source` field on `resource_type` and `runner` blocks for URL-based definition sharing (`pikoci://` and `https://` schemes), built-in `git` resource type with API-aware check for GitHub/GitLab, built-in `docker` runner, HCL standard functions (string, collection, numeric, encoding, regex), and optional `params` on resource types ([#11](https://github.com/xescugc/pikoci/issues/11), [#143](https://github.com/xescugc/pikoci/issues/143), [#206](https://github.com/xescugc/pikoci/issues/206), [#104](https://github.com/xescugc/pikoci/issues/104))
+- Add `docs/` folder with GitHub Actions workflow to sync wiki on push ([#211](https://github.com/xescugc/pikoci/issues/211))
+- Add public pipelines support: pipelines can be marked public, exposing read-only views of the graph, jobs, builds, and resources without authentication ([#100](https://github.com/xescugc/pikoci/issues/100))
+- Add webhook triggers for resources: each resource gets a webhook token for external trigger via `POST /webhooks/<token>`, with token regeneration endpoint ([#144](https://github.com/xescugc/pikoci/issues/144), [#181](https://github.com/xescugc/pikoci/issues/181))
+- Replace shellquote splitting with native HCL list args for runner command arguments ([#201](https://github.com/xescugc/pikoci/issues/201))
 - Replace pixel-art PNG logo/favicon with new hexagonal SVG logo using PICO-8 brand colors, remove old `aseprite/` folder ([#202](https://github.com/xescugc/pikoci/issues/202))
-- Add ordered plan execution and `put` step support: jobs now execute `get`, `task`, and `put` steps in the order they appear in HCL, enabling CD workflows like build→push→deploy. The `put` step invokes `resource_type.push` to push content to resources ([#169](https://github.com/xescugc/pikoci/issues/169), [#72](https://github.com/xescugc/pikoci/issues/72))
+- Add ordered plan execution and `put` step support: jobs now execute `get`, `task`, and `put` steps in the order they appear in HCL, enabling CD workflows like build, push, deploy. The `put` step invokes `resource_type.push` to push content to resources ([#169](https://github.com/xescugc/pikoci/issues/169), [#72](https://github.com/xescugc/pikoci/issues/72))
+- Fix SPA catch-all intercepting API requests ([#140](https://github.com/xescugc/pikoci/issues/140))
+- Rename QID to PikoCI ([#136](https://github.com/xescugc/pikoci/issues/136))
 - Redesign UI with PICO-8 color palette, Plus Jakarta Sans / JetBrains Mono fonts, dark mode toggle, improved pipeline graph styling, and modernized layout for all views ([#133](https://github.com/xescugc/pikoci/issues/133))
 - CLI auto-refreshes stale JWT when backend returns `X-Refresh-Token` header, persisting the new token to disk ([#130](https://github.com/xescugc/pikoci/issues/130))
+- Add PostgreSQL, RabbitMQ, and Kafka backend support with integration tests ([#128](https://github.com/xescugc/pikoci/pull/128))
 - Fix entity still shown in collection when backend creation fails: add Unit of Work (transaction) pattern for multi-step DB operations and `wait: true` to frontend `collection.create()` calls ([#123](https://github.com/xescugc/pikoci/issues/123))
 - Fix user permission changes not reflected until re-login: backend signals stale JWT via `X-Refresh-Token` header, frontend auto-refreshes session ([#126](https://github.com/xescugc/pikoci/pull/126))
 - Add users and teams with role-based access control, refactor HTTP transport from go-kit to direct handlers ([#124](https://github.com/xescugc/pikoci/pull/124))

--- a/docs/Functions.md
+++ b/docs/Functions.md
@@ -1,0 +1,114 @@
+# Functions
+
+HCL functions are available in pipeline definitions for string manipulation, collection operations, encoding, and more.
+
+## String functions
+
+| Function      | Description                              | Example                                  |
+|---------------|------------------------------------------|------------------------------------------|
+| `chomp`       | Remove trailing newline                  | `chomp("hello\n")` -> `"hello"`          |
+| `format`      | Format a string (printf-style)           | `format("v%s-%s", "1.0", "prod")` -> `"v1.0-prod"` |
+| `formatlist`  | Format each element in a list            | `formatlist("-%s", ["a","b"])` -> `["-a","-b"]` |
+| `indent`      | Indent all lines of a string             | `indent(2, "a\nb")` -> `"a\n  b"`       |
+| `join`        | Join list elements with separator        | `join(",", ["a","b","c"])` -> `"a,b,c"`  |
+| `lower`       | Convert to lowercase                     | `lower("HELLO")` -> `"hello"`           |
+| `replace`     | Replace substring                        | `replace("hello", "l", "r")` -> `"herro"` |
+| `split`       | Split string into list                   | `split(",", "a,b,c")` -> `["a","b","c"]` |
+| `substr`      | Extract substring                        | `substr("hello", 1, 3)` -> `"ell"`      |
+| `title`       | Capitalize first letter of each word     | `title("hello world")` -> `"Hello World"` |
+| `trim`        | Remove characters from both ends         | `trim("?!hello?!", "!?")` -> `"hello"`  |
+| `trimprefix`  | Remove prefix                            | `trimprefix("helloworld", "hello")` -> `"world"` |
+| `trimsuffix`  | Remove suffix                            | `trimsuffix("helloworld", "world")` -> `"hello"` |
+| `trimspace`   | Remove leading/trailing whitespace       | `trimspace("  hello  ")` -> `"hello"`   |
+| `upper`       | Convert to uppercase                     | `upper("hello")` -> `"HELLO"`           |
+
+## Collection functions
+
+| Function    | Description                              | Example                                  |
+|-------------|------------------------------------------|------------------------------------------|
+| `concat`    | Concatenate lists                        | `concat(["a"], ["b"])` -> `["a","b"]`    |
+| `contains`  | Check if list/set contains value         | `contains(["a","b"], "a")` -> `true`     |
+| `distinct`  | Remove duplicates from list              | `distinct(["a","a","b"])` -> `["a","b"]` |
+| `flatten`   | Flatten nested lists                     | `flatten([["a"],["b"]])` -> `["a","b"]`  |
+| `keys`      | Get map keys                             | `keys({a=1, b=2})` -> `["a","b"]`       |
+| `length`    | Get length of list, map, or string       | `length(["a","b"])` -> `2`               |
+| `lookup`    | Look up value in map with default        | `lookup({a="1"}, "a", "0")` -> `"1"`    |
+| `merge`     | Merge maps                               | `merge({a=1}, {b=2})` -> `{a=1, b=2}`   |
+| `reverse`   | Reverse a list                           | `reverse(["a","b"])` -> `["b","a"]`      |
+| `sort`      | Sort a list of strings                   | `sort(["b","a"])` -> `["a","b"]`         |
+| `values`    | Get map values                           | `values({a=1, b=2})` -> `[1, 2]`        |
+
+## Numeric functions
+
+| Function | Description                | Example                    |
+|----------|----------------------------|----------------------------|
+| `abs`    | Absolute value             | `abs(-5)` -> `5`          |
+| `ceil`   | Round up to nearest integer| `ceil(1.2)` -> `2`        |
+| `floor`  | Round down to nearest integer| `floor(1.8)` -> `1`     |
+| `max`    | Maximum of given numbers   | `max(1, 3, 2)` -> `3`     |
+| `min`    | Minimum of given numbers   | `min(1, 3, 2)` -> `1`     |
+
+## Encoding functions
+
+| Function     | Description                | Example                              |
+|--------------|----------------------------|--------------------------------------|
+| `jsonencode` | Encode value as JSON       | `jsonencode({a=1})` -> `"{\"a\":1}"` |
+| `jsondecode` | Decode JSON string         | `jsondecode("{\"a\":1}")` -> `{a=1}` |
+| `csvdecode`  | Decode CSV string          | `csvdecode("a,b\n1,2")` -> list of maps |
+
+## Regex functions
+
+| Function       | Description                         | Example                                   |
+|----------------|-------------------------------------|-------------------------------------------|
+| `regex`        | Match regex, return first match     | `regex("v(\\d+)", "v123")` -> `"123"`     |
+| `regexall`     | Match regex, return all matches     | `regexall("\\d+", "a1b2")` -> `["1","2"]` |
+| `regexreplace` | Replace regex matches               | `regexreplace("hello", "l+", "r")` -> `"hero"` |
+
+## Practical examples
+
+Building docker args:
+
+```hcl
+task "test" {
+  run "docker" {
+    image = "golang:1.23"
+    cmd   = "make test"
+    args  = concat(
+      ["-e", "CI=true"],
+      ["-v", "/cache:/cache"],
+    )
+  }
+}
+```
+
+String formatting:
+
+```hcl
+variable "version" {
+  type    = string
+  default = "1.0"
+}
+
+variable "env" {
+  type    = string
+  default = "prod"
+}
+
+task "tag" {
+  run "exec" {
+    path = "echo"
+    args = [format("v%s-%s", var.version, var.env)]
+  }
+}
+```
+
+Joining values:
+
+```hcl
+task "echo" {
+  run "exec" {
+    path = "echo"
+    args = [join(",", ["a", "b", "c"])]
+  }
+}
+```

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -11,6 +11,7 @@ PikoCI is a portable, self-hosted CI/CD system. One binary, any database, any qu
 - [Server Configuration](Server) - Server flags and options
 - [Database Backends](Database) - Supported database systems
 - [Queue Backends](Queue) - Supported queue/pubsub systems
+- [Functions](Functions) - HCL functions available in pipelines
 - [Variables and Secrets](Variables) - Pipeline variables
 - [CLI Reference](CLI) - Client commands and flags
 - [Public Pipelines](Public-Pipelines) - Sharing pipeline status publicly

--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -50,6 +50,14 @@ resource_type "git" {
 }
 ```
 
+| Field    | Required | Description                                         |
+|----------|----------|-----------------------------------------------------|
+| `name`   | yes      | Label on the block                                  |
+| `source` | no       | URL to fetch definition (e.g. `pikoci://git`)       |
+| `params` | no       | List of parameter names                             |
+
+When `source` is set, inline commands are not needed.
+
 ## resource
 
 An instance of a resource type. See [Resource Types](Resource-Types).
@@ -93,6 +101,13 @@ runner "docker" {
   }
 }
 ```
+
+| Field    | Required | Description                                    |
+|----------|----------|------------------------------------------------|
+| `name`   | yes      | Label on the block                             |
+| `source` | no       | URL to fetch definition (e.g. `pikoci://docker`) |
+
+When `source` is set, inline `run` block is not needed.
 
 ## job
 
@@ -200,6 +215,8 @@ task "deploy" {
 
 ## Full example
 
+Using built-in `git` and `docker` (no inline resource_type or runner blocks needed):
+
 ```hcl
 variable "repo_url" {
   type    = string
@@ -211,26 +228,10 @@ variable "repo_name" {
   default = "pikoci"
 }
 
-resource_type "git" {
-  params = ["url", "name"]
-
-  check "exec" {
-    path = "/bin/sh"
-    args = ["-ec", "git ls-remote $param_url HEAD | awk '{print $1}'"]
-  }
-
-  pull "exec" {
-    path = "/bin/sh"
-    args = ["-ec", "git clone $param_url $param_name && git checkout $version_ref"]
-  }
-
-  push "exec" {}
-}
-
 resource "git" "pikoci" {
   params {
     url  = var.repo_url
-    name = "${var.repo_name}"
+    name = var.repo_name
   }
 }
 
@@ -245,9 +246,9 @@ job "test" {
   }
 
   task "run-tests" {
-    run "exec" {
-      path = "/bin/sh"
-      args = ["-ec", "cd ${var.repo_name} && make test"]
+    run "docker" {
+      image = "golang:1.23"
+      cmd   = "cd ${var.repo_name} && make test"
     }
   }
 }

--- a/docs/Resource-Types.md
+++ b/docs/Resource-Types.md
@@ -28,10 +28,13 @@ resource_type "git" {
 | Field    | Required | Description                                         |
 |----------|----------|-----------------------------------------------------|
 | `name`   | yes      | Label on the block                                  |
-| `params` | yes      | List of parameter names the resource type accepts   |
-| `check`  | yes      | Runner command to detect new versions               |
-| `pull`   | yes      | Runner command to fetch a specific version           |
+| `source` | no       | URL to fetch the definition from (mutually exclusive with inline commands) |
+| `params` | no       | List of parameter names the resource type accepts   |
+| `check`  | yes*     | Runner command to detect new versions               |
+| `pull`   | yes*     | Runner command to fetch a specific version           |
 | `push`   | no       | Runner command to publish (used by `put` steps)     |
+
+\* Not required when `source` is set.
 
 ### Operations
 
@@ -56,6 +59,49 @@ Inside `check`, `pull`, and `push` commands, PikoCI exposes:
 | `$put_<key>`        | Put step parameter value (push only)         |
 | `$WORKDIR`          | Temporary working directory for the job      |
 | `$path`, `$args`    | Runner `run` block values (for the exec runner) |
+
+## Sourcing from URL
+
+Instead of defining commands inline, you can point to an external HCL file:
+
+```hcl
+resource_type "my-git" {
+  source = "pikoci://git"
+}
+```
+
+Two URL formats are supported:
+
+- **`pikoci://<name>`** resolves to the PikoCI registry. For shipped built-ins (`git`, `cron`), the embedded definition is used directly (no network call). For other names, fetches from `https://raw.githubusercontent.com/xescugc/pikoci/master/pikoci/builtin/resource_types/<name>.hcl`.
+- **`https://...`** or **`http://...`** fetches HCL from any URL.
+
+When `source` is set, you must not define inline `check`, `pull`, or `push` blocks. PikoCI will error if both are present.
+
+## Overriding built-ins
+
+All built-in resource types (`cron`, `git`) can be overridden by defining a `resource_type` block with the same name in your pipeline. Inline definitions always take precedence over built-ins.
+
+This is useful when the built-in behavior doesn't match your needs. For example, the built-in `git` resource type uses `git ls-remote` or the GitHub/GitLab API to check for new commits. If you need a simpler check (no API, no token support) or want to add custom logic, define your own:
+
+```hcl
+resource_type "git" {
+  params = ["url", "name"]
+
+  check "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "git ls-remote $param_url HEAD | awk '{print $1}' | jq -Rsc '[{\"ref\": .}]'"]
+  }
+
+  pull "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "git clone $param_url $param_name && cd $param_name && git checkout $version_ref"]
+  }
+
+  push "exec" { }
+}
+```
+
+This replaces the built-in `git` entirely for this pipeline. Resources using `resource "git" "..."` will use your definition instead.
 
 ## Defining a resource
 
@@ -114,3 +160,132 @@ The `check_interval` field accepts:
 
 - `@every <duration>`, e.g. `@every 10s`, `@every 5m`, `@every 1h`
 - Standard cron expressions, e.g. `0 */5 * * *`
+
+## Built-in: git
+
+The `git` resource type is built in with API-aware check support for GitHub and GitLab. You do not need to define it, just use it directly:
+
+```hcl
+resource "git" "my-repo" {
+  params {
+    url  = "https://github.com/xescugc/pikoci.git"
+    name = "pikoci"
+  }
+}
+```
+
+### Params
+
+| Param    | Required | Description                                      |
+|----------|----------|--------------------------------------------------|
+| `url`    | yes      | Repository URL (HTTPS)                           |
+| `name`   | yes      | Directory name to clone into                     |
+| `branch` | no       | Branch to track (defaults to HEAD)               |
+| `token`  | no       | API/HTTPS auth token for private repos           |
+| `pr`     | no       | Set to `"true"` to check for open pull requests instead of commits (requires `token`, GitHub/GitLab only) |
+
+### Token setup
+
+**GitHub**: Create a personal access token at **Settings > Developer settings > Personal access tokens > Fine-grained tokens**. The token needs **Contents** (read) permission for commit checks and cloning. For PR mode, it also needs **Pull requests** (read). For private repos, the token must have access to the repository.
+
+**GitLab**: Create a project or personal access token at **Settings > Access Tokens**. The token needs the `read_repository` scope for commit checks and cloning. For PR mode (merge requests), it also needs `read_api`.
+
+Pass the token via a pipeline variable to avoid hardcoding it:
+
+```hcl
+variable "git_token" {
+  type = string
+}
+
+resource "git" "my-repo" {
+  params {
+    url   = "https://github.com/myorg/my-repo.git"
+    name  = "my-repo"
+    token = var.git_token
+  }
+}
+```
+
+Then provide the value in your vars file: `{"git_token": "ghp_..."}`.
+
+### Check behavior
+
+When `token` is provided and the URL matches a supported provider, the check uses the provider's API for efficiency:
+
+- **GitHub** (`github.com`): Uses `GET /repos/{owner}/{repo}/commits?sha={branch}` with `Authorization: token` header
+- **GitLab** (`gitlab.com`): Uses `GET /api/v4/projects/{id}/repository/commits?ref_name={branch}` with `PRIVATE-TOKEN` header
+- **Other providers**: Falls back to `git ls-remote`
+
+Without a token, all providers use `git ls-remote`.
+
+### PR mode
+
+When `pr = "true"` is set, the check command lists open pull requests (or merge requests on GitLab) instead of checking for commits. Each open PR becomes a version with its head SHA and PR number:
+
+```json
+[{"ref": "abc123", "pr": "42"}, {"ref": "def456", "pr": "43"}]
+```
+
+When a new PR is opened or an existing PR is updated (new commits pushed), PikoCI detects the change and triggers the job. The pull step fetches the PR's head ref so your CI runs against the PR code.
+
+This requires a `token` and is supported on GitHub and GitLab.
+
+### Pull behavior
+
+Clones the repository with `git clone`, injecting the token into the HTTPS URL when provided. In PR mode, fetches the PR head ref. Otherwise, checks out the specific version ref.
+
+### Push behavior
+
+Pushes from the cloned directory, injecting the token into the remote URL when provided.
+
+### Examples
+
+Public repository:
+
+```hcl
+resource "git" "my-repo" {
+  params {
+    url  = "https://github.com/xescugc/pikoci.git"
+    name = "pikoci"
+  }
+}
+```
+
+Private repository with token:
+
+```hcl
+resource "git" "private-repo" {
+  params {
+    url    = "https://github.com/myorg/private-repo.git"
+    name   = "private-repo"
+    branch = "main"
+    token  = var.github_token
+  }
+}
+```
+
+CI on pull requests:
+
+```hcl
+resource "git" "prs" {
+  params {
+    url   = "https://github.com/myorg/my-repo.git"
+    name  = "my-repo"
+    token = var.github_token
+    pr    = "true"
+  }
+}
+
+job "ci" {
+  get "git" "prs" {
+    trigger = true
+  }
+
+  task "test" {
+    run "docker" {
+      image = "golang:1.23"
+      cmd   = "cd my-repo && make test"
+    }
+  }
+}
+```

--- a/docs/Runners.md
+++ b/docs/Runners.md
@@ -19,12 +19,15 @@ runner "docker" {
 }
 ```
 
-| Field  | Required | Description                          |
-|--------|----------|--------------------------------------|
-| `name` | yes      | Label on the block                   |
-| `run`  | yes      | Block with `path` and `args`         |
-| `path` | no       | Executable path                      |
-| `args` | no       | List of arguments                    |
+| Field    | Required | Description                          |
+|----------|----------|--------------------------------------|
+| `name`   | yes      | Label on the block                   |
+| `source` | no       | URL to fetch the definition from (mutually exclusive with inline `run`) |
+| `run`    | yes*     | Block with `path` and `args`         |
+| `path`   | no       | Executable path                      |
+| `args`   | no       | List of arguments                    |
+
+\* Not required when `source` is set.
 
 ### Variable expansion
 
@@ -36,6 +39,48 @@ Inside `path` and `args`, PikoCI expands:
 | `$<param>`  | Any parameter passed from a `run` block in a task |
 
 For example, when a task uses `run "docker" { image = "golang:1.25" cmd = "make test" }`, the runner receives `$image` and `$cmd` as expandable variables.
+
+## Sourcing from URL
+
+Instead of defining the runner inline, you can point to an external HCL file:
+
+```hcl
+runner "my-docker" {
+  source = "pikoci://docker"
+}
+```
+
+Two URL formats are supported:
+
+- **`pikoci://<name>`** resolves to the PikoCI registry. For shipped built-ins (`exec`, `docker`), the embedded definition is used directly (no network call).
+- **`https://...`** or **`http://...`** fetches HCL from any URL.
+
+When `source` is set, you must not define an inline `run` block. PikoCI will error if both are present.
+
+## Overriding built-ins
+
+All built-in runners (`exec`, `docker`) can be overridden by defining a `runner` block with the same name in your pipeline. Inline definitions always take precedence over built-ins.
+
+This is useful when you need different default behavior. For example, the built-in `docker` runner uses `/bin/sh -ec` to run commands. If you want to always run with `--network=host` or use a different shell:
+
+```hcl
+runner "docker" {
+  run {
+    path = "docker"
+    args = [
+      "run", "--rm",
+      "--network=host",
+      "-v", "$WORKDIR:/workdir",
+      "-w", "/workdir",
+      "$args",
+      "$image",
+      "/bin/bash", "-ec", "$cmd",
+    ]
+  }
+}
+```
+
+This replaces the built-in `docker` runner entirely for this pipeline.
 
 ## Using a runner
 
@@ -84,6 +129,83 @@ runner "exec" {
 ```
 
 You do not need to declare the `exec` runner in your pipeline. It is always available.
+
+## Built-in: docker
+
+The `docker` runner is built in. It runs commands inside Docker containers:
+
+```hcl
+task "test" {
+  run "docker" {
+    image = "golang:1.23"
+    cmd   = "make test"
+  }
+}
+```
+
+### Params
+
+| Param   | Required | Description                              |
+|---------|----------|------------------------------------------|
+| `image` | yes      | Docker image to run                      |
+| `cmd`   | yes      | Shell command to execute inside the container |
+| `args`  | no       | Extra docker flags (env, volumes, etc.)  |
+
+The docker runner mounts `$WORKDIR` as `/workdir` inside the container and runs the command with `/bin/sh -ec`.
+
+### Extra docker flags
+
+Use the `args` parameter to pass additional flags to `docker run`:
+
+```hcl
+task "test" {
+  run "docker" {
+    image = "golang:1.23"
+    cmd   = "make test"
+    args  = ["-e", "CI=true", "-e", "FOO=bar"]
+  }
+}
+```
+
+With volumes:
+
+```hcl
+task "test" {
+  run "docker" {
+    image = "golang:1.23"
+    cmd   = "make test"
+    args  = ["-v", "/data:/data"]
+  }
+}
+```
+
+With privileged mode:
+
+```hcl
+task "build-image" {
+  run "docker" {
+    image = "docker:latest"
+    cmd   = "docker build -t myapp ."
+    args  = ["--privileged"]
+  }
+}
+```
+
+Using HCL functions to build args dynamically:
+
+```hcl
+task "test" {
+  run "docker" {
+    image = "golang:1.23"
+    cmd   = "make test"
+    args  = concat(
+      ["-e", "CI=true"],
+      ["-e", "FOO=bar"],
+      ["-v", "/cache:/cache"],
+    )
+  }
+}
+```
 
 ## Example: custom shell runner
 

--- a/pikoci/builtin/builtin.go
+++ b/pikoci/builtin/builtin.go
@@ -1,0 +1,101 @@
+package builtin
+
+import (
+	"embed"
+	"fmt"
+	"sync"
+
+	"github.com/hashicorp/hcl/v2/hclsimple"
+	"github.com/xescugc/pikoci/pikoci/restype"
+	"github.com/xescugc/pikoci/pikoci/runner"
+)
+
+//go:embed resource_types/*.hcl
+var resourceTypeFS embed.FS
+
+//go:embed runners/*.hcl
+var runnerFS embed.FS
+
+type hclResourceType struct {
+	ResourceTypes []restype.ResourceType `hcl:"resource_type,block"`
+}
+
+type hclRunner struct {
+	Runners []runner.Runner `hcl:"runner,block"`
+}
+
+var (
+	resourceTypes     map[string]restype.ResourceType
+	resourceTypesOnce sync.Once
+
+	runners     map[string]runner.Runner
+	runnersOnce sync.Once
+)
+
+func ResourceTypes() map[string]restype.ResourceType {
+	resourceTypesOnce.Do(func() {
+		resourceTypes = make(map[string]restype.ResourceType)
+		entries, err := resourceTypeFS.ReadDir("resource_types")
+		if err != nil {
+			panic(fmt.Sprintf("failed to read embedded resource_types: %v", err))
+		}
+		for _, e := range entries {
+			data, err := resourceTypeFS.ReadFile("resource_types/" + e.Name())
+			if err != nil {
+				panic(fmt.Sprintf("failed to read embedded resource_type %s: %v", e.Name(), err))
+			}
+			var hrt hclResourceType
+			err = hclsimple.Decode(e.Name(), data, nil, &hrt)
+			if err != nil {
+				panic(fmt.Sprintf("failed to decode embedded resource_type %s: %v", e.Name(), err))
+			}
+			for _, rt := range hrt.ResourceTypes {
+				resourceTypes[rt.Name] = rt
+			}
+		}
+	})
+	return resourceTypes
+}
+
+func Runners() map[string]runner.Runner {
+	runnersOnce.Do(func() {
+		runners = make(map[string]runner.Runner)
+		entries, err := runnerFS.ReadDir("runners")
+		if err != nil {
+			panic(fmt.Sprintf("failed to read embedded runners: %v", err))
+		}
+		for _, e := range entries {
+			data, err := runnerFS.ReadFile("runners/" + e.Name())
+			if err != nil {
+				panic(fmt.Sprintf("failed to read embedded runner %s: %v", e.Name(), err))
+			}
+			var hr hclRunner
+			err = hclsimple.Decode(e.Name(), data, nil, &hr)
+			if err != nil {
+				panic(fmt.Sprintf("failed to decode embedded runner %s: %v", e.Name(), err))
+			}
+			for _, ru := range hr.Runners {
+				runners[ru.Name] = ru
+			}
+		}
+	})
+	return runners
+}
+
+// ResourceTypeHCL returns the raw HCL bytes for a built-in resource type, if it exists.
+func ResourceTypeHCL(name string) ([]byte, bool) {
+	data, err := resourceTypeFS.ReadFile("resource_types/" + name + ".hcl")
+	if err != nil {
+		return nil, false
+	}
+	return data, true
+}
+
+// RunnerHCL returns the raw HCL bytes for a built-in runner, if it exists.
+func RunnerHCL(name string) ([]byte, bool) {
+	data, err := runnerFS.ReadFile("runners/" + name + ".hcl")
+	if err != nil {
+		return nil, false
+	}
+	return data, true
+}

--- a/pikoci/builtin/builtin_test.go
+++ b/pikoci/builtin/builtin_test.go
@@ -1,0 +1,83 @@
+package builtin_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xescugc/pikoci/pikoci/builtin"
+)
+
+func TestResourceTypes(t *testing.T) {
+	rts := builtin.ResourceTypes()
+	require.NotEmpty(t, rts)
+
+	t.Run("cron", func(t *testing.T) {
+		rt, ok := rts["cron"]
+		require.True(t, ok)
+		assert.Equal(t, "cron", rt.Name)
+		assert.Equal(t, "exec", rt.Check.Runner)
+	})
+
+	t.Run("git", func(t *testing.T) {
+		rt, ok := rts["git"]
+		require.True(t, ok)
+		assert.Equal(t, "git", rt.Name)
+		assert.Equal(t, "exec", rt.Check.Runner)
+		assert.Equal(t, "exec", rt.Pull.Runner)
+		assert.Equal(t, "exec", rt.Push.Runner)
+		assert.Contains(t, rt.Params, "url")
+		assert.Contains(t, rt.Params, "name")
+		assert.Contains(t, rt.Params, "token")
+		assert.Contains(t, rt.Params, "branch")
+		assert.Contains(t, rt.Params, "pr")
+	})
+}
+
+func TestRunners(t *testing.T) {
+	rus := builtin.Runners()
+	require.NotEmpty(t, rus)
+
+	t.Run("exec", func(t *testing.T) {
+		ru, ok := rus["exec"]
+		require.True(t, ok)
+		assert.Equal(t, "exec", ru.Name)
+		assert.Equal(t, "$path", ru.Run.Path)
+		assert.Equal(t, []string{"$args"}, ru.Run.Args)
+	})
+
+	t.Run("docker", func(t *testing.T) {
+		ru, ok := rus["docker"]
+		require.True(t, ok)
+		assert.Equal(t, "docker", ru.Name)
+		assert.Equal(t, "docker", ru.Run.Path)
+		assert.Contains(t, ru.Run.Args, "run")
+		assert.Contains(t, ru.Run.Args, "--rm")
+	})
+}
+
+func TestResourceTypeHCL(t *testing.T) {
+	t.Run("existing", func(t *testing.T) {
+		data, ok := builtin.ResourceTypeHCL("git")
+		assert.True(t, ok)
+		assert.NotEmpty(t, data)
+	})
+
+	t.Run("nonexistent", func(t *testing.T) {
+		_, ok := builtin.ResourceTypeHCL("nonexistent")
+		assert.False(t, ok)
+	})
+}
+
+func TestRunnerHCL(t *testing.T) {
+	t.Run("existing", func(t *testing.T) {
+		data, ok := builtin.RunnerHCL("exec")
+		assert.True(t, ok)
+		assert.NotEmpty(t, data)
+	})
+
+	t.Run("nonexistent", func(t *testing.T) {
+		_, ok := builtin.RunnerHCL("nonexistent")
+		assert.False(t, ok)
+	})
+}

--- a/pikoci/builtin/resource_types/cron.hcl
+++ b/pikoci/builtin/resource_types/cron.hcl
@@ -1,0 +1,13 @@
+resource_type "cron" {
+  check "exec" {
+    path = "/bin/sh"
+    args = [
+      "-ec",
+      <<-EOT
+      echo "[{\"date\":\"$(date)\"}]"
+      EOT
+    ]
+  }
+  pull "exec" { }
+  push "exec" { }
+}

--- a/pikoci/builtin/resource_types/git.hcl
+++ b/pikoci/builtin/resource_types/git.hcl
@@ -1,0 +1,135 @@
+resource_type "git" {
+  params = [
+    "url",
+    "branch",
+    "name",
+    "token",
+    "pr",
+  ]
+  check "exec" {
+    path = "/bin/sh"
+    args = [
+      "-ec",
+      <<-EOT
+      URL="$param_url"
+      BRANCH="$${param_branch:-HEAD}"
+      TOKEN="$param_token"
+      PR="$param_pr"
+
+      # PR mode: check for open pull requests
+      if [ "$PR" = "true" ]; then
+        if [ -z "$TOKEN" ]; then
+          echo "error: pr=true requires a token" >&2
+          exit 1
+        fi
+
+        # GitHub PRs
+        if echo "$URL" | grep -q "github.com"; then
+          REPO=$(echo "$URL" | sed -E 's|https?://github\.com/||;s|\.git$||')
+          curl -sf -H "Authorization: token $TOKEN" \
+            "https://api.github.com/repos/$REPO/pulls?state=open&sort=updated&direction=desc&per_page=100" \
+            | jq '[.[] | {"ref": .head.sha, "pr": (.number | tostring)}]'
+          exit 0
+        fi
+
+        # GitLab MRs
+        if echo "$URL" | grep -q "gitlab.com"; then
+          PROJECT=$(echo "$URL" | sed -E 's|https?://gitlab\.com/||;s|\.git$||' | sed 's|/|%2F|g')
+          curl -sf -H "PRIVATE-TOKEN: $TOKEN" \
+            "https://gitlab.com/api/v4/projects/$PROJECT/merge_requests?state=opened&order_by=updated_at&sort=desc&per_page=100" \
+            | jq '[.[] | {"ref": .sha, "pr": (.iid | tostring)}]'
+          exit 0
+        fi
+
+        echo "error: pr=true is only supported for github.com and gitlab.com" >&2
+        exit 1
+      fi
+
+      # GitHub API
+      if [ -n "$TOKEN" ] && echo "$URL" | grep -q "github.com"; then
+        REPO=$(echo "$URL" | sed -E 's|https?://github\.com/||;s|\.git$||')
+        REF=$(curl -sf -H "Authorization: token $TOKEN" \
+          "https://api.github.com/repos/$REPO/commits?sha=$BRANCH&per_page=1" \
+          | jq -r '.[0].sha')
+        if [ -n "$REF" ] && [ "$REF" != "null" ]; then
+          echo "[{\"ref\":\"$REF\"}]"
+          exit 0
+        fi
+      fi
+
+      # GitLab API
+      if [ -n "$TOKEN" ] && echo "$URL" | grep -q "gitlab.com"; then
+        PROJECT=$(echo "$URL" | sed -E 's|https?://gitlab\.com/||;s|\.git$||' | sed 's|/|%2F|g')
+        REF=$(curl -sf -H "PRIVATE-TOKEN: $TOKEN" \
+          "https://gitlab.com/api/v4/projects/$PROJECT/repository/commits?ref_name=$BRANCH&per_page=1" \
+          | jq -r '.[0].id')
+        if [ -n "$REF" ] && [ "$REF" != "null" ]; then
+          echo "[{\"ref\":\"$REF\"}]"
+          exit 0
+        fi
+      fi
+
+      # Fallback: git ls-remote
+      if [ -n "$TOKEN" ]; then
+        REF=$(git -c credential.helper="!f() { echo password=$TOKEN; }; f" ls-remote "$URL" "$BRANCH" | awk '{print $1}')
+      else
+        REF=$(git ls-remote "$URL" "$BRANCH" | awk '{print $1}')
+      fi
+      if [ -z "$REF" ]; then
+        REF=$(git ls-remote "$URL" HEAD | awk '{print $1}')
+      fi
+      echo "[{\"ref\":\"$REF\"}]"
+      EOT
+    ]
+  }
+  pull "exec" {
+    path = "/bin/sh"
+    args = [
+      "-ec",
+      <<-EOT
+      URL="$param_url"
+      TOKEN="$param_token"
+      BRANCH="$param_branch"
+      PR="$param_pr"
+
+      # Inject token into HTTPS URL if provided
+      if [ -n "$TOKEN" ]; then
+        URL=$(echo "$URL" | sed -E "s|https://|https://oauth2:$${TOKEN}@|")
+      fi
+
+      if [ "$PR" = "true" ] && [ -n "$version_pr" ]; then
+        # PR mode: fetch the PR head ref
+        git clone "$URL" "$param_name"
+        cd "$param_name"
+        git fetch origin "pull/$version_pr/head:pr-$version_pr"
+        git checkout "pr-$version_pr"
+      elif [ -n "$BRANCH" ]; then
+        git clone -b "$BRANCH" "$URL" "$param_name"
+        cd "$param_name"
+        git checkout "$version_ref"
+      else
+        git clone "$URL" "$param_name"
+        cd "$param_name"
+        git checkout "$version_ref"
+      fi
+      EOT
+    ]
+  }
+  push "exec" {
+    path = "/bin/sh"
+    args = [
+      "-ec",
+      <<-EOT
+      URL="$param_url"
+      TOKEN="$param_token"
+
+      cd "$param_name"
+      if [ -n "$TOKEN" ]; then
+        REMOTE_URL=$(echo "$URL" | sed -E "s|https://|https://oauth2:$${TOKEN}@|")
+        git remote set-url origin "$REMOTE_URL"
+      fi
+      git push
+      EOT
+    ]
+  }
+}

--- a/pikoci/builtin/runners/docker.hcl
+++ b/pikoci/builtin/runners/docker.hcl
@@ -1,0 +1,13 @@
+runner "docker" {
+  run {
+    path = "docker"
+    args = [
+      "run", "--rm",
+      "-v", "$WORKDIR:/workdir",
+      "-w", "/workdir",
+      "$args",
+      "$image",
+      "/bin/sh", "-ec", "$cmd",
+    ]
+  }
+}

--- a/pikoci/builtin/runners/exec.hcl
+++ b/pikoci/builtin/runners/exec.hcl
@@ -1,0 +1,6 @@
+runner "exec" {
+  run {
+    path = "$path"
+    args = ["$args"]
+  }
+}

--- a/pikoci/helper.go
+++ b/pikoci/helper.go
@@ -14,8 +14,11 @@ import (
 	"github.com/xescugc/pikoci/pikoci/resource"
 	"github.com/xescugc/pikoci/pikoci/restype"
 	"github.com/xescugc/pikoci/pikoci/runner"
+	"github.com/xescugc/pikoci/pikoci/source"
 	"github.com/xescugc/pikoci/pikoci/utils"
 	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+	"github.com/zclconf/go-cty/cty/function/stdlib"
 	"github.com/zclconf/go-cty/cty/gocty"
 )
 
@@ -65,23 +68,121 @@ type hclJob struct {
 	Ensure    []utils.RunnerCommand `hcl:"ensure,block"`
 }
 
+// hclResourceType is an intermediate struct that allows optional check/pull/push blocks
+// when source is provided.
+type hclResourceType struct {
+	Name   string   `json:"name" hcl:"name,label"`
+	Source string   `json:"source,omitempty" hcl:"source,optional"`
+	Params []string `json:"params" hcl:"params,optional"`
+
+	Check []utils.RunnerCommand `json:"check" hcl:"check,block"`
+	Pull  []utils.RunnerCommand `json:"pull" hcl:"pull,block"`
+	Push  []utils.RunnerCommand `json:"push" hcl:"push,block"`
+}
+
+func (hrt hclResourceType) toResourceType() restype.ResourceType {
+	rt := restype.ResourceType{
+		Name:   hrt.Name,
+		Source: hrt.Source,
+		Params: hrt.Params,
+	}
+	if len(hrt.Check) > 0 {
+		rt.Check = hrt.Check[0]
+	}
+	if len(hrt.Pull) > 0 {
+		rt.Pull = hrt.Pull[0]
+	}
+	if len(hrt.Push) > 0 {
+		rt.Push = hrt.Push[0]
+	}
+	return rt
+}
+
+// hclRunnerDef is an intermediate struct that allows optional run block
+// when source is provided.
+type hclRunnerDef struct {
+	Name   string             `json:"name" hcl:"name,label"`
+	Source string             `json:"source,omitempty" hcl:"source,optional"`
+	Run    []utils.RunCommand `json:"run" hcl:"run,block"`
+}
+
+func (hrd hclRunnerDef) toRunner() runner.Runner {
+	ru := runner.Runner{
+		Name:   hrd.Name,
+		Source: hrd.Source,
+	}
+	if len(hrd.Run) > 0 {
+		ru.Run = hrd.Run[0]
+	}
+	return ru
+}
+
 // hclPipeline is the intermediate HCL-decoded pipeline.
 type hclPipeline struct {
-	Name          string                 `json:"name"`
-	Jobs          []hclJob               `hcl:"job,block"`
-	Resources     []resource.Resource    `hcl:"resource,block"`
-	ResourceTypes []restype.ResourceType `hcl:"resource_type,block"`
-	Runners       []runner.Runner        `hcl:"runner,block"`
-	Remain        hcl.Body               `hcl:",remain"`
+	Name          string              `json:"name"`
+	Jobs          []hclJob            `hcl:"job,block"`
+	Resources     []resource.Resource `hcl:"resource,block"`
+	ResourceTypes []hclResourceType   `hcl:"resource_type,block"`
+	Runners       []hclRunnerDef      `hcl:"runner,block"`
+	Remain        hcl.Body            `hcl:",remain"`
+}
+
+func hclFunctions() map[string]function.Function {
+	return map[string]function.Function{
+		// String
+		"chomp":      stdlib.ChompFunc,
+		"format":     stdlib.FormatFunc,
+		"formatlist": stdlib.FormatListFunc,
+		"indent":     stdlib.IndentFunc,
+		"join":       stdlib.JoinFunc,
+		"lower":      stdlib.LowerFunc,
+		"replace":    stdlib.ReplaceFunc,
+		"split":      stdlib.SplitFunc,
+		"substr":     stdlib.SubstrFunc,
+		"title":      stdlib.TitleFunc,
+		"trim":       stdlib.TrimFunc,
+		"trimprefix": stdlib.TrimPrefixFunc,
+		"trimsuffix": stdlib.TrimSuffixFunc,
+		"trimspace":  stdlib.TrimSpaceFunc,
+		"upper":      stdlib.UpperFunc,
+		// Collection
+		"concat":   stdlib.ConcatFunc,
+		"contains": stdlib.ContainsFunc,
+		"distinct": stdlib.DistinctFunc,
+		"flatten":  stdlib.FlattenFunc,
+		"keys":     stdlib.KeysFunc,
+		"length":   stdlib.LengthFunc,
+		"lookup":   stdlib.LookupFunc,
+		"merge":    stdlib.MergeFunc,
+		"reverse":  stdlib.ReverseListFunc,
+		"sort":     stdlib.SortFunc,
+		"values":   stdlib.ValuesFunc,
+		// Numeric
+		"abs":   stdlib.AbsoluteFunc,
+		"ceil":  stdlib.CeilFunc,
+		"floor": stdlib.FloorFunc,
+		"max":   stdlib.MaxFunc,
+		"min":   stdlib.MinFunc,
+		// Encoding
+		"jsonencode": stdlib.JSONEncodeFunc,
+		"jsondecode": stdlib.JSONDecodeFunc,
+		"csvdecode":  stdlib.CSVDecodeFunc,
+		// Regex
+		"regex":        stdlib.RegexFunc,
+		"regexall":     stdlib.RegexAllFunc,
+		"regexreplace": stdlib.RegexReplaceFunc,
+	}
 }
 
 func (q *PikoCI) readPipeline(ctx context.Context, rpp []byte, vars map[string]interface{}) (*pipeline.Pipeline, error) {
+	funcs := hclFunctions()
 	ectx := &hcl.EvalContext{
 		Variables: map[string]cty.Value{
 			"string": cty.StringVal("string"),
 			"number": cty.StringVal("number"),
 			"bool":   cty.StringVal("bool"),
 		},
+		Functions: funcs,
 	}
 	var pvars pipeline.Variables
 	err := hclsimple.Decode("pipeline.hcl", rpp, ectx, &pvars)
@@ -158,6 +259,7 @@ func (q *PikoCI) readPipeline(ctx context.Context, rpp []byte, vars map[string]i
 		Variables: map[string]cty.Value{
 			"var": cty.ObjectVal(ecvars),
 		},
+		Functions: funcs,
 	}
 
 	var hp hclPipeline
@@ -169,6 +271,45 @@ func (q *PikoCI) readPipeline(ctx context.Context, rpp []byte, vars map[string]i
 		return nil, fmt.Errorf("failed to Decode Pipeline config: %w", err)
 	}
 
+	// Convert intermediate types and resolve sources
+	var resourceTypes []restype.ResourceType
+	for _, hrt := range hp.ResourceTypes {
+		if hrt.Source != "" {
+			hasInline := len(hrt.Check) > 0 || len(hrt.Pull) > 0 || len(hrt.Push) > 0
+			if hasInline {
+				return nil, fmt.Errorf("resource_type %q has both source and inline commands, which is not allowed", hrt.Name)
+			}
+			resolved, err := source.ResolveResourceType(ctx, hrt.Source)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve source for resource_type %q: %w", hrt.Name, err)
+			}
+			resolved.Name = hrt.Name
+			resolved.Source = hrt.Source
+			resourceTypes = append(resourceTypes, *resolved)
+		} else {
+			resourceTypes = append(resourceTypes, hrt.toResourceType())
+		}
+	}
+
+	var runners []runner.Runner
+	for _, hrd := range hp.Runners {
+		if hrd.Source != "" {
+			hasInline := len(hrd.Run) > 0
+			if hasInline {
+				return nil, fmt.Errorf("runner %q has both source and inline commands, which is not allowed", hrd.Name)
+			}
+			resolved, err := source.ResolveRunner(ctx, hrd.Source)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve source for runner %q: %w", hrd.Name, err)
+			}
+			resolved.Name = hrd.Name
+			resolved.Source = hrd.Source
+			runners = append(runners, *resolved)
+		} else {
+			runners = append(runners, hrd.toRunner())
+		}
+	}
+
 	// Parse the raw HCL to determine block ordering within each job.
 	jobPlans, err := parseJobPlans(rpp, hp.Jobs)
 	if err != nil {
@@ -177,8 +318,8 @@ func (q *PikoCI) readPipeline(ctx context.Context, rpp []byte, vars map[string]i
 
 	pp := pipeline.Pipeline{
 		Resources:     hp.Resources,
-		ResourceTypes: hp.ResourceTypes,
-		Runners:       hp.Runners,
+		ResourceTypes: resourceTypes,
+		Runners:       runners,
 	}
 
 	for _, hj := range hp.Jobs {

--- a/pikoci/mysql/migrate/migrations/V12Source.go
+++ b/pikoci/mysql/migrate/migrations/V12Source.go
@@ -1,0 +1,9 @@
+package migrations
+
+var V12Source = Migration{
+	Name: "V12Source",
+	SQL: `
+		ALTER TABLE resource_types ADD COLUMN source VARCHAR(512) DEFAULT NULL;
+		ALTER TABLE runners ADD COLUMN source VARCHAR(512) DEFAULT NULL;
+	`,
+}

--- a/pikoci/mysql/migrate/migrations/migrations.go
+++ b/pikoci/mysql/migrate/migrations/migrations.go
@@ -12,7 +12,7 @@ type Migration struct {
 // in compilation time if some order is wrong
 // if it where to have more than one person working
 // on it
-var Migrations = [12]Migration{
+var Migrations = [13]Migration{
 	V0Initial,
 	V1ResourceCheckInterval,
 	V2JobsAndBuilds,
@@ -25,4 +25,5 @@ var Migrations = [12]Migration{
 	V9OrderedPlan,
 	V10WebhookToken,
 	V11PublicPipelines,
+	V12Source,
 }

--- a/pikoci/mysql/resource_type.go
+++ b/pikoci/mysql/resource_type.go
@@ -23,6 +23,7 @@ func NewResourceTypeRepository(db sqlr.Querier) *ResourceTypeRepository {
 type dbResourceType struct {
 	ID     sql.NullInt64
 	Name   sql.NullString
+	Source sql.NullString
 	Params sql.NullString
 	Check  sql.NullString
 	Pull   sql.NullString
@@ -36,6 +37,7 @@ func newDBResourceType(rt restype.ResourceType) dbResourceType {
 	ps, _ := json.Marshal(rt.Push)
 	return dbResourceType{
 		Name:   toNullString(rt.Name),
+		Source: toNullString(rt.Source),
 		Params: toNullString(string(i)),
 		Check:  toNullString(string(c)),
 		Pull:   toNullString(string(pl)),
@@ -45,8 +47,9 @@ func newDBResourceType(rt restype.ResourceType) dbResourceType {
 
 func (dbrt *dbResourceType) toDomainEntity() *restype.ResourceType {
 	rt := &restype.ResourceType{
-		ID:   uint32(dbrt.ID.Int64),
-		Name: dbrt.Name.String,
+		ID:     uint32(dbrt.ID.Int64),
+		Name:   dbrt.Name.String,
+		Source: dbrt.Source.String,
 	}
 
 	_ = json.Unmarshal([]byte(dbrt.Params.String), &rt.Params)
@@ -60,8 +63,8 @@ func (dbrt *dbResourceType) toDomainEntity() *restype.ResourceType {
 func (r *ResourceTypeRepository) Create(ctx context.Context, tc, pn string, rt restype.ResourceType) (uint32, error) {
 	dbrt := newDBResourceType(rt)
 	res, err := r.querier.ExecContext(ctx, `
-		INSERT INTO resource_types(name, `+"`check`"+`, pull, push, params, pipeline_id)
-		VALUES (?, ?, ?, ?, ?,
+		INSERT INTO resource_types(name, source, `+"`check`"+`, pull, push, params, pipeline_id)
+		VALUES (?, ?, ?, ?, ?, ?,
 			-- pipeline_id
 			(
 				SELECT p.id
@@ -69,7 +72,7 @@ func (r *ResourceTypeRepository) Create(ctx context.Context, tc, pn string, rt r
 				JOIN teams AS t
 					ON p.team_id = t.id
 				WHERE t.canonical = ? AND p.name = ?
-			))`, dbrt.Name, dbrt.Check, dbrt.Pull, dbrt.Push, dbrt.Params, tc, pn)
+			))`, dbrt.Name, dbrt.Source, dbrt.Check, dbrt.Pull, dbrt.Push, dbrt.Params, tc, pn)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -86,7 +89,7 @@ func (r *ResourceTypeRepository) Update(ctx context.Context, tc, pn, rtn string,
 	dbrt := newDBResourceType(rt)
 	res, err := r.querier.ExecContext(ctx, `
 		UPDATE resource_types AS rt
-		SET name = ?, `+"`check`"+` = ?, pull = ?, push = ?, params = ?
+		SET name = ?, source = ?, `+"`check`"+` = ?, pull = ?, push = ?, params = ?
 		FROM (
 			SELECT rt.id
 			FROM resource_types AS rt
@@ -97,7 +100,7 @@ func (r *ResourceTypeRepository) Update(ctx context.Context, tc, pn, rtn string,
 			WHERE t.canonical = ? AND p.name = ? AND rt.name = ?
 		) AS rtt
 		WHERE rtt.id = rt.id
-	`, dbrt.Name, dbrt.Check, dbrt.Pull, dbrt.Push, dbrt.Params, tc, pn, rtn)
+	`, dbrt.Name, dbrt.Source, dbrt.Check, dbrt.Pull, dbrt.Push, dbrt.Params, tc, pn, rtn)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -112,7 +115,7 @@ func (r *ResourceTypeRepository) Update(ctx context.Context, tc, pn, rtn string,
 
 func (r *ResourceTypeRepository) Find(ctx context.Context, tc, pn, rtn string) (*restype.ResourceType, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT rt.id, rt.name, `+"rt.`check`"+`, rt.pull, rt.push, rt.params
+		SELECT rt.id, rt.name, rt.source, `+"rt.`check`"+`, rt.pull, rt.push, rt.params
 		FROM resource_types AS rt
 		JOIN pipelines AS p
 			ON rt.pipeline_id = p.id
@@ -131,7 +134,7 @@ func (r *ResourceTypeRepository) Find(ctx context.Context, tc, pn, rtn string) (
 
 func (r *ResourceTypeRepository) Filter(ctx context.Context, tc, pn string) ([]*restype.ResourceType, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT rt.id, rt.name, `+"rt.`check`"+`, rt.pull, rt.push, rt.params
+		SELECT rt.id, rt.name, rt.source, `+"rt.`check`"+`, rt.pull, rt.push, rt.params
 		FROM resource_types AS rt
 		JOIN pipelines AS p
 			ON rt.pipeline_id = p.id
@@ -183,6 +186,7 @@ func scanResourceType(s sqlr.Scanner) (*restype.ResourceType, error) {
 	err := s.Scan(
 		&rt.ID,
 		&rt.Name,
+		&rt.Source,
 		&rt.Check,
 		&rt.Pull,
 		&rt.Push,

--- a/pikoci/mysql/runner.go
+++ b/pikoci/mysql/runner.go
@@ -21,23 +21,26 @@ func NewRunnerRepository(db sqlr.Querier) *RunnerRepository {
 }
 
 type dbRunner struct {
-	ID   sql.NullInt64
-	Name sql.NullString
-	Run  sql.NullString
+	ID     sql.NullInt64
+	Name   sql.NullString
+	Source sql.NullString
+	Run    sql.NullString
 }
 
 func newDBRunner(ru runner.Runner) dbRunner {
 	r, _ := json.Marshal(ru.Run)
 	return dbRunner{
-		Name: toNullString(ru.Name),
-		Run:  toNullString(string(r)),
+		Name:   toNullString(ru.Name),
+		Source: toNullString(ru.Source),
+		Run:    toNullString(string(r)),
 	}
 }
 
 func (dbru *dbRunner) toDomainEntity() *runner.Runner {
 	ru := &runner.Runner{
-		ID:   uint32(dbru.ID.Int64),
-		Name: dbru.Name.String,
+		ID:     uint32(dbru.ID.Int64),
+		Name:   dbru.Name.String,
+		Source: dbru.Source.String,
 	}
 
 	_ = json.Unmarshal([]byte(dbru.Run.String), &ru.Run)
@@ -48,8 +51,8 @@ func (dbru *dbRunner) toDomainEntity() *runner.Runner {
 func (r *RunnerRepository) Create(ctx context.Context, tc, pn string, ru runner.Runner) (uint32, error) {
 	dbru := newDBRunner(ru)
 	res, err := r.querier.ExecContext(ctx, `
-		INSERT INTO runners(name, run, pipeline_id)
-		VALUES (?, ?,
+		INSERT INTO runners(name, source, run, pipeline_id)
+		VALUES (?, ?, ?,
 			-- pipeline_id
 			(
 				SELECT p.id
@@ -57,7 +60,7 @@ func (r *RunnerRepository) Create(ctx context.Context, tc, pn string, ru runner.
 				JOIN teams AS t
 					ON p.team_id = t.id
 				WHERE t.canonical = ? AND p.name = ?
-			))`, dbru.Name, dbru.Run, tc, pn)
+			))`, dbru.Name, dbru.Source, dbru.Run, tc, pn)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -74,7 +77,7 @@ func (r *RunnerRepository) Update(ctx context.Context, tc, pn, run string, ru ru
 	dbru := newDBRunner(ru)
 	res, err := r.querier.ExecContext(ctx, `
 		UPDATE runners AS ru
-		SET name = ?, run = ?
+		SET name = ?, source = ?, run = ?
 		FROM (
 			SELECT ru.id
 			FROM runners AS ru
@@ -85,7 +88,7 @@ func (r *RunnerRepository) Update(ctx context.Context, tc, pn, run string, ru ru
 			WHERE t.canonical = ? AND p.name = ? AND ru.name = ?
 		) AS ruru
 		WHERE ruru.id = ru.id
-	`, dbru.Name, dbru.Run, tc, pn, run)
+	`, dbru.Name, dbru.Source, dbru.Run, tc, pn, run)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -100,7 +103,7 @@ func (r *RunnerRepository) Update(ctx context.Context, tc, pn, run string, ru ru
 
 func (r *RunnerRepository) Find(ctx context.Context, tc, pn, run string) (*runner.Runner, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT ru.id, ru.name, ru.run
+		SELECT ru.id, ru.name, ru.source, ru.run
 		FROM runners AS ru
 		JOIN pipelines AS p
 			ON ru.pipeline_id = p.id
@@ -119,7 +122,7 @@ func (r *RunnerRepository) Find(ctx context.Context, tc, pn, run string) (*runne
 
 func (r *RunnerRepository) Filter(ctx context.Context, tc, pn string) ([]*runner.Runner, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT ru.id, ru.name, ru.run
+		SELECT ru.id, ru.name, ru.source, ru.run
 		FROM runners AS ru
 		JOIN pipelines AS p
 			ON ru.pipeline_id = p.id
@@ -171,6 +174,7 @@ func scanRunner(s sqlr.Scanner) (*runner.Runner, error) {
 	err := s.Scan(
 		&ru.ID,
 		&ru.Name,
+		&ru.Source,
 		&ru.Run,
 	)
 

--- a/pikoci/pipeline/pipeline.go
+++ b/pikoci/pipeline/pipeline.go
@@ -2,11 +2,11 @@ package pipeline
 
 import (
 	"github.com/hashicorp/hcl/v2"
+	"github.com/xescugc/pikoci/pikoci/builtin"
 	"github.com/xescugc/pikoci/pikoci/job"
 	"github.com/xescugc/pikoci/pikoci/resource"
 	"github.com/xescugc/pikoci/pikoci/restype"
 	"github.com/xescugc/pikoci/pikoci/runner"
-	"github.com/xescugc/pikoci/pikoci/utils"
 )
 
 type Pipeline struct {
@@ -38,17 +38,8 @@ func (pp *Pipeline) ResourceType(rtn string) (restype.ResourceType, bool) {
 		}
 	}
 
-	if rtn == "cron" {
-		return restype.ResourceType{
-			Name: "cron",
-			Check: utils.RunnerCommand{
-				Runner: "exec",
-				Args:   []string{"-ec", `echo "[{\"date\":\"$(date)\"}]"`},
-				Params: map[string]string{
-					"path": "/bin/sh",
-				},
-			},
-		}, true
+	if brt, ok := builtin.ResourceTypes()[rtn]; ok {
+		return brt, true
 	}
 
 	return restype.ResourceType{}, false
@@ -71,14 +62,8 @@ func (pp *Pipeline) Runner(run string) (runner.Runner, bool) {
 		}
 	}
 
-	if run == "exec" {
-		return runner.Runner{
-			Name: "exec",
-			Run: utils.RunCommand{
-				Path: "$path",
-				Args: []string{"$args"},
-			},
-		}, true
+	if bru, ok := builtin.Runners()[run]; ok {
+		return bru, true
 	}
 
 	return runner.Runner{}, false

--- a/pikoci/pipeline/pipeline_test.go
+++ b/pikoci/pipeline/pipeline_test.go
@@ -8,26 +8,20 @@ import (
 	"github.com/xescugc/pikoci/pikoci/resource"
 	"github.com/xescugc/pikoci/pikoci/restype"
 	"github.com/xescugc/pikoci/pikoci/runner"
+	"github.com/xescugc/pikoci/pikoci/utils"
 )
 
 func TestPipeline_ResourceType(t *testing.T) {
 	pp := &pipeline.Pipeline{
 		ResourceTypes: []restype.ResourceType{
-			{Name: "git"},
-			{Name: "docker"},
+			{Name: "custom"},
 		},
 	}
 
 	t.Run("finds existing resource type", func(t *testing.T) {
-		rt, ok := pp.ResourceType("git")
+		rt, ok := pp.ResourceType("custom")
 		assert.True(t, ok)
-		assert.Equal(t, "git", rt.Name)
-	})
-
-	t.Run("finds second resource type", func(t *testing.T) {
-		rt, ok := pp.ResourceType("docker")
-		assert.True(t, ok)
-		assert.Equal(t, "docker", rt.Name)
+		assert.Equal(t, "custom", rt.Name)
 	})
 
 	t.Run("returns built-in cron type", func(t *testing.T) {
@@ -35,6 +29,27 @@ func TestPipeline_ResourceType(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, "cron", rt.Name)
 		assert.Equal(t, "exec", rt.Check.Runner)
+	})
+
+	t.Run("returns built-in git type", func(t *testing.T) {
+		rt, ok := pp.ResourceType("git")
+		assert.True(t, ok)
+		assert.Equal(t, "git", rt.Name)
+		assert.Equal(t, "exec", rt.Check.Runner)
+		assert.Equal(t, "exec", rt.Pull.Runner)
+		assert.Contains(t, rt.Params, "url")
+		assert.Contains(t, rt.Params, "token")
+	})
+
+	t.Run("inline overrides built-in", func(t *testing.T) {
+		pp2 := &pipeline.Pipeline{
+			ResourceTypes: []restype.ResourceType{
+				{Name: "git", Params: []string{"url"}},
+			},
+		}
+		rt, ok := pp2.ResourceType("git")
+		assert.True(t, ok)
+		assert.Equal(t, []string{"url"}, rt.Params)
 	})
 
 	t.Run("returns false for unknown type", func(t *testing.T) {
@@ -66,14 +81,14 @@ func TestPipeline_Resource(t *testing.T) {
 func TestPipeline_Runner(t *testing.T) {
 	pp := &pipeline.Pipeline{
 		Runners: []runner.Runner{
-			{Name: "docker"},
+			{Name: "custom"},
 		},
 	}
 
 	t.Run("finds existing runner", func(t *testing.T) {
-		r, ok := pp.Runner("docker")
+		r, ok := pp.Runner("custom")
 		assert.True(t, ok)
-		assert.Equal(t, "docker", r.Name)
+		assert.Equal(t, "custom", r.Name)
 	})
 
 	t.Run("returns built-in exec runner", func(t *testing.T) {
@@ -82,6 +97,25 @@ func TestPipeline_Runner(t *testing.T) {
 		assert.Equal(t, "exec", r.Name)
 		assert.Equal(t, "$path", r.Run.Path)
 		assert.Equal(t, []string{"$args"}, r.Run.Args)
+	})
+
+	t.Run("returns built-in docker runner", func(t *testing.T) {
+		r, ok := pp.Runner("docker")
+		assert.True(t, ok)
+		assert.Equal(t, "docker", r.Name)
+		assert.Equal(t, "docker", r.Run.Path)
+		assert.Contains(t, r.Run.Args, "run")
+	})
+
+	t.Run("inline overrides built-in", func(t *testing.T) {
+		pp2 := &pipeline.Pipeline{
+			Runners: []runner.Runner{
+				{Name: "docker", Run: utils.RunCommand{Path: "/custom/docker"}},
+			},
+		}
+		r, ok := pp2.Runner("docker")
+		assert.True(t, ok)
+		assert.Equal(t, "/custom/docker", r.Run.Path)
 	})
 
 	t.Run("returns false for unknown runner", func(t *testing.T) {

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -591,8 +591,9 @@ func sanitizePipelineForPublic(pp *pipeline.Pipeline) *pipeline.Pipeline {
 	rts := make([]restype.ResourceType, len(cp.ResourceTypes))
 	for i, rt := range cp.ResourceTypes {
 		rts[i] = restype.ResourceType{
-			ID:   rt.ID,
-			Name: rt.Name,
+			ID:     rt.ID,
+			Name:   rt.Name,
+			Source: rt.Source,
 		}
 	}
 	cp.ResourceTypes = rts

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -204,3 +204,128 @@ job "test" {
 	_, err := s.S.CreatePipeline(ctx, "main", "compat-pipeline", hclConfig, nil)
 	require.NoError(t, err)
 }
+
+func TestCreatePipeline_HCLFunctions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+variable "greeting" {
+  type    = string
+  default = "hello"
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+  params {}
+}
+
+job "test" {
+  get "cron" "timer" {
+    trigger = true
+  }
+  task "echo" {
+    run "exec" {
+      path = "echo"
+      args = [upper(var.greeting), join(",", ["a", "b", "c"])]
+    }
+  }
+}
+`)
+
+	s.Pipelines.EXPECT().Create(ctx, "main", gomock.Any()).Return(uint32(1), nil)
+	s.Jobs.EXPECT().Create(ctx, "main", "func-pipeline", gomock.Any()).DoAndReturn(
+		func(ctx context.Context, tc, pn string, j job.Job) (uint32, error) {
+			require.Len(t, j.Plan, 2)
+			assert.Equal(t, job.StepTypeTask, j.Plan[1].Type)
+			require.Len(t, j.Plan[1].Task.Run.Args, 2)
+			assert.Equal(t, "HELLO", j.Plan[1].Task.Run.Args[0])
+			assert.Equal(t, "a,b,c", j.Plan[1].Task.Run.Args[1])
+			return uint32(1), nil
+		})
+	s.Resources.EXPECT().Create(ctx, "main", "func-pipeline", gomock.Any()).Return(uint32(1), nil)
+	s.Pipelines.EXPECT().Find(ctx, "main", "func-pipeline").Return(&pipeline.Pipeline{ID: 1, Name: "func-pipeline"}, nil)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "func-pipeline", hclConfig, nil)
+	require.NoError(t, err)
+}
+
+func TestCreatePipeline_SourceAndInlineConflict(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+resource_type "my-git" {
+  source = "pikoci://git"
+  params = ["url"]
+  check "exec" {
+    path = "echo"
+    args = ["check"]
+  }
+  pull "exec" { }
+  push "exec" { }
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+  params {}
+}
+
+job "test" {
+  get "cron" "timer" { trigger = true }
+  task "echo" {
+    run "exec" {
+      path = "echo"
+      args = ["hello"]
+    }
+  }
+}
+`)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "conflict-pipeline", hclConfig, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "both source and inline commands")
+}
+
+func TestCreatePipeline_SourceResolution(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+resource_type "my-git" {
+  source = "pikoci://git"
+}
+
+resource "my-git" "repo" {
+  params {
+    url  = "https://example.com/repo.git"
+    name = "repo"
+  }
+}
+
+job "test" {
+  get "my-git" "repo" { trigger = true }
+  task "echo" {
+    run "exec" {
+      path = "echo"
+      args = ["hello"]
+    }
+  }
+}
+`)
+
+	s.Pipelines.EXPECT().Create(ctx, "main", gomock.Any()).Return(uint32(1), nil)
+	s.Jobs.EXPECT().Create(ctx, "main", "source-pipeline", gomock.Any()).Return(uint32(1), nil)
+	s.ResourceTypes.EXPECT().Create(ctx, "main", "source-pipeline", gomock.Any()).DoAndReturn(
+		func(ctx context.Context, tc, pn string, rt interface{}) (uint32, error) {
+			return uint32(1), nil
+		})
+	s.Resources.EXPECT().Create(ctx, "main", "source-pipeline", gomock.Any()).Return(uint32(1), nil)
+	s.Pipelines.EXPECT().Find(ctx, "main", "source-pipeline").Return(&pipeline.Pipeline{ID: 1, Name: "source-pipeline"}, nil)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "source-pipeline", hclConfig, nil)
+	require.NoError(t, err)
+}

--- a/pikoci/restype/resource_type.go
+++ b/pikoci/restype/resource_type.go
@@ -5,7 +5,8 @@ import "github.com/xescugc/pikoci/pikoci/utils"
 type ResourceType struct {
 	ID     uint32   `json:"id"`
 	Name   string   `json:"name" hcl:"name,label"`
-	Params []string `json:"params" hcl:"params"`
+	Source string   `json:"source,omitempty" hcl:"source,optional"`
+	Params []string `json:"params" hcl:"params,optional"`
 
 	Check utils.RunnerCommand `json:"check" hcl:"check,block"`
 	Pull  utils.RunnerCommand `json:"pull" hcl:"pull,block"`

--- a/pikoci/runner/runner.go
+++ b/pikoci/runner/runner.go
@@ -3,7 +3,8 @@ package runner
 import "github.com/xescugc/pikoci/pikoci/utils"
 
 type Runner struct {
-	ID   uint32           `json:"id"`
-	Name string           `json:"name" hcl:"name,label"`
-	Run  utils.RunCommand `json:"run" hcl:"run,block"`
+	ID     uint32          `json:"id"`
+	Name   string          `json:"name" hcl:"name,label"`
+	Source string          `json:"source,omitempty" hcl:"source,optional"`
+	Run    utils.RunCommand `json:"run" hcl:"run,block"`
 }

--- a/pikoci/service_test.go
+++ b/pikoci/service_test.go
@@ -31,9 +31,7 @@ func TestCreatePipeline(t *testing.T) {
 
 	s.Pipelines.EXPECT().Create(ctx, tc, gomock.Any()).Return(uint32(1), nil)
 	s.Jobs.EXPECT().Create(ctx, tc, ppn, gomock.Any()).Return(uint32(1), nil).Times(3)
-	s.ResourceTypes.EXPECT().Create(ctx, tc, ppn, gomock.Any()).Return(uint32(1), nil).Times(1)
 	s.Resources.EXPECT().Create(ctx, tc, ppn, gomock.Any()).Return(uint32(1), nil).Times(1)
-	s.Runners.EXPECT().Create(ctx, tc, ppn, gomock.Any()).Return(uint32(1), nil).Times(1)
 	// GetPipeline uses Find which now does a single JOIN query
 	s.Pipelines.EXPECT().Find(ctx, tc, ppn).Return(&pipeline.Pipeline{Name: ppn}, nil)
 

--- a/pikoci/source/resolver.go
+++ b/pikoci/source/resolver.go
@@ -1,0 +1,107 @@
+package source
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2/hclsimple"
+	"github.com/xescugc/pikoci/pikoci/builtin"
+	"github.com/xescugc/pikoci/pikoci/restype"
+	"github.com/xescugc/pikoci/pikoci/runner"
+)
+
+const (
+	pikoPrefix = "pikoci://"
+	baseURL    = "https://raw.githubusercontent.com/xescugc/pikoci/master/pikoci/builtin"
+)
+
+type hclResourceType struct {
+	ResourceTypes []restype.ResourceType `hcl:"resource_type,block"`
+}
+
+type hclRunner struct {
+	Runners []runner.Runner `hcl:"runner,block"`
+}
+
+func ResolveResourceType(ctx context.Context, src string) (*restype.ResourceType, error) {
+	data, err := resolveHCL(ctx, src, "resource_types")
+	if err != nil {
+		return nil, err
+	}
+
+	var hrt hclResourceType
+	err = hclsimple.Decode("source.hcl", data, nil, &hrt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode resource type from source %q: %w", src, err)
+	}
+	if len(hrt.ResourceTypes) == 0 {
+		return nil, fmt.Errorf("no resource_type block found in source %q", src)
+	}
+	return &hrt.ResourceTypes[0], nil
+}
+
+func ResolveRunner(ctx context.Context, src string) (*runner.Runner, error) {
+	data, err := resolveHCL(ctx, src, "runners")
+	if err != nil {
+		return nil, err
+	}
+
+	var hr hclRunner
+	err = hclsimple.Decode("source.hcl", data, nil, &hr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode runner from source %q: %w", src, err)
+	}
+	if len(hr.Runners) == 0 {
+		return nil, fmt.Errorf("no runner block found in source %q", src)
+	}
+	return &hr.Runners[0], nil
+}
+
+func resolveHCL(ctx context.Context, src, kind string) ([]byte, error) {
+	if strings.HasPrefix(src, pikoPrefix) {
+		name := strings.TrimPrefix(src, pikoPrefix)
+		// Try embedded built-in first
+		switch kind {
+		case "resource_types":
+			if data, ok := builtin.ResourceTypeHCL(name); ok {
+				return data, nil
+			}
+		case "runners":
+			if data, ok := builtin.RunnerHCL(name); ok {
+				return data, nil
+			}
+		}
+		// Fall back to GitHub raw URL
+		url := fmt.Sprintf("%s/%s/%s.hcl", baseURL, kind, name)
+		return fetchURL(ctx, url)
+	}
+
+	if strings.HasPrefix(src, "https://") || strings.HasPrefix(src, "http://") {
+		return fetchURL(ctx, src)
+	}
+
+	return nil, fmt.Errorf("unsupported source URL scheme: %q", src)
+}
+
+func fetchURL(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request for %q: %w", url, err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch %q: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch %q: status %d", url, resp.StatusCode)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response from %q: %w", url, err)
+	}
+	return data, nil
+}

--- a/pikoci/source/resolver_test.go
+++ b/pikoci/source/resolver_test.go
@@ -1,0 +1,96 @@
+package source_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xescugc/pikoci/pikoci/source"
+)
+
+func TestResolveResourceType_PikoCI(t *testing.T) {
+	rt, err := source.ResolveResourceType(context.Background(), "pikoci://git")
+	require.NoError(t, err)
+	assert.Equal(t, "git", rt.Name)
+	assert.Equal(t, "exec", rt.Check.Runner)
+}
+
+func TestResolveResourceType_HTTP(t *testing.T) {
+	hcl := `
+resource_type "custom" {
+  params = ["url"]
+  check "exec" {
+    path = "/bin/sh"
+    args = ["-c", "echo ok"]
+  }
+  pull "exec" { }
+  push "exec" { }
+}
+`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(hcl))
+	}))
+	defer srv.Close()
+
+	rt, err := source.ResolveResourceType(context.Background(), srv.URL+"/custom.hcl")
+	require.NoError(t, err)
+	assert.Equal(t, "custom", rt.Name)
+	assert.Equal(t, []string{"url"}, rt.Params)
+}
+
+func TestResolveResourceType_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, err := source.ResolveResourceType(context.Background(), srv.URL+"/notfound.hcl")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status 404")
+}
+
+func TestResolveResourceType_InvalidHCL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not valid hcl {{{{"))
+	}))
+	defer srv.Close()
+
+	_, err := source.ResolveResourceType(context.Background(), srv.URL+"/bad.hcl")
+	require.Error(t, err)
+}
+
+func TestResolveResourceType_UnsupportedScheme(t *testing.T) {
+	_, err := source.ResolveResourceType(context.Background(), "ftp://example.com/foo.hcl")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported source URL scheme")
+}
+
+func TestResolveRunner_PikoCI(t *testing.T) {
+	ru, err := source.ResolveRunner(context.Background(), "pikoci://exec")
+	require.NoError(t, err)
+	assert.Equal(t, "exec", ru.Name)
+	assert.Equal(t, "$path", ru.Run.Path)
+}
+
+func TestResolveRunner_HTTP(t *testing.T) {
+	hcl := `
+runner "myrunner" {
+  run {
+    path = "/usr/bin/env"
+    args = ["bash", "-c", "$script"]
+  }
+}
+`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(hcl))
+	}))
+	defer srv.Close()
+
+	ru, err := source.ResolveRunner(context.Background(), srv.URL+"/myrunner.hcl")
+	require.NoError(t, err)
+	assert.Equal(t, "myrunner", ru.Name)
+	assert.Equal(t, "/usr/bin/env", ru.Run.Path)
+}

--- a/pikoci/testdata/pipeline.hcl
+++ b/pikoci/testdata/pipeline.hcl
@@ -1,53 +1,6 @@
-resource_type "git" {
-  params = [
-    "url",
-    "name",
-  ]
-  check "exec" {
-    path = "/bin/sh"
-    args = [
-      "-ec",
-      <<-EOT
-      git clone --quiet $param_url $param_name
-      cd $param_name
-      if [[ -n $version_ref ]]; then
-        git log $version_ref..HEAD --pretty=format:"%H" | jq -Rsc "(. / \"\n\" | map(select(length>0) | { \"ref\": . }))"
-      else
-        git log -1 --pretty=format:"%H" | jq -Rsc "(. / \"\n\" | map(select(length>0) | { \"ref\": . }))"
-      fi
-      EOT
-    ]
-  }
-  pull "exec" {
-    path = "/bin/sh"
-    args = [
-      "-ec",
-      <<-EOT
-      git clone $param_url $param_name
-      cd $param_name
-      git checkout $version_ref
-      EOT
-    ]
-  }
-  push "exec" { }
-}
-
-runner "docker" {
-  run {
-    path = "docker"
-    args = [
-      "run", "--rm",
-      "-v","$WORKDIR:/workdir",
-      "-w","/workdir",
-      "$image",
-      "$cmd"
-    ]
-  }
-}
-
 resource "git" "qid" {
   params {
-    url = var.repo_url 
+    url = var.repo_url
     name = "${var.repo_name}"
   }
 }

--- a/pikoci/testdata/tutorial.hcl
+++ b/pikoci/testdata/tutorial.hcl
@@ -1,41 +1,7 @@
-resource_type "git" {
-  params = [
-    "url",
-    "name",
-  ]
-  check "exec" {
-    path = "/bin/sh"
-    args = [
-      "-ec",
-      <<-EOT
-      git clone --quiet $param_url $param_name
-      cd $param_name
-      if [[ -n $version_ref ]]; then
-        git log $version_ref..HEAD --pretty=format:"%H" | jq -Rsc "(. / \"\n\" | map(select(length>0) | { \"ref\": . }))"
-      else
-        git log -1 --pretty=format:"%H" | jq -Rsc "(. / \"\n\" | map(select(length>0) | { \"ref\": . }))"
-      fi
-      EOT
-    ]
-  }
-  pull "exec" {
-    path = "/bin/sh"
-    args = [
-      "-ec",
-      <<-EOT
-      git clone $param_url $param_name
-      cd $param_name
-      git checkout $version_ref
-      EOT
-    ]
-  }
-  push "exec" { }
-}
-
 resource "git" "repo" {
   params {
-    url = var.repo_url 
-    name = var.repo_name 
+    url = var.repo_url
+    name = var.repo_name
   }
 }
 


### PR DESCRIPTION
## Summary

- Add `source` field on `resource_type` and `runner` blocks for URL-based definition sharing (`pikoci://` and `https://`/`http://` schemes)
- Add built-in `git` resource type with API-aware check for GitHub/GitLab, PR mode (`pr = "true"`) for CI on pull requests, and token-based HTTPS auth
- Add built-in `docker` runner with `$args` passthrough for extra docker flags (env, volumes, privileged)
- Move hardcoded `cron` and `exec` built-ins to embedded HCL files via `go:embed`
- Wire go-cty stdlib functions (string, collection, numeric, encoding, regex) into the HCL eval context
- Make `params` optional on `resource_type`, add V12 DB migration for `source` column
- Built-ins are implicit and can be overridden by inline pipeline definitions
- Update testdata, docs (Functions page, source field, built-in git/docker, token setup, overriding built-ins), and changelog

Closes #11, #143, #206, #104