### PR TITLE
Add optional timeout on plan steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add optional `timeout` field on get, task, and put plan steps. When set, the step's runner execution is cancelled after the specified duration, the step is marked as failed with a timeout message, and on_failure/ensure hooks still run normally ([#173](https://github.com/xescugc/pikoci/issues/173))
 - Replace in-memory cron scheduler with database-polling scheduler for horizontal scaling support. Multiple server instances can now run concurrently with PostgreSQL or MySQL. Minimum check_interval is now 10 seconds. Manual and webhook triggers reset the check interval timer ([#213](https://github.com/xescugc/pikoci/issues/213), [#215](https://github.com/xescugc/pikoci/issues/215))
 - Add `source` field on `resource_type` and `runner` blocks for URL-based definition sharing (`pikoci://` and `https://` schemes), built-in `git` resource type with API-aware check for GitHub/GitLab, built-in `docker` runner, HCL standard functions (string, collection, numeric, encoding, regex), and optional `params` on resource types ([#11](https://github.com/xescugc/pikoci/issues/11), [#143](https://github.com/xescugc/pikoci/issues/143), [#206](https://github.com/xescugc/pikoci/issues/206), [#104](https://github.com/xescugc/pikoci/issues/104))
 - Add `docs/` folder with GitHub Actions workflow to sync wiki on push ([#211](https://github.com/xescugc/pikoci/issues/211))

--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -166,6 +166,7 @@ get "git" "my_repo" {
 | `name`    | yes      | Label, resource name                           |
 | `trigger` | no       | Auto-run the job on new versions (default `false`) |
 | `passed`  | no       | List of job names that must have run with this version first |
+| `timeout` | no       | Maximum duration for the step (e.g. `"2m"`, `"30s"`) |
 
 ### task
 
@@ -180,6 +181,11 @@ task "test" {
 }
 ```
 
+| Field     | Required | Description                                    |
+|-----------|----------|------------------------------------------------|
+| `name`    | yes      | Label on the block                             |
+| `timeout` | no       | Maximum duration for the step (e.g. `"10m"`, `"1h"`) |
+
 ### put
 
 Pushes to a resource, running its `push` command.
@@ -191,6 +197,12 @@ put "git" "my_repo" {
   }
 }
 ```
+
+| Field     | Required | Description                                    |
+|-----------|----------|------------------------------------------------|
+| `type`    | yes      | Label, resource type name                      |
+| `name`    | yes      | Label, resource name                           |
+| `timeout` | no       | Maximum duration for the step (e.g. `"5m"`, `"30s"`) |
 
 ### Step hooks
 
@@ -209,6 +221,24 @@ task "deploy" {
   on_failure "exec" {
     path = "echo"
     args = ["deploy failed"]
+  }
+}
+```
+
+### Step timeout
+
+Any step can set a `timeout` to limit how long its runner execution takes. The value is a Go duration string (e.g. `"30s"`, `"5m"`, `"1h30m"`). If the step exceeds the timeout, the process is killed, the step is marked as failed with a "step timed out after ..." message in the logs, and `on_failure`/`ensure` hooks still run normally. If no timeout is set, the step runs with no time limit.
+
+```hcl
+task "long-build" {
+  timeout = "10m"
+  run "exec" {
+    path = "make"
+    args = ["build"]
+  }
+  on_failure "exec" {
+    path = "echo"
+    args = ["build timed out or failed"]
   }
 }
 ```

--- a/pikoci/helper.go
+++ b/pikoci/helper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/hcl/v2"
@@ -28,6 +29,7 @@ type hclGetStep struct {
 	Name    string   `json:"name" hcl:"name,label"`
 	Passed  []string `json:"passed" hcl:"passed,optional"`
 	Trigger bool     `json:"trigger" hcl:"trigger,optional"`
+	Timeout string   `json:"timeout" hcl:"timeout,optional"`
 
 	OnSuccess []utils.RunnerCommand `json:"on_success" hcl:"on_success,block"`
 	OnFailure []utils.RunnerCommand `json:"on_failure" hcl:"on_failure,block"`
@@ -36,8 +38,9 @@ type hclGetStep struct {
 
 // hclTaskStep is the HCL-decoded task step with per-step hooks.
 type hclTaskStep struct {
-	Name string              `json:"name" hcl:"name,label"`
-	Run  utils.RunnerCommand `json:"run" hcl:"run,block"`
+	Name    string              `json:"name" hcl:"name,label"`
+	Timeout string              `json:"timeout" hcl:"timeout,optional"`
+	Run     utils.RunnerCommand `json:"run" hcl:"run,block"`
 
 	OnSuccess []utils.RunnerCommand `json:"on_success" hcl:"on_success,block"`
 	OnFailure []utils.RunnerCommand `json:"on_failure" hcl:"on_failure,block"`
@@ -46,8 +49,9 @@ type hclTaskStep struct {
 
 // hclPutStep is the HCL-decoded put step.
 type hclPutStep struct {
-	Type string `hcl:"type,label"`
-	Name string `hcl:"name,label"`
+	Type    string `hcl:"type,label"`
+	Name    string `hcl:"name,label"`
+	Timeout string `hcl:"timeout,optional"`
 
 	OnSuccess []utils.RunnerCommand `hcl:"on_success,block"`
 	OnFailure []utils.RunnerCommand `hcl:"on_failure,block"`
@@ -372,8 +376,17 @@ func parseJobPlans(rpp []byte, hclJobs []hclJob) (map[string][]job.PlanStep, err
 				}
 				g := hj.Get[getIdx]
 				getIdx++
+				var timeout time.Duration
+				if g.Timeout != "" {
+					var err error
+					timeout, err = time.ParseDuration(g.Timeout)
+					if err != nil {
+						return nil, fmt.Errorf("invalid timeout %q on get step %q: %w", g.Timeout, g.Name, err)
+					}
+				}
 				plan = append(plan, job.PlanStep{
-					Type: job.StepTypeGet,
+					Type:    job.StepTypeGet,
+					Timeout: timeout,
 					Get: &job.GetStep{
 						Type:    g.Type,
 						Name:    g.Name,
@@ -390,8 +403,17 @@ func parseJobPlans(rpp []byte, hclJobs []hclJob) (map[string][]job.PlanStep, err
 				}
 				t := hj.Task[taskIdx]
 				taskIdx++
+				var timeout time.Duration
+				if t.Timeout != "" {
+					var err error
+					timeout, err = time.ParseDuration(t.Timeout)
+					if err != nil {
+						return nil, fmt.Errorf("invalid timeout %q on task step %q: %w", t.Timeout, t.Name, err)
+					}
+				}
 				plan = append(plan, job.PlanStep{
-					Type: job.StepTypeTask,
+					Type:    job.StepTypeTask,
+					Timeout: timeout,
 					Task: &job.TaskStep{
 						Name: t.Name,
 						Run:  t.Run,
@@ -406,8 +428,17 @@ func parseJobPlans(rpp []byte, hclJobs []hclJob) (map[string][]job.PlanStep, err
 				}
 				p := hj.Put[putIdx]
 				putIdx++
+				var timeout time.Duration
+				if p.Timeout != "" {
+					var err error
+					timeout, err = time.ParseDuration(p.Timeout)
+					if err != nil {
+						return nil, fmt.Errorf("invalid timeout %q on put step %q: %w", p.Timeout, p.Name, err)
+					}
+				}
 				plan = append(plan, job.PlanStep{
-					Type: job.StepTypePut,
+					Type:    job.StepTypePut,
+					Timeout: timeout,
 					Put: &job.PutStep{
 						Type:   p.Type,
 						Name:   p.Name,

--- a/pikoci/job/job.go
+++ b/pikoci/job/job.go
@@ -1,6 +1,10 @@
 package job
 
-import "github.com/xescugc/pikoci/pikoci/utils"
+import (
+	"time"
+
+	"github.com/xescugc/pikoci/pikoci/utils"
+)
 
 type StepType string
 
@@ -44,6 +48,7 @@ func (j *Job) PlanGetSteps() []PlanStep {
 
 type PlanStep struct {
 	Type      StepType              `json:"type"`
+	Timeout   time.Duration         `json:"timeout,omitempty"`
 	Get       *GetStep              `json:"get,omitempty"`
 	Task      *TaskStep             `json:"task,omitempty"`
 	Put       *PutStep              `json:"put,omitempty"`

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -3,6 +3,7 @@ package pikoci_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -284,6 +285,77 @@ job "test" {
 	_, err := s.S.CreatePipeline(ctx, "main", "conflict-pipeline", hclConfig, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "both source and inline commands")
+}
+
+func TestCreatePipeline_WithTimeout(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+  params {}
+}
+
+job "test" {
+  get "cron" "timer" {
+    trigger = true
+    timeout = "2m"
+  }
+  task "build" {
+    timeout = "10m"
+    run "exec" {
+      path = "echo"
+      args = ["building"]
+    }
+  }
+}
+`)
+
+	s.Pipelines.EXPECT().Create(ctx, "main", gomock.Any()).Return(uint32(1), nil)
+	s.Jobs.EXPECT().Create(ctx, "main", "timeout-pipeline", gomock.Any()).DoAndReturn(
+		func(ctx context.Context, tc, pn string, j job.Job) (uint32, error) {
+			require.Len(t, j.Plan, 2)
+			assert.Equal(t, 2*time.Minute, j.Plan[0].Timeout)
+			assert.Equal(t, 10*time.Minute, j.Plan[1].Timeout)
+			return uint32(1), nil
+		})
+	s.Resources.EXPECT().Create(ctx, "main", "timeout-pipeline", gomock.Any()).Return(uint32(1), nil)
+	s.Pipelines.EXPECT().Find(ctx, "main", "timeout-pipeline").Return(&pipeline.Pipeline{ID: 1, Name: "timeout-pipeline"}, nil)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "timeout-pipeline", hclConfig, nil)
+	require.NoError(t, err)
+}
+
+func TestCreatePipeline_InvalidTimeout(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+  params {}
+}
+
+job "test" {
+  get "cron" "timer" {
+    trigger = true
+  }
+  task "build" {
+    timeout = "invalid"
+    run "exec" {
+      path = "echo"
+      args = ["building"]
+    }
+  }
+}
+`)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "invalid-timeout-pipeline", hclConfig, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid timeout")
 }
 
 func TestCreatePipeline_SourceResolution(t *testing.T) {

--- a/worker/service.go
+++ b/worker/service.go
@@ -207,6 +207,13 @@ func (w *Worker) runPlan(ctx context.Context, m queue.Body, b *build.Build, cwd 
 // runGetStep runs a single get step (resource pull).
 // Returns true if the step failed.
 func (w *Worker) runGetStep(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, g job.GetStep, ps job.PlanStep) bool {
+	runCtx := ctx
+	if ps.Timeout > 0 {
+		var cancel context.CancelFunc
+		runCtx, cancel = context.WithTimeout(ctx, ps.Timeout)
+		defer cancel()
+	}
+
 	r, ok := pp.Resource(utils.ResourceCanonical(g.Type, g.Name))
 	if !ok {
 		return false
@@ -231,8 +238,11 @@ func (w *Worker) runGetStep(ctx context.Context, m queue.Body, b *build.Build, c
 		Args:   rt.Pull.Args,
 		Params: params,
 	}
-	out, d, err := w.runRunner(ctx, ru, cwd, rc)
+	out, d, err := w.runRunner(runCtx, ru, cwd, rc)
 	if err != nil {
+		if runCtx.Err() == context.DeadlineExceeded {
+			out += fmt.Sprintf("\nstep timed out after %s", ps.Timeout)
+		}
 		b.Steps = append(b.Steps, build.Step{Type: "get", Name: g.Name, Logs: out, Duration: d})
 		b.Status = build.Failed
 		w.failBuild(ctx, m, *b, nil)
@@ -260,13 +270,23 @@ func (w *Worker) runGetStep(ctx context.Context, m queue.Body, b *build.Build, c
 // runTaskStep runs a single task step.
 // Returns true if the step failed.
 func (w *Worker) runTaskStep(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, t job.TaskStep, ps job.PlanStep) bool {
+	runCtx := ctx
+	if ps.Timeout > 0 {
+		var cancel context.CancelFunc
+		runCtx, cancel = context.WithTimeout(ctx, ps.Timeout)
+		defer cancel()
+	}
+
 	ru, ok := pp.Runner(t.Run.Runner)
 	if !ok {
 		return false
 	}
 
-	out, d, err := w.runRunner(ctx, ru, cwd, t.Run)
+	out, d, err := w.runRunner(runCtx, ru, cwd, t.Run)
 	if err != nil {
+		if runCtx.Err() == context.DeadlineExceeded {
+			out += fmt.Sprintf("\nstep timed out after %s", ps.Timeout)
+		}
 		b.Steps = append(b.Steps, build.Step{Type: "task", Name: t.Name, Logs: out, Duration: d})
 		b.Status = build.Failed
 		w.failBuild(ctx, m, *b, nil)
@@ -287,6 +307,13 @@ func (w *Worker) runTaskStep(ctx context.Context, m queue.Body, b *build.Build, 
 // runPutStep runs a single put step (resource push).
 // Returns true if the step failed.
 func (w *Worker) runPutStep(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, p job.PutStep, ps job.PlanStep) bool {
+	runCtx := ctx
+	if ps.Timeout > 0 {
+		var cancel context.CancelFunc
+		runCtx, cancel = context.WithTimeout(ctx, ps.Timeout)
+		defer cancel()
+	}
+
 	rCan := utils.ResourceCanonical(p.Type, p.Name)
 	r, ok := pp.Resource(rCan)
 	if !ok {
@@ -322,8 +349,11 @@ func (w *Worker) runPutStep(ctx context.Context, m queue.Body, b *build.Build, c
 		Args:   rt.Push.Args,
 		Params: params,
 	}
-	out, d, err := w.runRunner(ctx, ru, cwd, rc)
+	out, d, err := w.runRunner(runCtx, ru, cwd, rc)
 	if err != nil {
+		if runCtx.Err() == context.DeadlineExceeded {
+			out += fmt.Sprintf("\nstep timed out after %s", ps.Timeout)
+		}
 		b.Steps = append(b.Steps, build.Step{Type: "put", Name: p.Name, Logs: out, Duration: d})
 		b.Status = build.Failed
 		w.failBuild(ctx, m, *b, nil)

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -986,5 +986,210 @@ func TestProcessJob_OrderedPlan_GetTaskPut(t *testing.T) {
 	w.processJob(ctx, m, cwd, pp)
 }
 
+func TestProcessJob_TaskTimeout(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical: "main",
+		PipelineName:  "test-pipeline",
+		JobName:       "timeout-job",
+	}
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "timeout-job",
+				Plan: []job.PlanStep{
+					{
+						Type:    job.StepTypeTask,
+						Timeout: 2 * time.Second,
+						Task: &job.TaskStep{
+							Name: "slow-task",
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Args:   []string{"10"},
+								Params: map[string]string{
+									"path": "sleep",
+								},
+							},
+						},
+						OnFailure: []utils.RunnerCommand{
+							{
+								Runner: "exec",
+								Args:   []string{"task failed due to timeout"},
+								Params: map[string]string{"path": "echo"},
+							},
+						},
+						Ensure: []utils.RunnerCommand{
+							{
+								Runner: "exec",
+								Args:   []string{"ensure runs"},
+								Params: map[string]string{"path": "echo"},
+							},
+						},
+					},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().CreateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, gomock.Any()).
+		Return(&build.Build{ID: 100}, nil)
+	svc.EXPECT().GetPipelineJob(ctx, m.TeamCanonical, m.PipelineName, m.JobName).
+		Return(&pp.Jobs[0], nil)
+
+	// failBuild + on_failure hook + ensure hook = 3 updates
+	var capturedBuild build.Build
+	svc.EXPECT().UpdateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, uint32(100), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, tc, pn, jn string, bID uint32, b build.Build) error {
+			capturedBuild = b
+			return nil
+		}).Times(3)
+
+	w.processJob(ctx, m, cwd, pp)
+
+	assert.Equal(t, build.Failed, capturedBuild.Status)
+	// The first step should contain the timeout message
+	require.NotEmpty(t, capturedBuild.Steps)
+	assert.Contains(t, capturedBuild.Steps[0].Logs, "timed out after 2s")
+}
+
+func TestProcessJob_GetTimeout(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical: "main",
+		PipelineName:  "test-pipeline",
+		JobName:       "get-timeout-job",
+		VersionID:     1,
+	}
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "get-timeout-job",
+				Plan: []job.PlanStep{
+					{
+						Type:    job.StepTypeGet,
+						Timeout: 1 * time.Second,
+						Get:     &job.GetStep{Type: "cron", Name: "my-cron", Trigger: true},
+					},
+				},
+			},
+		},
+		Resources: []resource.Resource{
+			{ID: 1, Name: "my-cron", Type: "cron", Canonical: "cron.my-cron"},
+		},
+		ResourceTypes: []restype.ResourceType{
+			{
+				ID: 1, Name: "cron",
+				Pull: utils.RunnerCommand{
+					Runner: "exec",
+					Args:   []string{"10"},
+					Params: map[string]string{"path": "sleep"},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().CreateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, gomock.Any()).
+		Return(&build.Build{ID: 101}, nil)
+	svc.EXPECT().GetPipelineJob(ctx, m.TeamCanonical, m.PipelineName, m.JobName).
+		Return(&pp.Jobs[0], nil)
+	svc.EXPECT().ListResourceVersions(ctx, m.TeamCanonical, m.PipelineName, "cron.my-cron").
+		Return([]*resource.Version{
+			{ID: 1, Version: map[string]interface{}{"date": "now"}},
+		}, nil)
+
+	// failBuild = 1 update
+	var capturedBuild build.Build
+	svc.EXPECT().UpdateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, uint32(101), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, tc, pn, jn string, bID uint32, b build.Build) error {
+			capturedBuild = b
+			return nil
+		})
+
+	w.processJob(ctx, m, cwd, pp)
+
+	assert.Equal(t, build.Failed, capturedBuild.Status)
+	require.NotEmpty(t, capturedBuild.Steps)
+	assert.Contains(t, capturedBuild.Steps[0].Logs, "timed out after 1s")
+}
+
+func TestProcessJob_NoTimeout_Succeeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical: "main",
+		PipelineName:  "test-pipeline",
+		JobName:       "no-timeout-job",
+	}
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "no-timeout-job",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						// Timeout is zero (not set)
+						Task: &job.TaskStep{
+							Name: "echo",
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Args:   []string{"hello"},
+								Params: map[string]string{"path": "echo"},
+							},
+						},
+					},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().CreateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, gomock.Any()).
+		Return(&build.Build{ID: 102}, nil)
+	svc.EXPECT().GetPipelineJob(ctx, m.TeamCanonical, m.PipelineName, m.JobName).
+		Return(&pp.Jobs[0], nil)
+
+	// UpdateJobBuild: after task step + after marking succeeded
+	var lastBuild build.Build
+	svc.EXPECT().UpdateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, uint32(102), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, tc, pn, jn string, bID uint32, b build.Build) error {
+			lastBuild = b
+			return nil
+		}).Times(2)
+
+	w.processJob(ctx, m, cwd, pp)
+
+	assert.Equal(t, build.Succeeded, lastBuild.Status)
+}
+
 // Silence the unused import warnings
 var _ = time.Now


### PR DESCRIPTION
## Summary

- Add optional `timeout` field (Go duration string, e.g. `"5m"`) on get, task, and put plan steps
- When set, wraps the runner execution context with `context.WithTimeout`; on expiry the process is killed, step is marked failed with a clear "step timed out after ..." log message
- Hooks (on_failure, ensure) still run normally after a timeout
- Invalid timeout values are rejected at pipeline creation time

Closes #173