### PR TITLE
Update docs to reflect idempotent --users flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The fastest way to get started. Pass a pipeline config directly at launch. When 
 
 Open [http://localhost:8080](http://localhost:8080) and log in with the default user `admin` and password `admin123`.
 
-> **Users:** pass `--users 'username:hashed-password'` to add more users at startup. Use `pikoci user-password` to generate password hashes.
+> **Users:** pass `--users 'username:hashed-password'` to add or update users at startup. If a user already exists, their password is updated. Use `pikoci user-password` to generate password hashes.
 
 ### Example pipeline
 

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -64,14 +64,14 @@ Save as `pipeline.hcl` and start the server with the command above.
 
 ## Add users
 
-The default user is `admin` / `admin123` (created by the initial database migration). To add more users:
+The default user is `admin` / `admin123` (created by the initial database migration). Use `--users` to add new users or change existing passwords:
 
 ```bash
 # Generate a hashed password
 ./pikoci user-password -u myuser -p mypassword
 # Output: myuser:$2a$10$...
 
-# Pass it to the server
+# Pass it to the server (also works to update the default admin password)
 ./pikoci server --jwt-secret my-secret --users 'myuser:$2a$10$...'
 ```
 

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -49,14 +49,23 @@ export PIKOCI_SERVER_PUBSUB_SYSTEM=nats
 
 ## Default user
 
-The initial database migration seeds a default user: `admin` / `admin123`. To add additional users, use the `user-password` command to generate hashed passwords and pass them with `--users`:
+The initial database migration seeds a default user: `admin` / `admin123`. Use the `--users` flag to add new users or update existing users' passwords. If a user already exists, their password is updated; otherwise a new user is created.
 
 ```bash
+# Change the default admin password
+./pikoci user-password -u admin -p new-secure-password
+# Output: admin:$2a$10$...
+
+./pikoci server --jwt-secret my-secret --users 'admin:$2a$10$...'
+
+# Add a new user
 ./pikoci user-password -u deploy -p s3cret
 # Output: deploy:$2a$10$...
 
-./pikoci server --jwt-secret my-secret --users 'deploy:$2a$10$...'
+./pikoci server --jwt-secret my-secret --users 'admin:$2a$10$...' --users 'deploy:$2a$10$...'
 ```
+
+The `--users` flag is idempotent and safe to pass on every restart.
 
 ## Examples
 


### PR DESCRIPTION
Follow-up to #233. Update README, Server docs, and Getting Started to document that `--users` updates existing users' passwords and is safe to pass on every restart.