### PR TITLE
Add deployment infrastructure, pure Go SQLite, and cobra+viper CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ qid.db
 /builds
 integration/screenshot.png
 deploy/pikoci.env
+*.pem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `raw` format support to the built-in `file` secret type via `format = "raw"`. Returns the entire file content under a single `content` key, useful for PEM keys and other non-structured files
 - Add `.env` format support to the built-in `file` secret type via `format = "env"` config attribute. The default format remains `json` (backwards compatible)
 - Add secret-backed variables: variables can declare a `secret` block to resolve their value lazily from a secret type at runtime. This gives secrets universal reach through the existing `var.<name>` syntax — resource params, task args, etc. Vars file overrides take precedence for local development. Deprecates step-level `secrets = {}` on get/task/put steps in favor of the simpler declare-once-use-everywhere variable approach
 - Replace `urfave/cli` + `koanf` with `cobra` + `viper` for CLI and config management. Environment variables now use simple uppercase names (e.g., `JWT_SECRET`, `DB_SYSTEM`) ([#238](https://github.com/xescugc/pikoci/issues/238))

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ test-mock: ## Runs unit/mock tests (no services needed)
 test-integration: ## Runs integration tests with in-memory backends (no services needed)
 	@PIKOCI_TEST_DB_SYSTEMS=$${PIKOCI_TEST_DB_SYSTEMS:-mem,sqlite} \
 	PIKOCI_TEST_PUBSUB_SYSTEMS=$${PIKOCI_TEST_PUBSUB_SYSTEMS:-mem} \
-	go test -tags integration ./integration/... -timeout 120s
+	go test -tags integration ./integration/backends/... -timeout 120s
 
 .PHONY: test-backends
 test-backends: ## Runs integration tests with all backends (requires test-services-up)
@@ -80,7 +80,7 @@ test-backends: ## Runs integration tests with all backends (requires test-servic
 	NATS_SERVER_URL=nats://127.0.0.1:4222 \
 	RABBIT_SERVER_URL=amqp://guest:guest@127.0.0.1:5672/ \
 	KAFKA_BROKERS=127.0.0.1:9092 \
-	go test -tags integration ./integration/... -timeout 120s
+	go test -tags integration ./integration/backends/... -timeout 120s
 
 PLATFORMS := linux/amd64 windows/amd64 darwin/amd64
 

--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,14 @@ lint: ## Runs staticcheck linter
 	@go tool staticcheck ./...
 
 .PHONY: test
-test: ## Runs all tests (use test-services-up first for external backends)
+test: ## Runs unit tests only (no external services needed)
+	@go test ./... -timeout 120s
+
+.PHONY: test-integration
+test-integration: ## Runs integration tests (in-memory backends, no external services)
 	@PIKOCI_TEST_DB_SYSTEMS=$${PIKOCI_TEST_DB_SYSTEMS:-mem,sqlite} \
 	PIKOCI_TEST_PUBSUB_SYSTEMS=$${PIKOCI_TEST_PUBSUB_SYSTEMS:-mem} \
-	go test ./... -timeout 120s
+	go test -tags integration ./... -timeout 120s
 
 .PHONY: test-all
 test-all: ## Runs all tests including external backends (requires test-services-up)
@@ -74,7 +78,7 @@ test-all: ## Runs all tests including external backends (requires test-services-
 	NATS_SERVER_URL=nats://127.0.0.1:4222 \
 	RABBIT_SERVER_URL=amqp://guest:guest@127.0.0.1:5672/ \
 	KAFKA_BROKERS=127.0.0.1:9092 \
-	go test ./... -timeout 120s
+	go test -tags integration ./... -timeout 120s
 
 PLATFORMS := linux/amd64 windows/amd64 darwin/amd64
 

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ gen: ## Runs go generate
 
 .PHONY: lint
 lint: ## Runs staticcheck linter
-	@go tool staticcheck ./...
+	@GOFLAGS=-buildvcs=false go tool staticcheck ./...
 
 .PHONY: test
 test: test-mock test-integration test-backends ## Runs all tests

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,7 @@ dserve: ## Serves the server
 
 .PHONY: serve
 serve: ## Serves the server
-	@echo '{"secrets_file":"$(CURDIR)/pikoci/testdata/secrets.json"}' > /tmp/pikoci-serve-vars.json
-	@go run . server -p 4000 -log-level=debug -jwt-secret potato -users 'pepito:$$2a$$14$$rwQk8Qvc2rij7qhFO4P1W.OiSF6AkgVU1RCrLaY2wawJcpkPEKwbm,grillo:$$2a$$14$$SvWir17.jlXxiZfe0pJuDedznetc/HWKv43YPsQQNo6MJiuypS2q6' -pipeline-name=test -pipeline-config=./pikoci/testdata/cron.hcl -pipeline-vars=/tmp/pikoci-serve-vars.json
+	@go run . server -p 4000 --log-level=debug --jwt-secret potato --users 'pepito:$$2a$$14$$rwQk8Qvc2rij7qhFO4P1W.OiSF6AkgVU1RCrLaY2wawJcpkPEKwbm,grillo:$$2a$$14$$SvWir17.jlXxiZfe0pJuDedznetc/HWKv43YPsQQNo6MJiuypS2q6' --pipeline-name=test --pipeline-config=./pikoci/testdata/cron.hcl
 
 .PHONY: worker
 worker: ## Starts a worker
@@ -60,17 +59,20 @@ lint: ## Runs staticcheck linter
 	@go tool staticcheck ./...
 
 .PHONY: test
-test: ## Runs unit tests only (no external services needed)
+test: test-mock test-integration test-backends ## Runs all tests
+
+.PHONY: test-mock
+test-mock: ## Runs unit/mock tests (no services needed)
 	@go test ./... -timeout 120s
 
 .PHONY: test-integration
-test-integration: ## Runs integration tests (in-memory backends, no external services)
+test-integration: ## Runs integration tests with in-memory backends (no services needed)
 	@PIKOCI_TEST_DB_SYSTEMS=$${PIKOCI_TEST_DB_SYSTEMS:-mem,sqlite} \
 	PIKOCI_TEST_PUBSUB_SYSTEMS=$${PIKOCI_TEST_PUBSUB_SYSTEMS:-mem} \
-	go test -tags integration ./... -timeout 120s
+	go test -tags integration ./integration/... -timeout 120s
 
-.PHONY: test-all
-test-all: ## Runs all tests including external backends (requires test-services-up)
+.PHONY: test-backends
+test-backends: ## Runs integration tests with all backends (requires test-services-up)
 	@PIKOCI_TEST_DB_SYSTEMS=mem,sqlite,mysql,postgresql \
 	PIKOCI_TEST_PUBSUB_SYSTEMS=mem,nats \
 	PIKOCI_TEST_VAULT=1 \
@@ -78,7 +80,7 @@ test-all: ## Runs all tests including external backends (requires test-services-
 	NATS_SERVER_URL=nats://127.0.0.1:4222 \
 	RABBIT_SERVER_URL=amqp://guest:guest@127.0.0.1:5672/ \
 	KAFKA_BROKERS=127.0.0.1:9092 \
-	go test -tags integration ./... -timeout 120s
+	go test -tags integration ./integration/... -timeout 120s
 
 PLATFORMS := linux/amd64 windows/amd64 darwin/amd64
 

--- a/README.md
+++ b/README.md
@@ -132,13 +132,87 @@ For production setups, run the server and workers as separate processes on diffe
 Full server and worker configuration options are covered in the [documentation](https://github.com/xescugc/pikoci/wiki/Server).
 
 
+## Dogfooding: PikoCI runs its own CI
+
+PikoCI uses itself for CI. The [full pipeline](deploy/pipeline.hcl) runs lint, unit tests, integration tests, and backend tests with services — all defined in HCL:
+
+```hcl
+resource_type "git" {
+  source = "pikoci://git"
+}
+
+resource "git" "pikoci_pr" {
+  params {
+    url   = var.git_url
+    name  = var.git_name
+    pr    = true
+    token = var.github_token
+  }
+}
+
+job "lint" {
+  get "git" "pikoci_pr" { trigger = true }
+  task "make" {
+    run "docker" {
+      image = "golang:1.25.1"
+      cmd   = "cd ${var.git_name} && make lint"
+    }
+  }
+}
+
+job "test-mock" {
+  get "git" "pikoci_pr" { trigger = true }
+  task "make" {
+    run "docker" {
+      image = "golang:1.25.1"
+      cmd   = "cd ${var.git_name} && make test-mock"
+    }
+  }
+}
+
+job "test-integration" {
+  get "git" "pikoci_pr" { trigger = true }
+  task "make" {
+    run "docker" {
+      image = "golang:1.25.1"
+      cmd   = "cd ${var.git_name} && make test-integration"
+    }
+  }
+}
+
+job "test-backends" {
+  get "git" "pikoci_pr" {
+    trigger = true
+    passed  = ["lint", "test-mock", "test-integration"]
+  }
+
+  service "mariadb" {}
+  service "postgresql" {}
+  service "nats" {}
+  service "rabbitmq" {}
+  service "kafka" {}
+  service "vault" {}
+
+  task "make" {
+    run "docker" {
+      image = "golang:1.25.1"
+      cmd   = "cd ${var.git_name} && make test-backends"
+      args  = ["--network=host"]
+    }
+  }
+}
+```
+
+The `test-backends` job uses [service types](https://github.com/xescugc/pikoci/wiki/Services) to spin up MariaDB, PostgreSQL, NATS, RabbitMQ, Kafka, and Vault as Docker containers, runs the backend integration tests against them, then tears everything down. See the [full pipeline](deploy/pipeline.hcl) for secrets, variables, and service definitions.
+
+
 ## Coming from Concourse?
 
 PikoCI's resource model is directly inspired by Concourse. The main differences:
 
 - **Runners** replace task `image_resource`. Define a runner once, reference it from any job
 - **Deployment** is a single binary instead of a multi-service setup requiring PostgreSQL
-- **Secrets** use `variable` blocks today, with a native `secret_type` / `secret` backend system planned
+- **Secrets** use `secret_type` blocks with secret-backed variables. Built-in support for Vault and file-based secrets (JSON, env, raw)
 
 [Concourse pipeline importer planned (#210)](https://github.com/xescugc/pikoci/issues/210).
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Full server and worker configuration options are covered in the [documentation](
 
 ## Dogfooding: PikoCI runs its own CI
 
-PikoCI uses itself for CI. The [full pipeline](deploy/pipeline.hcl) runs lint, unit tests, integration tests, and backend tests with services — all defined in HCL:
+PikoCI uses itself for CI. See it live at [pikoci.com/teams/main/pipelines/pr_test](https://pikoci.com/teams/main/pipelines/pr_test). The [full pipeline](deploy/pipeline.hcl) runs lint, unit tests, integration tests, and backend tests with services — all defined in HCL:
 
 ```hcl
 resource_type "git" {

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -148,6 +148,10 @@ scp "$DEPLOY_DIR/pikoci.service" "$SSH_HOST":/etc/systemd/system/pikoci.service
 scp "$DEPLOY_DIR/docker-compose.yml" "$SSH_HOST":/opt/pikoci/docker-compose.yml
 scp "$DEPLOY_DIR/Caddyfile" "$SSH_HOST":/opt/pikoci/Caddyfile
 scp "$DEPLOY_DIR/prometheus.yml" "$SSH_HOST":/opt/pikoci/prometheus.yml
+ssh "$SSH_HOST" 'mkdir -p /opt/pikoci/grafana/provisioning/datasources /opt/pikoci/grafana/provisioning/dashboards /opt/pikoci/grafana/dashboards'
+scp "$DEPLOY_DIR/grafana/provisioning/datasources/prometheus.yml" "$SSH_HOST":/opt/pikoci/grafana/provisioning/datasources/prometheus.yml
+scp "$DEPLOY_DIR/grafana/provisioning/dashboards/default.yml" "$SSH_HOST":/opt/pikoci/grafana/provisioning/dashboards/default.yml
+scp "$DEPLOY_DIR/grafana/dashboards/pikoci.json" "$SSH_HOST":/opt/pikoci/grafana/dashboards/pikoci.json
 
 # --- Sync env file ---
 # The full env file goes to two places:

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,19 +1,69 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Deploy PikoCI to a remote server.
+# =============================================================================
+# deploy.sh — Deploy PikoCI to a remote server
+# =============================================================================
 #
-# Usage: ./deploy.sh [--build] <ssh-host>
+# This script handles the full deployment of PikoCI and its supporting services
+# (Caddy, Prometheus, Grafana, Node Exporter) to a remote Linux server via SSH.
 #
-# By default, downloads the latest release from GitHub.
-# Pass --build to build from source instead.
+# It is idempotent: safe to run repeatedly. Each run stops the running service,
+# replaces the binary and configs, and restarts everything.
 #
-# Detects the server architecture automatically (amd64/arm64).
-# Installs Docker on the server if not already present.
+# PREREQUISITES:
+#   - SSH access to the target server (configure in ~/.ssh/config)
+#   - deploy/pikoci.env must exist (copy from deploy/pikoci.env.example)
+#   - Go toolchain (only if using --build)
 #
-# Examples:
-#   ./deploy.sh root@pikoci.com
-#   ./deploy.sh --build root@pikoci.com
+# USAGE:
+#   ./deploy.sh [--build] <ssh-host>
+#
+# OPTIONS:
+#   --build    Build the binary from source instead of downloading the latest
+#              GitHub release. Requires Go installed locally.
+#
+# EXAMPLES:
+#   ./deploy.sh pikoci                 # Download latest release, deploy
+#   ./deploy.sh --build pikoci         # Build from source, deploy
+#   ./deploy.sh root@94.130.151.123    # Deploy using IP directly
+#
+# WHAT IT DOES (in order):
+#   1. Validates that deploy/pikoci.env exists
+#   2. Detects the server's CPU architecture (amd64 or arm64)
+#   3. Obtains the PikoCI binary (download release or build from source)
+#   4. Stops the running PikoCI systemd service (if any)
+#   5. Copies the binary to /usr/local/bin/pikoci on the server
+#   6. Creates server directories, system user, and sets ownership:
+#      - /opt/pikoci      — Docker Compose configs and supporting services
+#      - /etc/pikoci       — PikoCI environment/config (restricted permissions)
+#      - /var/lib/pikoci   — PikoCI data directory (owned by pikoci user)
+#   7. Copies config files to the server:
+#      - pikoci.service    → /etc/systemd/system/
+#      - docker-compose.yml, Caddyfile, prometheus.yml → /opt/pikoci/
+#   8. Copies the env file to two locations:
+#      - /etc/pikoci/pikoci.env  — read by systemd (chmod 600)
+#      - /opt/pikoci/pikoci.env  — read by Docker Compose containers (chmod 600)
+#      - /opt/pikoci/.env        — filtered subset (PIKOCI_DOMAIN, GF_*) for
+#                                  Docker Compose variable interpolation in
+#                                  docker-compose.yml (avoids bcrypt $ warnings)
+#   9. Installs Docker on the server if not already present
+#  10. Reloads systemd and restarts the PikoCI service
+#  11. Runs docker compose up -d for supporting services
+#
+# SERVER LAYOUT:
+#   /usr/local/bin/pikoci              — PikoCI binary
+#   /etc/systemd/system/pikoci.service — systemd unit
+#   /etc/pikoci/pikoci.env             — env vars for PikoCI (secrets)
+#   /var/lib/pikoci/                   — PikoCI data (SQLite DB, XDG data)
+#   /opt/pikoci/                       — Docker Compose stack
+#   /opt/pikoci/docker-compose.yml     — Caddy, Prometheus, Grafana, Node Exporter
+#   /opt/pikoci/Caddyfile              — reverse proxy config
+#   /opt/pikoci/prometheus.yml         — Prometheus scrape targets
+#   /opt/pikoci/pikoci.env             — env vars for Docker Compose containers
+#   /opt/pikoci/.env                   — filtered env vars for Compose interpolation
+#
+# =============================================================================
 
 BUILD=false
 
@@ -43,13 +93,17 @@ fi
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DEPLOY_DIR="$REPO_ROOT/deploy"
 
+# --- Validate local prerequisites ---
+
 if [ ! -f "$DEPLOY_DIR/pikoci.env" ]; then
     echo "Error: deploy/pikoci.env not found."
     echo "Create it from the template: cp deploy/pikoci.env.example deploy/pikoci.env"
     exit 1
 fi
 
-# Detect server architecture
+# --- Detect server architecture ---
+# PikoCI is a Go binary; we need to match the target CPU.
+
 SERVER_ARCH=$(ssh "$SSH_HOST" 'uname -m')
 case "$SERVER_ARCH" in
     x86_64)  GOARCH=amd64 ;;
@@ -60,6 +114,8 @@ case "$SERVER_ARCH" in
         ;;
 esac
 BINARY="$REPO_ROOT/builds/pikoci-linux-$GOARCH"
+
+# --- Obtain binary ---
 
 if [ "$BUILD" = true ]; then
     echo "==> Building PikoCI binary (linux/$GOARCH)..."
@@ -72,11 +128,19 @@ else
     chmod +x "$BINARY"
 fi
 
+# --- Stop running service ---
+# Must stop before copying to avoid "text file busy" errors.
+
 echo "==> Stopping PikoCI service..."
 ssh "$SSH_HOST" 'systemctl stop pikoci 2>/dev/null || true'
 
+# --- Copy binary ---
+
 echo "==> Copying binary to $SSH_HOST..."
 scp "$BINARY" "$SSH_HOST":/usr/local/bin/pikoci
+
+# --- Sync deploy configs ---
+# Creates directories and the pikoci system user on first run.
 
 echo "==> Syncing deploy configs..."
 ssh "$SSH_HOST" 'mkdir -p /opt/pikoci /etc/pikoci /var/lib/pikoci && id -u pikoci &>/dev/null || useradd --system --no-create-home pikoci && chown pikoci:pikoci /var/lib/pikoci'
@@ -85,6 +149,15 @@ scp "$DEPLOY_DIR/docker-compose.yml" "$SSH_HOST":/opt/pikoci/docker-compose.yml
 scp "$DEPLOY_DIR/Caddyfile" "$SSH_HOST":/opt/pikoci/Caddyfile
 scp "$DEPLOY_DIR/prometheus.yml" "$SSH_HOST":/opt/pikoci/prometheus.yml
 
+# --- Sync env file ---
+# The full env file goes to two places:
+#   /etc/pikoci/pikoci.env  — systemd reads this via EnvironmentFile=
+#   /opt/pikoci/pikoci.env  — Docker Compose containers read this via env_file:
+#
+# A filtered .env is created for Docker Compose YAML interpolation (${VAR}).
+# Only PIKOCI_DOMAIN, PIKOCI_GRAFANA_DOMAIN, and GF_* vars are included to
+# avoid warnings from bcrypt $ characters in USERS values.
+
 echo "==> Syncing env file..."
 scp "$DEPLOY_DIR/pikoci.env" "$SSH_HOST":/etc/pikoci/pikoci.env
 ssh "$SSH_HOST" 'chmod 600 /etc/pikoci/pikoci.env'
@@ -92,11 +165,14 @@ scp "$DEPLOY_DIR/pikoci.env" "$SSH_HOST":/opt/pikoci/pikoci.env
 ssh "$SSH_HOST" 'chmod 600 /opt/pikoci/pikoci.env'
 ssh "$SSH_HOST" 'rm -f /opt/pikoci/.env && grep -E "^(PIKOCI_DOMAIN|PIKOCI_GRAFANA_DOMAIN|GF_)" /opt/pikoci/pikoci.env > /opt/pikoci/.env'
 
-# Install Docker if not present
+# --- Install Docker if not present ---
+
 if ! ssh "$SSH_HOST" 'command -v docker &>/dev/null'; then
     echo "==> Installing Docker on $SSH_HOST..."
     ssh "$SSH_HOST" 'curl -fsSL https://get.docker.com | sh'
 fi
+
+# --- Restart services ---
 
 echo "==> Restarting PikoCI service..."
 ssh "$SSH_HOST" 'systemctl daemon-reload && systemctl restart pikoci'

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -169,6 +169,13 @@ scp "$DEPLOY_DIR/pikoci.env" "$SSH_HOST":/opt/pikoci/pikoci.env
 ssh "$SSH_HOST" 'chmod 600 /opt/pikoci/pikoci.env'
 ssh "$SSH_HOST" 'rm -f /opt/pikoci/.env && grep -E "^(PIKOCI_DOMAIN|PIKOCI_GRAFANA_DOMAIN|GF_)" /opt/pikoci/pikoci.env > /opt/pikoci/.env'
 
+# Copy GitHub App PEM key if present
+if [ -f "$DEPLOY_DIR/pikoci_github_app.pem" ]; then
+    echo "==> Syncing GitHub App PEM key..."
+    scp "$DEPLOY_DIR/pikoci_github_app.pem" "$SSH_HOST":/etc/pikoci/pikoci_github_app.pem
+    ssh "$SSH_HOST" 'chown pikoci:pikoci /etc/pikoci/pikoci_github_app.pem && chmod 600 /etc/pikoci/pikoci_github_app.pem'
+fi
+
 # --- Install required packages ---
 
 if ! ssh "$SSH_HOST" 'command -v jq &>/dev/null'; then

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -160,7 +160,7 @@ scp "$DEPLOY_DIR/prometheus.yml" "$SSH_HOST":/opt/pikoci/prometheus.yml
 
 echo "==> Syncing env file..."
 scp "$DEPLOY_DIR/pikoci.env" "$SSH_HOST":/etc/pikoci/pikoci.env
-ssh "$SSH_HOST" 'chmod 600 /etc/pikoci/pikoci.env'
+ssh "$SSH_HOST" 'chown pikoci:pikoci /etc/pikoci/pikoci.env && chmod 600 /etc/pikoci/pikoci.env'
 scp "$DEPLOY_DIR/pikoci.env" "$SSH_HOST":/opt/pikoci/pikoci.env
 ssh "$SSH_HOST" 'chmod 600 /opt/pikoci/pikoci.env'
 ssh "$SSH_HOST" 'rm -f /opt/pikoci/.env && grep -E "^(PIKOCI_DOMAIN|PIKOCI_GRAFANA_DOMAIN|GF_)" /opt/pikoci/pikoci.env > /opt/pikoci/.env'

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -165,7 +165,17 @@ scp "$DEPLOY_DIR/pikoci.env" "$SSH_HOST":/opt/pikoci/pikoci.env
 ssh "$SSH_HOST" 'chmod 600 /opt/pikoci/pikoci.env'
 ssh "$SSH_HOST" 'rm -f /opt/pikoci/.env && grep -E "^(PIKOCI_DOMAIN|PIKOCI_GRAFANA_DOMAIN|GF_)" /opt/pikoci/pikoci.env > /opt/pikoci/.env'
 
-# --- Install Docker if not present ---
+# --- Install required packages ---
+
+if ! ssh "$SSH_HOST" 'command -v jq &>/dev/null'; then
+    echo "==> Installing jq on $SSH_HOST..."
+    ssh "$SSH_HOST" 'apt-get install -y jq || apk add jq || dnf install -y jq'
+fi
+
+if ! ssh "$SSH_HOST" 'command -v git &>/dev/null'; then
+    echo "==> Installing git on $SSH_HOST..."
+    ssh "$SSH_HOST" 'apt-get install -y git || apk add git || dnf install -y git'
+fi
 
 if ! ssh "$SSH_HOST" 'command -v docker &>/dev/null'; then
     echo "==> Installing Docker on $SSH_HOST..."

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -143,7 +143,7 @@ scp "$BINARY" "$SSH_HOST":/usr/local/bin/pikoci
 # Creates directories and the pikoci system user on first run.
 
 echo "==> Syncing deploy configs..."
-ssh "$SSH_HOST" 'mkdir -p /opt/pikoci /etc/pikoci /var/lib/pikoci && id -u pikoci &>/dev/null || useradd --system --no-create-home pikoci && chown pikoci:pikoci /var/lib/pikoci'
+ssh "$SSH_HOST" 'mkdir -p /opt/pikoci /etc/pikoci /var/lib/pikoci && id -u pikoci &>/dev/null || useradd --system --no-create-home pikoci && chown pikoci:pikoci /var/lib/pikoci && usermod -aG docker pikoci 2>/dev/null || true'
 scp "$DEPLOY_DIR/pikoci.service" "$SSH_HOST":/etc/systemd/system/pikoci.service
 scp "$DEPLOY_DIR/docker-compose.yml" "$SSH_HOST":/opt/pikoci/docker-compose.yml
 scp "$DEPLOY_DIR/Caddyfile" "$SSH_HOST":/opt/pikoci/Caddyfile

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -33,6 +33,8 @@ services:
       - GF_SERVER_ROOT_URL=https://${PIKOCI_GRAFANA_DOMAIN}
     volumes:
       - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
 
   node-exporter:
     image: prom/node-exporter:latest

--- a/deploy/grafana/dashboards/pikoci.json
+++ b/deploy/grafana/dashboards/pikoci.json
@@ -1,17 +1,205 @@
 {
-  "annotations": { "list": [] },
+  "annotations": {
+    "list": []
+  },
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "links": [],
   "panels": [
     {
+      "title": "System CPU %",
+      "type": "gauge",
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "steps": [
+              {
+                "value": 0,
+                "color": "green"
+              },
+              {
+                "value": 0.7,
+                "color": "yellow"
+              },
+              {
+                "value": 0.9,
+                "color": "red"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "1 - avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m]))",
+          "legendFormat": "CPU",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "System Memory %",
+      "type": "gauge",
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "steps": [
+              {
+                "value": 0,
+                "color": "green"
+              },
+              {
+                "value": 0.7,
+                "color": "yellow"
+              },
+              {
+                "value": 0.9,
+                "color": "red"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)",
+          "legendFormat": "Memory",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Disk Usage %",
+      "type": "gauge",
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "steps": [
+              {
+                "value": 0,
+                "color": "green"
+              },
+              {
+                "value": 0.7,
+                "color": "yellow"
+              },
+              {
+                "value": 0.9,
+                "color": "red"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "1 - (node_filesystem_avail_bytes{mountpoint=\"/\"} / node_filesystem_size_bytes{mountpoint=\"/\"})",
+          "legendFormat": "Disk",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "System Load Average",
+      "type": "stat",
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "node_load1",
+          "legendFormat": "1m",
+          "refId": "A"
+        },
+        {
+          "expr": "node_load5",
+          "legendFormat": "5m",
+          "refId": "B"
+        },
+        {
+          "expr": "node_load15",
+          "legendFormat": "15m",
+          "refId": "C"
+        }
+      ]
+    },
+    {
       "title": "HTTP Request Rate",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 10 } },
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          }
+        },
         "overrides": []
       },
       "targets": [
@@ -25,10 +213,24 @@
     {
       "title": "HTTP Request Duration (p50 / p90 / p99)",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10 } },
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          }
+        },
         "overrides": []
       },
       "targets": [
@@ -52,10 +254,24 @@
     {
       "title": "HTTP Requests by Method",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "reqps", "custom": { "drawStyle": "bars", "fillOpacity": 50 } },
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 50
+          }
+        },
         "overrides": []
       },
       "targets": [
@@ -69,10 +285,28 @@
     {
       "title": "Error Rate (4xx + 5xx)",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 20 }, "color": { "mode": "fixed", "fixedColor": "red" } },
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20
+          },
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "red"
+          }
+        },
         "overrides": []
       },
       "targets": [
@@ -86,10 +320,24 @@
     {
       "title": "Goroutines",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 16 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 22
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } },
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          }
+        },
         "overrides": []
       },
       "targets": [
@@ -103,10 +351,24 @@
     {
       "title": "Memory Usage",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 16 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 22
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10 } },
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          }
+        },
         "overrides": []
       },
       "targets": [
@@ -130,10 +392,24 @@
     {
       "title": "GC Pause Duration",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 16 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 22
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10 } },
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          }
+        },
         "overrides": []
       },
       "targets": [
@@ -147,10 +423,24 @@
     {
       "title": "Process CPU Usage",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 24 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 30
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "percentunit", "custom": { "drawStyle": "line", "fillOpacity": 10 } },
+        "defaults": {
+          "unit": "percentunit",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          }
+        },
         "overrides": []
       },
       "targets": [
@@ -164,10 +454,24 @@
     {
       "title": "Open File Descriptors",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 24 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 30
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } },
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          }
+        },
         "overrides": []
       },
       "targets": [
@@ -186,10 +490,24 @@
     {
       "title": "Process Resident Memory",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 24 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 30
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10 } },
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          }
+        },
         "overrides": []
       },
       "targets": [
@@ -208,10 +526,20 @@
     {
       "title": "Total HTTP Requests",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 32 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 38
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "short" },
+        "defaults": {
+          "unit": "short"
+        },
         "overrides": []
       },
       "targets": [
@@ -225,10 +553,20 @@
     {
       "title": "Uptime",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 32 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 38
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "s" },
+        "defaults": {
+          "unit": "s"
+        },
         "overrides": []
       },
       "targets": [
@@ -242,10 +580,20 @@
     {
       "title": "Current Goroutines",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 32 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 38
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "short" },
+        "defaults": {
+          "unit": "short"
+        },
         "overrides": []
       },
       "targets": [
@@ -259,10 +607,20 @@
     {
       "title": "Heap Alloc",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 32 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 38
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "bytes" },
+        "defaults": {
+          "unit": "bytes"
+        },
         "overrides": []
       },
       "targets": [
@@ -276,10 +634,26 @@
     {
       "title": "System CPU Usage %",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 36 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "percentunit", "min": 0, "max": 1, "custom": { "drawStyle": "line", "fillOpacity": 20 } },
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20
+          }
+        },
         "overrides": []
       },
       "targets": [
@@ -303,10 +677,26 @@
     {
       "title": "System Memory Usage %",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 36 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 42
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "percentunit", "min": 0, "max": 1, "custom": { "drawStyle": "line", "fillOpacity": 20 } },
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20
+          }
+        },
         "overrides": []
       },
       "targets": [
@@ -316,90 +706,19 @@
           "refId": "A"
         }
       ]
-    },
-    {
-      "title": "System CPU %",
-      "type": "gauge",
-      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 44 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": { "unit": "percentunit", "min": 0, "max": 1, "thresholds": { "steps": [{"value": 0, "color": "green"}, {"value": 0.7, "color": "yellow"}, {"value": 0.9, "color": "red"}] } },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "expr": "1 - avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m]))",
-          "legendFormat": "CPU",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "title": "System Memory %",
-      "type": "gauge",
-      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 44 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": { "unit": "percentunit", "min": 0, "max": 1, "thresholds": { "steps": [{"value": 0, "color": "green"}, {"value": 0.7, "color": "yellow"}, {"value": 0.9, "color": "red"}] } },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "expr": "1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)",
-          "legendFormat": "Memory",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "title": "Disk Usage %",
-      "type": "gauge",
-      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 44 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": { "unit": "percentunit", "min": 0, "max": 1, "thresholds": { "steps": [{"value": 0, "color": "green"}, {"value": 0.7, "color": "yellow"}, {"value": 0.9, "color": "red"}] } },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "expr": "1 - (node_filesystem_avail_bytes{mountpoint=\"/\"} / node_filesystem_size_bytes{mountpoint=\"/\"})",
-          "legendFormat": "Disk",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "title": "System Load Average",
-      "type": "stat",
-      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 44 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": { "unit": "short" },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "expr": "node_load1",
-          "legendFormat": "1m",
-          "refId": "A"
-        },
-        {
-          "expr": "node_load5",
-          "legendFormat": "5m",
-          "refId": "B"
-        },
-        {
-          "expr": "node_load15",
-          "legendFormat": "15m",
-          "refId": "C"
-        }
-      ]
     }
   ],
   "schemaVersion": 39,
-  "tags": ["pikoci"],
-  "templating": { "list": [] },
-  "time": { "from": "now-1h", "to": "now" },
+  "tags": [
+    "pikoci"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "browser",
   "title": "PikoCI",

--- a/deploy/grafana/dashboards/pikoci.json
+++ b/deploy/grafana/dashboards/pikoci.json
@@ -1,0 +1,286 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "title": "HTTP Request Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total[5m])) by (code)",
+          "legendFormat": "{{code}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "HTTP Request Duration (p50 / p90 / p99)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.90, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "title": "HTTP Requests by Method",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "custom": { "drawStyle": "bars", "fillOpacity": 50 } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total[5m])) by (method)",
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Error Rate (4xx + 5xx)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 20 }, "color": { "mode": "fixed", "fixedColor": "red" } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{code=~\"4..|5..\"}[5m]))",
+          "legendFormat": "errors",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Goroutines",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "go_goroutines",
+          "legendFormat": "goroutines",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Memory Usage",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "go_memstats_alloc_bytes",
+          "legendFormat": "alloc",
+          "refId": "A"
+        },
+        {
+          "expr": "go_memstats_sys_bytes",
+          "legendFormat": "sys",
+          "refId": "B"
+        },
+        {
+          "expr": "go_memstats_heap_inuse_bytes",
+          "legendFormat": "heap in-use",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "title": "GC Pause Duration",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "rate(go_gc_duration_seconds_sum[5m])",
+          "legendFormat": "gc time/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Process CPU Usage",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "percentunit", "custom": { "drawStyle": "line", "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "rate(process_cpu_seconds_total[5m])",
+          "legendFormat": "CPU",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Open File Descriptors",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "process_open_fds",
+          "legendFormat": "open FDs",
+          "refId": "A"
+        },
+        {
+          "expr": "process_max_fds",
+          "legendFormat": "max FDs",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "title": "Process Resident Memory",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes",
+          "legendFormat": "RSS",
+          "refId": "A"
+        },
+        {
+          "expr": "process_virtual_memory_bytes",
+          "legendFormat": "virtual",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "title": "Total HTTP Requests",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 32 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "short" },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(http_requests_total)",
+          "legendFormat": "total",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Uptime",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 32 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "s" },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "time() - process_start_time_seconds",
+          "legendFormat": "uptime",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Current Goroutines",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 32 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "short" },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "go_goroutines",
+          "legendFormat": "goroutines",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Heap Alloc",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 32 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "bytes" },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "go_memstats_alloc_bytes",
+          "legendFormat": "heap",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["pikoci"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "PikoCI",
+  "uid": "pikoci-overview",
+  "version": 1
+}

--- a/deploy/grafana/dashboards/pikoci.json
+++ b/deploy/grafana/dashboards/pikoci.json
@@ -272,6 +272,128 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "title": "System CPU Usage %",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 36 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "percentunit", "min": 0, "max": 1, "custom": { "drawStyle": "line", "fillOpacity": 20 } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "1 - avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m]))",
+          "legendFormat": "total CPU",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(rate(node_cpu_seconds_total{mode=\"user\"}[5m]))",
+          "legendFormat": "user",
+          "refId": "B"
+        },
+        {
+          "expr": "avg(rate(node_cpu_seconds_total{mode=\"system\"}[5m]))",
+          "legendFormat": "system",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "title": "System Memory Usage %",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 36 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "percentunit", "min": 0, "max": 1, "custom": { "drawStyle": "line", "fillOpacity": 20 } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)",
+          "legendFormat": "used %",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "System CPU %",
+      "type": "gauge",
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 44 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "percentunit", "min": 0, "max": 1, "thresholds": { "steps": [{"value": 0, "color": "green"}, {"value": 0.7, "color": "yellow"}, {"value": 0.9, "color": "red"}] } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "1 - avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m]))",
+          "legendFormat": "CPU",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "System Memory %",
+      "type": "gauge",
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 44 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "percentunit", "min": 0, "max": 1, "thresholds": { "steps": [{"value": 0, "color": "green"}, {"value": 0.7, "color": "yellow"}, {"value": 0.9, "color": "red"}] } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)",
+          "legendFormat": "Memory",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Disk Usage %",
+      "type": "gauge",
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 44 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "percentunit", "min": 0, "max": 1, "thresholds": { "steps": [{"value": 0, "color": "green"}, {"value": 0.7, "color": "yellow"}, {"value": 0.9, "color": "red"}] } },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "1 - (node_filesystem_avail_bytes{mountpoint=\"/\"} / node_filesystem_size_bytes{mountpoint=\"/\"})",
+          "legendFormat": "Disk",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "System Load Average",
+      "type": "stat",
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 44 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "short" },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "node_load1",
+          "legendFormat": "1m",
+          "refId": "A"
+        },
+        {
+          "expr": "node_load5",
+          "legendFormat": "5m",
+          "refId": "B"
+        },
+        {
+          "expr": "node_load15",
+          "legendFormat": "15m",
+          "refId": "C"
+        }
+      ]
     }
   ],
   "schemaVersion": 39,

--- a/deploy/grafana/provisioning/dashboards/default.yml
+++ b/deploy/grafana/provisioning/dashboards/default.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+providers:
+  - name: PikoCI
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/deploy/grafana/provisioning/datasources/prometheus.yml
+++ b/deploy/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/deploy/pikoci.env.example
+++ b/deploy/pikoci.env.example
@@ -1,4 +1,4 @@
-# Domain for Caddy reverse proxy
+# Domain for Caddy reverse proxy and Grafana
 PIKOCI_DOMAIN=pikoci.com
 PIKOCI_GRAFANA_DOMAIN=grafana.pikoci.com
 
@@ -15,9 +15,22 @@ PUBSUB_SYSTEM=mem
 # Run embedded worker (set to false if running workers separately)
 RUN_WORKER=true
 
+# Number of concurrent workers (default 1)
+# CONCURRENCY=2
+
+# Log level (debug, info, warn, error)
+# LOG_LEVEL=info
+
 # Users: override the default admin password
 # Generate hashes with: pikoci user-password -u admin -p your-password
 # USERS=admin:$2a$10$...
 
 # Grafana admin password
 GF_SECURITY_ADMIN_PASSWORD=changeme
+
+# GitHub personal access token (for git resource type PR checks)
+# GITHUB_TOKEN=ghp_...
+
+# GitHub App credentials (for github-check resource type)
+# GITHUB_APP_ID=12345
+# GITHUB_APP_INSTALLATION_ID=67890

--- a/docs/Concourse.md
+++ b/docs/Concourse.md
@@ -50,7 +50,7 @@ jobs:
 
 **PikoCI:**
 ```hcl
-runner "docker" {
+runner_type "docker" {
   run {
     path = "docker"
     args = ["run", "--rm", "-v", "$WORKDIR:/workdir", "-w", "/workdir", "$image", "$cmd"]

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -38,7 +38,17 @@ curl -L https://github.com/xescugc/pikoci/releases/latest/download/linux-amd64 -
 chmod +x /usr/local/bin/pikoci
 ```
 
-### 2. Create the system user and directories
+### 2. Install prerequisites
+
+The server needs `git`, `jq`, and `curl` for the built-in resource types (e.g. the `git` resource type uses `jq` and `curl` to query GitHub/GitLab APIs). Docker is required for the `docker` runner and for supporting services.
+
+```bash
+apt-get install -y git jq curl
+```
+
+The deploy script (`deploy/deploy.sh`) installs these automatically if missing.
+
+### 3. Create the system user and directories
 
 ```bash
 useradd --system --no-create-home pikoci
@@ -46,7 +56,7 @@ mkdir -p /var/lib/pikoci /etc/pikoci
 chown pikoci:pikoci /var/lib/pikoci
 ```
 
-### 3. Configure PikoCI
+### 4. Configure PikoCI
 
 Copy the example env file and fill in your values:
 
@@ -77,7 +87,7 @@ pikoci user-password -u admin -p your-password
 
 See [Server Configuration](Server) for all available options.
 
-### 4. Deploy
+### 5. Deploy
 
 The deploy script copies everything to the server — binary, configs, and env files:
 
@@ -101,7 +111,7 @@ systemctl status pikoci
 curl http://localhost:8080/metrics
 ```
 
-### 5. Supporting services
+### 6. Supporting services
 
 The deploy script also syncs Docker Compose configs and env files. To start them manually:
 
@@ -117,7 +127,7 @@ This starts:
 - **Grafana** — dashboards (accessible at `grafana.pikoci.com`)
 - **Node Exporter** — host-level metrics
 
-### 6. DNS
+### 7. DNS
 
 Point your domain's A record to the server IP:
 

--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -82,12 +82,12 @@ resource "cron" "every_10s" {
 | `params`         | no       | Block with key/value pairs passed to the resource type |
 | `check_interval` | no       | Cron expression or `@every <duration>` for automatic checks |
 
-## runner
+## runner_type
 
 Defines a reusable execution environment. See [Runners](Runners).
 
 ```hcl
-runner "docker" {
+runner_type "docker" {
   run {
     path = "docker"
     args = [
@@ -148,12 +148,12 @@ task "migrate" {
 
 See [Variables](Variables) for full secret-backed variable documentation.
 
-## service
+## service_type
 
 Defines an ephemeral process that runs alongside a job's tasks. See [Services](Services).
 
 ```hcl
-service "postgres" {
+service_type "postgres" {
   params = ["version"]
 
   start "exec" {
@@ -291,7 +291,7 @@ put "git" "my_repo" {
 
 ### service
 
-References a top-level service or defines an inline service for the job. Services are started before tasks and stopped unconditionally after.
+References a top-level `service_type` for the job. Services are started before tasks and stopped unconditionally after.
 
 ```hcl
 job "test" {

--- a/docs/Resource-Types.md
+++ b/docs/Resource-Types.md
@@ -305,8 +305,18 @@ The `github-check` resource type reports build status back to GitHub as check ru
 To use it, declare the resource type with `source = "pikoci://github-check"`:
 
 ```hcl
+# Read the PEM key using the file secret type with raw format
+secret_type "app-key" {
+  source = "pikoci://file"
+  format = "raw"
+  path   = "/etc/pikoci/github-app.pem"
+}
+
 variable "github_app_key" {
   type = string
+  secret "app-key" {
+    key = "content"
+  }
 }
 
 resource_type "github-check" {
@@ -356,7 +366,7 @@ job "test" {
 |-------------------|----------|--------------------------------------------------|
 | `app_id`          | yes      | GitHub App ID                                    |
 | `installation_id` | yes      | GitHub App installation ID                       |
-| `private_key`     | yes      | GitHub App private key (PEM format)              |
+| `private_key`     | yes      | GitHub App private key content (PEM format). Use the `file` secret type with `format = "raw"` to read from a PEM file |
 | `repository`      | yes      | Repository in `owner/repo` format                |
 
 ### Put params
@@ -378,8 +388,9 @@ Either `status` or `conclusion` must be set. Use `status = "in_progress"` first 
 3. Under **Permissions**, grant **Checks** read & write
 4. Uncheck **Active** under Webhook (no webhook needed)
 5. Create the app and note the **App ID** from the settings page
-6. Click **Generate a private key** (downloads a `.pem` file). This is the `private_key` value
-7. Install the app on the target repository or organization
-8. Note the **Installation ID** from the URL after installing, or via `GET /app/installations`
+6. Click **Generate a private key** (downloads a `.pem` file)
+7. Copy the `.pem` file to the server (e.g. `/etc/pikoci/github-app.pem`)
+8. Install the app on the target repository or organization
+9. Note the **Installation ID** from the URL after installing, or via `GET /app/installations`
 
-Pass credentials securely via pipeline variables or secret types, not hardcoded in the pipeline file.
+Use the `file` secret type with `format = "raw"` to read the PEM key (see example above). Never hardcode the private key in the pipeline file.

--- a/docs/Runners.md
+++ b/docs/Runners.md
@@ -5,7 +5,7 @@ Runners define how commands are executed. A runner wraps process execution so yo
 ## Defining a runner
 
 ```hcl
-runner "docker" {
+runner_type "docker" {
   run {
     path = "docker"
     args = [
@@ -45,7 +45,7 @@ For example, when a task uses `run "docker" { image = "golang:1.25" cmd = "make 
 Instead of defining the runner inline, you can point to an external HCL file:
 
 ```hcl
-runner "my-docker" {
+runner_type "my-docker" {
   source = "pikoci://docker"
 }
 ```
@@ -59,12 +59,12 @@ When `source` is set, you must not define an inline `run` block. PikoCI will err
 
 ## Overriding built-ins
 
-All built-in runners (`exec`, `docker`) can be overridden by defining a `runner` block with the same name in your pipeline. Inline definitions always take precedence over built-ins.
+All built-in runners (`exec`, `docker`) can be overridden by defining a `runner_type` block with the same name in your pipeline. Inline definitions always take precedence over built-ins.
 
 This is useful when you need different default behavior. For example, the built-in `docker` runner uses `/bin/sh -ec` to run commands. If you want to always run with `--network=host` or use a different shell:
 
 ```hcl
-runner "docker" {
+runner_type "docker" {
   run {
     path = "docker"
     args = [
@@ -120,7 +120,7 @@ The exec runner expands `$path` and `$args` from the `run` block:
 
 ```go
 // Built-in exec runner definition
-runner "exec" {
+runner_type "exec" {
   run {
     path = "$path"
     args = ["$args"]
@@ -210,7 +210,7 @@ task "test" {
 ## Example: custom shell runner
 
 ```hcl
-runner "bash" {
+runner_type "bash" {
   run {
     path = "/bin/bash"
     args = ["-c", "$script"]

--- a/docs/Secret-Types.md
+++ b/docs/Secret-Types.md
@@ -192,7 +192,7 @@ secret_type "my-file" {
 
 | Attribute | Required | Default | Description                                      |
 |-----------|----------|---------|--------------------------------------------------|
-| `format`  | no       | `json`  | File format: `json` or `env`                     |
+| `format`  | no       | `json`  | File format: `json`, `env`, or `raw`              |
 | `path`    | no       |         | Default file path; can be overridden per-variable |
 
 The file path can be set on the `secret_type` block as a default, on each variable's `secret` block, or both (the variable-level `path` takes precedence):
@@ -279,6 +279,27 @@ DB_HOST=db.example.com
 DB_PASSWORD=s3cret
 DB_USER="admin"
 ```
+
+### `raw` format
+
+When `format = "raw"`, the entire file content is returned as a single value under the key `content`. This is useful for files that aren't structured as JSON or key-value pairs, such as PEM certificates, SSH keys, or tokens:
+
+```hcl
+secret_type "app-key" {
+  source = "pikoci://file"
+  format = "raw"
+  path   = "/etc/pikoci/github-app.pem"
+}
+
+variable "github_app_key" {
+  type = string
+  secret "app-key" {
+    key = "content"
+  }
+}
+```
+
+The variable receives the full file content as-is.
 
 ## Example: custom secret type
 

--- a/docs/Secret-Types.md
+++ b/docs/Secret-Types.md
@@ -193,10 +193,48 @@ secret_type "my-file" {
 | Attribute | Required | Default | Description                                      |
 |-----------|----------|---------|--------------------------------------------------|
 | `format`  | no       | `json`  | File format: `json` or `env`                     |
+| `path`    | no       |         | Default file path; can be overridden per-variable |
 
-The file path comes from the variable's secret block:
+The file path can be set on the `secret_type` block as a default, on each variable's `secret` block, or both (the variable-level `path` takes precedence):
 
 ```hcl
+# Default path on the secret_type — variables just pick keys
+secret_type "db-file" {
+  source = "pikoci://file"
+  path   = "/run/secrets/db.json"
+}
+
+variable "db_user" {
+  type = string
+  secret "db-file" {
+    key = "username"
+  }
+}
+
+variable "db_password" {
+  type = string
+  secret "db-file" {
+    key = "password"
+  }
+}
+
+# Override path for a specific variable
+variable "api_key" {
+  type = string
+  secret "db-file" {
+    path = "/run/secrets/api.json"
+    key  = "key"
+  }
+}
+```
+
+If no default `path` is set on the secret_type, each variable must provide its own:
+
+```hcl
+secret_type "my-file" {
+  source = "pikoci://file"
+}
+
 variable "db_user" {
   type = string
   secret "my-file" {

--- a/docs/Services.md
+++ b/docs/Services.md
@@ -1,13 +1,13 @@
 # Services
 
-A service is an ephemeral process that runs alongside a job's tasks. Services are started before tasks and stopped unconditionally after, regardless of whether the tasks succeed or fail. Common use cases include databases, caches, message brokers, or any dependency that needs to be running while tasks execute.
+A service type defines an ephemeral process that runs alongside a job's tasks. Services are started before tasks and stopped unconditionally after, regardless of whether the tasks succeed or fail. Common use cases include databases, caches, message brokers, or any dependency that needs to be running while tasks execute.
 
-## Defining a service
+## Defining a service type
 
-Services are runner-agnostic. You can start any process: a local daemon, a container, a background script, etc.
+Service types are runner-agnostic. You can start any process: a local daemon, a container, a background script, etc.
 
 ```hcl
-service "postgres" {
+service_type "postgres" {
   start "exec" {
     path = "/bin/sh"
     args = ["-ec", "pg_ctl -D $WORKDIR/pgdata -l $WORKDIR/pg.log start"]
@@ -60,7 +60,7 @@ The `stop` block runs unconditionally after all tasks complete, whether they suc
 Instead of defining `start`/`stop` commands inline, you can point to an external HCL file:
 
 ```hcl
-service "postgres" {
+service_type "postgres" {
   source = "https://example.com/services/postgres.hcl"
   params = ["version"]
 }
@@ -73,9 +73,9 @@ Two URL formats are supported:
 
 When `source` is set, you must not define inline `start`, `stop`, or `ready_check` blocks. PikoCI will error if both are present.
 
-## Referencing services in jobs
+## Referencing service types in jobs
 
-Reference a top-level service by name in a job:
+Reference a top-level service type by name in a job:
 
 ```hcl
 job "test" {
@@ -142,7 +142,7 @@ Services appear in the build as steps with type "service" and names like "postgr
 Start PostgreSQL directly on the worker. No containers needed:
 
 ```hcl
-service "postgres" {
+service_type "postgres" {
   start "exec" {
     path = "/bin/sh"
     args = ["-ec", "initdb -D $WORKDIR/pgdata && pg_ctl -D $WORKDIR/pgdata -l $WORKDIR/pg.log start"]
@@ -167,7 +167,7 @@ service "postgres" {
 Use podman for rootless, daemonless containers:
 
 ```hcl
-service "postgres" {
+service_type "postgres" {
   params = ["version"]
 
   start "exec" {
@@ -194,7 +194,7 @@ service "postgres" {
 A simple Redis instance with no ready check (starts fast enough):
 
 ```hcl
-service "redis" {
+service_type "redis" {
   start "exec" {
     path = "/bin/sh"
     args = ["-ec", "redis-server --daemonize yes --dir $WORKDIR"]

--- a/integration/backends/db_test.go
+++ b/integration/backends/db_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package backends_test
 
 import (

--- a/integration/backends/main_test.go
+++ b/integration/backends/main_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package backends_test
 
 import (

--- a/integration/backends/pubsub_test.go
+++ b/integration/backends/pubsub_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package backends_test
 
 import (

--- a/integration/backends/secrets_test.go
+++ b/integration/backends/secrets_test.go
@@ -310,7 +310,7 @@ job "deploy" {
   task "use-env-secrets" {
     run "exec" {
       path = "/bin/sh"
-      args = ["-ec", "echo db_host=${var.db_host} db_password=${var.db_password} db_user=${var.db_user} db_conn=${var.db_conn}"]
+      args = ["-ec", "echo 'db_host=${var.db_host}' 'db_password=${var.db_password}' 'db_user=${var.db_user}' 'db_conn=${var.db_conn}'"]
     }
   }
 }

--- a/integration/backends/secrets_test.go
+++ b/integration/backends/secrets_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package backends_test
 
 import (

--- a/integration/backends/services_test.go
+++ b/integration/backends/services_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package backends_test
 
 import (
@@ -80,7 +82,7 @@ func TestServicesE2E(t *testing.T) {
 		markerFile := tmpDir + "/service-marker"
 
 		hclConfig := []byte(fmt.Sprintf(`
-service "test-svc" {
+service_type "test-svc" {
   start "exec" {
     path = "/bin/sh"
     args = ["-ec", "touch %s && echo started"]
@@ -164,7 +166,7 @@ job "use-service" {
 
 	t.Run("ServiceReadyCheckTimeout", func(t *testing.T) {
 		hclConfig := []byte(`
-service "slow-svc" {
+service_type "slow-svc" {
   start "exec" {
     path = "/bin/sh"
     args = ["-ec", "echo started"]
@@ -252,7 +254,7 @@ job "use-slow-service" {
 		versionFile := tmpDir + "/version"
 
 		hclConfig := []byte(fmt.Sprintf(`
-service "param-svc" {
+service_type "param-svc" {
   params = ["version"]
 
   start "exec" {
@@ -325,7 +327,7 @@ job "use-param-service" {
 
 	t.Run("ServiceStopOnTaskFailure", func(t *testing.T) {
 		hclConfig := []byte(`
-service "fail-svc" {
+service_type "fail-svc" {
   start "exec" {
     path = "/bin/sh"
     args = ["-ec", "echo started"]

--- a/integration/backends/vault_test.go
+++ b/integration/backends/vault_test.go
@@ -90,7 +90,7 @@ func TestSecretsVaultE2E(t *testing.T) {
 
 	for _, bin := range []string{"vault", "jq"} {
 		if _, err := exec.LookPath(bin); err != nil {
-			t.Fatalf("%s not found in PATH", bin)
+			t.Skipf("%s not found in PATH, skipping", bin)
 		}
 	}
 

--- a/integration/backends/vault_test.go
+++ b/integration/backends/vault_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package backends_test
 
 import (

--- a/integration/helper_test.go
+++ b/integration/helper_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration_test
 
 import (

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration_test
 
 import (

--- a/integration/pikoci_test.go
+++ b/integration/pikoci_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package integration_test
 
 import (

--- a/pikoci/build/build.go
+++ b/pikoci/build/build.go
@@ -31,4 +31,5 @@ type Step struct {
 	VersionID uint32        `json:"version_id"`
 	Logs      string        `json:"logs"`
 	Duration  time.Duration `json:"duration"`
+	Status    Status        `json:"status"`
 }

--- a/pikoci/builds.go
+++ b/pikoci/builds.go
@@ -58,7 +58,7 @@ func (q *PikoCI) UpdateJobBuild(ctx context.Context, tc, pn, jn string, bID uint
 	}
 
 	if b.Status != build.Started && b.Duration == 0 {
-		b.Duration = time.Now().Sub(b.StartedAt)
+		b.Duration = time.Since(b.StartedAt)
 	}
 
 	err := q.Builds.Update(ctx, tc, pn, jn, bID, b)

--- a/pikoci/builtin/builtin.go
+++ b/pikoci/builtin/builtin.go
@@ -11,7 +11,7 @@ import (
 	"github.com/xescugc/pikoci/pikoci/sectype"
 )
 
-//go:embed resource_types/*.hcl
+//go:embed resource_types/cron.hcl resource_types/git.hcl
 var resourceTypeFS embed.FS
 
 //go:embed runners/*.hcl

--- a/pikoci/builtin/builtin.go
+++ b/pikoci/builtin/builtin.go
@@ -25,7 +25,7 @@ type hclResourceType struct {
 }
 
 type hclRunner struct {
-	Runners []runner.Runner `hcl:"runner,block"`
+	Runners []runner.Runner `hcl:"runner_type,block"`
 }
 
 type hclSecretType struct {

--- a/pikoci/builtin/builtin.go
+++ b/pikoci/builtin/builtin.go
@@ -11,7 +11,7 @@ import (
 	"github.com/xescugc/pikoci/pikoci/sectype"
 )
 
-//go:embed resource_types/cron.hcl resource_types/git.hcl
+//go:embed resource_types/*.hcl
 var resourceTypeFS embed.FS
 
 //go:embed runners/*.hcl

--- a/pikoci/builtin/resource_types/git.hcl
+++ b/pikoci/builtin/resource_types/git.hcl
@@ -11,27 +11,32 @@ resource_type "git" {
     args = [
       "-ec",
       <<-EOT
+      URL="$param_url"
+      BRANCH="$${param_branch:-HEAD}"
+      TOKEN="$param_token"
+      PR="$param_pr"
+
       # PR mode: check for open pull requests
-      if [ "$param_pr" = "true" ]; then
-        if [ -z "$param_token" ]; then
+      if [ "$PR" = "true" ]; then
+        if [ -z "$TOKEN" ]; then
           echo "error: pr=true requires a token" >&2
           exit 1
         fi
 
         # GitHub PRs
-        if echo "$param_url" | grep -q "github.com"; then
-          REPO=$(echo "$param_url" | sed -E 's|https?://github\.com/||;s|\.git$$||')
-          curl -sf -H "Authorization: token $param_token" \
-            "https://api.github.com/repos/$$REPO/pulls?state=open&sort=updated&direction=desc&per_page=100" \
+        if echo "$URL" | grep -q "github.com"; then
+          REPO=$(echo "$URL" | sed -E 's|https?://github\.com/||;s|\.git$||')
+          curl -sf -H "Authorization: token $TOKEN" \
+            "https://api.github.com/repos/$REPO/pulls?state=open&sort=updated&direction=desc&per_page=100" \
             | jq '[.[] | {"ref": .head.sha, "pr": (.number | tostring)}]'
           exit 0
         fi
 
         # GitLab MRs
-        if echo "$param_url" | grep -q "gitlab.com"; then
-          PROJECT=$(echo "$param_url" | sed -E 's|https?://gitlab\.com/||;s|\.git$$||' | sed 's|/|%2F|g')
-          curl -sf -H "PRIVATE-TOKEN: $param_token" \
-            "https://gitlab.com/api/v4/projects/$$PROJECT/merge_requests?state=opened&order_by=updated_at&sort=desc&per_page=100" \
+        if echo "$URL" | grep -q "gitlab.com"; then
+          PROJECT=$(echo "$URL" | sed -E 's|https?://gitlab\.com/||;s|\.git$||' | sed 's|/|%2F|g')
+          curl -sf -H "PRIVATE-TOKEN: $TOKEN" \
+            "https://gitlab.com/api/v4/projects/$PROJECT/merge_requests?state=opened&order_by=updated_at&sort=desc&per_page=100" \
             | jq '[.[] | {"ref": .sha, "pr": (.iid | tostring)}]'
           exit 0
         fi
@@ -41,40 +46,39 @@ resource_type "git" {
       fi
 
       # GitHub API
-      BRANCH="$${param_branch:-HEAD}"
-      if [ -n "$param_token" ] && echo "$param_url" | grep -q "github.com"; then
-        REPO=$(echo "$param_url" | sed -E 's|https?://github\.com/||;s|\.git$$||')
-        REF=$(curl -sf -H "Authorization: token $param_token" \
-          "https://api.github.com/repos/$$REPO/commits?sha=$$BRANCH&per_page=1" \
+      if [ -n "$TOKEN" ] && echo "$URL" | grep -q "github.com"; then
+        REPO=$(echo "$URL" | sed -E 's|https?://github\.com/||;s|\.git$||')
+        REF=$(curl -sf -H "Authorization: token $TOKEN" \
+          "https://api.github.com/repos/$REPO/commits?sha=$BRANCH&per_page=1" \
           | jq -r '.[0].sha')
-        if [ -n "$$REF" ] && [ "$$REF" != "null" ]; then
-          echo "[{\"ref\":\"$$REF\"}]"
+        if [ -n "$REF" ] && [ "$REF" != "null" ]; then
+          echo "[{\"ref\":\"$REF\"}]"
           exit 0
         fi
       fi
 
       # GitLab API
-      if [ -n "$param_token" ] && echo "$param_url" | grep -q "gitlab.com"; then
-        PROJECT=$(echo "$param_url" | sed -E 's|https?://gitlab\.com/||;s|\.git$$||' | sed 's|/|%2F|g')
-        REF=$(curl -sf -H "PRIVATE-TOKEN: $param_token" \
-          "https://gitlab.com/api/v4/projects/$$PROJECT/repository/commits?ref_name=$$BRANCH&per_page=1" \
+      if [ -n "$TOKEN" ] && echo "$URL" | grep -q "gitlab.com"; then
+        PROJECT=$(echo "$URL" | sed -E 's|https?://gitlab\.com/||;s|\.git$||' | sed 's|/|%2F|g')
+        REF=$(curl -sf -H "PRIVATE-TOKEN: $TOKEN" \
+          "https://gitlab.com/api/v4/projects/$PROJECT/repository/commits?ref_name=$BRANCH&per_page=1" \
           | jq -r '.[0].id')
-        if [ -n "$$REF" ] && [ "$$REF" != "null" ]; then
-          echo "[{\"ref\":\"$$REF\"}]"
+        if [ -n "$REF" ] && [ "$REF" != "null" ]; then
+          echo "[{\"ref\":\"$REF\"}]"
           exit 0
         fi
       fi
 
       # Fallback: git ls-remote
-      if [ -n "$param_token" ]; then
-        REF=$$(git -c credential.helper="!f() { echo password=$param_token; }; f" ls-remote "$param_url" "$$BRANCH" | awk '{print $$1}')
+      if [ -n "$TOKEN" ]; then
+        REF=$(git -c credential.helper="!f() { echo password=$TOKEN; }; f" ls-remote "$URL" "$BRANCH" | awk '{print $1}')
       else
-        REF=$$(git ls-remote "$param_url" "$$BRANCH" | awk '{print $$1}')
+        REF=$(git ls-remote "$URL" "$BRANCH" | awk '{print $1}')
       fi
-      if [ -z "$$REF" ]; then
-        REF=$$(git ls-remote "$param_url" HEAD | awk '{print $$1}')
+      if [ -z "$REF" ]; then
+        REF=$(git ls-remote "$URL" HEAD | awk '{print $1}')
       fi
-      echo "[{\"ref\":\"$$REF\"}]"
+      echo "[{\"ref\":\"$REF\"}]"
       EOT
     ]
   }
@@ -83,24 +87,28 @@ resource_type "git" {
     args = [
       "-ec",
       <<-EOT
+      URL="$param_url"
+      TOKEN="$param_token"
+      BRANCH="$param_branch"
+      PR="$param_pr"
+
       # Inject token into HTTPS URL if provided
-      CLONE_URL="$param_url"
-      if [ -n "$param_token" ]; then
-        CLONE_URL=$$(echo "$param_url" | sed -E "s|https://|https://oauth2:$param_token@|")
+      if [ -n "$TOKEN" ]; then
+        URL=$(echo "$URL" | sed -E "s|https://|https://oauth2:$${TOKEN}@|")
       fi
 
-      if [ "$param_pr" = "true" ] && [ -n "$version_pr" ]; then
+      if [ "$PR" = "true" ] && [ -n "$version_pr" ]; then
         # PR mode: fetch the PR head ref
-        git clone "$$CLONE_URL" "$param_name"
+        git clone "$URL" "$param_name"
         cd "$param_name"
         git fetch origin "pull/$version_pr/head:pr-$version_pr"
         git checkout "pr-$version_pr"
-      elif [ -n "$param_branch" ]; then
-        git clone -b "$param_branch" "$$CLONE_URL" "$param_name"
+      elif [ -n "$BRANCH" ]; then
+        git clone -b "$BRANCH" "$URL" "$param_name"
         cd "$param_name"
         git checkout "$version_ref"
       else
-        git clone "$$CLONE_URL" "$param_name"
+        git clone "$URL" "$param_name"
         cd "$param_name"
         git checkout "$version_ref"
       fi
@@ -112,10 +120,13 @@ resource_type "git" {
     args = [
       "-ec",
       <<-EOT
+      URL="$param_url"
+      TOKEN="$param_token"
+
       cd "$param_name"
-      if [ -n "$param_token" ]; then
-        REMOTE_URL=$$(echo "$param_url" | sed -E "s|https://|https://oauth2:$param_token@|")
-        git remote set-url origin "$$REMOTE_URL"
+      if [ -n "$TOKEN" ]; then
+        REMOTE_URL=$(echo "$URL" | sed -E "s|https://|https://oauth2:$${TOKEN}@|")
+        git remote set-url origin "$REMOTE_URL"
       fi
       git push
       EOT

--- a/pikoci/builtin/resource_types/git.hcl
+++ b/pikoci/builtin/resource_types/git.hcl
@@ -11,32 +11,27 @@ resource_type "git" {
     args = [
       "-ec",
       <<-EOT
-      URL="$param_url"
-      BRANCH="$${param_branch:-HEAD}"
-      TOKEN="$param_token"
-      PR="$param_pr"
-
       # PR mode: check for open pull requests
-      if [ "$PR" = "true" ]; then
-        if [ -z "$TOKEN" ]; then
+      if [ "$param_pr" = "true" ]; then
+        if [ -z "$param_token" ]; then
           echo "error: pr=true requires a token" >&2
           exit 1
         fi
 
         # GitHub PRs
-        if echo "$URL" | grep -q "github.com"; then
-          REPO=$(echo "$URL" | sed -E 's|https?://github\.com/||;s|\.git$||')
-          curl -sf -H "Authorization: token $TOKEN" \
-            "https://api.github.com/repos/$REPO/pulls?state=open&sort=updated&direction=desc&per_page=100" \
+        if echo "$param_url" | grep -q "github.com"; then
+          REPO=$(echo "$param_url" | sed -E 's|https?://github\.com/||;s|\.git$$||')
+          curl -sf -H "Authorization: token $param_token" \
+            "https://api.github.com/repos/$$REPO/pulls?state=open&sort=updated&direction=desc&per_page=100" \
             | jq '[.[] | {"ref": .head.sha, "pr": (.number | tostring)}]'
           exit 0
         fi
 
         # GitLab MRs
-        if echo "$URL" | grep -q "gitlab.com"; then
-          PROJECT=$(echo "$URL" | sed -E 's|https?://gitlab\.com/||;s|\.git$||' | sed 's|/|%2F|g')
-          curl -sf -H "PRIVATE-TOKEN: $TOKEN" \
-            "https://gitlab.com/api/v4/projects/$PROJECT/merge_requests?state=opened&order_by=updated_at&sort=desc&per_page=100" \
+        if echo "$param_url" | grep -q "gitlab.com"; then
+          PROJECT=$(echo "$param_url" | sed -E 's|https?://gitlab\.com/||;s|\.git$$||' | sed 's|/|%2F|g')
+          curl -sf -H "PRIVATE-TOKEN: $param_token" \
+            "https://gitlab.com/api/v4/projects/$$PROJECT/merge_requests?state=opened&order_by=updated_at&sort=desc&per_page=100" \
             | jq '[.[] | {"ref": .sha, "pr": (.iid | tostring)}]'
           exit 0
         fi
@@ -46,39 +41,40 @@ resource_type "git" {
       fi
 
       # GitHub API
-      if [ -n "$TOKEN" ] && echo "$URL" | grep -q "github.com"; then
-        REPO=$(echo "$URL" | sed -E 's|https?://github\.com/||;s|\.git$||')
-        REF=$(curl -sf -H "Authorization: token $TOKEN" \
-          "https://api.github.com/repos/$REPO/commits?sha=$BRANCH&per_page=1" \
+      BRANCH="$${param_branch:-HEAD}"
+      if [ -n "$param_token" ] && echo "$param_url" | grep -q "github.com"; then
+        REPO=$(echo "$param_url" | sed -E 's|https?://github\.com/||;s|\.git$$||')
+        REF=$(curl -sf -H "Authorization: token $param_token" \
+          "https://api.github.com/repos/$$REPO/commits?sha=$$BRANCH&per_page=1" \
           | jq -r '.[0].sha')
-        if [ -n "$REF" ] && [ "$REF" != "null" ]; then
-          echo "[{\"ref\":\"$REF\"}]"
+        if [ -n "$$REF" ] && [ "$$REF" != "null" ]; then
+          echo "[{\"ref\":\"$$REF\"}]"
           exit 0
         fi
       fi
 
       # GitLab API
-      if [ -n "$TOKEN" ] && echo "$URL" | grep -q "gitlab.com"; then
-        PROJECT=$(echo "$URL" | sed -E 's|https?://gitlab\.com/||;s|\.git$||' | sed 's|/|%2F|g')
-        REF=$(curl -sf -H "PRIVATE-TOKEN: $TOKEN" \
-          "https://gitlab.com/api/v4/projects/$PROJECT/repository/commits?ref_name=$BRANCH&per_page=1" \
+      if [ -n "$param_token" ] && echo "$param_url" | grep -q "gitlab.com"; then
+        PROJECT=$(echo "$param_url" | sed -E 's|https?://gitlab\.com/||;s|\.git$$||' | sed 's|/|%2F|g')
+        REF=$(curl -sf -H "PRIVATE-TOKEN: $param_token" \
+          "https://gitlab.com/api/v4/projects/$$PROJECT/repository/commits?ref_name=$$BRANCH&per_page=1" \
           | jq -r '.[0].id')
-        if [ -n "$REF" ] && [ "$REF" != "null" ]; then
-          echo "[{\"ref\":\"$REF\"}]"
+        if [ -n "$$REF" ] && [ "$$REF" != "null" ]; then
+          echo "[{\"ref\":\"$$REF\"}]"
           exit 0
         fi
       fi
 
       # Fallback: git ls-remote
-      if [ -n "$TOKEN" ]; then
-        REF=$(git -c credential.helper="!f() { echo password=$TOKEN; }; f" ls-remote "$URL" "$BRANCH" | awk '{print $1}')
+      if [ -n "$param_token" ]; then
+        REF=$$(git -c credential.helper="!f() { echo password=$param_token; }; f" ls-remote "$param_url" "$$BRANCH" | awk '{print $$1}')
       else
-        REF=$(git ls-remote "$URL" "$BRANCH" | awk '{print $1}')
+        REF=$$(git ls-remote "$param_url" "$$BRANCH" | awk '{print $$1}')
       fi
-      if [ -z "$REF" ]; then
-        REF=$(git ls-remote "$URL" HEAD | awk '{print $1}')
+      if [ -z "$$REF" ]; then
+        REF=$$(git ls-remote "$param_url" HEAD | awk '{print $$1}')
       fi
-      echo "[{\"ref\":\"$REF\"}]"
+      echo "[{\"ref\":\"$$REF\"}]"
       EOT
     ]
   }
@@ -87,28 +83,24 @@ resource_type "git" {
     args = [
       "-ec",
       <<-EOT
-      URL="$param_url"
-      TOKEN="$param_token"
-      BRANCH="$param_branch"
-      PR="$param_pr"
-
       # Inject token into HTTPS URL if provided
-      if [ -n "$TOKEN" ]; then
-        URL=$(echo "$URL" | sed -E "s|https://|https://oauth2:$${TOKEN}@|")
+      CLONE_URL="$param_url"
+      if [ -n "$param_token" ]; then
+        CLONE_URL=$$(echo "$param_url" | sed -E "s|https://|https://oauth2:$param_token@|")
       fi
 
-      if [ "$PR" = "true" ] && [ -n "$version_pr" ]; then
+      if [ "$param_pr" = "true" ] && [ -n "$version_pr" ]; then
         # PR mode: fetch the PR head ref
-        git clone "$URL" "$param_name"
+        git clone "$$CLONE_URL" "$param_name"
         cd "$param_name"
         git fetch origin "pull/$version_pr/head:pr-$version_pr"
         git checkout "pr-$version_pr"
-      elif [ -n "$BRANCH" ]; then
-        git clone -b "$BRANCH" "$URL" "$param_name"
+      elif [ -n "$param_branch" ]; then
+        git clone -b "$param_branch" "$$CLONE_URL" "$param_name"
         cd "$param_name"
         git checkout "$version_ref"
       else
-        git clone "$URL" "$param_name"
+        git clone "$$CLONE_URL" "$param_name"
         cd "$param_name"
         git checkout "$version_ref"
       fi
@@ -120,13 +112,10 @@ resource_type "git" {
     args = [
       "-ec",
       <<-EOT
-      URL="$param_url"
-      TOKEN="$param_token"
-
       cd "$param_name"
-      if [ -n "$TOKEN" ]; then
-        REMOTE_URL=$(echo "$URL" | sed -E "s|https://|https://oauth2:$${TOKEN}@|")
-        git remote set-url origin "$REMOTE_URL"
+      if [ -n "$param_token" ]; then
+        REMOTE_URL=$$(echo "$param_url" | sed -E "s|https://|https://oauth2:$param_token@|")
+        git remote set-url origin "$$REMOTE_URL"
       fi
       git push
       EOT

--- a/pikoci/builtin/resource_types/git.hcl
+++ b/pikoci/builtin/resource_types/git.hcl
@@ -28,7 +28,7 @@ resource_type "git" {
           REPO=$(echo "$URL" | sed -E 's|https?://github\.com/||;s|\.git$||')
           curl -sf -H "Authorization: token $TOKEN" \
             "https://api.github.com/repos/$REPO/pulls?state=open&sort=updated&direction=desc&per_page=100" \
-            | jq '[.[] | {"ref": .head.sha, "pr": (.number | tostring)}]'
+            | jq -c '[.[] | {"ref": .head.sha, "pr": (.number | tostring)}]'
           exit 0
         fi
 
@@ -37,7 +37,7 @@ resource_type "git" {
           PROJECT=$(echo "$URL" | sed -E 's|https?://gitlab\.com/||;s|\.git$||' | sed 's|/|%2F|g')
           curl -sf -H "PRIVATE-TOKEN: $TOKEN" \
             "https://gitlab.com/api/v4/projects/$PROJECT/merge_requests?state=opened&order_by=updated_at&sort=desc&per_page=100" \
-            | jq '[.[] | {"ref": .sha, "pr": (.iid | tostring)}]'
+            | jq -c '[.[] | {"ref": .sha, "pr": (.iid | tostring)}]'
           exit 0
         fi
 

--- a/pikoci/builtin/resource_types/github-check.hcl
+++ b/pikoci/builtin/resource_types/github-check.hcl
@@ -26,9 +26,15 @@ resource_type "github-check" {
         CHECK_NAME="$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME"
       fi
 
-      # Default head SHA from git if not provided
+      # Default head SHA from git if not provided.
+      # Try any git repo found in WORKDIR (the get step clones there).
       if [ -z "$HEAD_SHA" ]; then
-        HEAD_SHA=$(git rev-parse HEAD 2>/dev/null || true)
+        for d in "$WORKDIR"/*/; do
+          if [ -d "$d/.git" ]; then
+            HEAD_SHA=$(git -C "$d" rev-parse HEAD 2>/dev/null || true)
+            break
+          fi
+        done
       fi
 
       if [ -z "$HEAD_SHA" ]; then

--- a/pikoci/builtin/resource_types/github-check.hcl
+++ b/pikoci/builtin/resource_types/github-check.hcl
@@ -67,7 +67,7 @@ resource_type "github-check" {
       if [ -z "$RESOURCE_NAME" ]; then
         RESOURCE_NAME="github-check"
       fi
-      ID_FILE="$WORKDIR/.github-check-${RESOURCE_NAME}.id"
+      ID_FILE="$WORKDIR/.github-check-$${RESOURCE_NAME}.id"
 
       if [ -n "$STATUS" ] && [ "$STATUS" = "in_progress" ]; then
         # Create a new check run

--- a/pikoci/builtin/resource_types/github-check.hcl
+++ b/pikoci/builtin/resource_types/github-check.hcl
@@ -42,8 +42,8 @@ resource_type "github-check" {
         exit 1
       fi
 
-      # Write private key to temp file
-      KEY_FILE=$(mktemp)
+      # Write private key to temp file (use WORKDIR since /tmp may be read-only)
+      KEY_FILE="$WORKDIR/.github-check-key.pem"
       trap 'rm -f "$KEY_FILE"' EXIT
       printf '%s' "$PRIVATE_KEY" > "$KEY_FILE"
 

--- a/pikoci/builtin/runners/docker.hcl
+++ b/pikoci/builtin/runners/docker.hcl
@@ -1,4 +1,4 @@
-runner "docker" {
+runner_type "docker" {
   run {
     path = "docker"
     args = [

--- a/pikoci/builtin/runners/exec.hcl
+++ b/pikoci/builtin/runners/exec.hcl
@@ -1,4 +1,4 @@
-runner "exec" {
+runner_type "exec" {
   run {
     path = "$path"
     args = ["$args"]

--- a/pikoci/builtin/secret_types/file.hcl
+++ b/pikoci/builtin/secret_types/file.hcl
@@ -1,29 +1,11 @@
 secret_type "file" {
-  params = ["path", "format"]
+  params = ["path"]
 
   get "exec" {
     path = "/bin/sh"
     args = [
       "-ec",
-      <<-EOT
-      FORMAT="${param_format:-json}"
-      if [ "$FORMAT" = "env" ]; then
-        awk -F= 'BEGIN{printf "{"}
-        /^[A-Za-z_][A-Za-z_0-9]*=/{
-          key=$1; val=substr($0,index($0,"=")+1);
-          gsub(/\r$/,"",val);
-          gsub(/^["'"'"']|["'"'"']$/,"",val);
-          gsub(/\\/,"\\\\",val); gsub(/"/,"\\\"",val);
-          printf "%s\"%s\":\"%s\"",sep,key,val; sep=","
-        }
-        END{printf "}"}' "$param_path"
-      elif [ "$FORMAT" = "json" ]; then
-        cat "$param_path"
-      else
-        echo "ERROR: unsupported format '$FORMAT'. Use 'json' or 'env'." >&2
-        exit 1
-      fi
-      EOT
+      "cat \"$param_path\""
     ]
   }
 }

--- a/pikoci/helper.go
+++ b/pikoci/helper.go
@@ -50,15 +50,16 @@ type hclTaskStep struct {
 }
 
 // hclPutStep is the HCL-decoded put step.
-// Note: hooks on put steps are parsed from the raw AST by parseHooks.
-// The remain field absorbs both put params AND hook blocks.
+// Uses hcl.Body remain to absorb both params (attributes) and hook blocks,
+// since map[string]string remain can only absorb attributes, not blocks.
+// Params and hooks are both extracted from the raw AST in parseJobPlans.
 type hclPutStep struct {
 	Type     string `hcl:"type,label"`
 	Name     string `hcl:"name,label"`
 	Timeout  string `hcl:"timeout,optional"`
 	Attempts int    `hcl:"attempts,optional"`
 
-	Params map[string]string `hcl:",remain"`
+	Remain hcl.Body `hcl:",remain"`
 }
 
 // hclJob is the intermediate HCL-decoded job with separate get/task/put arrays.
@@ -551,7 +552,9 @@ func parseHooks(block *hclsyntax.Block, ectx *hcl.EvalContext, hookType string) 
 					if val.Type().IsListType() || val.Type().IsTupleType() {
 						for it := val.ElementIterator(); it.Next(); {
 							_, v := it.Element()
-							rc.Args = append(rc.Args, v.AsString())
+							if v.Type() == cty.String {
+								rc.Args = append(rc.Args, v.AsString())
+							}
 						}
 					}
 				} else {
@@ -741,6 +744,19 @@ func parseJobPlans(rpp []byte, ectx *hcl.EvalContext, hclJobs []hclJob, services
 				if p.Attempts < 0 {
 					return nil, nil, nil, fmt.Errorf("invalid attempts %d on put step %q: must be >= 0", p.Attempts, p.Name)
 				}
+				// Extract put params from AST attributes (exclude known fields)
+				putParams := make(map[string]string)
+				for name, attr := range innerBlock.Body.Attributes {
+					if name == "timeout" || name == "attempts" {
+						continue
+					}
+					val, vdiags := attr.Expr.Value(ectx)
+					if vdiags.HasErrors() {
+						continue
+					}
+					putParams[name] = val.AsString()
+				}
+
 				plan = append(plan, job.PlanStep{
 					Type:     job.StepTypePut,
 					Timeout:  timeout,
@@ -748,7 +764,7 @@ func parseJobPlans(rpp []byte, ectx *hcl.EvalContext, hclJobs []hclJob, services
 					Put: &job.PutStep{
 						Type:   p.Type,
 						Name:   p.Name,
-						Params: p.Params,
+						Params: putParams,
 					},
 					OnSuccess: parseHooks(innerBlock, ectx, "on_success"),
 					OnFailure: parseHooks(innerBlock, ectx, "on_failure"),

--- a/pikoci/helper.go
+++ b/pikoci/helper.go
@@ -209,9 +209,9 @@ type hclPipeline struct {
 	Jobs          []hclJob            `hcl:"job,block"`
 	Resources     []resource.Resource `hcl:"resource,block"`
 	ResourceTypes []hclResourceType   `hcl:"resource_type,block"`
-	Runners       []hclRunnerDef      `hcl:"runner,block"`
+	Runners       []hclRunnerDef      `hcl:"runner_type,block"`
 	SecretTypes   []hclSecretType     `hcl:"secret_type,block"`
-	Services      []hclService        `hcl:"service,block"`
+	Services      []hclService        `hcl:"service_type,block"`
 	Remain        hcl.Body            `hcl:",remain"`
 }
 
@@ -387,11 +387,11 @@ func (q *PikoCI) readPipeline(ctx context.Context, rpp []byte, vars map[string]i
 		if hrd.Source != "" {
 			hasInline := len(hrd.Run) > 0
 			if hasInline {
-				return nil, fmt.Errorf("runner %q has both source and inline commands, which is not allowed", hrd.Name)
+				return nil, fmt.Errorf("runner_type %q has both source and inline commands, which is not allowed", hrd.Name)
 			}
 			resolved, err := source.ResolveRunner(ctx, hrd.Source)
 			if err != nil {
-				return nil, fmt.Errorf("failed to resolve source for runner %q: %w", hrd.Name, err)
+				return nil, fmt.Errorf("failed to resolve source for runner_type %q: %w", hrd.Name, err)
 			}
 			resolved.Name = hrd.Name
 			resolved.Source = hrd.Source
@@ -465,11 +465,11 @@ func (q *PikoCI) readPipeline(ctx context.Context, rpp []byte, vars map[string]i
 		if hs.Source != "" {
 			hasInline := len(hs.Start) > 0 || len(hs.Stop) > 0 || len(hs.ReadyCheck) > 0
 			if hasInline {
-				return nil, fmt.Errorf("service %q has both source and inline commands, which is not allowed", hs.Name)
+				return nil, fmt.Errorf("service_type %q has both source and inline commands, which is not allowed", hs.Name)
 			}
 			resolved, err := source.ResolveService(ctx, hs.Source)
 			if err != nil {
-				return nil, fmt.Errorf("failed to resolve source for service %q: %w", hs.Name, err)
+				return nil, fmt.Errorf("failed to resolve source for service_type %q: %w", hs.Name, err)
 			}
 			resolved.Name = hs.Name
 			resolved.Source = hs.Source
@@ -479,10 +479,10 @@ func (q *PikoCI) readPipeline(ctx context.Context, rpp []byte, vars map[string]i
 			services = append(services, *resolved)
 		} else {
 			if len(hs.Start) == 0 {
-				return nil, fmt.Errorf("service %q must have a start block", hs.Name)
+				return nil, fmt.Errorf("service_type %q must have a start block", hs.Name)
 			}
 			if len(hs.Stop) == 0 {
-				return nil, fmt.Errorf("service %q must have a stop block", hs.Name)
+				return nil, fmt.Errorf("service_type %q must have a stop block", hs.Name)
 			}
 			services = append(services, hs.toService())
 		}
@@ -635,7 +635,7 @@ func parseJobPlans(rpp []byte, ectx *hcl.EvalContext, hclJobs []hclJob, services
 				serviceIdx++
 
 				if _, ok := serviceByName[sr.Name]; !ok {
-					return nil, nil, nil, fmt.Errorf("service %q referenced in job %q does not exist", sr.Name, hj.Name)
+					return nil, nil, nil, fmt.Errorf("service_type %q referenced in job %q does not exist", sr.Name, hj.Name)
 				}
 
 				// Parse param overrides from the remain body

--- a/pikoci/helper.go
+++ b/pikoci/helper.go
@@ -26,16 +26,17 @@ import (
 
 // hclGetStep is the HCL-decoded get step with per-step hooks.
 type hclGetStep struct {
-	Type    string   `json:"type" hcl:"type,label"`
-	Name    string   `json:"name" hcl:"name,label"`
-	Passed  []string `json:"passed" hcl:"passed,optional"`
+	Type     string   `json:"type" hcl:"type,label"`
+	Name     string   `json:"name" hcl:"name,label"`
+	Passed   []string `json:"passed" hcl:"passed,optional"`
 	Trigger  bool     `json:"trigger" hcl:"trigger,optional"`
 	Timeout  string   `json:"timeout" hcl:"timeout,optional"`
 	Attempts int      `json:"attempts" hcl:"attempts,optional"`
 
-	OnSuccess []utils.RunnerCommand `json:"on_success" hcl:"on_success,block"`
-	OnFailure []utils.RunnerCommand `json:"on_failure" hcl:"on_failure,block"`
-	Ensure    []utils.RunnerCommand `json:"ensure" hcl:"ensure,block"`
+	// Remain absorbs hook blocks (on_success, on_failure, ensure) so hclsimple.Decode
+	// doesn't reject them. Hooks are parsed from the raw AST by parseHooks instead,
+	// which supports both labeled (runner) and unlabeled (put) hook blocks.
+	Remain hcl.Body `hcl:",remain"`
 }
 
 // hclTaskStep is the HCL-decoded task step with per-step hooks.
@@ -45,21 +46,17 @@ type hclTaskStep struct {
 	Attempts int                 `json:"attempts" hcl:"attempts,optional"`
 	Run      utils.RunnerCommand `json:"run" hcl:"run,block"`
 
-	OnSuccess []utils.RunnerCommand `json:"on_success" hcl:"on_success,block"`
-	OnFailure []utils.RunnerCommand `json:"on_failure" hcl:"on_failure,block"`
-	Ensure    []utils.RunnerCommand `json:"ensure" hcl:"ensure,block"`
+	Remain hcl.Body `hcl:",remain"` // absorbs hook blocks; parsed by parseHooks from AST
 }
 
 // hclPutStep is the HCL-decoded put step.
+// Note: hooks on put steps are parsed from the raw AST by parseHooks.
+// The remain field absorbs both put params AND hook blocks.
 type hclPutStep struct {
-	Type     string   `hcl:"type,label"`
-	Name     string   `hcl:"name,label"`
-	Timeout  string   `hcl:"timeout,optional"`
-	Attempts int      `hcl:"attempts,optional"`
-
-	OnSuccess []utils.RunnerCommand `hcl:"on_success,block"`
-	OnFailure []utils.RunnerCommand `hcl:"on_failure,block"`
-	Ensure    []utils.RunnerCommand `hcl:"ensure,block"`
+	Type     string `hcl:"type,label"`
+	Name     string `hcl:"name,label"`
+	Timeout  string `hcl:"timeout,optional"`
+	Attempts int    `hcl:"attempts,optional"`
 
 	Params map[string]string `hcl:",remain"`
 }
@@ -72,9 +69,7 @@ type hclJob struct {
 	Put     []hclPutStep     `hcl:"put,block"`
 	Service []hclServiceRef  `hcl:"service,block"`
 
-	OnSuccess []utils.RunnerCommand `hcl:"on_success,block"`
-	OnFailure []utils.RunnerCommand `hcl:"on_failure,block"`
-	Ensure    []utils.RunnerCommand `hcl:"ensure,block"`
+	Remain hcl.Body `hcl:",remain"` // absorbs hook blocks; parsed by parseHooks from AST
 }
 
 // hclResourceType is an intermediate struct that allows optional check/pull/push blocks
@@ -521,21 +516,6 @@ func (q *PikoCI) readPipeline(ctx context.Context, rpp []byte, vars map[string]i
 	return &pp, nil
 }
 
-// runnerCmdsToHookSteps converts a slice of RunnerCommand to HookStep.
-func runnerCmdsToHookSteps(cmds []utils.RunnerCommand) []job.HookStep {
-	if len(cmds) == 0 {
-		return nil
-	}
-	steps := make([]job.HookStep, 0, len(cmds))
-	for _, c := range cmds {
-		c := c
-		steps = append(steps, job.HookStep{
-			Type:   job.StepTypeRunner,
-			Runner: &c,
-		})
-	}
-	return steps
-}
 
 // jobHooks holds parsed hook steps for a job.
 type jobHooks struct {
@@ -544,54 +524,74 @@ type jobHooks struct {
 	Ensure    []job.HookStep
 }
 
-// parseHookPuts finds put blocks inside a specific hook type (on_success, on_failure, ensure)
-// within the given AST block. Returns HookSteps for any put blocks found.
-// parseHookPuts finds put blocks inside unlabeled hook blocks (on_success, on_failure, ensure).
-// Labeled hook blocks (e.g. on_success "exec" { ... }) are runner commands decoded by HCL.
-// Unlabeled hook blocks (e.g. on_success { put "type" "name" { ... } }) contain put steps.
-func parseHookPuts(block *hclsyntax.Block, ectx *hcl.EvalContext, hookType string) []job.HookStep {
+// parseHooks finds all hook steps (runner commands and put blocks) inside a specific
+// hook type (on_success, on_failure, ensure) within the given AST block.
+// Labeled blocks (e.g. on_success "exec" { ... }) are runner commands.
+// Unlabeled blocks (e.g. on_success { put "type" "name" { ... } }) contain put steps.
+func parseHooks(block *hclsyntax.Block, ectx *hcl.EvalContext, hookType string) []job.HookStep {
 	var steps []job.HookStep
 	for _, b := range block.Body.Blocks {
-		if b.Type != hookType || len(b.Labels) != 0 {
+		if b.Type != hookType {
 			continue
 		}
-		for _, inner := range b.Body.Blocks {
-			if inner.Type != "put" || len(inner.Labels) != 2 {
-				continue
+
+		if len(b.Labels) == 1 {
+			// Labeled hook: runner command (e.g. on_success "exec" { args = [...] })
+			rc := utils.RunnerCommand{
+				Runner: b.Labels[0],
+				Params: make(map[string]string),
 			}
-			putType := inner.Labels[0]
-			putName := inner.Labels[1]
-			params := make(map[string]string)
-			for name, attr := range inner.Body.Attributes {
+			for name, attr := range b.Body.Attributes {
 				val, vdiags := attr.Expr.Value(ectx)
 				if vdiags.HasErrors() {
 					continue
 				}
-				params[name] = val.AsString()
+				if name == "args" {
+					// Parse args as a list of strings
+					if val.Type().IsListType() || val.Type().IsTupleType() {
+						for it := val.ElementIterator(); it.Next(); {
+							_, v := it.Element()
+							rc.Args = append(rc.Args, v.AsString())
+						}
+					}
+				} else {
+					rc.Params[name] = val.AsString()
+				}
 			}
 			steps = append(steps, job.HookStep{
-				Type: job.StepTypePut,
-				Put: &job.PutStep{
-					Type:   putType,
-					Name:   putName,
-					Params: params,
-				},
+				Type:   job.StepTypeRunner,
+				Runner: &rc,
 			})
+		} else if len(b.Labels) == 0 {
+			// Unlabeled hook: contains put blocks
+			for _, inner := range b.Body.Blocks {
+				if inner.Type != "put" || len(inner.Labels) != 2 {
+					continue
+				}
+				putType := inner.Labels[0]
+				putName := inner.Labels[1]
+				params := make(map[string]string)
+				for name, attr := range inner.Body.Attributes {
+					val, vdiags := attr.Expr.Value(ectx)
+					if vdiags.HasErrors() {
+						continue
+					}
+					params[name] = val.AsString()
+				}
+				steps = append(steps, job.HookStep{
+					Type: job.StepTypePut,
+					Put: &job.PutStep{
+						Type:   putType,
+						Name:   putName,
+						Params: params,
+					},
+				})
+			}
 		}
 	}
 	return steps
 }
 
-// mergeHookSteps combines two hook step slices, returning nil if both are empty.
-func mergeHookSteps(a, b []job.HookStep) []job.HookStep {
-	if len(a) == 0 && len(b) == 0 {
-		return nil
-	}
-	result := make([]job.HookStep, 0, len(a)+len(b))
-	result = append(result, a...)
-	result = append(result, b...)
-	return result
-}
 
 // parseJobPlans walks the raw HCL AST to extract get/task/put blocks in source
 // order for each job, then builds ordered PlanStep slices using the decoded data.
@@ -691,9 +691,9 @@ func parseJobPlans(rpp []byte, ectx *hcl.EvalContext, hclJobs []hclJob, services
 						Passed:  g.Passed,
 						Trigger: g.Trigger,
 					},
-					OnSuccess: mergeHookSteps(runnerCmdsToHookSteps(g.OnSuccess), parseHookPuts(innerBlock, ectx, "on_success")),
-					OnFailure: mergeHookSteps(runnerCmdsToHookSteps(g.OnFailure), parseHookPuts(innerBlock, ectx, "on_failure")),
-					Ensure:    mergeHookSteps(runnerCmdsToHookSteps(g.Ensure), parseHookPuts(innerBlock, ectx, "ensure")),
+					OnSuccess: parseHooks(innerBlock, ectx, "on_success"),
+					OnFailure: parseHooks(innerBlock, ectx, "on_failure"),
+					Ensure:    parseHooks(innerBlock, ectx, "ensure"),
 				})
 			case "task":
 				if taskIdx >= len(hj.Task) {
@@ -720,9 +720,9 @@ func parseJobPlans(rpp []byte, ectx *hcl.EvalContext, hclJobs []hclJob, services
 						Name: t.Name,
 						Run:  t.Run,
 					},
-					OnSuccess: mergeHookSteps(runnerCmdsToHookSteps(t.OnSuccess), parseHookPuts(innerBlock, ectx, "on_success")),
-					OnFailure: mergeHookSteps(runnerCmdsToHookSteps(t.OnFailure), parseHookPuts(innerBlock, ectx, "on_failure")),
-					Ensure:    mergeHookSteps(runnerCmdsToHookSteps(t.Ensure), parseHookPuts(innerBlock, ectx, "ensure")),
+					OnSuccess: parseHooks(innerBlock, ectx, "on_success"),
+					OnFailure: parseHooks(innerBlock, ectx, "on_failure"),
+					Ensure:    parseHooks(innerBlock, ectx, "ensure"),
 				})
 			case "put":
 				if putIdx >= len(hj.Put) {
@@ -750,9 +750,9 @@ func parseJobPlans(rpp []byte, ectx *hcl.EvalContext, hclJobs []hclJob, services
 						Name:   p.Name,
 						Params: p.Params,
 					},
-					OnSuccess: mergeHookSteps(runnerCmdsToHookSteps(p.OnSuccess), parseHookPuts(innerBlock, ectx, "on_success")),
-					OnFailure: mergeHookSteps(runnerCmdsToHookSteps(p.OnFailure), parseHookPuts(innerBlock, ectx, "on_failure")),
-					Ensure:    mergeHookSteps(runnerCmdsToHookSteps(p.Ensure), parseHookPuts(innerBlock, ectx, "ensure")),
+					OnSuccess: parseHooks(innerBlock, ectx, "on_success"),
+					OnFailure: parseHooks(innerBlock, ectx, "on_failure"),
+					Ensure:    parseHooks(innerBlock, ectx, "ensure"),
 				})
 			}
 		}
@@ -761,9 +761,9 @@ func parseJobPlans(rpp []byte, ectx *hcl.EvalContext, hclJobs []hclJob, services
 
 		// Parse job-level hooks
 		jh := jobHooks{
-			OnSuccess: mergeHookSteps(runnerCmdsToHookSteps(hj.OnSuccess), parseHookPuts(block, ectx, "on_success")),
-			OnFailure: mergeHookSteps(runnerCmdsToHookSteps(hj.OnFailure), parseHookPuts(block, ectx, "on_failure")),
-			Ensure:    mergeHookSteps(runnerCmdsToHookSteps(hj.Ensure), parseHookPuts(block, ectx, "ensure")),
+			OnSuccess: parseHooks(block, ectx, "on_success"),
+			OnFailure: parseHooks(block, ectx, "on_failure"),
+			Ensure:    parseHooks(block, ectx, "ensure"),
 		}
 		jobHooksMap[hj.Name] = jh
 	}

--- a/pikoci/mysql/helper.go
+++ b/pikoci/mysql/helper.go
@@ -4,8 +4,6 @@ import (
 	"database/sql"
 	"fmt"
 	"time"
-
-	"github.com/cycloidio/sqlr"
 )
 
 // lastInsertedID extracts the id from the query result.
@@ -56,18 +54,4 @@ func toNullInt64(i int) sql.NullInt64 {
 // toNullTime returns sql.NullTIme. The time is considered valid if it's not equal Zero.
 func toNullTime(t time.Time) sql.NullTime {
 	return sql.NullTime{Time: t, Valid: !t.IsZero()}
-}
-
-func scanCount(s sqlr.Scanner) (int, error) {
-	var c int
-
-	err := s.Scan(
-		&c,
-	)
-
-	if err != nil {
-		return 0, fmt.Errorf("failed to scan: %w", err)
-	}
-
-	return c, nil
 }

--- a/pikoci/mysql/new.go
+++ b/pikoci/mysql/new.go
@@ -65,16 +65,26 @@ func New(host string, port int, user, password string, ops Options) (*sql.DB, er
 
 	switch ops.System {
 	case Mem:
+		// In-memory SQLite with shared cache (so multiple connections see the same data).
+		// _pragma=foreign_keys(1) enables ON DELETE CASCADE on every connection in the pool
+		// (per-connection PRAGMA wouldn't work with sql.DB's connection pool).
 		db, err = sql.Open("sqlite", "file::memory:?cache=shared&_pragma=foreign_keys(1)")
 	case SQLite:
+		// File-backed SQLite. Data persists across restarts.
+		// _pragma=foreign_keys(1) enables ON DELETE CASCADE on every connection in the pool.
 		db, err = sql.Open("sqlite", ops.DBFile+"?_pragma=foreign_keys(1)")
 	case PostgreSQL:
+		// PostgreSQL has foreign keys enabled by default. sslmode=disable for local/dev setups.
 		dsn := fmt.Sprintf(
 			"host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
 			host, port, user, password, ops.DBName,
 		)
 		db, err = sql.Open("postgres", dsn)
 	case MySQL:
+		// MySQL/MariaDB. Foreign keys are enforced by default with InnoDB.
+		// clientFoundRows: UPDATE returns rows matched instead of rows changed (needed for isEntityFound).
+		// parseTime: scan DATE/DATETIME into time.Time.
+		// multiStatements: allow multiple SQL statements in one Exec (needed for migrations).
 		dsn := fmt.Sprintf(
 			"%s:%s@tcp(%s:%d)/%s?clientFoundRows=%t&parseTime=%t&multiStatements=%t",
 			user, password, host, port, ops.DBName, ops.ClientFoundRows, ops.ParseTime, ops.MultiStatements,

--- a/pikoci/mysql/new.go
+++ b/pikoci/mysql/new.go
@@ -65,9 +65,15 @@ func New(host string, port int, user, password string, ops Options) (*sql.DB, er
 
 	switch ops.System {
 	case Mem:
-		db, err = sql.Open("sqlite", "file::memory:?cache=shared&_foreign_keys=true")
+		db, err = sql.Open("sqlite", "file::memory:?cache=shared")
+		if err == nil {
+			db.Exec("PRAGMA foreign_keys = ON")
+		}
 	case SQLite:
-		db, err = sql.Open("sqlite", ops.DBFile+"?_foreign_keys=true")
+		db, err = sql.Open("sqlite", ops.DBFile)
+		if err == nil {
+			db.Exec("PRAGMA foreign_keys = ON")
+		}
 	case PostgreSQL:
 		dsn := fmt.Sprintf(
 			"host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",

--- a/pikoci/mysql/new.go
+++ b/pikoci/mysql/new.go
@@ -65,15 +65,9 @@ func New(host string, port int, user, password string, ops Options) (*sql.DB, er
 
 	switch ops.System {
 	case Mem:
-		db, err = sql.Open("sqlite", "file::memory:?cache=shared")
-		if err == nil {
-			db.Exec("PRAGMA foreign_keys = ON")
-		}
+		db, err = sql.Open("sqlite", "file::memory:?cache=shared&_pragma=foreign_keys(1)")
 	case SQLite:
-		db, err = sql.Open("sqlite", ops.DBFile)
-		if err == nil {
-			db.Exec("PRAGMA foreign_keys = ON")
-		}
+		db, err = sql.Open("sqlite", ops.DBFile+"?_pragma=foreign_keys(1)")
 	case PostgreSQL:
 		dsn := fmt.Sprintf(
 			"host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",

--- a/pikoci/mysql/pipeline.go
+++ b/pikoci/mysql/pipeline.go
@@ -174,17 +174,20 @@ func (r *PipelineRepository) Filter(ctx context.Context, tc string) ([]*pipeline
 }
 
 func (r *PipelineRepository) Delete(ctx context.Context, tc, pn string) error {
-	res, err := r.querier.ExecContext(ctx, `
-		DELETE
-		FROM pipelines
-		WHERE id IN (
-			SELECT p.id
-			FROM pipelines AS p
-			JOIN teams AS t
-				ON p.team_id = t.id
-			WHERE t.canonical = ? AND p.name = ?
-		)
-	`, tc, pn)
+	// Use a two-step delete: first resolve the ID, then delete by ID.
+	// SQLite does not trigger ON DELETE CASCADE with subquery-based deletes.
+	var id uint32
+	err := r.querier.QueryRowContext(ctx, `
+		SELECT p.id
+		FROM pipelines AS p
+		JOIN teams AS t ON p.team_id = t.id
+		WHERE t.canonical = ? AND p.name = ?
+	`, tc, pn).Scan(&id)
+	if err != nil {
+		return fmt.Errorf("failed to find pipeline for deletion: %w", err)
+	}
+
+	res, err := r.querier.ExecContext(ctx, `DELETE FROM pipelines WHERE id = ?`, id)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}

--- a/pikoci/mysql/pipeline_test.go
+++ b/pikoci/mysql/pipeline_test.go
@@ -1,0 +1,120 @@
+package mysql_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xescugc/pikoci/pikoci/mysql"
+	"github.com/xescugc/pikoci/pikoci/mysql/migrate"
+)
+
+func setupTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := mysql.New("", 0, "", "", mysql.Options{
+		MultiStatements: true,
+		ClientFoundRows: true,
+		System:          mysql.Mem,
+	})
+	require.NoError(t, err)
+	err = migrate.Migrate(db, mysql.Mem)
+	require.NoError(t, err)
+	return db
+}
+
+func TestDeletePipeline_CascadesJobs(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	// Use the seeded "main" team (id=1, created by migration)
+	res, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name) VALUES (1, 'test-pipe')`)
+	require.NoError(t, err)
+	ppID, _ := res.LastInsertId()
+
+	// Create jobs
+	_, err = db.ExecContext(ctx, `INSERT INTO jobs (pipeline_id, name) VALUES (?, 'lint')`, ppID)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO jobs (pipeline_id, name) VALUES (?, 'test')`, ppID)
+	require.NoError(t, err)
+
+	// Verify jobs exist
+	var jobCount int
+	err = db.QueryRowContext(ctx, `SELECT COUNT(*) FROM jobs WHERE pipeline_id = ?`, ppID).Scan(&jobCount)
+	require.NoError(t, err)
+	assert.Equal(t, 2, jobCount)
+
+	// Delete the pipeline using the repository
+	pr := mysql.NewPipelineRepository(db)
+	err = pr.Delete(ctx, "main", "test-pipe")
+	require.NoError(t, err)
+
+	// Verify cascade: jobs should be deleted
+	err = db.QueryRowContext(ctx, `SELECT COUNT(*) FROM jobs WHERE pipeline_id = ?`, ppID).Scan(&jobCount)
+	require.NoError(t, err)
+	assert.Equal(t, 0, jobCount, "jobs should be cascade-deleted when pipeline is deleted")
+}
+
+func TestDeletePipeline_CascadesResources(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	res, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name) VALUES (1, 'cascade-res')`)
+	require.NoError(t, err)
+	ppID, _ := res.LastInsertId()
+
+	_, err = db.ExecContext(ctx, `INSERT INTO resources (pipeline_id, name, type, canonical) VALUES (?, 'repo', 'git', 'git.repo')`, ppID)
+	require.NoError(t, err)
+
+	pr := mysql.NewPipelineRepository(db)
+	err = pr.Delete(ctx, "main", "cascade-res")
+	require.NoError(t, err)
+
+	var count int
+	err = db.QueryRowContext(ctx, `SELECT COUNT(*) FROM resources WHERE pipeline_id = ?`, ppID).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "resources should be cascade-deleted when pipeline is deleted")
+}
+
+func TestDeletePipeline_CascadesResourceTypes(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	res, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name) VALUES (1, 'cascade-rt')`)
+	require.NoError(t, err)
+	ppID, _ := res.LastInsertId()
+
+	_, err = db.ExecContext(ctx, `INSERT INTO resource_types (pipeline_id, name) VALUES (?, 'git')`, ppID)
+	require.NoError(t, err)
+
+	pr := mysql.NewPipelineRepository(db)
+	err = pr.Delete(ctx, "main", "cascade-rt")
+	require.NoError(t, err)
+
+	var count int
+	err = db.QueryRowContext(ctx, `SELECT COUNT(*) FROM resource_types WHERE pipeline_id = ?`, ppID).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "resource_types should be cascade-deleted when pipeline is deleted")
+}
+
+func TestDeletePipeline_CascadesRunners(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	res, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name) VALUES (1, 'cascade-run')`)
+	require.NoError(t, err)
+	ppID, _ := res.LastInsertId()
+
+	_, err = db.ExecContext(ctx, `INSERT INTO runners (pipeline_id, name) VALUES (?, 'docker')`, ppID)
+	require.NoError(t, err)
+
+	pr := mysql.NewPipelineRepository(db)
+	err = pr.Delete(ctx, "main", "cascade-run")
+	require.NoError(t, err)
+
+	var count int
+	err = db.QueryRowContext(ctx, `SELECT COUNT(*) FROM runners WHERE pipeline_id = ?`, ppID).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "runners should be cascade-deleted when pipeline is deleted")
+}

--- a/pikoci/mysql/user.go
+++ b/pikoci/mysql/user.go
@@ -109,6 +109,9 @@ func (r *UserRepository) FindWithMemberships(ctx context.Context, un string) (*u
 			ON tu.team_id = t.id
 		WHERE u.username = ?
 	`, un)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query user with memberships: %w", err)
+	}
 
 	u, err := scanUserWithMemberships(rows)
 	if err != nil {

--- a/pikoci/pipeline/pipeline.go
+++ b/pikoci/pipeline/pipeline.go
@@ -25,9 +25,9 @@ type Pipeline struct {
 	Jobs          []job.Job                 `json:"jobs" hcl:"job,block"`
 	Resources     []resource.Resource       `json:"resources" hcl:"resource,block"`
 	ResourceTypes []restype.ResourceType    `json:"resource_types" hcl:"resource_type,block"`
-	Runners       []runner.Runner           `json:"runners" hcl:"runner,block"`
+	Runners       []runner.Runner           `json:"runners" hcl:"runner_type,block"`
 	SecretTypes   []sectype.SecretType      `json:"secret_types" hcl:"secret_type,block"`
-	Services      []service.Service         `json:"services" hcl:"service,block"`
+	Services      []service.Service         `json:"services" hcl:"service_type,block"`
 	SecretVars    map[string]VariableSecret `json:"secret_vars,omitempty"`
 	Remain        hcl.Body                  `json:"-" hcl:",remain"`
 	Raw           []byte                    `json:"raw"`
@@ -46,7 +46,7 @@ type Variable struct {
 
 type VariableSecret struct {
 	Type string `json:"type" hcl:"type,label"`
-	Path string `json:"path" hcl:"path"`
+	Path string `json:"path,omitempty" hcl:"path,optional"`
 	Key  string `json:"key" hcl:"key"`
 }
 
@@ -129,7 +129,7 @@ type hclServiceRaw struct {
 
 // hclPipelineServices is a minimal struct for parsing only service blocks from raw HCL.
 type hclPipelineServices struct {
-	Services []hclServiceRaw `hcl:"service,block"`
+	Services []hclServiceRaw `hcl:"service_type,block"`
 	Remain   hcl.Body        `hcl:",remain"`
 }
 
@@ -155,7 +155,7 @@ func ParseServicesFromRaw(ctx context.Context, raw []byte) ([]service.Service, e
 		if hs.Source != "" {
 			resolved, err := source.ResolveService(ctx, hs.Source)
 			if err != nil {
-				return nil, fmt.Errorf("failed to resolve source for service %q: %w", hs.Name, err)
+				return nil, fmt.Errorf("failed to resolve source for service_type %q: %w", hs.Name, err)
 			}
 			resolved.Name = hs.Name
 			resolved.Source = hs.Source

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -481,7 +481,8 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 		})
 
 		burl := fmt.Sprintf(`"/teams/%s/pipelines/%s/jobs/%s/builds"`, tc, pp.Name, j.Name)
-		err = graph.AddNode(jg, j.Name, map[string]string{
+		quotedJobName := fmt.Sprintf(`"%s"`, j.Name)
+		err = graph.AddNode(jg, quotedJobName, map[string]string{
 			string(gographviz.Margin):    "0.5",
 			string(gographviz.Shape):     "rectangle",
 			string(gographviz.FillColor): color,
@@ -503,7 +504,7 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 				} else {
 					opt[string(gographviz.Style)] = "dashed"
 				}
-				err = graph.AddEdge(rCan, j.Name, false, opt)
+				err = graph.AddEdge(rCan, quotedJobName, false, opt)
 				if err != nil {
 					return nil, fmt.Errorf("failed to add edge to Graph: %w", err)
 				}
@@ -512,7 +513,7 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 		// Draw job→resource edges for all put steps (plan + hooks)
 		for _, p := range j.AllPutSteps() {
 			rCan := fmt.Sprintf(`"%s.%s"`, p.Type, p.Name)
-			err = graph.AddEdge(j.Name, rCan, false, map[string]string{
+			err = graph.AddEdge(quotedJobName, rCan, false, map[string]string{
 				string(gographviz.Style): "solid",
 			})
 			if err != nil {
@@ -523,6 +524,7 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 
 	// Now we print all the jobs interconnections depending on resources
 	for _, j := range pp.Jobs {
+		quotedJobName := fmt.Sprintf(`"%s"`, j.Name)
 		for _, g := range j.GetSteps() {
 			if len(g.Passed) != 0 {
 				for _, p := range g.Passed {
@@ -543,11 +545,12 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 					if err != nil {
 						return nil, fmt.Errorf("failed to add node to Graph: %w", err)
 					}
-					err = graph.AddEdge(p, nn, false, nil)
+					quotedPassedName := fmt.Sprintf(`"%s"`, p)
+					err = graph.AddEdge(quotedPassedName, nn, false, nil)
 					if err != nil {
 						return nil, fmt.Errorf("failed to add edge to Graph: %w", err)
 					}
-					err = graph.AddEdge(nn, j.Name, false, nil)
+					err = graph.AddEdge(nn, quotedJobName, false, nil)
 					if err != nil {
 						return nil, fmt.Errorf("failed to add edge to Graph: %w", err)
 					}

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -510,10 +510,28 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 				}
 			}
 		}
-		// Draw job→resource edges for all put steps (plan + hooks)
+		// Draw job→resource edges for all put steps (plan + hooks).
+		// Each job gets its own output resource node to avoid all jobs
+		// pointing to a single shared resource box.
 		for _, p := range j.AllPutSteps() {
-			rCan := fmt.Sprintf(`"%s.%s"`, p.Type, p.Name)
-			err = graph.AddEdge(quotedJobName, rCan, false, map[string]string{
+			rCan := fmt.Sprintf("%s.%s", p.Type, p.Name)
+			nn := fmt.Sprintf(`"%s-%s-out"`, j.Name, rCan)
+			vurl := fmt.Sprintf(`"/teams/%s/pipelines/%s/resources/%s/versions"`, tc, pp.Name, rCan)
+			border := resourceBorders[rCan]
+			err = graph.AddNode(pn, nn, map[string]string{
+				string(gographviz.Label):     fmt.Sprintf(`"%s"`, rCan),
+				string(gographviz.Margin):    "0.2",
+				string(gographviz.Shape):     "cds",
+				string(gographviz.FillColor): colorResource,
+				string(gographviz.Style):     "filled",
+				string(gographviz.FontColor): "white",
+				string(gographviz.URL):       vurl,
+				string(gographviz.Color):     border,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to add node to Graph: %w", err)
+			}
+			err = graph.AddEdge(quotedJobName, nn, false, map[string]string{
 				string(gographviz.Style): "solid",
 			})
 			if err != nil {

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -887,3 +887,155 @@ job "deploy" {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "both source and inline commands")
 }
+
+func TestCreatePipeline_HooksLabeledRunner(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "deploy" {
+  get "cron" "timer" { trigger = true }
+  task "run" {
+    run "exec" {
+      path = "echo"
+      args = ["testing"]
+    }
+    on_success "exec" {
+      path = "/bin/sh"
+      args = ["-ec", "echo success"]
+    }
+    on_failure "exec" {
+      path = "/bin/sh"
+      args = ["-ec", "echo failure"]
+    }
+  }
+}
+`)
+
+	s.Pipelines.EXPECT().Create(ctx, "main", gomock.Any()).Return(uint32(1), nil)
+	s.Jobs.EXPECT().Create(ctx, "main", "hooks-labeled", gomock.Any()).Return(uint32(1), nil)
+	s.Resources.EXPECT().Create(ctx, "main", "hooks-labeled", gomock.Any()).Return(uint32(1), nil)
+	s.Pipelines.EXPECT().Find(ctx, "main", "hooks-labeled").Return(&pipeline.Pipeline{Name: "hooks-labeled"}, nil)
+
+	pp, err := s.S.CreatePipeline(ctx, "main", "hooks-labeled", hclConfig, nil)
+	require.NoError(t, err)
+	require.NotNil(t, pp)
+}
+
+func TestCreatePipeline_HooksUnlabeledPut(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+resource_type "notify" {
+  push "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo notifying"]
+  }
+}
+
+resource "notify" "slack" {
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "deploy" {
+  get "cron" "timer" { trigger = true }
+  task "run" {
+    run "exec" {
+      path = "echo"
+      args = ["testing"]
+    }
+    on_success {
+      put "notify" "slack" {
+        message = "success"
+      }
+    }
+    on_failure {
+      put "notify" "slack" {
+        message = "failure"
+      }
+    }
+  }
+}
+`)
+
+	s.Pipelines.EXPECT().Create(ctx, "main", gomock.Any()).Return(uint32(1), nil)
+	s.Jobs.EXPECT().Create(ctx, "main", "hooks-unlabeled", gomock.Any()).Return(uint32(1), nil)
+	s.Resources.EXPECT().Create(ctx, "main", "hooks-unlabeled", gomock.Any()).Return(uint32(1), nil).Times(2)
+	s.ResourceTypes.EXPECT().Create(ctx, "main", "hooks-unlabeled", gomock.Any()).Return(uint32(1), nil)
+	s.Pipelines.EXPECT().Find(ctx, "main", "hooks-unlabeled").Return(&pipeline.Pipeline{Name: "hooks-unlabeled"}, nil)
+
+	pp, err := s.S.CreatePipeline(ctx, "main", "hooks-unlabeled", hclConfig, nil)
+	require.NoError(t, err)
+	require.NotNil(t, pp)
+}
+
+func TestCreatePipeline_HooksMixed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	// Mix labeled runner hooks and unlabeled put hooks in the same job
+	hclConfig := []byte(`
+resource_type "notify" {
+  push "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo notifying"]
+  }
+}
+
+resource "notify" "slack" {
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "deploy" {
+  get "cron" "timer" { trigger = true }
+
+  task "run" {
+    run "exec" {
+      path = "echo"
+      args = ["testing"]
+    }
+  }
+
+  on_success "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo job-level-success"]
+  }
+
+  on_success {
+    put "notify" "slack" {
+      message = "success"
+    }
+  }
+
+  on_failure {
+    put "notify" "slack" {
+      message = "failure"
+    }
+  }
+}
+`)
+
+	s.Pipelines.EXPECT().Create(ctx, "main", gomock.Any()).Return(uint32(1), nil)
+	s.Jobs.EXPECT().Create(ctx, "main", "hooks-mixed", gomock.Any()).Return(uint32(1), nil)
+	s.Resources.EXPECT().Create(ctx, "main", "hooks-mixed", gomock.Any()).Return(uint32(1), nil).Times(2)
+	s.ResourceTypes.EXPECT().Create(ctx, "main", "hooks-mixed", gomock.Any()).Return(uint32(1), nil)
+	s.Pipelines.EXPECT().Find(ctx, "main", "hooks-mixed").Return(&pipeline.Pipeline{Name: "hooks-mixed"}, nil)
+
+	pp, err := s.S.CreatePipeline(ctx, "main", "hooks-mixed", hclConfig, nil)
+	require.NoError(t, err)
+	require.NotNil(t, pp)
+}

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -692,7 +692,7 @@ func TestCreatePipeline_WithServices(t *testing.T) {
 	ctx := context.TODO()
 
 	hclConfig := []byte(`
-service "test-db" {
+service_type "test-db" {
   params = ["version"]
 
   start "exec" {
@@ -782,7 +782,7 @@ job "deploy" {
 
 	_, err := s.S.CreatePipeline(ctx, "main", "no-inline-svc-pipeline", hclConfig, nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "service \"inline-db\" referenced in job")
+	assert.Contains(t, err.Error(), "service_type \"inline-db\" referenced in job")
 }
 
 func TestCreatePipeline_ServiceMissingReference(t *testing.T) {
@@ -812,7 +812,7 @@ job "deploy" {
 
 	_, err := s.S.CreatePipeline(ctx, "main", "svc-missing-pipeline", hclConfig, nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "service \"nonexistent\" referenced in job")
+	assert.Contains(t, err.Error(), "service_type \"nonexistent\" referenced in job")
 }
 
 func TestCreatePipeline_ServiceMissingStart(t *testing.T) {
@@ -821,7 +821,7 @@ func TestCreatePipeline_ServiceMissingStart(t *testing.T) {
 	ctx := context.TODO()
 
 	hclConfig := []byte(`
-service "bad" {
+service_type "bad" {
   stop "exec" {
     path = "/bin/sh"
     args = ["-ec", "echo stopping"]
@@ -855,7 +855,7 @@ func TestCreatePipeline_ServiceSourceAndInlineConflict(t *testing.T) {
 	ctx := context.TODO()
 
 	hclConfig := []byte(`
-service "bad" {
+service_type "bad" {
   source = "https://example.com/service.hcl"
   start "exec" {
     path = "/bin/sh"

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -1039,3 +1039,61 @@ job "deploy" {
 	require.NoError(t, err)
 	require.NotNil(t, pp)
 }
+
+func TestCreatePipeline_HooksOnPutStep(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+resource_type "notify" {
+  push "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo notifying"]
+  }
+}
+
+resource "notify" "slack" {
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "deploy" {
+  get "cron" "timer" { trigger = true }
+
+  task "run" {
+    run "exec" {
+      path = "echo"
+      args = ["testing"]
+    }
+  }
+
+  put "notify" "slack" {
+    message = "deployed"
+
+    on_success "exec" {
+      path = "/bin/sh"
+      args = ["-ec", "echo put-success"]
+    }
+
+    on_failure {
+      put "notify" "slack" {
+        message = "put-failed"
+      }
+    }
+  }
+}
+`)
+
+	s.Pipelines.EXPECT().Create(ctx, "main", gomock.Any()).Return(uint32(1), nil)
+	s.Jobs.EXPECT().Create(ctx, "main", "hooks-on-put", gomock.Any()).Return(uint32(1), nil)
+	s.Resources.EXPECT().Create(ctx, "main", "hooks-on-put", gomock.Any()).Return(uint32(1), nil).Times(2)
+	s.ResourceTypes.EXPECT().Create(ctx, "main", "hooks-on-put", gomock.Any()).Return(uint32(1), nil)
+	s.Pipelines.EXPECT().Find(ctx, "main", "hooks-on-put").Return(&pipeline.Pipeline{Name: "hooks-on-put"}, nil)
+
+	pp, err := s.S.CreatePipeline(ctx, "main", "hooks-on-put", hclConfig, nil)
+	require.NoError(t, err)
+	require.NotNil(t, pp)
+}

--- a/pikoci/scheduler/parse.go
+++ b/pikoci/scheduler/parse.go
@@ -7,7 +7,7 @@ import (
 	cron "github.com/netresearch/go-cron"
 )
 
-var parser = cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor).WithMinEveryInterval(10 * time.Second)
+var parser = cron.MustNewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor).WithMinEveryInterval(10 * time.Second)
 
 const minCheckInterval = 10 * time.Second
 

--- a/pikoci/source/resolver.go
+++ b/pikoci/source/resolver.go
@@ -25,7 +25,7 @@ type hclResourceType struct {
 }
 
 type hclRunner struct {
-	Runners []runner.Runner `hcl:"runner,block"`
+	Runners []runner.Runner `hcl:"runner_type,block"`
 }
 
 type hclSecretType struct {
@@ -33,7 +33,7 @@ type hclSecretType struct {
 }
 
 type hclService struct {
-	Services []service.Service `hcl:"service,block"`
+	Services []service.Service `hcl:"service_type,block"`
 }
 
 func ResolveResourceType(ctx context.Context, src string) (*restype.ResourceType, error) {
@@ -65,7 +65,7 @@ func ResolveRunner(ctx context.Context, src string) (*runner.Runner, error) {
 		return nil, fmt.Errorf("failed to decode runner from source %q: %w", src, err)
 	}
 	if len(hr.Runners) == 0 {
-		return nil, fmt.Errorf("no runner block found in source %q", src)
+		return nil, fmt.Errorf("no runner_type block found in source %q", src)
 	}
 	return &hr.Runners[0], nil
 }
@@ -99,7 +99,7 @@ func ResolveService(ctx context.Context, src string) (*service.Service, error) {
 		return nil, fmt.Errorf("failed to decode service from source %q: %w", src, err)
 	}
 	if len(hs.Services) == 0 {
-		return nil, fmt.Errorf("no service block found in source %q", src)
+		return nil, fmt.Errorf("no service_type block found in source %q", src)
 	}
 	return &hs.Services[0], nil
 }

--- a/pikoci/source/resolver_test.go
+++ b/pikoci/source/resolver_test.go
@@ -77,7 +77,7 @@ func TestResolveRunner_PikoCI(t *testing.T) {
 
 func TestResolveRunner_HTTP(t *testing.T) {
 	hcl := `
-runner "myrunner" {
+runner_type "myrunner" {
   run {
     path = "/usr/bin/env"
     args = ["bash", "-c", "$script"]

--- a/pikoci/teams.go
+++ b/pikoci/teams.go
@@ -14,7 +14,7 @@ func (q *PikoCI) CreateTeam(ctx context.Context, un string, t team.Team) (*team.
 	if !utils.ValidateCanonical(un) {
 		return nil, fmt.Errorf("invalid Username format %q", un)
 	} else if t.Name == "" {
-		return nil, fmt.Errorf("Team Name is required")
+		return nil, fmt.Errorf("team name is required")
 	}
 
 	t.Canonical = utils.Canonicalize(t.Name)
@@ -186,7 +186,7 @@ func (q *PikoCI) validateTeamAdmins(ctx context.Context, tc, mu string, m *team.
 	}
 
 	if admins == 0 {
-		return fmt.Errorf("Cannot have a Team with no Admins")
+		return fmt.Errorf("cannot have a team with no admins")
 	}
 	return nil
 }

--- a/pikoci/teams_test.go
+++ b/pikoci/teams_test.go
@@ -37,7 +37,7 @@ func TestCreateTeam_EmptyName(t *testing.T) {
 
 	_, err := s.S.CreateTeam(ctx, "admin", team.Team{Name: ""})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "Team Name is required")
+	assert.Contains(t, err.Error(), "team name is required")
 }
 
 func TestCreateTeam_InvalidUsername(t *testing.T) {
@@ -163,7 +163,7 @@ func TestUpdateTeamMember_WouldRemoveLastAdmin(t *testing.T) {
 
 	_, err := s.S.UpdateTeamMember(ctx, "main", "admin", team.Member{Admin: false})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no Admins")
+	assert.Contains(t, err.Error(), "no admins")
 }
 
 func TestDeleteTeamMember(t *testing.T) {

--- a/pikoci/testdata/cron.hcl
+++ b/pikoci/testdata/cron.hcl
@@ -1,25 +1,19 @@
-variable "secrets_file" {
-  type    = string
-  default = "pikoci/testdata/secrets.json"
-}
-
 secret_type "my-file" {
   source = "pikoci://file"
+  path   = "pikoci/testdata/secrets.json"
 }
 
 variable "greeting" {
   type = string
   secret "my-file" {
-    path = var.secrets_file
-    key  = "greeting"
+    key = "greeting"
   }
 }
 
 variable "env" {
   type = string
   secret "my-file" {
-    path = var.secrets_file
-    key  = "env"
+    key = "env"
   }
 }
 

--- a/pikoci/testdata/service.hcl
+++ b/pikoci/testdata/service.hcl
@@ -1,4 +1,4 @@
-service "test-db" {
+service_type "test-db" {
   params = ["version"]
 
   start "exec" {

--- a/pikoci/transport/http/builds.go
+++ b/pikoci/transport/http/builds.go
@@ -23,29 +23,6 @@ type CreateJobBuildResponse struct {
 
 func (r CreateJobBuildResponse) Error() string { return r.Err }
 
-func createJobBuild(s pikoci.Service) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		var (
-			req CreateJobBuildRequest
-			ctx = r.Context()
-		)
-		vars := mux.Vars(r)
-		req.TeamCanonical = vars["team_canonical"]
-		req.PipelineName = vars["pipeline_name"]
-		req.JobName = vars["job_name"]
-		err := json.NewDecoder(r.Body).Decode(&req)
-		if err != nil {
-			encodeResponse(CreateJobBuildResponse{Err: err.Error()}, w)
-			return
-		}
-		b, err := s.CreateJobBuild(ctx, req.TeamCanonical, req.PipelineName, req.JobName, req.Build)
-		var errs string
-		if err != nil {
-			errs = err.Error()
-		}
-		encodeResponse(CreateJobBuildResponse{Build: b, Err: errs}, w)
-	}
-}
 
 type UpdateJobBuildRequest struct {
 	TeamCanonical string      `json:"team_canonical"`

--- a/pikoci/transport/http/handler.go
+++ b/pikoci/transport/http/handler.go
@@ -16,9 +16,11 @@ import (
 	"github.com/xescugc/pikoci/pikoci/user"
 )
 
+type contextKey string
+
 const (
-	UsernameContextKey   string = "username_context_key"
-	IsPublicAccessKey    string = "is_public_access_key"
+	UsernameContextKey   contextKey = "username_context_key"
+	IsPublicAccessKey    contextKey = "is_public_access_key"
 )
 
 var publicFallbackRoutes = map[RouteName]bool{

--- a/pikoci/transport/http/templates/template.go
+++ b/pikoci/transport/http/templates/template.go
@@ -28,8 +28,6 @@ func init() {
 	}
 
 	loadTemplates(viewsDir)
-
-	return
 }
 
 func loadTemplates(path string) error {

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -396,11 +396,11 @@
           <div class="piko-step-row">
             <div class="piko-step-row-header" onclick="this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'block' : 'none'">
               <span><span class="piko-step-label"><%- s.type || "step" %></span> <%- s.name %> <span style="color:var(--text-muted);">(<%- s.duration %>)</span></span>
-              <% if (status === "failed" && s === lastStep && _job.length === 0) { %>
+              <% if (s.status === "failed") { %>
                 <span class="piko-badge piko-badge-failed">fail</span>
-              <% } else if (status === "started" && s === lastStep && _job.length === 0) { %>
+              <% } else if (s.status === "started") { %>
                 <span class="piko-badge piko-badge-started">running</span>
-              <% } else if (s.logs) { %>
+              <% } else if (s.status === "succeeded" || s.logs) { %>
                 <span class="piko-badge piko-badge-succeeded">ok</span>
               <% } %>
             </div>
@@ -416,11 +416,11 @@
           <div class="piko-step-row">
             <div class="piko-step-row-header" onclick="this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'block' : 'none'">
               <span><span class="piko-step-label">job</span> <%- j.name %> <span style="color:var(--text-muted);">(<%- j.duration %>)</span></span>
-              <% if (status === "failed" && j === lastJob) { %>
+              <% if (j.status === "failed") { %>
                 <span class="piko-badge piko-badge-failed">fail</span>
-              <% } else if (status === "started" && j === lastJob) { %>
+              <% } else if (j.status === "started") { %>
                 <span class="piko-badge piko-badge-started">running</span>
-              <% } else if (j.logs) { %>
+              <% } else if (j.status === "succeeded" || j.logs) { %>
                 <span class="piko-badge piko-badge-succeeded">ok</span>
               <% } %>
             </div>

--- a/pikoci/users.go
+++ b/pikoci/users.go
@@ -21,7 +21,7 @@ func (q *PikoCI) UserLogin(ctx context.Context, un, pass string) (*user.WithMemb
 
 	ok := utils.CheckPasswordHash(pass, um.Password)
 	if !ok {
-		return nil, "", fmt.Errorf("Username or Password is wrong")
+		return nil, "", fmt.Errorf("username or password is wrong")
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{

--- a/worker/service.go
+++ b/worker/service.go
@@ -790,6 +790,10 @@ func (w *Worker) processResourceCheck(ctx context.Context, m queue.Body, cwd str
 	resolved, err := w.resolveSecretVars(ctx, cwd, pp)
 	if err != nil {
 		w.logger.Error("failed to resolve secret vars for resource check", "error", err)
+		r.Logs = err.Error()
+		if nerr := w.pikoci.UpdatePipelineResource(ctx, m.TeamCanonical, m.PipelineName, r.Canonical, r); nerr != nil {
+			w.logger.Error("failed update resource", "resource", r.Canonical, "pipeline", m.PipelineName, "error", nerr)
+		}
 		return
 	}
 	replaceSecretPlaceholders(params, resolved)

--- a/worker/service.go
+++ b/worker/service.go
@@ -51,11 +51,14 @@ func New(s pikoci.Service, t queue.Topic, ss queue.Subscription, l *slog.Logger)
 }
 
 func (w *Worker) Run(ctx context.Context) error {
+	w.logger.Info("Worker waiting for messages...")
 	for {
 		msg, err := w.subscription.Receive(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to receive message: %w", err)
 		}
+
+		w.logger.Info("received message", "body", string(msg.Body))
 
 		var m queue.Body
 		if err := json.Unmarshal(msg.Body, &m); err != nil {
@@ -755,16 +758,20 @@ func (w *Worker) runHooks(ctx context.Context, m queue.Body, b *build.Build, ste
 func (w *Worker) processResourceCheck(ctx context.Context, m queue.Body, cwd string, pp *pipeline.Pipeline) {
 	r, ok := pp.Resource(m.ResourceCanonical)
 	if !ok {
+		w.logger.Error("resource not found in pipeline", "resource", m.ResourceCanonical)
 		return
 	}
 	rt, ok := pp.ResourceType(r.Type)
 	if !ok {
+		w.logger.Error("resource type not found", "type", r.Type, "resource", m.ResourceCanonical)
 		return
 	}
 
 	if rt.Check == nil {
+		w.logger.Error("resource type has no check command", "type", r.Type)
 		return
 	}
+	w.logger.Info("running resource check", "resource", m.ResourceCanonical, "type", r.Type)
 
 	params := make(map[string]string)
 	for k, v := range rt.Check.Params {
@@ -929,12 +936,12 @@ func (w *Worker) runRunner(ctx context.Context, ru runner.Runner, cwd string, rc
 	var out string
 	for _, a := range ru.Run.Args {
 		if a == "$args" {
-			for _, ca := range rc.Args {
-				ea := os.Expand(ca, envFn)
-				if ea != "" {
-					args = append(args, ea)
-				}
-			}
+			// Pass command args through without os.Expand.
+			// The $param_* and $version_* variables are set as env vars
+			// on the process, so the shell expands them naturally.
+			// This allows shell scripts to use local variables and awk
+			// without Go's os.Expand destroying them.
+			args = append(args, rc.Args...)
 			continue
 		}
 		ea := os.Expand(a, envFn)

--- a/worker/service.go
+++ b/worker/service.go
@@ -396,7 +396,7 @@ func (w *Worker) runGetStep(ctx context.Context, m queue.Body, b *build.Build, c
 	}
 
 	if err != nil {
-		b.Steps = append(b.Steps, build.Step{Type: "get", Name: g.Name, Logs: out, Duration: d})
+		b.Steps = append(b.Steps, build.Step{Type: "get", Name: g.Name, Logs: out, Duration: d, Status: build.Failed})
 		b.Status = build.Failed
 		w.failBuild(ctx, m, *b, nil)
 		w.logger.Error("failed to run get step", "step", g.Name, "error", err)
@@ -411,6 +411,7 @@ func (w *Worker) runGetStep(ctx context.Context, m queue.Body, b *build.Build, c
 		VersionID: m.VersionID,
 		Logs:      out,
 		Duration:  d,
+		Status:    build.Succeeded,
 	})
 	if err := w.updateBuild(ctx, m, *b); err != nil {
 		return true
@@ -481,7 +482,7 @@ func (w *Worker) runTaskStep(ctx context.Context, m queue.Body, b *build.Build, 
 	}
 
 	if err != nil {
-		b.Steps = append(b.Steps, build.Step{Type: "task", Name: t.Name, Logs: out, Duration: d})
+		b.Steps = append(b.Steps, build.Step{Type: "task", Name: t.Name, Logs: out, Duration: d, Status: build.Failed})
 		b.Status = build.Failed
 		w.failBuild(ctx, m, *b, nil)
 		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.OnFailure, "on_failure")
@@ -489,7 +490,7 @@ func (w *Worker) runTaskStep(ctx context.Context, m queue.Body, b *build.Build, 
 		return true
 	}
 
-	b.Steps = append(b.Steps, build.Step{Type: "task", Name: t.Name, Logs: out, Duration: d})
+	b.Steps = append(b.Steps, build.Step{Type: "task", Name: t.Name, Logs: out, Duration: d, Status: build.Succeeded})
 	if err := w.updateBuild(ctx, m, *b); err != nil {
 		return true
 	}
@@ -592,7 +593,7 @@ func (w *Worker) runPutStep(ctx context.Context, m queue.Body, b *build.Build, c
 	}
 
 	if err != nil {
-		b.Steps = append(b.Steps, build.Step{Type: "put", Name: p.Name, Logs: out, Duration: d})
+		b.Steps = append(b.Steps, build.Step{Type: "put", Name: p.Name, Logs: out, Duration: d, Status: build.Failed})
 		b.Status = build.Failed
 		w.failBuild(ctx, m, *b, nil)
 		w.logger.Error("failed to run put step", "step", p.Name, "error", err)
@@ -601,7 +602,7 @@ func (w *Worker) runPutStep(ctx context.Context, m queue.Body, b *build.Build, c
 		return true
 	}
 
-	b.Steps = append(b.Steps, build.Step{Type: "put", Name: p.Name, Logs: out, Duration: d})
+	b.Steps = append(b.Steps, build.Step{Type: "put", Name: p.Name, Logs: out, Duration: d, Status: build.Succeeded})
 	if err := w.updateBuild(ctx, m, *b); err != nil {
 		return true
 	}
@@ -747,7 +748,7 @@ func (w *Worker) runHooks(ctx context.Context, m queue.Body, b *build.Build, ste
 			}
 		}
 
-		*steps = append(*steps, build.Step{Type: "hook", Name: name, Logs: out, Duration: d})
+		*steps = append(*steps, build.Step{Type: "hook", Name: name, Logs: out, Duration: d, Status: build.Succeeded})
 		if err := w.updateBuild(ctx, m, *b); err != nil {
 			return
 		}
@@ -1068,14 +1069,14 @@ func (w *Worker) startServices(ctx context.Context, m queue.Body, b *build.Build
 
 		out, d, err := w.runRunner(ctx, ru, cwd, rc)
 		if err != nil {
-			b.Steps = append(b.Steps, build.Step{Type: "service", Name: ss.Name + ":start", Logs: out, Duration: d})
+			b.Steps = append(b.Steps, build.Step{Type: "service", Name: ss.Name + ":start", Logs: out, Duration: d, Status: build.Failed})
 			b.Status = build.Failed
 			w.failBuild(ctx, m, *b, nil)
 			w.logger.Error("failed to start service", "service", ss.Name, "error", err)
 			return started
 		}
 
-		b.Steps = append(b.Steps, build.Step{Type: "service", Name: ss.Name + ":start", Logs: out, Duration: d})
+		b.Steps = append(b.Steps, build.Step{Type: "service", Name: ss.Name + ":start", Logs: out, Duration: d, Status: build.Succeeded})
 		if err := w.updateBuild(ctx, m, *b); err != nil {
 			return started
 		}
@@ -1217,13 +1218,13 @@ func (w *Worker) waitForServices(ctx context.Context, m queue.Body, b *build.Bui
 	allReady := true
 	for r := range results {
 		if r.err != nil {
-			b.Steps = append(b.Steps, build.Step{Type: "service", Name: r.name + ":ready", Logs: r.out, Duration: r.d})
+			b.Steps = append(b.Steps, build.Step{Type: "service", Name: r.name + ":ready", Logs: r.out, Duration: r.d, Status: build.Failed})
 			b.Status = build.Failed
 			w.failBuild(ctx, m, *b, nil)
 			w.logger.Error("service ready_check failed", "service", r.name, "error", r.err)
 			allReady = false
 		} else {
-			b.Steps = append(b.Steps, build.Step{Type: "service", Name: r.name + ":ready", Logs: r.out, Duration: r.d})
+			b.Steps = append(b.Steps, build.Step{Type: "service", Name: r.name + ":ready", Logs: r.out, Duration: r.d, Status: build.Succeeded})
 			w.updateBuild(ctx, m, *b)
 		}
 	}
@@ -1258,10 +1259,12 @@ func (w *Worker) stopServices(m queue.Body, b *build.Build, cwd string, pp *pipe
 		}
 
 		out, d, err := w.runRunner(stopCtx, ru, cwd, rc)
+		stepStatus := build.Succeeded
 		if err != nil {
+			stepStatus = build.Failed
 			w.logger.Error("failed to stop service", "service", ss.Name, "error", err)
 		}
-		b.Steps = append(b.Steps, build.Step{Type: "service", Name: ss.Name + ":stop", Logs: out, Duration: d})
+		b.Steps = append(b.Steps, build.Step{Type: "service", Name: ss.Name + ":stop", Logs: out, Duration: d, Status: stepStatus})
 		w.updateBuild(stopCtx, m, *b)
 	}
 }

--- a/worker/service.go
+++ b/worker/service.go
@@ -1006,13 +1006,18 @@ func (w *Worker) fetchSecrets(ctx context.Context, cwd string, pp *pipeline.Pipe
 			return nil, fmt.Errorf("failed to fetch secret from %q at %q: %s\n%w", stName, path, out, err)
 		}
 
-		// Parse last line of stdout as JSON object
-		sout := strings.Split(strings.Trim(out, "\n"), "\n")
-		rawJSON := sout[len(sout)-1]
-
+		// Parse output based on format config
+		format := st.Config["format"]
 		var secretData map[string]string
-		if err := json.Unmarshal([]byte(rawJSON), &secretData); err != nil {
-			return nil, fmt.Errorf("failed to parse secret output from %q as JSON: %w", stName, err)
+		if format == "env" {
+			secretData = parseEnvFormat(out)
+		} else {
+			// Default: parse last line of stdout as JSON object
+			sout := strings.Split(strings.Trim(out, "\n"), "\n")
+			rawJSON := sout[len(sout)-1]
+			if err := json.Unmarshal([]byte(rawJSON), &secretData); err != nil {
+				return nil, fmt.Errorf("failed to parse secret output from %q as JSON: %w", stName, err)
+			}
 		}
 
 		for k, v := range secretData {
@@ -1307,6 +1312,49 @@ func replaceSecretPlaceholdersInSlice(ss []string, resolved map[string]string) {
 			}
 		}
 	}
+}
+
+// parseEnvFormat parses KEY=VALUE lines (e.g. .env files) into a map.
+// Comment lines (#), blank lines, and lines without a valid variable name are ignored.
+// Values optionally wrapped in single or double quotes are stripped.
+func parseEnvFormat(data string) map[string]string {
+	result := make(map[string]string)
+	for _, line := range strings.Split(data, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		idx := strings.Index(line, "=")
+		if idx < 1 {
+			continue
+		}
+		key := line[:idx]
+		// Validate key is a valid variable name
+		valid := true
+		for i, c := range key {
+			if i == 0 {
+				if !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_') {
+					valid = false
+					break
+				}
+			} else {
+				if !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_') {
+					valid = false
+					break
+				}
+			}
+		}
+		if !valid {
+			continue
+		}
+		val := line[idx+1:]
+		// Strip surrounding quotes
+		if len(val) >= 2 && ((val[0] == '"' && val[len(val)-1] == '"') || (val[0] == '\'' && val[len(val)-1] == '\'')) {
+			val = val[1 : len(val)-1]
+		}
+		result[key] = val
+	}
+	return result
 }
 
 func createKeyValuePairs(m map[string]string) string {

--- a/worker/service.go
+++ b/worker/service.go
@@ -1021,9 +1021,14 @@ func (w *Worker) fetchSecrets(ctx context.Context, cwd string, pp *pipeline.Pipe
 		// Parse output based on format config
 		format := st.Config["format"]
 		var secretData map[string]string
-		if format == "env" {
+		switch format {
+		case "env":
 			secretData = parseEnvFormat(out)
-		} else {
+		case "raw":
+			// Raw format: entire file content as a single "content" key.
+			// Trim trailing newline added by the shell command (e.g. cat).
+			secretData = map[string]string{"content": strings.TrimRight(out, "\n")}
+		default:
 			// Default: parse last line of stdout as JSON object
 			sout := strings.Split(strings.Trim(out, "\n"), "\n")
 			rawJSON := sout[len(sout)-1]

--- a/worker/service.go
+++ b/worker/service.go
@@ -718,6 +718,8 @@ func (w *Worker) runHooks(ctx context.Context, m queue.Body, b *build.Build, ste
 				params[k] = v
 			}
 			rc.Params = params
+			replaceSecretPlaceholders(rc.Params, resolved)
+			replaceSecretPlaceholdersInSlice(rc.Args, resolved)
 			if len(buildStatus) > 0 {
 				rc.Params["BUILD_STATUS"] = buildStatus[0]
 			}

--- a/worker/service.go
+++ b/worker/service.go
@@ -984,8 +984,11 @@ func (w *Worker) fetchSecrets(ctx context.Context, cwd string, pp *pipeline.Pipe
 		for k, v := range st.Config {
 			params["param_"+k] = v
 		}
-		// Add path as param_path (the dynamic per-step value)
-		params["param_path"] = path
+		// Add path as param_path (the dynamic per-step value), only if set.
+		// When empty, the secret_type's config path (from st.Config) is used as default.
+		if path != "" {
+			params["param_path"] = path
+		}
 
 		ru, ok := pp.Runner(st.Get.Runner)
 		if !ok {

--- a/worker/service.go
+++ b/worker/service.go
@@ -161,7 +161,7 @@ func (w *Worker) processJob(ctx context.Context, m queue.Body, cwd string, pp *p
 		return
 	}
 
-	failed := w.runPlan(ctx, m, &b, cwd, pp, j)
+	failed, resolved := w.runPlan(ctx, m, &b, cwd, pp, j)
 
 	if !failed {
 		b.Status = build.Succeeded
@@ -169,15 +169,15 @@ func (w *Worker) processJob(ctx context.Context, m queue.Body, cwd string, pp *p
 			return
 		}
 		w.triggerDownstreamJobs(ctx, m, &b, pp, j)
-		w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.OnSuccess, "on_success", "succeeded")
+		w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.OnSuccess, "on_success", resolved, "succeeded")
 	} else {
-		w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.OnFailure, "on_failure", "failed")
+		w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.OnFailure, "on_failure", resolved, "failed")
 	}
 	status := "succeeded"
 	if b.Status == build.Failed {
 		status = "failed"
 	}
-	w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.Ensure, "ensure", status)
+	w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.Ensure, "ensure", resolved, status)
 }
 
 // checkPassedConstraints verifies that all jobs in the "passed" list have a
@@ -248,7 +248,7 @@ func (w *Worker) checkVersionAvailability(ctx context.Context, m queue.Body, b *
 // runPlan runs all plan steps (service/get/task/put) in order.
 // Service steps are collected and started before other steps, then stopped unconditionally after.
 // Returns true if the job failed during plan execution.
-func (w *Worker) runPlan(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, j *job.Job) bool {
+func (w *Worker) runPlan(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, j *job.Job) (bool, map[string]string) {
 	// Collect service steps and remaining steps
 	var serviceSteps []job.ServiceStep
 	var remainingPlan []job.PlanStep
@@ -267,12 +267,12 @@ func (w *Worker) runPlan(ctx context.Context, m queue.Body, b *build.Build, cwd 
 
 		// If any service failed to start, fail the build
 		if len(startedServices) != len(serviceSteps) {
-			return true
+			return true, nil
 		}
 
 		// Wait for ready checks
 		if !w.waitForServices(ctx, m, b, cwd, pp, startedServices) {
-			return true
+			return true, nil
 		}
 	}
 
@@ -280,7 +280,7 @@ func (w *Worker) runPlan(ctx context.Context, m queue.Body, b *build.Build, cwd 
 	resolved, err := w.resolveSecretVars(ctx, cwd, pp)
 	if err != nil {
 		w.failBuild(ctx, m, *b, fmt.Errorf("failed to resolve secret vars: %w", err))
-		return true
+		return true, nil
 	}
 
 	// Run remaining plan steps (get/task/put)
@@ -291,30 +291,34 @@ func (w *Worker) runPlan(ctx context.Context, m queue.Body, b *build.Build, cwd 
 				continue
 			}
 			if w.runGetStep(ctx, m, b, cwd, pp, *ps.Get, ps, resolved) {
-				return true
+				return true, resolved
 			}
 		case job.StepTypeTask:
 			if ps.Task == nil {
 				continue
 			}
 			if w.runTaskStep(ctx, m, b, cwd, pp, *ps.Task, ps, resolved) {
-				return true
+				return true, resolved
 			}
 		case job.StepTypePut:
 			if ps.Put == nil {
 				continue
 			}
 			if w.runPutStep(ctx, m, b, cwd, pp, *ps.Put, ps, resolved) {
-				return true
+				return true, resolved
 			}
 		}
 	}
-	return false
+	return false, resolved
 }
 
 // runGetStep runs a single get step (resource pull).
 // Returns true if the step failed.
 func (w *Worker) runGetStep(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, g job.GetStep, ps job.PlanStep, resolved ...map[string]string) bool {
+	var secretResolved map[string]string
+	if len(resolved) > 0 {
+		secretResolved = resolved[0]
+	}
 	r, ok := pp.Resource(utils.ResourceCanonical(g.Type, g.Name))
 	if !ok {
 		return false
@@ -338,10 +342,6 @@ func (w *Worker) runGetStep(ctx context.Context, m queue.Body, b *build.Build, c
 		return false
 	}
 
-	var secretResolved map[string]string
-	if len(resolved) > 0 {
-		secretResolved = resolved[0]
-	}
 	replaceSecretPlaceholders(params, secretResolved)
 
 	for k, v := range buildMetadataParams(b, m) {
@@ -400,8 +400,8 @@ func (w *Worker) runGetStep(ctx context.Context, m queue.Body, b *build.Build, c
 		b.Status = build.Failed
 		w.failBuild(ctx, m, *b, nil)
 		w.logger.Error("failed to run get step", "step", g.Name, "error", err)
-		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, g.Name, ps.OnFailure, "on_failure")
-		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, g.Name, ps.Ensure, "ensure")
+		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, g.Name, ps.OnFailure, "on_failure", secretResolved)
+		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, g.Name, ps.Ensure, "ensure", secretResolved)
 		return true
 	}
 
@@ -416,14 +416,18 @@ func (w *Worker) runGetStep(ctx context.Context, m queue.Body, b *build.Build, c
 	if err := w.updateBuild(ctx, m, *b); err != nil {
 		return true
 	}
-	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, g.Name, ps.OnSuccess, "on_success")
-	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, g.Name, ps.Ensure, "ensure")
+	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, g.Name, ps.OnSuccess, "on_success", secretResolved)
+	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, g.Name, ps.Ensure, "ensure", secretResolved)
 	return false
 }
 
 // runTaskStep runs a single task step.
 // Returns true if the step failed.
 func (w *Worker) runTaskStep(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, t job.TaskStep, ps job.PlanStep, resolved ...map[string]string) bool {
+	var secretResolved map[string]string
+	if len(resolved) > 0 {
+		secretResolved = resolved[0]
+	}
 	ru, ok := pp.Runner(t.Run.Runner)
 	if !ok {
 		return false
@@ -433,10 +437,6 @@ func (w *Worker) runTaskStep(ctx context.Context, m queue.Body, b *build.Build, 
 		t.Run.Params = make(map[string]string)
 	}
 
-	var secretResolved map[string]string
-	if len(resolved) > 0 {
-		secretResolved = resolved[0]
-	}
 	replaceSecretPlaceholders(t.Run.Params, secretResolved)
 	replaceSecretPlaceholdersInSlice(t.Run.Args, secretResolved)
 
@@ -485,8 +485,8 @@ func (w *Worker) runTaskStep(ctx context.Context, m queue.Body, b *build.Build, 
 		b.Steps = append(b.Steps, build.Step{Type: "task", Name: t.Name, Logs: out, Duration: d, Status: build.Failed})
 		b.Status = build.Failed
 		w.failBuild(ctx, m, *b, nil)
-		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.OnFailure, "on_failure")
-		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.Ensure, "ensure")
+		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.OnFailure, "on_failure", secretResolved)
+		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.Ensure, "ensure", secretResolved)
 		return true
 	}
 
@@ -494,14 +494,18 @@ func (w *Worker) runTaskStep(ctx context.Context, m queue.Body, b *build.Build, 
 	if err := w.updateBuild(ctx, m, *b); err != nil {
 		return true
 	}
-	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.OnSuccess, "on_success")
-	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.Ensure, "ensure")
+	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.OnSuccess, "on_success", secretResolved)
+	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.Ensure, "ensure", secretResolved)
 	return false
 }
 
 // runPutStep runs a single put step (resource push).
 // Returns true if the step failed.
 func (w *Worker) runPutStep(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, p job.PutStep, ps job.PlanStep, resolved ...map[string]string) bool {
+	var secretResolved map[string]string
+	if len(resolved) > 0 {
+		secretResolved = resolved[0]
+	}
 	rCan := utils.ResourceCanonical(p.Type, p.Name)
 	r, ok := pp.Resource(rCan)
 	if !ok {
@@ -539,10 +543,6 @@ func (w *Worker) runPutStep(ctx context.Context, m queue.Body, b *build.Build, c
 		return false
 	}
 
-	var secretResolved map[string]string
-	if len(resolved) > 0 {
-		secretResolved = resolved[0]
-	}
 	replaceSecretPlaceholders(params, secretResolved)
 
 	pushArgs := make([]string, len(rt.Push.Args))
@@ -597,8 +597,8 @@ func (w *Worker) runPutStep(ctx context.Context, m queue.Body, b *build.Build, c
 		b.Status = build.Failed
 		w.failBuild(ctx, m, *b, nil)
 		w.logger.Error("failed to run put step", "step", p.Name, "error", err)
-		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, p.Name, ps.OnFailure, "on_failure")
-		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, p.Name, ps.Ensure, "ensure")
+		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, p.Name, ps.OnFailure, "on_failure", secretResolved)
+		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, p.Name, ps.Ensure, "ensure", secretResolved)
 		return true
 	}
 
@@ -606,8 +606,8 @@ func (w *Worker) runPutStep(ctx context.Context, m queue.Body, b *build.Build, c
 	if err := w.updateBuild(ctx, m, *b); err != nil {
 		return true
 	}
-	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, p.Name, ps.OnSuccess, "on_success")
-	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, p.Name, ps.Ensure, "ensure")
+	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, p.Name, ps.OnSuccess, "on_success", secretResolved)
+	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, p.Name, ps.Ensure, "ensure", secretResolved)
 	return false
 }
 
@@ -695,7 +695,7 @@ func (w *Worker) triggerDownstreamJobs(ctx context.Context, m queue.Body, b *bui
 
 // runHooks runs a list of hooks (on_success, on_failure, ensure) and appends
 // the results as build steps.
-func (w *Worker) runHooks(ctx context.Context, m queue.Body, b *build.Build, steps *[]build.Step, cwd string, pp *pipeline.Pipeline, stepName string, hooks []job.HookStep, hookType string, buildStatus ...string) {
+func (w *Worker) runHooks(ctx context.Context, m queue.Body, b *build.Build, steps *[]build.Step, cwd string, pp *pipeline.Pipeline, stepName string, hooks []job.HookStep, hookType string, resolved map[string]string, buildStatus ...string) {
 	for i, h := range hooks {
 		var out string
 		var d time.Duration
@@ -730,7 +730,7 @@ func (w *Worker) runHooks(ctx context.Context, m queue.Body, b *build.Build, ste
 				Type: job.StepTypePut,
 				Put:  h.Put,
 			}
-			w.runPutStep(ctx, m, b, cwd, pp, *h.Put, ps)
+			w.runPutStep(ctx, m, b, cwd, pp, *h.Put, ps, resolved)
 			continue
 		default:
 			continue

--- a/worker/service.go
+++ b/worker/service.go
@@ -1026,8 +1026,7 @@ func (w *Worker) fetchSecrets(ctx context.Context, cwd string, pp *pipeline.Pipe
 			secretData = parseEnvFormat(out)
 		case "raw":
 			// Raw format: entire file content as a single "content" key.
-			// Trim trailing newline added by the shell command (e.g. cat).
-			secretData = map[string]string{"content": strings.TrimRight(out, "\n")}
+			secretData = map[string]string{"content": out}
 		default:
 			// Default: parse last line of stdout as JSON object
 			sout := strings.Split(strings.Trim(out, "\n"), "\n")

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -1817,5 +1817,120 @@ func TestRunRunner_ParamVarsExpandedByShell(t *testing.T) {
 	assert.Contains(t, out, "url=https://example.com", "param_url should be expanded by shell from env")
 }
 
+func TestProcessResourceCheck_RawSecretFormat(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, topic := newTestWorker(ctrl)
+
+	ctx := context.Background()
+
+	// Create a temp PEM-like file
+	tmpDir := t.TempDir()
+	pemFile := tmpDir + "/test.pem"
+	pemContent := "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn\n-----END RSA PRIVATE KEY-----\n"
+	os.WriteFile(pemFile, []byte(pemContent), 0644)
+
+	m := queue.Body{
+		TeamCanonical:     "main",
+		PipelineName:      "test-pipeline",
+		ResourceCanonical: "cron.timer",
+	}
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "test-job",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "cron", Name: "timer", Trigger: true}},
+				},
+			},
+		},
+		Resources: []resource.Resource{
+			{
+				ID: 1, Name: "timer", Type: "cron", Canonical: "cron.timer",
+				Params: &resource.Params{
+					Params: map[string]string{
+						"key": "__pikoci_secret:pem::content__",
+					},
+				},
+			},
+		},
+		ResourceTypes: []restype.ResourceType{
+			{
+				ID: 1, Name: "cron",
+				Params: []string{"key"},
+				Check: &utils.RunnerCommand{
+					Runner: "exec",
+					Args:   []string{"-ec", `printf "[{\"date\":\"now\"}]\n"`},
+					Params: map[string]string{"path": "/bin/sh"},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+		SecretTypes: []sectype.SecretType{
+			{
+				Name: "pem",
+				Get: utils.RunnerCommand{
+					Runner: "exec",
+					Args:   []string{"-ec", fmt.Sprintf(`cat "%s"`, pemFile)},
+					Params: map[string]string{"path": "/bin/sh"},
+				},
+				Config: map[string]string{"format": "raw", "path": pemFile},
+			},
+		},
+		SecretVars: map[string]pipeline.VariableSecret{
+			"app_key": {Type: "pem", Key: "content"},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().ListResourceVersions(ctx, m.TeamCanonical, m.PipelineName, "cron.timer").
+		Return([]*resource.Version{}, nil)
+	svc.EXPECT().CreateResourceVersion(ctx, m.TeamCanonical, m.PipelineName, "cron.timer", gomock.Any()).
+		Return(&resource.Version{ID: 1, Version: map[string]interface{}{"date": "now"}}, nil)
+	topic.EXPECT().Send(ctx, gomock.Any()).Return(nil)
+
+	w.processResourceCheck(ctx, m, cwd, pp)
+}
+
+func TestFetchSecrets_RawFormat(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, _, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	cwd := t.TempDir()
+
+	// Create a PEM-like file
+	pemFile := cwd + "/key.pem"
+	pemContent := "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn\n-----END RSA PRIVATE KEY-----"
+	os.WriteFile(pemFile, []byte(pemContent+"\n"), 0644)
+
+	pp := &pipeline.Pipeline{
+		SecretTypes: []sectype.SecretType{
+			{
+				Name: "pem",
+				Get: utils.RunnerCommand{
+					Runner: "exec",
+					Args:   []string{"-ec", fmt.Sprintf(`cat "%s"`, pemFile)},
+					Params: map[string]string{"path": "/bin/sh"},
+				},
+				Config: map[string]string{"format": "raw", "path": pemFile},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+
+	secrets := map[string]string{"pem": ""}
+	result, err := w.fetchSecrets(ctx, cwd, pp, secrets)
+	require.NoError(t, err)
+	assert.Equal(t, pemContent, result["secret_content"], "raw format should return trimmed file content under 'content' key")
+}
+
 // Silence the unused import warnings
 var _ = time.Now

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -1598,5 +1598,224 @@ func TestProcessResourceCheck_WithSecretVars(t *testing.T) {
 	w.processResourceCheck(ctx, m, cwd, pp)
 }
 
+func TestParseEnvFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]string
+	}{
+		{
+			name:  "basic key=value",
+			input: "DB_HOST=localhost\nDB_PORT=5432\n",
+			expected: map[string]string{
+				"DB_HOST": "localhost",
+				"DB_PORT": "5432",
+			},
+		},
+		{
+			name:  "double quoted values stripped",
+			input: `DB_USER="admin"`,
+			expected: map[string]string{
+				"DB_USER": "admin",
+			},
+		},
+		{
+			name:  "single quoted values stripped",
+			input: `DB_PASS='s3cret'`,
+			expected: map[string]string{
+				"DB_PASS": "s3cret",
+			},
+		},
+		{
+			name:  "comments and blank lines ignored",
+			input: "# comment\n\nKEY=value\n  \n",
+			expected: map[string]string{
+				"KEY": "value",
+			},
+		},
+		{
+			name:  "value containing equals sign",
+			input: "CONN=host=db;port=5432\n",
+			expected: map[string]string{
+				"CONN": "host=db;port=5432",
+			},
+		},
+		{
+			name:     "empty input",
+			input:    "",
+			expected: map[string]string{},
+		},
+		{
+			name:  "CRLF line endings",
+			input: "KEY=value\r\n",
+			expected: map[string]string{
+				"KEY": "value",
+			},
+		},
+		{
+			name:  "invalid variable names skipped",
+			input: "VALID=yes\n123BAD=no\n-also-bad=no\n",
+			expected: map[string]string{
+				"VALID": "yes",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseEnvFormat(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestProcessResourceCheck_SecretResolutionError_UpdatesResourceLogs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical:     "main",
+		PipelineName:      "test-pipeline",
+		ResourceCanonical: "git.repo",
+	}
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Resources: []resource.Resource{
+			{
+				ID: 1, Name: "repo", Type: "git", Canonical: "git.repo",
+				Params: &resource.Params{
+					Params: map[string]string{
+						"url":   "https://github.com/example/repo.git",
+						"token": "__pikoci_secret:vault:secret/bad:token__",
+					},
+				},
+			},
+		},
+		ResourceTypes: []restype.ResourceType{
+			{
+				ID: 1, Name: "git",
+				Params: []string{"url", "token"},
+				Check: &utils.RunnerCommand{
+					Runner: "exec",
+					Args:   []string{"-ec", `echo "check"`},
+					Params: map[string]string{"path": "/bin/sh"},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+		SecretTypes: []sectype.SecretType{
+			{
+				Name: "vault",
+				Get: utils.RunnerCommand{
+					Runner: "exec",
+					Args:   []string{"-ec", `exit 1`},
+					Params: map[string]string{"path": "/bin/sh"},
+				},
+			},
+		},
+		SecretVars: map[string]pipeline.VariableSecret{
+			"git_token": {Type: "vault", Path: "secret/bad", Key: "token"},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().ListResourceVersions(ctx, m.TeamCanonical, m.PipelineName, "git.repo").
+		Return([]*resource.Version{}, nil)
+
+	// Expect the resource to be updated with error logs
+	svc.EXPECT().UpdatePipelineResource(ctx, m.TeamCanonical, m.PipelineName, "git.repo", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _ string, r resource.Resource) error {
+			assert.NotEmpty(t, r.Logs, "resource logs should contain the error")
+			assert.Contains(t, r.Logs, "failed to resolve secrets")
+			return nil
+		})
+
+	w.processResourceCheck(ctx, m, cwd, pp)
+}
+
+func TestRunRunner_ShellVariablesNotDestroyed(t *testing.T) {
+	// Verifies that shell-local variables in command args are not
+	// destroyed by os.Expand — they should pass through to the shell.
+	ctrl := gomock.NewController(t)
+	w, _, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	cwd := t.TempDir()
+
+	ru := runner.Runner{
+		Name: "exec",
+		Run:  utils.RunCommand{Path: "$path", Args: []string{"$args"}},
+	}
+
+	// This script sets a shell variable and uses it.
+	// Before the fix, os.Expand would empty $MY_VAR.
+	rc := utils.RunnerCommand{
+		Runner: "exec",
+		Args:   []string{"-ec", `MY_VAR="hello_from_shell"; echo "$MY_VAR"`},
+		Params: map[string]string{"path": "/bin/sh"},
+	}
+
+	out, _, err := w.runRunner(ctx, ru, cwd, rc)
+	require.NoError(t, err)
+	assert.Contains(t, out, "hello_from_shell", "shell variable should survive and be echoed")
+}
+
+func TestRunRunner_AwkPositionalArgsWork(t *testing.T) {
+	// Verifies that awk $1, $0 etc. work in command args.
+	ctrl := gomock.NewController(t)
+	w, _, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	cwd := t.TempDir()
+
+	ru := runner.Runner{
+		Name: "exec",
+		Run:  utils.RunCommand{Path: "$path", Args: []string{"$args"}},
+	}
+
+	rc := utils.RunnerCommand{
+		Runner: "exec",
+		Args:   []string{"-ec", `echo "foo bar" | awk '{print $1}'`},
+		Params: map[string]string{"path": "/bin/sh"},
+	}
+
+	out, _, err := w.runRunner(ctx, ru, cwd, rc)
+	require.NoError(t, err)
+	assert.Contains(t, out, "foo", "awk $1 should extract first field")
+	assert.NotContains(t, out, "bar", "awk $1 should not include second field")
+}
+
+func TestRunRunner_ParamVarsExpandedByShell(t *testing.T) {
+	// Verifies that $param_* variables are available to the shell via env vars.
+	ctrl := gomock.NewController(t)
+	w, _, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	cwd := t.TempDir()
+
+	ru := runner.Runner{
+		Name: "exec",
+		Run:  utils.RunCommand{Path: "$path", Args: []string{"$args"}},
+	}
+
+	rc := utils.RunnerCommand{
+		Runner: "exec",
+		Args:   []string{"-ec", `echo "url=$param_url"`},
+		Params: map[string]string{
+			"path":      "/bin/sh",
+			"param_url": "https://example.com",
+		},
+	}
+
+	out, _, err := w.runRunner(ctx, ru, cwd, rc)
+	require.NoError(t, err)
+	assert.Contains(t, out, "url=https://example.com", "param_url should be expanded by shell from env")
+}
+
 // Silence the unused import warnings
 var _ = time.Now

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -646,7 +646,7 @@ func TestRunHooks(t *testing.T) {
 	svc.EXPECT().UpdateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, uint32(60), gomock.Any()).
 		Return(nil).Times(2)
 
-	w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "task-name", hooks, "on_success")
+	w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "task-name", hooks, "on_success", nil)
 
 	require.Len(t, b.Job, 2)
 	assert.Equal(t, "task-name:0:on_success", b.Job[0].Name)
@@ -676,7 +676,7 @@ func TestRunHooks_SingleHook_NoIndex(t *testing.T) {
 	svc.EXPECT().UpdateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, uint32(61), gomock.Any()).
 		Return(nil)
 
-	w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "step", hooks, "ensure")
+	w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "step", hooks, "ensure", nil)
 
 	require.Len(t, b.Job, 1)
 	assert.Equal(t, "step:ensure", b.Job[0].Name)
@@ -705,7 +705,7 @@ func TestRunHooks_JobLevel_NoStepName(t *testing.T) {
 	svc.EXPECT().UpdateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, uint32(62), gomock.Any()).
 		Return(nil)
 
-	w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", hooks, "on_failure")
+	w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", hooks, "on_failure", nil)
 
 	require.Len(t, b.Job, 1)
 	assert.Equal(t, "on_failure", b.Job[0].Name)

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -1906,8 +1906,8 @@ func TestFetchSecrets_RawFormat(t *testing.T) {
 
 	// Create a PEM-like file
 	pemFile := cwd + "/key.pem"
-	pemContent := "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn\n-----END RSA PRIVATE KEY-----"
-	os.WriteFile(pemFile, []byte(pemContent+"\n"), 0644)
+	pemContent := "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn\n-----END RSA PRIVATE KEY-----\n"
+	os.WriteFile(pemFile, []byte(pemContent), 0644)
 
 	pp := &pipeline.Pipeline{
 		SecretTypes: []sectype.SecretType{


### PR DESCRIPTION
Closes #258

Deployment infrastructure, CLI migration to cobra/viper, and extensive fixes from dogfooding the first real pipeline.

Highlights: rename runner/service → runner_type/service_type, fix os.Expand destroying shell variables, add .env/raw secret formats, per-step build status, hook system fix for unlabeled put blocks, SQLite cascade delete, Grafana dashboard provisioning, per-job output resource nodes in graph, and `checkVersionAvailability` to prevent hooks from running when no resource version exists.

Full changelog in commits.