### PR TITLE
Fix integration tests: portable paths and geckodriver 0.36 compat

### DIFF
--- a/integration/helper_test.go
+++ b/integration/helper_test.go
@@ -2,35 +2,64 @@ package integration_test
 
 import (
 	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/tebeka/selenium"
 )
 
 const (
-	// These paths will be different on your system.
-	seleniumPath    = "/home/xescugc/repos/qid/integration/vendor/selenium-server.jar"
-	geckoDriverPath = "/home/xescugc/repos/qid/integration/vendor/geckodriver"
-	port            = 8080
+	port = 8080
 )
 
+var geckoDriverPath string
+
+func init() {
+	_, f, _, _ := runtime.Caller(0)
+	geckoDriverPath = filepath.Join(filepath.Dir(f), "vendor", "geckodriver")
+}
+
 func getRemote(t *testing.T) selenium.WebDriver {
-	opts := []selenium.ServiceOption{
-		selenium.StartFrameBuffer(),           // Start an X frame buffer for the browser to run in.
-		selenium.GeckoDriver(geckoDriverPath), // Specify the path to GeckoDriver in order to use Firefox.
-		//selenium.Output(os.Stderr),            // Output debug information to STDERR.
-	}
-	//selenium.SetDebug(true)
-	service, err := selenium.NewSeleniumService(seleniumPath, port, opts...)
+	// Start Xvfb for headless browser testing.
+	fbuf, err := selenium.NewFrameBuffer()
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		service.Stop()
+		fbuf.Stop()
 	})
+
+	// Start geckodriver bound to 127.0.0.1 (the default).
+	cmd := exec.Command(geckoDriverPath, "--port", strconv.Itoa(port))
+	cmd.Env = append(os.Environ(), "DISPLAY=:"+fbuf.Display, "XAUTHORITY="+fbuf.AuthPath)
+	err = cmd.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		cmd.Process.Kill()
+		cmd.Wait()
+	})
+
+	// Wait for geckodriver to be ready.
+	addr := fmt.Sprintf("http://127.0.0.1:%d", port)
+	for i := 0; i < 30; i++ {
+		time.Sleep(time.Second)
+		resp, err := http.Get(addr + "/status")
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				break
+			}
+		}
+	}
 
 	// Connect to the WebDriver instance running locally.
 	caps := selenium.Capabilities{"browserName": "firefox"}
-	wd, err := selenium.NewRemote(caps, fmt.Sprintf("http://localhost:%d/wd/hub", port))
+	wd, err := selenium.NewRemote(caps, addr)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		wd.Quit()


### PR DESCRIPTION
## Summary
- Remove Selenium Server dependency — geckodriver 0.36 dropped the legacy protocol that Selenium 3 uses, so drive geckodriver directly instead
- Resolve geckodriver path relative to the source file using `runtime.Caller`, so tests work regardless of where the repo is cloned
- Use `127.0.0.1` instead of `localhost` to avoid IPv6 resolution issues (localhost → `::1` while geckodriver binds to `127.0.0.1`)

## Test plan
- [x] `make test` passes with all tests green