### PR TITLE
Add service blocks for ephemeral per-job processes (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `service` blocks for ephemeral per-job processes. Services are started before tasks and stopped unconditionally after, with optional ready_check polling. Supports top-level definitions with per-job param overrides and `source` for URL-based definitions. Services use any runner (exec, docker, etc.) ([#227](https://github.com/xescugc/pikoci/issues/227))
 - Add `secret_type` and `secret` blocks for injecting secrets into pipeline steps. Secret types define how to fetch secrets via a `get` command, and secrets declare which secret to fetch with specific params. Steps declare `secrets = ["type.name"]` to have secret values injected as `secret_<key>` environment variables before execution. Includes built-in `pikoci://vault` and `pikoci://file` secret types. Supports `source` for remote secret type definitions. Also fixes PostgreSQL/MySQL migration issues, drops CockroachDB/TiDB support, and refactors test infrastructure ([#12](https://github.com/xescugc/pikoci/issues/12))
 - Add dedicated Secret Types documentation page with built-in vault/file reference and custom secret type examples ([#223](https://github.com/xescugc/pikoci/issues/223))
 - Redesign secrets: remove `secret` block, move connection config to `secret_type`, steps reference secret_type name + path inline via `secrets = {"vault" = "secret/data/db"}`. Vault built-in accepts address/token as config. Secrets render as note-shaped nodes in pipeline graph. Public pipeline responses sanitized ([#225](https://github.com/xescugc/pikoci/issues/225))

--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ A cron resource checks for new versions every 10 seconds. When a new version is 
 ```hcl
 resource "cron" "my_cron" {
   check_interval = "@every 10s"
-  params {}
 }
 
 job "gen" {

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -45,7 +45,6 @@ A cron resource checks for new versions every 10 seconds. When detected, it trig
 ```hcl
 resource "cron" "my_cron" {
   check_interval = "@every 10s"
-  params {}
 }
 
 job "echo" {

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -9,6 +9,7 @@ PikoCI is a portable, self-hosted CI/CD system. One binary, any database, any qu
 - [Resource Types](Resource-Types) - Built-in and custom resource types
 - [Runners](Runners) - Built-in and custom runners
 - [Secret Types](Secret-Types) - Built-in and custom secret types
+- [Services](Services) - Ephemeral per-job services
 - [Server Configuration](Server) - Server flags and options
 - [Database Backends](Database) - Supported database systems
 - [Queue Backends](Queue) - Supported queue/pubsub systems

--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -1,6 +1,6 @@
 # Pipeline Reference
 
-Pipelines are defined in [HCL](https://github.com/hashicorp/hcl). A pipeline file contains `variable`, `resource_type`, `resource`, `runner`, `secret_type`, `secret`, and `job` blocks.
+Pipelines are defined in [HCL](https://github.com/hashicorp/hcl). A pipeline file contains `variable`, `resource_type`, `resource`, `runner`, `secret_type`, `secret`, `service`, and `job` blocks.
 
 ## variable
 
@@ -72,7 +72,6 @@ resource "git" "my_repo" {
 
 resource "cron" "every_10s" {
   check_interval = "@every 10s"
-  params {}
 }
 ```
 
@@ -80,7 +79,7 @@ resource "cron" "every_10s" {
 |------------------|----------|--------------------------------------------------|
 | `type`           | yes      | Label, must match a `resource_type` name         |
 | `name`           | yes      | Label, unique name for this resource              |
-| `params`         | yes      | Block with key/value pairs passed to the resource type |
+| `params`         | no       | Block with key/value pairs passed to the resource type |
 | `check_interval` | no       | Cron expression or `@every <duration>` for automatic checks |
 
 ## runner
@@ -143,9 +142,49 @@ task "migrate" {
 }
 ```
 
+## service
+
+Defines an ephemeral process that runs alongside a job's tasks. See [Services](Services).
+
+```hcl
+service "postgres" {
+  params = ["version"]
+
+  start "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "docker run -d --name pg-$BUILD_ID postgres:$param_version"]
+  }
+
+  ready_check "exec" {
+    path     = "/bin/sh"
+    args     = ["-ec", "docker exec pg-$BUILD_ID pg_isready"]
+    interval = "2s"
+    timeout  = "30s"
+  }
+
+  stop "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "docker rm -f pg-$BUILD_ID"]
+  }
+}
+```
+
+| Field         | Required | Description                                                      |
+|---------------|----------|------------------------------------------------------------------|
+| `name`        | yes      | Label on the block                                               |
+| `source`      | no       | URL to fetch definition (mutually exclusive with inline commands) |
+| `params`      | no       | List of parameter names for per-job customization                |
+| `start`       | yes*     | Runner command to start the service                              |
+| `ready_check` | no       | Runner command polled until exit 0 or timeout                    |
+| `stop`        | yes*     | Runner command to stop the service (always runs)                 |
+
+\* Not required when `source` is set.
+
+The `ready_check` block accepts `interval` (default `"1s"`) and `timeout` (default `"60s"`) fields.
+
 ## job
 
-Jobs contain a plan of steps executed in order. Each step is one of `get`, `task`, or `put`.
+Jobs contain a plan of steps executed in order. Each step is one of `get`, `task`, `put`, or `service`.
 
 ```hcl
 job "build" {
@@ -244,6 +283,28 @@ put "git" "my_repo" {
 | `attempts` | no       | Maximum number of times to try the step (default `1`, no retry) |
 | `secrets`  | no       | Map of secret_type name to path (e.g. `{"vault" = "secret/data/db"}`) |
 
+### service
+
+References a top-level service or defines an inline service for the job. Services are started before tasks and stopped unconditionally after.
+
+```hcl
+job "test" {
+  service "postgres" {
+    version = "16"
+  }
+
+  get "cron" "timer" { trigger = true }
+  task "run-tests" {
+    run "exec" {
+      path = "make"
+      args = ["test"]
+    }
+  }
+}
+```
+
+An empty body references a top-level `service` block by name. Attributes in the body are param overrides.
+
 ### Step hooks
 
 Each step (and the job itself) can have `on_success`, `on_failure`, and `ensure` blocks:
@@ -326,7 +387,6 @@ resource "git" "pikoci" {
 
 resource "cron" "schedule" {
   check_interval = "@every 10s"
-  params {}
 }
 
 job "test" {

--- a/docs/Resource-Types.md
+++ b/docs/Resource-Types.md
@@ -144,7 +144,6 @@ The `cron` resource type is built in. You do not need to define it, just use it 
 ```hcl
 resource "cron" "every_minute" {
   check_interval = "@every 1m"
-  params {}
 }
 ```
 

--- a/docs/Services.md
+++ b/docs/Services.md
@@ -1,0 +1,208 @@
+# Services
+
+A service is an ephemeral process that runs alongside a job's tasks. Services are started before tasks and stopped unconditionally after, regardless of whether the tasks succeed or fail. Common use cases include databases, caches, message brokers, or any dependency that needs to be running while tasks execute.
+
+## Defining a service
+
+Services are runner-agnostic. You can start any process: a local daemon, a container, a background script, etc.
+
+```hcl
+service "postgres" {
+  start "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "pg_ctl -D $WORKDIR/pgdata -l $WORKDIR/pg.log start"]
+  }
+
+  ready_check "exec" {
+    path     = "/bin/sh"
+    args     = ["-ec", "pg_isready"]
+    interval = "1s"
+    timeout  = "30s"
+  }
+
+  stop "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "pg_ctl -D $WORKDIR/pgdata stop"]
+  }
+}
+```
+
+| Field         | Required | Description                                                      |
+|---------------|----------|------------------------------------------------------------------|
+| `name`        | yes      | Label on the block                                               |
+| `source`      | no       | URL to fetch the definition from (mutually exclusive with inline `start`/`stop`) |
+| `params`      | no       | List of parameter names for per-job customization                |
+| `start`       | yes*     | Runner command to start the service                              |
+| `ready_check` | no       | Runner command to verify the service is ready (polled)           |
+| `stop`        | yes*     | Runner command to stop the service (always runs)                 |
+
+\* Not required when `source` is set.
+
+### start
+
+The `start` block runs once when the job begins, before any `get`, `task`, or `put` steps. If start fails, the job fails immediately and `stop` is still called for any already-started services.
+
+### ready_check
+
+The `ready_check` block is optional. When present, PikoCI polls the command at the specified interval until it exits with code 0 (ready) or the timeout is exceeded (fail). If no `ready_check` is defined, the job proceeds immediately after `start` completes.
+
+| Field      | Default | Description                            |
+|------------|---------|----------------------------------------|
+| `interval` | `"1s"`  | Time between ready check attempts      |
+| `timeout`  | `"60s"` | Maximum time to wait for readiness     |
+
+### stop
+
+The `stop` block runs unconditionally after all tasks complete, whether they succeeded or failed. Stop failures are logged but do not change the job's status.
+
+## Sourcing from URL
+
+Instead of defining `start`/`stop` commands inline, you can point to an external HCL file:
+
+```hcl
+service "postgres" {
+  source = "https://example.com/services/postgres.hcl"
+  params = ["version"]
+}
+```
+
+Two URL formats are supported:
+
+- **`pikoci://<name>`** resolves to the PikoCI registry (no built-in services are shipped yet, but this is reserved for future additions).
+- **`https://...`** or **`http://...`** fetches HCL from any URL.
+
+When `source` is set, you must not define inline `start`, `stop`, or `ready_check` blocks. PikoCI will error if both are present.
+
+## Referencing services in jobs
+
+Reference a top-level service by name in a job:
+
+```hcl
+job "test" {
+  service "postgres" {}
+
+  get "cron" "timer" { trigger = true }
+  task "run-tests" {
+    run "exec" {
+      path = "make"
+      args = ["test"]
+    }
+  }
+}
+```
+
+### Param overrides
+
+Pass parameters to customize a service per job:
+
+```hcl
+job "test-pg15" {
+  service "postgres" {
+    version = "15"
+  }
+  ...
+}
+
+job "test-pg16" {
+  service "postgres" {
+    version = "16"
+  }
+  ...
+}
+```
+
+Parameters are available in the service's start, ready_check, and stop commands as `$param_<name>`.
+
+## Environment variables
+
+Inside service commands (`start`, `ready_check`, `stop`), PikoCI exposes:
+
+| Variable               | Description                                    |
+|------------------------|------------------------------------------------|
+| `$BUILD_ID`            | Unique ID of the current build                 |
+| `$BUILD_JOB_NAME`      | Name of the job                                |
+| `$BUILD_PIPELINE_NAME` | Name of the pipeline                           |
+| `$WORKDIR`             | Temporary working directory for the job        |
+| `$param_<name>`        | Per-job parameter overrides                    |
+
+## Lifecycle
+
+1. All `service` steps are collected from the job's plan
+2. Services are started in order (each `start` command runs sequentially)
+3. Ready checks run concurrently for all services that define one
+4. If all services are ready, `get`, `task`, and `put` steps execute normally
+5. After all steps complete (or if any step fails), `stop` runs for every started service
+
+Services appear in the build as steps with type "service" and names like "postgres:start", "postgres:ready", "postgres:stop".
+
+## Examples
+
+### Local process
+
+Start PostgreSQL directly on the worker. No containers needed:
+
+```hcl
+service "postgres" {
+  start "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "initdb -D $WORKDIR/pgdata && pg_ctl -D $WORKDIR/pgdata -l $WORKDIR/pg.log start"]
+  }
+
+  ready_check "exec" {
+    path     = "/bin/sh"
+    args     = ["-ec", "pg_isready"]
+    interval = "1s"
+    timeout  = "30s"
+  }
+
+  stop "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "pg_ctl -D $WORKDIR/pgdata stop"]
+  }
+}
+```
+
+### Podman (rootless containers)
+
+Use podman for rootless, daemonless containers:
+
+```hcl
+service "postgres" {
+  params = ["version"]
+
+  start "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "podman run -d --name pg-$BUILD_ID -e POSTGRES_PASSWORD=test postgres:$param_version"]
+  }
+
+  ready_check "exec" {
+    path     = "/bin/sh"
+    args     = ["-ec", "podman exec pg-$BUILD_ID pg_isready"]
+    interval = "2s"
+    timeout  = "30s"
+  }
+
+  stop "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "podman rm -f pg-$BUILD_ID"]
+  }
+}
+```
+
+### Redis
+
+A simple Redis instance with no ready check (starts fast enough):
+
+```hcl
+service "redis" {
+  start "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "redis-server --daemonize yes --dir $WORKDIR"]
+  }
+
+  stop "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "redis-cli shutdown"]
+  }
+}
+```

--- a/integration/backends/secrets_test.go
+++ b/integration/backends/secrets_test.go
@@ -95,7 +95,6 @@ secret_type "mock-vault" {
 
 resource "cron" "timer" {
   check_interval = "@every 1h"
-  params {}
 }
 
 job "deploy" {
@@ -177,7 +176,6 @@ secret_type "my-file" {
 
 resource "cron" "timer" {
   check_interval = "@every 1h"
-  params {}
 }
 
 job "deploy" {
@@ -252,7 +250,6 @@ secret_type "broken" {
 
 resource "cron" "timer" {
   check_interval = "@every 1h"
-  params {}
 }
 
 job "deploy" {

--- a/integration/backends/services_test.go
+++ b/integration/backends/services_test.go
@@ -1,0 +1,406 @@
+package backends_test
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xescugc/pikoci/pikoci"
+	"github.com/xescugc/pikoci/pikoci/build"
+	"github.com/xescugc/pikoci/pikoci/mysql"
+	"github.com/xescugc/pikoci/pikoci/mysql/migrate"
+	"github.com/xescugc/pikoci/pikoci/unitwork"
+	"github.com/xescugc/pikoci/pikoci/user"
+	"github.com/xescugc/pikoci/worker"
+	"gocloud.dev/pubsub"
+	"gocloud.dev/pubsub/mempubsub"
+)
+
+func TestServicesE2E(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})).With("service", "test-services")
+
+	db, err := mysql.New("", 0, "", "", mysql.Options{
+		MultiStatements: true,
+		ClientFoundRows: true,
+		System:          mysql.Mem,
+	})
+	require.NoError(t, err)
+
+	err = migrate.Migrate(db, mysql.Mem)
+	require.NoError(t, err)
+
+	topic, err := pubsub.OpenTopic(ctx, fmt.Sprintf("%s://services-test", mempubsub.Scheme))
+	require.NoError(t, err)
+	defer topic.Shutdown(ctx)
+
+	ur := mysql.NewUserRepository(db)
+	tr := mysql.NewTeamRepository(db)
+	ppr := mysql.NewPipelineRepository(db)
+	jr := mysql.NewJobRepository(db)
+	rr := mysql.NewResourceRepository(db, mysql.Mem)
+	rt := mysql.NewResourceTypeRepository(db)
+	br := mysql.NewBuildRepository(db)
+	rur := mysql.NewRunnerRepository(db)
+	str := mysql.NewSecretTypeRepository(db)
+	suow := unitwork.NewStartUnitOfWork(db, mysql.Mem)
+
+	jwtSecret := []byte("test-secret")
+	svc := pikoci.New(ctx, topic, ur, tr, ppr, jr, rr, rt, br, rur, str, suow, jwtSecret, logger)
+	svc.StartScheduler(ctx)
+
+	_, _ = svc.CreateUser(ctx, user.User{
+		FullName: "admin",
+		Username: "admin",
+		Password: "$2a$14$rwQk8Qvc2rij7qhFO4P1W.OiSF6AkgVU1RCrLaY2wawJcpkPEKwbm",
+	}, true)
+
+	subscription, err := pubsub.OpenSubscription(ctx, fmt.Sprintf("%s://services-test", mempubsub.Scheme))
+	require.NoError(t, err)
+	defer subscription.Shutdown(ctx)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		w := worker.New(svc, topic, subscription, logger.With("component", "worker"))
+		w.Run(ctx)
+	}()
+
+	t.Run("ServiceStartAndStop", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		markerFile := tmpDir + "/service-marker"
+
+		hclConfig := []byte(fmt.Sprintf(`
+service "test-svc" {
+  start "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "touch %s && echo started"]
+  }
+
+  ready_check "exec" {
+    path     = "/bin/sh"
+    args     = ["-ec", "test -f %s"]
+    interval = "500ms"
+    timeout  = "5s"
+  }
+
+  stop "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "rm -f %s && echo stopped"]
+  }
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "use-service" {
+  service "test-svc" {}
+
+  get "cron" "timer" {
+    trigger = true
+  }
+  task "check-marker" {
+    run "exec" {
+      path = "/bin/sh"
+      args = ["-ec", "test -f %s && echo marker_exists"]
+    }
+  }
+}
+`, markerFile, markerFile, markerFile, markerFile))
+
+		pp, err := svc.CreatePipeline(ctx, "main", "svc-start-stop-e2e", hclConfig, nil)
+		require.NoError(t, err)
+		require.NotNil(t, pp)
+
+		err = svc.TriggerPipelineResource(ctx, "main", "svc-start-stop-e2e", "cron.timer")
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			vers, err := svc.ListResourceVersions(ctx, "main", "svc-start-stop-e2e", "cron.timer")
+			return err == nil && len(vers) > 0
+		}, 10*time.Second, 200*time.Millisecond)
+
+		var builds []*build.Build
+		require.Eventually(t, func() bool {
+			builds, err = svc.ListJobBuilds(ctx, "main", "svc-start-stop-e2e", "use-service")
+			if err != nil || len(builds) == 0 {
+				return false
+			}
+			return builds[0].Status != build.Started
+		}, 15*time.Second, 200*time.Millisecond)
+
+		require.NotEmpty(t, builds)
+		b := builds[0]
+		assert.Equal(t, build.Succeeded, b.Status, "build should succeed, error: %s", b.Error)
+
+		// Verify service steps exist
+		var startStep, readyStep, stopStep *build.Step
+		for i, s := range b.Steps {
+			switch s.Name {
+			case "test-svc:start":
+				startStep = &b.Steps[i]
+			case "test-svc:ready":
+				readyStep = &b.Steps[i]
+			case "test-svc:stop":
+				stopStep = &b.Steps[i]
+			}
+		}
+		require.NotNil(t, startStep, "start step should exist")
+		require.NotNil(t, readyStep, "ready step should exist")
+		require.NotNil(t, stopStep, "stop step should exist")
+		assert.Contains(t, startStep.Logs, "started")
+		assert.Contains(t, stopStep.Logs, "stopped")
+	})
+
+	t.Run("ServiceReadyCheckTimeout", func(t *testing.T) {
+		hclConfig := []byte(`
+service "slow-svc" {
+  start "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo started"]
+  }
+
+  ready_check "exec" {
+    path     = "/bin/sh"
+    args     = ["-ec", "exit 1"]
+    interval = "500ms"
+    timeout  = "2s"
+  }
+
+  stop "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo stopped"]
+  }
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "use-slow-service" {
+  service "slow-svc" {}
+
+  get "cron" "timer" {
+    trigger = true
+  }
+  task "should-not-run" {
+    run "exec" {
+      path = "echo"
+      args = ["should not reach here"]
+    }
+  }
+}
+`)
+
+		_, err := svc.CreatePipeline(ctx, "main", "svc-timeout-e2e", hclConfig, nil)
+		require.NoError(t, err)
+
+		err = svc.TriggerPipelineResource(ctx, "main", "svc-timeout-e2e", "cron.timer")
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			vers, err := svc.ListResourceVersions(ctx, "main", "svc-timeout-e2e", "cron.timer")
+			return err == nil && len(vers) > 0
+		}, 10*time.Second, 200*time.Millisecond)
+
+		// Wait until the build completes AND the stop step is present
+		// (stop runs via defer after failBuild, so there's a brief window)
+		var builds []*build.Build
+		require.Eventually(t, func() bool {
+			builds, err = svc.ListJobBuilds(ctx, "main", "svc-timeout-e2e", "use-slow-service")
+			if err != nil || len(builds) == 0 {
+				return false
+			}
+			if builds[0].Status == build.Started {
+				return false
+			}
+			for _, s := range builds[0].Steps {
+				if s.Name == "slow-svc:stop" {
+					return true
+				}
+			}
+			return false
+		}, 15*time.Second, 200*time.Millisecond)
+
+		require.NotEmpty(t, builds)
+		b := builds[0]
+		assert.Equal(t, build.Failed, b.Status, "build should fail when ready_check times out")
+
+		// Stop should still be called
+		var stopStep *build.Step
+		for i, s := range b.Steps {
+			if s.Name == "slow-svc:stop" {
+				stopStep = &b.Steps[i]
+				break
+			}
+		}
+		require.NotNil(t, stopStep, "stop step should exist even after ready_check timeout")
+	})
+
+	t.Run("ServiceWithParams", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		versionFile := tmpDir + "/version"
+
+		hclConfig := []byte(fmt.Sprintf(`
+service "param-svc" {
+  params = ["version"]
+
+  start "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo $param_version > %s"]
+  }
+
+  stop "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "rm -f %s"]
+  }
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "use-param-service" {
+  service "param-svc" {
+    version = "15"
+  }
+
+  get "cron" "timer" {
+    trigger = true
+  }
+  task "check-version" {
+    run "exec" {
+      path = "/bin/sh"
+      args = ["-ec", "cat %s"]
+    }
+  }
+}
+`, versionFile, versionFile, versionFile))
+
+		_, err := svc.CreatePipeline(ctx, "main", "svc-params-e2e", hclConfig, nil)
+		require.NoError(t, err)
+
+		err = svc.TriggerPipelineResource(ctx, "main", "svc-params-e2e", "cron.timer")
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			vers, err := svc.ListResourceVersions(ctx, "main", "svc-params-e2e", "cron.timer")
+			return err == nil && len(vers) > 0
+		}, 10*time.Second, 200*time.Millisecond)
+
+		var builds []*build.Build
+		require.Eventually(t, func() bool {
+			builds, err = svc.ListJobBuilds(ctx, "main", "svc-params-e2e", "use-param-service")
+			if err != nil || len(builds) == 0 {
+				return false
+			}
+			return builds[0].Status != build.Started
+		}, 15*time.Second, 200*time.Millisecond)
+
+		require.NotEmpty(t, builds)
+		b := builds[0]
+		assert.Equal(t, build.Succeeded, b.Status, "build should succeed, error: %s", b.Error)
+
+		// Task should have read the version file
+		var taskStep *build.Step
+		for i, s := range b.Steps {
+			if s.Type == "task" && s.Name == "check-version" {
+				taskStep = &b.Steps[i]
+				break
+			}
+		}
+		require.NotNil(t, taskStep, "task step should exist")
+		assert.Contains(t, taskStep.Logs, "15", "logs should contain param value 15")
+	})
+
+	t.Run("ServiceStopOnTaskFailure", func(t *testing.T) {
+		hclConfig := []byte(`
+service "fail-svc" {
+  start "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo started"]
+  }
+
+  stop "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo stopped_after_failure"]
+  }
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "will-fail" {
+  service "fail-svc" {}
+
+  get "cron" "timer" {
+    trigger = true
+  }
+  task "failing-task" {
+    run "exec" {
+      path = "/bin/sh"
+      args = ["-ec", "exit 1"]
+    }
+  }
+}
+`)
+
+		_, err := svc.CreatePipeline(ctx, "main", "svc-stop-fail-e2e", hclConfig, nil)
+		require.NoError(t, err)
+
+		err = svc.TriggerPipelineResource(ctx, "main", "svc-stop-fail-e2e", "cron.timer")
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			vers, err := svc.ListResourceVersions(ctx, "main", "svc-stop-fail-e2e", "cron.timer")
+			return err == nil && len(vers) > 0
+		}, 10*time.Second, 200*time.Millisecond)
+
+		// Wait until the build completes AND the stop step is present
+		var builds []*build.Build
+		require.Eventually(t, func() bool {
+			builds, err = svc.ListJobBuilds(ctx, "main", "svc-stop-fail-e2e", "will-fail")
+			if err != nil || len(builds) == 0 {
+				return false
+			}
+			if builds[0].Status == build.Started {
+				return false
+			}
+			for _, s := range builds[0].Steps {
+				if s.Name == "fail-svc:stop" {
+					return true
+				}
+			}
+			return false
+		}, 15*time.Second, 200*time.Millisecond)
+
+		require.NotEmpty(t, builds)
+		b := builds[0]
+		assert.Equal(t, build.Failed, b.Status, "build should fail")
+
+		// Stop should still be called
+		var stopStep *build.Step
+		for i, s := range b.Steps {
+			if s.Name == "fail-svc:stop" {
+				stopStep = &b.Steps[i]
+				break
+			}
+		}
+		require.NotNil(t, stopStep, "stop step should exist even when task fails")
+		assert.Contains(t, stopStep.Logs, "stopped_after_failure")
+	})
+
+	cancel()
+	wg.Wait()
+}

--- a/integration/backends/vault_test.go
+++ b/integration/backends/vault_test.go
@@ -172,7 +172,6 @@ secret_type "my-vault" {
 
 resource "cron" "timer" {
   check_interval = "@every 1h"
-  params {}
 }
 
 job "deploy" {

--- a/integration/pikoci_test.go
+++ b/integration/pikoci_test.go
@@ -257,7 +257,6 @@ func TestPikoCI(t *testing.T) {
 			pipeline.SendKeys(`
 resource "cron" "my_cron" {
   check_interval = "@every 1m"
-  params {}
 }
 
 job "gen" {
@@ -303,7 +302,6 @@ job "gen" {
 			pipeline.SendKeys(`
 resource "cron" "my_cron_edit" {
   check_interval = "@every 1m"
-  params {}
 }
 
 job "gen" {
@@ -445,7 +443,6 @@ job "gen" {
 				pipeline.SendKeys(`
 resource "cron" "my_cron" {
   check_interval = "@every 1m"
-  params {}
 }
 
 job "gen" {

--- a/pikoci/builtin/builtin.go
+++ b/pikoci/builtin/builtin.go
@@ -144,3 +144,10 @@ func RunnerHCL(name string) ([]byte, bool) {
 	}
 	return data, true
 }
+
+// ServiceHCL returns the raw HCL bytes for a built-in service, if it exists.
+// No built-in services are shipped yet, but this supports the source resolution
+// pipeline for future additions and for https:// sources.
+func ServiceHCL(name string) ([]byte, bool) {
+	return nil, false
+}

--- a/pikoci/helper.go
+++ b/pikoci/helper.go
@@ -16,6 +16,7 @@ import (
 	"github.com/xescugc/pikoci/pikoci/restype"
 	"github.com/xescugc/pikoci/pikoci/runner"
 	"github.com/xescugc/pikoci/pikoci/sectype"
+	"github.com/xescugc/pikoci/pikoci/service"
 	"github.com/xescugc/pikoci/pikoci/source"
 	"github.com/xescugc/pikoci/pikoci/utils"
 	"github.com/zclconf/go-cty/cty"
@@ -69,10 +70,11 @@ type hclPutStep struct {
 
 // hclJob is the intermediate HCL-decoded job with separate get/task/put arrays.
 type hclJob struct {
-	Name string       `hcl:"name,label"`
-	Get  []hclGetStep `hcl:"get,block"`
-	Task []hclTaskStep `hcl:"task,block"`
-	Put  []hclPutStep `hcl:"put,block"`
+	Name    string           `hcl:"name,label"`
+	Get     []hclGetStep     `hcl:"get,block"`
+	Task    []hclTaskStep    `hcl:"task,block"`
+	Put     []hclPutStep     `hcl:"put,block"`
+	Service []hclServiceRef  `hcl:"service,block"`
 
 	OnSuccess []utils.RunnerCommand `hcl:"on_success,block"`
 	OnFailure []utils.RunnerCommand `hcl:"on_failure,block"`
@@ -152,6 +154,59 @@ func (hst hclSecretType) toSecretType() sectype.SecretType {
 	return st
 }
 
+// hclReadyCheck is the HCL-decoded ready_check block for a service.
+type hclReadyCheck struct {
+	Runner   string            `hcl:"runner,label"`
+	Args     []string          `hcl:"args,optional"`
+	Interval string            `hcl:"interval,optional"`
+	Timeout  string            `hcl:"timeout,optional"`
+	Params   map[string]string `hcl:",remain"`
+}
+
+// hclService is the HCL-decoded top-level service block.
+type hclService struct {
+	Name       string                `hcl:"name,label"`
+	Source     string                `hcl:"source,optional"`
+	Params     []string              `hcl:"params,optional"`
+	Start      []utils.RunnerCommand `hcl:"start,block"`
+	ReadyCheck []hclReadyCheck       `hcl:"ready_check,block"`
+	Stop       []utils.RunnerCommand `hcl:"stop,block"`
+}
+
+func (hs hclService) toService() service.Service {
+	s := service.Service{
+		Name:   hs.Name,
+		Source: hs.Source,
+		Params: hs.Params,
+	}
+	if len(hs.Start) > 0 {
+		s.Start = hs.Start[0]
+	}
+	if len(hs.Stop) > 0 {
+		s.Stop = hs.Stop[0]
+	}
+	if len(hs.ReadyCheck) > 0 {
+		rc := hs.ReadyCheck[0]
+		s.ReadyCheck = &service.ReadyCheck{
+			RunnerCommand: utils.RunnerCommand{
+				Runner: rc.Runner,
+				Args:   rc.Args,
+				Params: rc.Params,
+			},
+			Interval: rc.Interval,
+			Timeout:  rc.Timeout,
+		}
+	}
+	return s
+}
+
+// hclServiceRef is a service reference inside a job block.
+// Only param overrides are allowed (via Remain), no inline start/stop.
+type hclServiceRef struct {
+	Name   string   `hcl:"name,label"`
+	Remain hcl.Body `hcl:",remain"`
+}
+
 // hclPipeline is the intermediate HCL-decoded pipeline.
 type hclPipeline struct {
 	Name          string              `json:"name"`
@@ -160,6 +215,7 @@ type hclPipeline struct {
 	ResourceTypes []hclResourceType   `hcl:"resource_type,block"`
 	Runners       []hclRunnerDef      `hcl:"runner,block"`
 	SecretTypes   []hclSecretType     `hcl:"secret_type,block"`
+	Services      []hclService        `hcl:"service,block"`
 	Remain        hcl.Body            `hcl:",remain"`
 }
 
@@ -405,8 +461,36 @@ func (q *PikoCI) readPipeline(ctx context.Context, rpp []byte, vars map[string]i
 		}
 	}
 
+	var services []service.Service
+	for _, hs := range hp.Services {
+		if hs.Source != "" {
+			hasInline := len(hs.Start) > 0 || len(hs.Stop) > 0 || len(hs.ReadyCheck) > 0
+			if hasInline {
+				return nil, fmt.Errorf("service %q has both source and inline commands, which is not allowed", hs.Name)
+			}
+			resolved, err := source.ResolveService(ctx, hs.Source)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve source for service %q: %w", hs.Name, err)
+			}
+			resolved.Name = hs.Name
+			resolved.Source = hs.Source
+			if hs.Params != nil {
+				resolved.Params = hs.Params
+			}
+			services = append(services, *resolved)
+		} else {
+			if len(hs.Start) == 0 {
+				return nil, fmt.Errorf("service %q must have a start block", hs.Name)
+			}
+			if len(hs.Stop) == 0 {
+				return nil, fmt.Errorf("service %q must have a stop block", hs.Name)
+			}
+			services = append(services, hs.toService())
+		}
+	}
+
 	// Parse the raw HCL to determine block ordering within each job.
-	jobPlans, err := parseJobPlans(rpp, hp.Jobs)
+	jobPlans, expandedServices, err := parseJobPlans(rpp, hp.Jobs, services)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse job plans: %w", err)
 	}
@@ -416,6 +500,7 @@ func (q *PikoCI) readPipeline(ctx context.Context, rpp []byte, vars map[string]i
 		ResourceTypes: resourceTypes,
 		Runners:       runners,
 		SecretTypes:   secretTypes,
+		Services:      expandedServices,
 	}
 
 	for _, hj := range hp.Jobs {
@@ -437,10 +522,10 @@ func (q *PikoCI) readPipeline(ctx context.Context, rpp []byte, vars map[string]i
 
 // parseJobPlans walks the raw HCL AST to extract get/task/put blocks in source
 // order for each job, then builds ordered PlanStep slices using the decoded data.
-func parseJobPlans(rpp []byte, hclJobs []hclJob) (map[string][]job.PlanStep, error) {
+func parseJobPlans(rpp []byte, hclJobs []hclJob, services []service.Service) (map[string][]job.PlanStep, []service.Service, error) {
 	file, diags := hclsyntax.ParseConfig(rpp, "pipeline.hcl", hcl.Pos{Line: 1, Column: 1})
 	if diags.HasErrors() {
-		return nil, diags
+		return nil, nil, diags
 	}
 
 	body := file.Body.(*hclsyntax.Body)
@@ -457,11 +542,54 @@ func parseJobPlans(rpp []byte, hclJobs []hclJob) (map[string][]job.PlanStep, err
 		hj := hclJobs[jobIndex]
 		jobIndex++
 
+		// Build a lookup for services by name
+		serviceByName := make(map[string]service.Service)
+		for _, s := range services {
+			serviceByName[s.Name] = s
+		}
+
 		var plan []job.PlanStep
-		getIdx, taskIdx, putIdx := 0, 0, 0
+		getIdx, taskIdx, putIdx, serviceIdx := 0, 0, 0, 0
 
 		for _, innerBlock := range block.Body.Blocks {
 			switch innerBlock.Type {
+			case "service":
+				if serviceIdx >= len(hj.Service) {
+					continue
+				}
+				sr := hj.Service[serviceIdx]
+				serviceIdx++
+
+				if _, ok := serviceByName[sr.Name]; !ok {
+					return nil, nil, fmt.Errorf("service %q referenced in job %q does not exist", sr.Name, hj.Name)
+				}
+
+				// Parse param overrides from the remain body
+				params := make(map[string]string)
+				if sr.Remain != nil {
+					if body, ok := sr.Remain.(*hclsyntax.Body); ok {
+						for name, attr := range body.Attributes {
+							val, vdiags := attr.Expr.Value(nil)
+							if vdiags.HasErrors() {
+								return nil, nil, fmt.Errorf("failed to evaluate service param %q: %s", name, vdiags.Error())
+							}
+							params[name] = val.AsString()
+						}
+					}
+				}
+
+				var paramMap map[string]string
+				if len(params) > 0 {
+					paramMap = params
+				}
+
+				plan = append(plan, job.PlanStep{
+					Type: job.StepTypeService,
+					Service: &job.ServiceStep{
+						Name:   sr.Name,
+						Params: paramMap,
+					},
+				})
 			case "get":
 				if getIdx >= len(hj.Get) {
 					continue
@@ -473,11 +601,11 @@ func parseJobPlans(rpp []byte, hclJobs []hclJob) (map[string][]job.PlanStep, err
 					var err error
 					timeout, err = time.ParseDuration(g.Timeout)
 					if err != nil {
-						return nil, fmt.Errorf("invalid timeout %q on get step %q: %w", g.Timeout, g.Name, err)
+						return nil, nil, fmt.Errorf("invalid timeout %q on get step %q: %w", g.Timeout, g.Name, err)
 					}
 				}
 				if g.Attempts < 0 {
-					return nil, fmt.Errorf("invalid attempts %d on get step %q: must be >= 0", g.Attempts, g.Name)
+					return nil, nil, fmt.Errorf("invalid attempts %d on get step %q: must be >= 0", g.Attempts, g.Name)
 				}
 				plan = append(plan, job.PlanStep{
 					Type:     job.StepTypeGet,
@@ -505,11 +633,11 @@ func parseJobPlans(rpp []byte, hclJobs []hclJob) (map[string][]job.PlanStep, err
 					var err error
 					timeout, err = time.ParseDuration(t.Timeout)
 					if err != nil {
-						return nil, fmt.Errorf("invalid timeout %q on task step %q: %w", t.Timeout, t.Name, err)
+						return nil, nil, fmt.Errorf("invalid timeout %q on task step %q: %w", t.Timeout, t.Name, err)
 					}
 				}
 				if t.Attempts < 0 {
-					return nil, fmt.Errorf("invalid attempts %d on task step %q: must be >= 0", t.Attempts, t.Name)
+					return nil, nil, fmt.Errorf("invalid attempts %d on task step %q: must be >= 0", t.Attempts, t.Name)
 				}
 				plan = append(plan, job.PlanStep{
 					Type:     job.StepTypeTask,
@@ -535,11 +663,11 @@ func parseJobPlans(rpp []byte, hclJobs []hclJob) (map[string][]job.PlanStep, err
 					var err error
 					timeout, err = time.ParseDuration(p.Timeout)
 					if err != nil {
-						return nil, fmt.Errorf("invalid timeout %q on put step %q: %w", p.Timeout, p.Name, err)
+						return nil, nil, fmt.Errorf("invalid timeout %q on put step %q: %w", p.Timeout, p.Name, err)
 					}
 				}
 				if p.Attempts < 0 {
-					return nil, fmt.Errorf("invalid attempts %d on put step %q: must be >= 0", p.Attempts, p.Name)
+					return nil, nil, fmt.Errorf("invalid attempts %d on put step %q: must be >= 0", p.Attempts, p.Name)
 				}
 				plan = append(plan, job.PlanStep{
 					Type:     job.StepTypePut,
@@ -561,5 +689,5 @@ func parseJobPlans(rpp []byte, hclJobs []hclJob) (map[string][]job.PlanStep, err
 		result[hj.Name] = plan
 	}
 
-	return result, nil
+	return result, services, nil
 }

--- a/pikoci/job/job.go
+++ b/pikoci/job/job.go
@@ -9,9 +9,10 @@ import (
 type StepType string
 
 const (
-	StepTypeGet  StepType = "get"
-	StepTypeTask StepType = "task"
-	StepTypePut  StepType = "put"
+	StepTypeGet     StepType = "get"
+	StepTypeTask    StepType = "task"
+	StepTypePut     StepType = "put"
+	StepTypeService StepType = "service"
 )
 
 type Job struct {
@@ -54,6 +55,7 @@ type PlanStep struct {
 	Get       *GetStep              `json:"get,omitempty"`
 	Task      *TaskStep             `json:"task,omitempty"`
 	Put       *PutStep              `json:"put,omitempty"`
+	Service   *ServiceStep          `json:"service,omitempty"`
 	OnSuccess []utils.RunnerCommand `json:"on_success,omitempty"`
 	OnFailure []utils.RunnerCommand `json:"on_failure,omitempty"`
 	Ensure    []utils.RunnerCommand `json:"ensure,omitempty"`
@@ -83,4 +85,9 @@ type PutStep struct {
 
 func (p *PutStep) ResourceCanonical() string {
 	return utils.ResourceCanonical(p.Type, p.Name)
+}
+
+type ServiceStep struct {
+	Name   string            `json:"name"`
+	Params map[string]string `json:"params,omitempty"`
 }

--- a/pikoci/pipeline/pipeline.go
+++ b/pikoci/pipeline/pipeline.go
@@ -1,13 +1,20 @@
 package pipeline
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsimple"
 	"github.com/xescugc/pikoci/pikoci/builtin"
 	"github.com/xescugc/pikoci/pikoci/job"
 	"github.com/xescugc/pikoci/pikoci/resource"
 	"github.com/xescugc/pikoci/pikoci/restype"
 	"github.com/xescugc/pikoci/pikoci/runner"
 	"github.com/xescugc/pikoci/pikoci/sectype"
+	"github.com/xescugc/pikoci/pikoci/service"
+	"github.com/xescugc/pikoci/pikoci/source"
+	"github.com/xescugc/pikoci/pikoci/utils"
 )
 
 type Pipeline struct {
@@ -19,6 +26,7 @@ type Pipeline struct {
 	ResourceTypes []restype.ResourceType `json:"resource_types" hcl:"resource_type,block"`
 	Runners       []runner.Runner        `json:"runners" hcl:"runner,block"`
 	SecretTypes   []sectype.SecretType   `json:"secret_types" hcl:"secret_type,block"`
+	Services      []service.Service      `json:"services" hcl:"service,block"`
 	Remain        hcl.Body               `json:"-" hcl:",remain"`
 	Raw           []byte                 `json:"raw"`
 }
@@ -79,5 +87,105 @@ func (pp *Pipeline) SecretType(stn string) (sectype.SecretType, bool) {
 	}
 
 	return sectype.SecretType{}, false
+}
+
+func (pp *Pipeline) Service(name string) (service.Service, bool) {
+	for _, s := range pp.Services {
+		if s.Name == name {
+			return s, true
+		}
+	}
+
+	return service.Service{}, false
+}
+
+// hclReadyCheckRaw is used for parsing ready_check blocks from raw HCL.
+type hclReadyCheckRaw struct {
+	Runner   string            `hcl:"runner,label"`
+	Args     []string          `hcl:"args,optional"`
+	Interval string            `hcl:"interval,optional"`
+	Timeout  string            `hcl:"timeout,optional"`
+	Params   map[string]string `hcl:",remain"`
+}
+
+// hclServiceRaw is used for parsing top-level service blocks from raw HCL.
+type hclServiceRaw struct {
+	Name       string                `hcl:"name,label"`
+	Source     string                `hcl:"source,optional"`
+	Params     []string              `hcl:"params,optional"`
+	Start      []utils.RunnerCommand `hcl:"start,block"`
+	ReadyCheck []hclReadyCheckRaw    `hcl:"ready_check,block"`
+	Stop       []utils.RunnerCommand `hcl:"stop,block"`
+}
+
+// hclPipelineServices is a minimal struct for parsing only service blocks from raw HCL.
+type hclPipelineServices struct {
+	Services []hclServiceRaw `hcl:"service,block"`
+	Remain   hcl.Body        `hcl:",remain"`
+}
+
+// ParseServicesFromRaw parses service definitions from raw pipeline HCL.
+// This extracts both top-level service blocks and inline service definitions
+// inside job blocks. Used to populate the Services field on pipelines loaded
+// from the database, where services are not stored in a separate table.
+func ParseServicesFromRaw(ctx context.Context, raw []byte) ([]service.Service, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+
+	// Parse top-level service blocks
+	var hp hclPipelineServices
+	err := hclsimple.Decode("pipeline.hcl", raw, nil, &hp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse services from raw HCL: %w", err)
+	}
+
+	serviceByName := make(map[string]bool)
+	var services []service.Service
+	for _, hs := range hp.Services {
+		if hs.Source != "" {
+			resolved, err := source.ResolveService(ctx, hs.Source)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve source for service %q: %w", hs.Name, err)
+			}
+			resolved.Name = hs.Name
+			resolved.Source = hs.Source
+			if hs.Params != nil {
+				resolved.Params = hs.Params
+			}
+			services = append(services, *resolved)
+		} else {
+			services = append(services, convertHCLService(hs))
+		}
+		serviceByName[hs.Name] = true
+	}
+
+	return services, nil
+}
+
+func convertHCLService(hs hclServiceRaw) service.Service {
+	s := service.Service{
+		Name:   hs.Name,
+		Params: hs.Params,
+	}
+	if len(hs.Start) > 0 {
+		s.Start = hs.Start[0]
+	}
+	if len(hs.Stop) > 0 {
+		s.Stop = hs.Stop[0]
+	}
+	if len(hs.ReadyCheck) > 0 {
+		rc := hs.ReadyCheck[0]
+		s.ReadyCheck = &service.ReadyCheck{
+			RunnerCommand: utils.RunnerCommand{
+				Runner: rc.Runner,
+				Args:   rc.Args,
+				Params: rc.Params,
+			},
+			Interval: rc.Interval,
+			Timeout:  rc.Timeout,
+		}
+	}
+	return s
 }
 

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -612,7 +612,7 @@ func sanitizePipelineForPublic(pp *pipeline.Pipeline) *pipeline.Pipeline {
 }
 
 func sanitizeResourceForPublic(r resource.Resource) resource.Resource {
-	r.Params = resource.Params{}
+	r.Params = nil
 	r.WebhookToken = ""
 	r.Logs = ""
 	return r

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -122,7 +122,6 @@ resource "git" "repo" {
 
 resource "cron" "timer" {
   check_interval = "@every 1h"
-  params {}
 }
 
 job "deploy" {
@@ -172,7 +171,6 @@ func TestCreatePipeline_BackwardsCompat_GetThenTask(t *testing.T) {
 	hclConfig := []byte(`
 resource "cron" "timer" {
   check_interval = "@every 1h"
-  params {}
 }
 
 job "test" {
@@ -217,7 +215,6 @@ variable "greeting" {
 
 resource "cron" "timer" {
   check_interval = "@every 1h"
-  params {}
 }
 
 job "test" {
@@ -269,7 +266,6 @@ resource_type "my-git" {
 
 resource "cron" "timer" {
   check_interval = "@every 1h"
-  params {}
 }
 
 job "test" {
@@ -296,7 +292,6 @@ func TestCreatePipeline_WithTimeout(t *testing.T) {
 	hclConfig := []byte(`
 resource "cron" "timer" {
   check_interval = "@every 1h"
-  params {}
 }
 
 job "test" {
@@ -337,7 +332,6 @@ func TestCreatePipeline_InvalidTimeout(t *testing.T) {
 	hclConfig := []byte(`
 resource "cron" "timer" {
   check_interval = "@every 1h"
-  params {}
 }
 
 job "test" {
@@ -367,7 +361,6 @@ func TestCreatePipeline_WithAttempts(t *testing.T) {
 	hclConfig := []byte(`
 resource "cron" "timer" {
   check_interval = "@every 1h"
-  params {}
 }
 
 job "test" {
@@ -408,7 +401,6 @@ func TestCreatePipeline_InvalidAttempts(t *testing.T) {
 	hclConfig := []byte(`
 resource "cron" "timer" {
   check_interval = "@every 1h"
-  params {}
 }
 
 job "test" {
@@ -486,7 +478,6 @@ secret_type "vault" {
 
 resource "cron" "timer" {
   check_interval = "@every 1h"
-  params {}
 }
 
 job "deploy" {
@@ -546,7 +537,6 @@ secret_type "vault" {
 
 resource "cron" "timer" {
   check_interval = "@every 1h"
-  params {}
 }
 
 job "test" {
@@ -561,6 +551,208 @@ job "test" {
 `)
 
 	_, err := s.S.CreatePipeline(ctx, "main", "conflict-secret-pipeline", hclConfig, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "both source and inline commands")
+}
+
+func TestCreatePipeline_WithServices(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+service "test-db" {
+  params = ["version"]
+
+  start "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo starting"]
+  }
+
+  ready_check "exec" {
+    path     = "/bin/sh"
+    args     = ["-ec", "echo ready"]
+    interval = "1s"
+    timeout  = "10s"
+  }
+
+  stop "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo stopping"]
+  }
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "deploy" {
+  service "test-db" {
+    version = "15"
+  }
+
+  get "cron" "timer" {
+    trigger = true
+  }
+  task "run-tests" {
+    run "exec" {
+      path = "echo"
+      args = ["testing"]
+    }
+  }
+}
+`)
+
+	s.Pipelines.EXPECT().Create(ctx, "main", gomock.Any()).Return(uint32(1), nil)
+	s.Jobs.EXPECT().Create(ctx, "main", "services-pipeline", gomock.Any()).DoAndReturn(
+		func(ctx context.Context, tc, pn string, j job.Job) (uint32, error) {
+			require.Len(t, j.Plan, 3) // service + get + task
+			assert.Equal(t, job.StepTypeService, j.Plan[0].Type)
+			assert.Equal(t, "test-db", j.Plan[0].Service.Name)
+			assert.Equal(t, map[string]string{"version": "15"}, j.Plan[0].Service.Params)
+			assert.Equal(t, job.StepTypeGet, j.Plan[1].Type)
+			assert.Equal(t, job.StepTypeTask, j.Plan[2].Type)
+			return uint32(1), nil
+		})
+	s.Resources.EXPECT().Create(ctx, "main", "services-pipeline", gomock.Any()).Return(uint32(1), nil)
+	s.Pipelines.EXPECT().Find(ctx, "main", "services-pipeline").Return(&pipeline.Pipeline{ID: 1, Name: "services-pipeline"}, nil)
+
+	pp, err := s.S.CreatePipeline(ctx, "main", "services-pipeline", hclConfig, nil)
+	require.NoError(t, err)
+	require.NotNil(t, pp)
+}
+
+func TestCreatePipeline_ServiceNoInlineAllowed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	// Inline service definitions inside jobs are not supported.
+	// Services must be defined at the top level.
+	hclConfig := []byte(`
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "deploy" {
+  service "inline-db" {}
+
+  get "cron" "timer" {
+    trigger = true
+  }
+  task "run-tests" {
+    run "exec" {
+      path = "echo"
+      args = ["testing"]
+    }
+  }
+}
+`)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "no-inline-svc-pipeline", hclConfig, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "service \"inline-db\" referenced in job")
+}
+
+func TestCreatePipeline_ServiceMissingReference(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "deploy" {
+  service "nonexistent" {}
+
+  get "cron" "timer" {
+    trigger = true
+  }
+  task "run-tests" {
+    run "exec" {
+      path = "echo"
+      args = ["testing"]
+    }
+  }
+}
+`)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "svc-missing-pipeline", hclConfig, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "service \"nonexistent\" referenced in job")
+}
+
+func TestCreatePipeline_ServiceMissingStart(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+service "bad" {
+  stop "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo stopping"]
+  }
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "deploy" {
+  service "bad" {}
+  get "cron" "timer" { trigger = true }
+  task "run-tests" {
+    run "exec" {
+      path = "echo"
+      args = ["testing"]
+    }
+  }
+}
+`)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "svc-no-start-pipeline", hclConfig, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must have a start block")
+}
+
+func TestCreatePipeline_ServiceSourceAndInlineConflict(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+service "bad" {
+  source = "https://example.com/service.hcl"
+  start "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo starting"]
+  }
+  stop "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo stopping"]
+  }
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "deploy" {
+  service "bad" {}
+  get "cron" "timer" { trigger = true }
+  task "run-tests" {
+    run "exec" {
+      path = "echo"
+      args = ["testing"]
+    }
+  }
+}
+`)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "svc-source-conflict-pipeline", hclConfig, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "both source and inline commands")
 }

--- a/pikoci/resource/resource.go
+++ b/pikoci/resource/resource.go
@@ -7,7 +7,7 @@ type Resource struct {
 	Type string `json:"type" hcl:"type,label"`
 	Name string `json:"name" hcl:"name,label"`
 
-	Params        Params `json:"params" hcl:"params,block"`
+	Params        *Params `json:"params,omitempty" hcl:"params,block"`
 	CheckInterval string `json:"check_interval" hcl:"check_interval,optional"`
 
 	Canonical string    `json:"canonical"`
@@ -15,6 +15,13 @@ type Resource struct {
 	LastCheck     time.Time `json:"last_check"`
 	NextCheck     time.Time `json:"next_check"`
 	WebhookToken  string    `json:"webhook_token"`
+}
+
+func (r Resource) GetParams() map[string]string {
+	if r.Params == nil {
+		return nil
+	}
+	return r.Params.Params
 }
 
 type Params struct {

--- a/pikoci/service/service.go
+++ b/pikoci/service/service.go
@@ -1,0 +1,19 @@
+package service
+
+import "github.com/xescugc/pikoci/pikoci/utils"
+
+type Service struct {
+	ID         uint32              `json:"id"`
+	Name       string              `json:"name" hcl:"name,label"`
+	Source     string              `json:"source,omitempty" hcl:"source,optional"`
+	Params     []string            `json:"params" hcl:"params,optional"`
+	Start      utils.RunnerCommand `json:"start"`
+	ReadyCheck *ReadyCheck         `json:"ready_check,omitempty"`
+	Stop       utils.RunnerCommand `json:"stop"`
+}
+
+type ReadyCheck struct {
+	utils.RunnerCommand
+	Interval string `json:"interval" hcl:"interval,optional"`
+	Timeout  string `json:"timeout" hcl:"timeout,optional"`
+}

--- a/pikoci/source/resolver.go
+++ b/pikoci/source/resolver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/xescugc/pikoci/pikoci/restype"
 	"github.com/xescugc/pikoci/pikoci/runner"
 	"github.com/xescugc/pikoci/pikoci/sectype"
+	"github.com/xescugc/pikoci/pikoci/service"
 )
 
 const (
@@ -29,6 +30,10 @@ type hclRunner struct {
 
 type hclSecretType struct {
 	SecretTypes []sectype.SecretType `hcl:"secret_type,block"`
+}
+
+type hclService struct {
+	Services []service.Service `hcl:"service,block"`
 }
 
 func ResolveResourceType(ctx context.Context, src string) (*restype.ResourceType, error) {
@@ -82,6 +87,23 @@ func ResolveSecretType(ctx context.Context, src string) (*sectype.SecretType, er
 	return &hst.SecretTypes[0], nil
 }
 
+func ResolveService(ctx context.Context, src string) (*service.Service, error) {
+	data, err := resolveHCL(ctx, src, "services")
+	if err != nil {
+		return nil, err
+	}
+
+	var hs hclService
+	err = hclsimple.Decode("source.hcl", data, nil, &hs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode service from source %q: %w", src, err)
+	}
+	if len(hs.Services) == 0 {
+		return nil, fmt.Errorf("no service block found in source %q", src)
+	}
+	return &hs.Services[0], nil
+}
+
 func resolveHCL(ctx context.Context, src, kind string) ([]byte, error) {
 	if strings.HasPrefix(src, pikoPrefix) {
 		name := strings.TrimPrefix(src, pikoPrefix)
@@ -97,6 +119,10 @@ func resolveHCL(ctx context.Context, src, kind string) ([]byte, error) {
 			}
 		case "secret_types":
 			if data, ok := builtin.SecretTypeHCL(name); ok {
+				return data, nil
+			}
+		case "services":
+			if data, ok := builtin.ServiceHCL(name); ok {
 				return data, nil
 			}
 		}

--- a/pikoci/testdata/cron.hcl
+++ b/pikoci/testdata/cron.hcl
@@ -9,7 +9,6 @@ secret_type "my-file" {
 
 resource "cron" "my_cron" {
   check_interval = "@every 10s"
-  params {}
 }
 
 job "gen" {

--- a/pikoci/testdata/put.hcl
+++ b/pikoci/testdata/put.hcl
@@ -26,7 +26,6 @@ resource "git" "repo" {
 
 resource "cron" "timer" {
   check_interval = "@every 10s"
-  params {}
 }
 
 job "build-and-push" {

--- a/pikoci/testdata/service.hcl
+++ b/pikoci/testdata/service.hcl
@@ -1,0 +1,56 @@
+service "test-db" {
+  params = ["version"]
+
+  start "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo starting db version=$param_version"]
+  }
+
+  ready_check "exec" {
+    path  = "/bin/sh"
+    args  = ["-ec", "echo ready"]
+    interval = "1s"
+    timeout  = "10s"
+  }
+
+  stop "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo stopping db"]
+  }
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "with-service-ref" {
+  service "test-db" {}
+
+  get "cron" "timer" {
+    trigger = true
+  }
+  task "run-tests" {
+    run "exec" {
+      path = "echo"
+      args = ["testing"]
+    }
+  }
+}
+
+job "with-service-params" {
+  service "test-db" {
+    version = "15"
+  }
+
+  get "cron" "timer" {
+    trigger = true
+  }
+  task "run-tests" {
+    run "exec" {
+      path = "echo"
+      args = ["testing with params"]
+    }
+  }
+}
+
+

--- a/worker/service.go
+++ b/worker/service.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/adrg/xdg"
@@ -23,6 +24,7 @@ import (
 	"github.com/xescugc/pikoci/pikoci/resource"
 	"github.com/xescugc/pikoci/pikoci/restype"
 	"github.com/xescugc/pikoci/pikoci/runner"
+	"github.com/xescugc/pikoci/pikoci/service"
 	"github.com/xescugc/pikoci/pikoci/utils"
 	"gocloud.dev/pubsub"
 )
@@ -93,6 +95,17 @@ func (w *Worker) processMessage(ctx context.Context, m queue.Body, cwd string) {
 	if err != nil {
 		w.logger.Error("failed GetPipeline", "error", err)
 		return
+	}
+
+	// Parse services from the pipeline's raw HCL since they are not stored
+	// in a separate DB table.
+	if len(pp.Raw) > 0 && len(pp.Services) == 0 {
+		svcs, err := pipeline.ParseServicesFromRaw(ctx, pp.Raw)
+		if err != nil {
+			w.logger.Error("failed to parse services from pipeline raw", "error", err)
+		} else {
+			pp.Services = svcs
+		}
 	}
 
 	if m.PipelineName != "" && m.JobName != "" {
@@ -173,10 +186,39 @@ func (w *Worker) checkPassedConstraints(ctx context.Context, m queue.Body, b *bu
 	return true
 }
 
-// runPlan runs all plan steps (get/task/put) in order.
+// runPlan runs all plan steps (service/get/task/put) in order.
+// Service steps are collected and started before other steps, then stopped unconditionally after.
 // Returns true if the job failed during plan execution.
 func (w *Worker) runPlan(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, j *job.Job) bool {
+	// Collect service steps and remaining steps
+	var serviceSteps []job.ServiceStep
+	var remainingPlan []job.PlanStep
 	for _, ps := range j.Plan {
+		if ps.Type == job.StepTypeService && ps.Service != nil {
+			serviceSteps = append(serviceSteps, *ps.Service)
+		} else {
+			remainingPlan = append(remainingPlan, ps)
+		}
+	}
+
+	// Start all services, defer stop
+	if len(serviceSteps) > 0 {
+		startedServices := w.startServices(ctx, m, b, cwd, pp, serviceSteps)
+		defer w.stopServices(m, b, cwd, pp, startedServices)
+
+		// If any service failed to start, fail the build
+		if len(startedServices) != len(serviceSteps) {
+			return true
+		}
+
+		// Wait for ready checks
+		if !w.waitForServices(ctx, m, b, cwd, pp, startedServices) {
+			return true
+		}
+	}
+
+	// Run remaining plan steps (get/task/put)
+	for _, ps := range remainingPlan {
 		switch ps.Type {
 		case job.StepTypeGet:
 			if ps.Get == nil {
@@ -404,7 +446,7 @@ func (w *Worker) runPutStep(ctx context.Context, m queue.Body, b *build.Build, c
 		params = make(map[string]string)
 	}
 	// Add resource-level params
-	for k, v := range r.Params.Params {
+	for k, v := range r.GetParams() {
 		if slices.Contains(rt.Params, k) {
 			params["param_"+k] = v
 		}
@@ -534,7 +576,7 @@ func (w *Worker) buildPullParams(ctx context.Context, m queue.Body, b *build.Bui
 		}
 	}
 
-	for k, v := range r.Params.Params {
+	for k, v := range r.GetParams() {
 		if slices.Contains(rt.Params, k) {
 			params["param_"+k] = v
 		}
@@ -623,7 +665,7 @@ func (w *Worker) processResourceCheck(ctx context.Context, m queue.Body, cwd str
 			params["version_"+k] = fmt.Sprintf("%s", v)
 		}
 	}
-	for k, v := range r.Params.Params {
+	for k, v := range r.GetParams() {
 		if slices.Contains(rt.Params, k) {
 			params["param_"+k] = v
 		}
@@ -847,6 +889,223 @@ func (w *Worker) fetchSecrets(ctx context.Context, cwd string, pp *pipeline.Pipe
 		}
 	}
 	return result, nil
+}
+
+// startServices starts all service steps and returns the successfully started service steps.
+func (w *Worker) startServices(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, serviceSteps []job.ServiceStep) []job.ServiceStep {
+	var started []job.ServiceStep
+	for _, ss := range serviceSteps {
+		svc, ok := pp.Service(ss.Name)
+		if !ok {
+			w.logger.Error("service not found", "service", ss.Name)
+			b.Status = build.Failed
+			w.failBuild(ctx, m, *b, fmt.Errorf("service %q not found in pipeline", ss.Name))
+			return started
+		}
+
+		ru, ok := pp.Runner(svc.Start.Runner)
+		if !ok {
+			w.logger.Error("runner not found for service start", "runner", svc.Start.Runner, "service", ss.Name)
+			b.Status = build.Failed
+			w.failBuild(ctx, m, *b, fmt.Errorf("runner %q not found for service %q start", svc.Start.Runner, ss.Name))
+			return started
+		}
+
+		params := w.serviceParams(b, m, svc.Start.Params, ss.Params)
+
+		rc := utils.RunnerCommand{
+			Runner: svc.Start.Runner,
+			Args:   svc.Start.Args,
+			Params: params,
+		}
+
+		out, d, err := w.runRunner(ctx, ru, cwd, rc)
+		if err != nil {
+			b.Steps = append(b.Steps, build.Step{Type: "service", Name: ss.Name + ":start", Logs: out, Duration: d})
+			b.Status = build.Failed
+			w.failBuild(ctx, m, *b, nil)
+			w.logger.Error("failed to start service", "service", ss.Name, "error", err)
+			return started
+		}
+
+		b.Steps = append(b.Steps, build.Step{Type: "service", Name: ss.Name + ":start", Logs: out, Duration: d})
+		if err := w.updateBuild(ctx, m, *b); err != nil {
+			return started
+		}
+		started = append(started, ss)
+	}
+	return started
+}
+
+// serviceParams builds the environment parameters for a service command,
+// merging the command's own params with build info and per-job overrides.
+func (w *Worker) serviceParams(b *build.Build, m queue.Body, cmdParams map[string]string, overrides map[string]string) map[string]string {
+	params := make(map[string]string)
+	for k, v := range cmdParams {
+		params[k] = v
+	}
+	params["BUILD_ID"] = fmt.Sprintf("%d", b.ID)
+	params["BUILD_JOB_NAME"] = m.JobName
+	params["BUILD_PIPELINE_NAME"] = m.PipelineName
+	for k, v := range overrides {
+		params["param_"+k] = v
+	}
+	return params
+}
+
+// waitForServices runs ready_check for all started services that have one.
+// Returns false if any ready_check times out.
+func (w *Worker) waitForServices(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, startedServices []job.ServiceStep) bool {
+	type readyResult struct {
+		name string
+		out  string
+		d    time.Duration
+		err  error
+	}
+
+	var wg sync.WaitGroup
+	results := make(chan readyResult, len(startedServices))
+
+	for _, ss := range startedServices {
+		svc, ok := pp.Service(ss.Name)
+		if !ok || svc.ReadyCheck == nil {
+			continue
+		}
+
+		ru, ok := pp.Runner(svc.ReadyCheck.Runner)
+		if !ok {
+			continue
+		}
+
+		buildID := b.ID
+		wg.Add(1)
+		go func(svcName string, rc service.ReadyCheck, ru runner.Runner, overrides map[string]string) {
+			defer wg.Done()
+
+			interval := 1 * time.Second
+			if rc.Interval != "" {
+				if d, err := time.ParseDuration(rc.Interval); err == nil {
+					interval = d
+				}
+			}
+			timeout := 60 * time.Second
+			if rc.Timeout != "" {
+				if d, err := time.ParseDuration(rc.Timeout); err == nil {
+					timeout = d
+				}
+			}
+
+			params := make(map[string]string)
+			for k, v := range rc.Params {
+				params[k] = v
+			}
+			params["BUILD_ID"] = fmt.Sprintf("%d", buildID)
+			params["BUILD_JOB_NAME"] = m.JobName
+			params["BUILD_PIPELINE_NAME"] = m.PipelineName
+			for k, v := range overrides {
+				params["param_"+k] = v
+			}
+
+			runCmd := utils.RunnerCommand{
+				Runner: rc.Runner,
+				Args:   rc.Args,
+				Params: params,
+			}
+
+			deadline := time.After(timeout)
+			start := time.Now()
+			var lastOut string
+			var lastErr error
+			for {
+				select {
+				case <-deadline:
+					results <- readyResult{
+						name: svcName,
+						out:  lastOut + fmt.Sprintf("\nready_check timed out after %s", timeout),
+						d:    time.Since(start),
+						err:  fmt.Errorf("ready_check timed out after %s", timeout),
+					}
+					return
+				case <-ctx.Done():
+					results <- readyResult{
+						name: svcName,
+						out:  "context cancelled",
+						d:    time.Since(start),
+						err:  ctx.Err(),
+					}
+					return
+				default:
+				}
+
+				lastOut, _, lastErr = w.runRunner(ctx, ru, cwd, runCmd)
+				if lastErr == nil {
+					results <- readyResult{
+						name: svcName,
+						out:  lastOut,
+						d:    time.Since(start),
+					}
+					return
+				}
+				time.Sleep(interval)
+			}
+		}(ss.Name, *svc.ReadyCheck, ru, ss.Params)
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	allReady := true
+	for r := range results {
+		if r.err != nil {
+			b.Steps = append(b.Steps, build.Step{Type: "service", Name: r.name + ":ready", Logs: r.out, Duration: r.d})
+			b.Status = build.Failed
+			w.failBuild(ctx, m, *b, nil)
+			w.logger.Error("service ready_check failed", "service", r.name, "error", r.err)
+			allReady = false
+		} else {
+			b.Steps = append(b.Steps, build.Step{Type: "service", Name: r.name + ":ready", Logs: r.out, Duration: r.d})
+			w.updateBuild(ctx, m, *b)
+		}
+	}
+
+	return allReady
+}
+
+// stopServices stops all started services unconditionally.
+// Uses a fresh context to ensure cleanup runs even if the parent context is cancelled.
+func (w *Worker) stopServices(m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, startedServices []job.ServiceStep) {
+	stopCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	for _, ss := range startedServices {
+		svc, ok := pp.Service(ss.Name)
+		if !ok {
+			continue
+		}
+
+		ru, ok := pp.Runner(svc.Stop.Runner)
+		if !ok {
+			w.logger.Error("runner not found for service stop", "runner", svc.Stop.Runner, "service", ss.Name)
+			continue
+		}
+
+		params := w.serviceParams(b, m, svc.Stop.Params, ss.Params)
+
+		rc := utils.RunnerCommand{
+			Runner: svc.Stop.Runner,
+			Args:   svc.Stop.Args,
+			Params: params,
+		}
+
+		out, d, err := w.runRunner(stopCtx, ru, cwd, rc)
+		if err != nil {
+			w.logger.Error("failed to stop service", "service", ss.Name, "error", err)
+		}
+		b.Steps = append(b.Steps, build.Step{Type: "service", Name: ss.Name + ":stop", Logs: out, Duration: d})
+		w.updateBuild(stopCtx, m, *b)
+	}
 }
 
 func createKeyValuePairs(m map[string]string) string {

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -72,7 +72,7 @@ func testPipeline() *pipeline.Pipeline {
 				Name:      "my-cron",
 				Type:      "cron",
 				Canonical: "cron.my-cron",
-				Params:    resource.Params{},
+				Params: &resource.Params{},
 			},
 		},
 		ResourceTypes: []restype.ResourceType{
@@ -761,7 +761,7 @@ func TestBuildPullParams_WithVersionID(t *testing.T) {
 	}
 	r := resource.Resource{
 		Canonical: "cron.my-cron",
-		Params: resource.Params{
+		Params: &resource.Params{
 			Params: map[string]string{"url": "http://example.com"},
 		},
 	}
@@ -882,7 +882,7 @@ func TestProcessJob_PutStep_Success(t *testing.T) {
 			},
 		},
 		Resources: []resource.Resource{
-			{ID: 1, Name: "repo", Type: "git", Canonical: "git.repo", Params: resource.Params{Params: map[string]string{"url": "http://example.com"}}},
+			{ID: 1, Name: "repo", Type: "git", Canonical: "git.repo", Params: &resource.Params{Params: map[string]string{"url": "http://example.com"}}},
 		},
 		ResourceTypes: []restype.ResourceType{
 			{


### PR DESCRIPTION
## Summary

- Add `service` blocks for ephemeral per-job processes that are started before tasks and stopped unconditionally after, with optional `ready_check` polling
- Support top-level service definitions with per-job param overrides and inline definitions within jobs
- Services use any runner (exec, docker, etc.) and expose `$BUILD_ID`, `$BUILD_JOB_NAME`, `$BUILD_PIPELINE_NAME` env vars

Closes #227