### PR TITLE
Fix #251: delete build when get step has no version available

### DIFF
--- a/worker/service.go
+++ b/worker/service.go
@@ -151,6 +151,13 @@ func (w *Worker) processJob(ctx context.Context, m queue.Body, cwd string, pp *p
 		return
 	}
 
+	// checkVersionAvailability verifies that the get step can pull a version.
+	// If no version is available (e.g. manual trigger with no resource versions),
+	// the build is deleted silently — no hooks run, no failure recorded.
+	if !w.checkVersionAvailability(ctx, m, &b, j, pp) {
+		return
+	}
+
 	failed := w.runPlan(ctx, m, &b, cwd, pp, j)
 
 	if !failed {
@@ -193,6 +200,55 @@ func (w *Worker) checkPassedConstraints(ctx context.Context, m queue.Body, b *bu
 			if builds[0].Status != build.Succeeded {
 				w.logger.Info("job will not run: passed job is not succeeded",
 					"job", m.JobName, "pipeline", m.PipelineName, "passed_job", p)
+				w.deleteBuild(ctx, m, *b)
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// checkVersionAvailability verifies that all get steps in the plan have a
+// version available to pull. If any get step has no version, the build is
+// deleted and false is returned (same behavior as checkPassedConstraints).
+// This prevents hooks from running when no work can be done.
+func (w *Worker) checkVersionAvailability(ctx context.Context, m queue.Body, b *build.Build, j *job.Job, pp *pipeline.Pipeline) bool {
+	for _, ps := range j.Plan {
+		if ps.Type != job.StepTypeGet || ps.Get == nil {
+			continue
+		}
+		g := ps.Get
+		rCan := utils.ResourceCanonical(g.Type, g.Name)
+		r, ok := pp.Resource(rCan)
+		if !ok {
+			continue
+		}
+
+		dbvers, err := w.pikoci.ListResourceVersions(ctx, m.TeamCanonical, m.PipelineName, r.Canonical)
+		if err != nil {
+			w.logger.Error("failed to list resource versions for availability check", "error", err)
+			w.deleteBuild(ctx, m, *b)
+			return false
+		}
+
+		if m.VersionID != 0 {
+			var found bool
+			for _, ver := range dbvers {
+				if ver.ID == m.VersionID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				w.logger.Info("job will not run: version not found",
+					"job", m.JobName, "pipeline", m.PipelineName, "resource", r.Canonical, "version_id", m.VersionID)
+				w.deleteBuild(ctx, m, *b)
+				return false
+			}
+		} else {
+			if len(dbvers) == 0 {
+				w.logger.Info("job will not run: no versions available",
+					"job", m.JobName, "pipeline", m.PipelineName, "resource", r.Canonical)
 				w.deleteBuild(ctx, m, *b)
 				return false
 			}

--- a/worker/service.go
+++ b/worker/service.go
@@ -221,37 +221,22 @@ func (w *Worker) checkVersionAvailability(ctx context.Context, m queue.Body, b *
 		rCan := utils.ResourceCanonical(g.Type, g.Name)
 		r, ok := pp.Resource(rCan)
 		if !ok {
+			w.logger.Warn("get step references unknown resource", "resource", rCan, "job", m.JobName)
 			continue
 		}
 
 		dbvers, err := w.pikoci.ListResourceVersions(ctx, m.TeamCanonical, m.PipelineName, r.Canonical)
 		if err != nil {
-			w.logger.Error("failed to list resource versions for availability check", "error", err)
-			w.deleteBuild(ctx, m, *b)
+			// Transient errors (DB, network) should fail the build, not silently delete it.
+			w.failBuild(ctx, m, *b, fmt.Errorf("failed to list resource versions: %w", err))
 			return false
 		}
 
-		if m.VersionID != 0 {
-			var found bool
-			for _, ver := range dbvers {
-				if ver.ID == m.VersionID {
-					found = true
-					break
-				}
-			}
-			if !found {
-				w.logger.Info("job will not run: version not found",
-					"job", m.JobName, "pipeline", m.PipelineName, "resource", r.Canonical, "version_id", m.VersionID)
-				w.deleteBuild(ctx, m, *b)
-				return false
-			}
-		} else {
-			if len(dbvers) == 0 {
-				w.logger.Info("job will not run: no versions available",
-					"job", m.JobName, "pipeline", m.PipelineName, "resource", r.Canonical)
-				w.deleteBuild(ctx, m, *b)
-				return false
-			}
+		if len(dbvers) == 0 {
+			w.logger.Info("job will not run: no versions available",
+				"job", m.JobName, "pipeline", m.PipelineName, "resource", r.Canonical)
+			w.deleteBuild(ctx, m, *b)
+			return false
 		}
 	}
 	return true

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -900,7 +900,6 @@ func TestCheckVersionAvailability_VersionExists_Passes(t *testing.T) {
 		TeamCanonical: "main",
 		PipelineName:  "test-pipeline",
 		JobName:       "test-job",
-		VersionID:     1,
 	}
 	b := build.Build{ID: 99}
 

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -223,7 +223,7 @@ func TestProcessJob_Success_WithGetAndTask(t *testing.T) {
 	svc.EXPECT().ListResourceVersions(ctx, m.TeamCanonical, m.PipelineName, "cron.my-cron").
 		Return([]*resource.Version{
 			{ID: 1, Version: map[string]interface{}{"date": "now"}},
-		}, nil)
+		}, nil).AnyTimes()
 
 	// UpdateJobBuild: after get step + after task step + after marking succeeded
 	svc.EXPECT().UpdateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, uint32(10), gomock.Any()).
@@ -563,7 +563,7 @@ func TestProcessResourceCheck_NewVersions(t *testing.T) {
 
 	// ListResourceVersions - no existing versions
 	svc.EXPECT().ListResourceVersions(ctx, m.TeamCanonical, m.PipelineName, "cron.my-cron").
-		Return([]*resource.Version{}, nil)
+		Return([]*resource.Version{}, nil).AnyTimes()
 
 	// CreateResourceVersion for the new version found
 	svc.EXPECT().CreateResourceVersion(ctx, m.TeamCanonical, m.PipelineName, "cron.my-cron", gomock.Any()).
@@ -777,7 +777,7 @@ func TestBuildPullParams_WithVersionID(t *testing.T) {
 		Return([]*resource.Version{
 			{ID: 3, Version: map[string]interface{}{"ref": "abc"}},
 			{ID: 5, Version: map[string]interface{}{"ref": "def"}},
-		}, nil)
+		}, nil).AnyTimes()
 
 	params := w.buildPullParams(ctx, m, &b, rt, r, g)
 	require.NotNil(t, params)
@@ -810,7 +810,7 @@ func TestBuildPullParams_NoVersionID_UsesLatest(t *testing.T) {
 		Return([]*resource.Version{
 			{ID: 1, Version: map[string]interface{}{"ref": "old"}},
 			{ID: 2, Version: map[string]interface{}{"ref": "latest"}},
-		}, nil)
+		}, nil).AnyTimes()
 
 	params := w.buildPullParams(ctx, m, &b, rt, r, g)
 	require.NotNil(t, params)
@@ -836,7 +836,7 @@ func TestBuildPullParams_NoVersions_Fails(t *testing.T) {
 	g := job.GetStep{}
 
 	svc.EXPECT().ListResourceVersions(ctx, m.TeamCanonical, m.PipelineName, "cron.my-cron").
-		Return([]*resource.Version{}, nil)
+		Return([]*resource.Version{}, nil).AnyTimes()
 
 	// Should call failBuild
 	svc.EXPECT().UpdateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, uint32(72), gomock.Any()).
@@ -844,6 +844,90 @@ func TestBuildPullParams_NoVersions_Fails(t *testing.T) {
 
 	params := w.buildPullParams(ctx, m, &b, rt, r, g)
 	assert.Nil(t, params)
+}
+
+func TestCheckVersionAvailability_NoVersions_DeletesBuild(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical: "main",
+		PipelineName:  "test-pipeline",
+		JobName:       "test-job",
+	}
+	b := build.Build{ID: 99}
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Resources: []resource.Resource{
+			{ID: 1, Name: "my-cron", Type: "cron", Canonical: "cron.my-cron"},
+		},
+	}
+	j := &job.Job{
+		Name: "test-job",
+		Plan: []job.PlanStep{
+			{
+				Type: job.StepTypeGet,
+				Get:  &job.GetStep{Type: "cron", Name: "my-cron"},
+			},
+			{
+				Type: job.StepTypePut,
+				Put:  &job.PutStep{Type: "notify", Name: "slack"},
+			},
+		},
+	}
+
+	// No versions available
+	svc.EXPECT().ListResourceVersions(ctx, m.TeamCanonical, m.PipelineName, "cron.my-cron").
+		Return([]*resource.Version{}, nil)
+
+	// Should delete build (not fail it)
+	svc.EXPECT().DeleteJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, uint32(99)).
+		Return(nil)
+
+	result := w.checkVersionAvailability(ctx, m, &b, j, pp)
+	assert.False(t, result, "should return false when no versions available")
+}
+
+func TestCheckVersionAvailability_VersionExists_Passes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical: "main",
+		PipelineName:  "test-pipeline",
+		JobName:       "test-job",
+		VersionID:     1,
+	}
+	b := build.Build{ID: 99}
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Resources: []resource.Resource{
+			{ID: 1, Name: "my-cron", Type: "cron", Canonical: "cron.my-cron"},
+		},
+	}
+	j := &job.Job{
+		Name: "test-job",
+		Plan: []job.PlanStep{
+			{
+				Type: job.StepTypeGet,
+				Get:  &job.GetStep{Type: "cron", Name: "my-cron"},
+			},
+		},
+	}
+
+	svc.EXPECT().ListResourceVersions(ctx, m.TeamCanonical, m.PipelineName, "cron.my-cron").
+		Return([]*resource.Version{
+			{ID: 1, Version: map[string]interface{}{"date": "now"}},
+		}, nil)
+
+	result := w.checkVersionAvailability(ctx, m, &b, j, pp)
+	assert.True(t, result, "should return true when version exists")
 }
 
 func TestProcessJob_PutStep_Success(t *testing.T) {
@@ -984,7 +1068,7 @@ func TestProcessJob_OrderedPlan_GetTaskPut(t *testing.T) {
 	svc.EXPECT().ListResourceVersions(ctx, m.TeamCanonical, m.PipelineName, "cron.my-cron").
 		Return([]*resource.Version{
 			{ID: 1, Version: map[string]interface{}{"date": "now"}},
-		}, nil)
+		}, nil).AnyTimes()
 
 	// UpdateJobBuild: after get + after task + after put + after success = 4
 	svc.EXPECT().UpdateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, uint32(90), gomock.Any()).
