### PR TITLE
Add .env format support to built-in file secret type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `.env` format support to the built-in `file` secret type via `format = "env"` config attribute. The default format remains `json` (backwards compatible)
 - Add secret-backed variables: variables can declare a `secret` block to resolve their value lazily from a secret type at runtime. This gives secrets universal reach through the existing `var.<name>` syntax — resource params, task args, etc. Vars file overrides take precedence for local development. Deprecates step-level `secrets = {}` on get/task/put steps in favor of the simpler declare-once-use-everywhere variable approach
 - Replace `urfave/cli` + `koanf` with `cobra` + `viper` for CLI and config management. Environment variables now use simple uppercase names (e.g., `JWT_SECRET`, `DB_SYSTEM`) ([#238](https://github.com/xescugc/pikoci/issues/238))
 - Replace `mattn/go-sqlite3` (CGO) with `modernc.org/sqlite` (pure Go) to enable cross-compilation without a C compiler

--- a/docs/Secret-Types.md
+++ b/docs/Secret-Types.md
@@ -180,7 +180,7 @@ Provide the token in your vars file: `{"vault_token": "hvs.CAESI..."}`.
 
 ## Built-in: file
 
-The `file` secret type is built in. It reads a JSON file from disk and exposes its keys for extraction by secret-backed variables.
+The `file` secret type is built in. It reads a file from disk and exposes its keys for extraction by secret-backed variables.
 
 ```hcl
 secret_type "my-file" {
@@ -188,7 +188,13 @@ secret_type "my-file" {
 }
 ```
 
-No config attributes needed. The file path comes from the variable's secret block:
+### Config
+
+| Attribute | Required | Default | Description                                      |
+|-----------|----------|---------|--------------------------------------------------|
+| `format`  | no       | `json`  | File format: `json` or `env`                     |
+
+The file path comes from the variable's secret block:
 
 ```hcl
 variable "db_user" {
@@ -200,10 +206,40 @@ variable "db_user" {
 }
 ```
 
-The file must contain a JSON object:
+### JSON format (default)
+
+When `format` is omitted or set to `"json"`, the file must contain a JSON object:
 
 ```json
 {"username": "admin", "password": "s3cret", "host": "db.example.com"}
+```
+
+### `.env` format
+
+When `format = "env"`, the file is parsed as a `.env` file with `KEY=VALUE` lines:
+
+```hcl
+secret_type "env-creds" {
+  source = "pikoci://file"
+  format = "env"
+}
+
+variable "db_password" {
+  type = string
+  secret "env-creds" {
+    path = "/run/secrets/db.env"
+    key  = "DB_PASSWORD"
+  }
+}
+```
+
+The `.env` file uses one `KEY=VALUE` per line. Comment lines (starting with `#`), blank lines, and any lines not matching a valid variable name are safely ignored. Values may optionally be wrapped in single or double quotes, which are stripped:
+
+```
+# Database credentials
+DB_HOST=db.example.com
+DB_PASSWORD=s3cret
+DB_USER="admin"
 ```
 
 ## Example: custom secret type

--- a/integration/backends/secrets_test.go
+++ b/integration/backends/secrets_test.go
@@ -252,6 +252,112 @@ job "deploy" {
 		assert.True(t, strings.Contains(taskStep.Logs, "api_secret=xyz789"), "logs should contain api_secret=xyz789, got: %s", taskStep.Logs)
 	})
 
+	t.Run("SecretBackedVariableWithFileSourceEnvFormat", func(t *testing.T) {
+		// Uses the built-in "file" secret_type with format = "env"
+		tmpDir := t.TempDir()
+		secretFile := tmpDir + "/secret.env"
+		err := os.WriteFile(secretFile, []byte("# Database credentials\nDB_HOST=db.example.com\nDB_PASSWORD=s3cret\nDB_USER=\"admin\"\nDB_CONN=host=db;port=5432\n"), 0644)
+		require.NoError(t, err)
+
+		hclConfig := []byte(fmt.Sprintf(`
+secret_type "env-file" {
+  source = "pikoci://file"
+  format = "env"
+}
+
+variable "db_host" {
+  type = string
+  secret "env-file" {
+    path = "%s"
+    key  = "DB_HOST"
+  }
+}
+
+variable "db_password" {
+  type = string
+  secret "env-file" {
+    path = "%s"
+    key  = "DB_PASSWORD"
+  }
+}
+
+variable "db_user" {
+  type = string
+  secret "env-file" {
+    path = "%s"
+    key  = "DB_USER"
+  }
+}
+
+variable "db_conn" {
+  type = string
+  secret "env-file" {
+    path = "%s"
+    key  = "DB_CONN"
+  }
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "deploy" {
+  get "cron" "timer" {
+    trigger = true
+  }
+  task "use-env-secrets" {
+    run "exec" {
+      path = "/bin/sh"
+      args = ["-ec", "echo db_host=${var.db_host} db_password=${var.db_password} db_user=${var.db_user} db_conn=${var.db_conn}"]
+    }
+  }
+}
+`, secretFile, secretFile, secretFile, secretFile))
+
+		pp, err := svc.CreatePipeline(ctx, "main", "secrets-env-file-e2e", hclConfig, nil)
+		require.NoError(t, err)
+		require.NotNil(t, pp)
+		assert.Len(t, pp.SecretTypes, 1)
+		assert.Equal(t, "env-file", pp.SecretTypes[0].Name)
+		assert.Equal(t, "pikoci://file", pp.SecretTypes[0].Source)
+
+		// Trigger resource check to create a version
+		err = svc.TriggerPipelineResource(ctx, "main", "secrets-env-file-e2e", "cron.timer")
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			vers, err := svc.ListResourceVersions(ctx, "main", "secrets-env-file-e2e", "cron.timer")
+			return err == nil && len(vers) > 0
+		}, 10*time.Second, 200*time.Millisecond)
+
+		// Wait for the build triggered by the resource to finish
+		var builds []*build.Build
+		require.Eventually(t, func() bool {
+			builds, err = svc.ListJobBuilds(ctx, "main", "secrets-env-file-e2e", "deploy")
+			if err != nil || len(builds) == 0 {
+				return false
+			}
+			return builds[0].Status != build.Started
+		}, 15*time.Second, 200*time.Millisecond)
+
+		require.NotEmpty(t, builds)
+		b := builds[0]
+		assert.Equal(t, build.Succeeded, b.Status, "build should succeed, error: %s", b.Error)
+
+		var taskStep *build.Step
+		for i, s := range b.Steps {
+			if s.Type == "task" && s.Name == "use-env-secrets" {
+				taskStep = &b.Steps[i]
+				break
+			}
+		}
+		require.NotNil(t, taskStep, "task step 'use-env-secrets' should exist in build steps")
+		assert.True(t, strings.Contains(taskStep.Logs, "db_host=db.example.com"), "logs should contain db_host=db.example.com, got: %s", taskStep.Logs)
+		assert.True(t, strings.Contains(taskStep.Logs, "db_password=s3cret"), "logs should contain db_password=s3cret, got: %s", taskStep.Logs)
+		assert.True(t, strings.Contains(taskStep.Logs, "db_user=admin"), "logs should contain db_user=admin (quotes stripped), got: %s", taskStep.Logs)
+		assert.True(t, strings.Contains(taskStep.Logs, "db_conn=host=db;port=5432"), "logs should contain db_conn=host=db;port=5432 (value with = sign), got: %s", taskStep.Logs)
+	})
+
 	cancel()
 	wg.Wait()
 }

--- a/pikoci/builtin/secret_types/file.hcl
+++ b/pikoci/builtin/secret_types/file.hcl
@@ -1,11 +1,29 @@
 secret_type "file" {
-  params = ["path"]
+  params = ["path", "format"]
 
   get "exec" {
     path = "/bin/sh"
     args = [
       "-ec",
-      "cat \"$param_path\""
+      <<-EOT
+      FORMAT="${param_format:-json}"
+      if [ "$FORMAT" = "env" ]; then
+        awk -F= 'BEGIN{printf "{"}
+        /^[A-Za-z_][A-Za-z_0-9]*=/{
+          key=$1; val=substr($0,index($0,"=")+1);
+          gsub(/\r$/,"",val);
+          gsub(/^["'"'"']|["'"'"']$/,"",val);
+          gsub(/\\/,"\\\\",val); gsub(/"/,"\\\"",val);
+          printf "%s\"%s\":\"%s\"",sep,key,val; sep=","
+        }
+        END{printf "}"}' "$param_path"
+      elif [ "$FORMAT" = "json" ]; then
+        cat "$param_path"
+      else
+        echo "ERROR: unsupported format '$FORMAT'. Use 'json' or 'env'." >&2
+        exit 1
+      fi
+      EOT
     ]
   }
 }


### PR DESCRIPTION
Closes #241

Extend the `pikoci://file` secret type with a `format` config attribute that accepts `json` (default, backwards compatible) or `env` for parsing `.env` files (`KEY=VALUE` format).

```hcl
secret_type "env-creds" {
  source = "pikoci://file"
  format = "env"
}
```