@@ -1124,7 +1208,7 @@ func TestProcessJob_GetTimeout(t *testing.T) {
 	svc.EXPECT().ListResourceVersions(ctx, m.TeamCanonical, m.PipelineName, "cron.my-cron").
 		Return([]*resource.Version{
 			{ID: 1, Version: map[string]interface{}{"date": "now"}},
-		}, nil)
+		}, nil).AnyTimes()
 
 	// failBuild = 1 update
 	var capturedBuild build.Build
@@ -1503,7 +1587,7 @@ func TestProcessResourceCheck_WithSecretVars(t *testing.T) {
 
 	// No existing versions
 	svc.EXPECT().ListResourceVersions(ctx, m.TeamCanonical, m.PipelineName, "git.repo").
-		Return([]*resource.Version{}, nil)
+		Return([]*resource.Version{}, nil).AnyTimes()
 
 	// CreateResourceVersion for the new version found
 	svc.EXPECT().CreateResourceVersion(ctx, m.TeamCanonical, m.PipelineName, "git.repo", gomock.Any()).


### PR DESCRIPTION
Closes #251

When a job's get step has no resource version to pull (e.g. manual trigger before any resource check), the build is now deleted silently instead of failed. This prevents on_failure hooks from running when no work was done.

Previously, the build would fail at the get step, triggering on_failure hooks. For pipelines with github-check put steps in hooks, this caused the put to fail because no repo was cloned (no HEAD SHA available).

## Changes

- Add `checkVersionAvailability()` in `processJob` — runs before `runPlan()`, same pattern as `checkPassedConstraints()`
- When no version is available, build is deleted and job returns immediately (no hooks)

## Tests

- `TestCheckVersionAvailability_NoVersions_DeletesBuild`
- `TestCheckVersionAvailability_VersionExists_Passes`