### PR TITLE
Fix #255: pin latest resource version on manual trigger and fix skipped job triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Hide unlinked resources from pipeline graph: resources only used in hook-level `put` steps (on_success/on_failure/ensure) no longer appear as disconnected nodes ([#256](https://github.com/xescugc/pikoci/issues/256))
 - Add `raw` format support to the built-in `file` secret type via `format = "raw"`. Returns the entire file content under a single `content` key, useful for PEM keys and other non-structured files
 - Add `.env` format support to the built-in `file` secret type via `format = "env"` config attribute. The default format remains `json` (backwards compatible)
 - Add secret-backed variables: variables can declare a `secret` block to resolve their value lazily from a secret type at runtime. This gives secrets universal reach through the existing `var.<name>` syntax — resource params, task args, etc. Vars file overrides take precedence for local development. Deprecates step-level `secrets = {}` on get/task/put steps in favor of the simpler declare-once-use-everywhere variable approach

--- a/pikoci/jobs.go
+++ b/pikoci/jobs.go
@@ -20,7 +20,7 @@ func (q *PikoCI) TriggerPipelineJob(ctx context.Context, tc, pn, jn string) erro
 		return fmt.Errorf("invalid Job Name format %q", jn)
 	}
 
-	_, err := q.Jobs.Find(ctx, tc, pn, jn)
+	j, err := q.Jobs.Find(ctx, tc, pn, jn)
 	if err != nil {
 		return fmt.Errorf("failed to Find Job %q on Pipeline %q: %w", jn, pn, err)
 	}
@@ -29,6 +29,19 @@ func (q *PikoCI) TriggerPipelineJob(ctx context.Context, tc, pn, jn string) erro
 		TeamCanonical: tc,
 		PipelineName:  pn,
 		JobName:       jn,
+	}
+
+	// Pin the latest version of the first get-step resource so the version
+	// is locked at trigger time rather than at execution time.
+	getSteps := j.GetSteps()
+	if len(getSteps) > 0 {
+		g := getSteps[0]
+		rCan := g.ResourceCanonical()
+		vers, err := q.Resources.FilterVersions(ctx, tc, pn, rCan)
+		if err == nil && len(vers) > 0 {
+			m.ResourceCanonical = rCan
+			m.VersionID = vers[len(vers)-1].ID
+		}
 	}
 
 	mb, err := json.Marshal(m)

--- a/pikoci/jobs_test.go
+++ b/pikoci/jobs_test.go
@@ -2,12 +2,16 @@ package pikoci_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/xescugc/pikoci/pikoci/job"
+	"github.com/xescugc/pikoci/pikoci/queue"
+	"github.com/xescugc/pikoci/pikoci/resource"
 	"go.uber.org/mock/gomock"
+	"gocloud.dev/pubsub"
 )
 
 func TestGetPipelineJob_InvalidCanonical(t *testing.T) {
@@ -73,4 +77,50 @@ func TestTriggerPipelineJob_SendError(t *testing.T) {
 	err := s.S.TriggerPipelineJob(ctx, "main", "pp", "jn")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to Trigger Job")
+}
+
+func TestTriggerPipelineJob_PinsLatestVersion(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+	tc := "main"
+	ppn := "pp"
+	jn := "jn"
+
+	j := &job.Job{
+		ID:   1,
+		Name: jn,
+		Plan: []job.PlanStep{
+			{
+				Type: job.StepTypeGet,
+				Get:  &job.GetStep{Type: "git", Name: "my-repo", Trigger: true},
+			},
+		},
+	}
+
+	versions := []*resource.Version{
+		{ID: 10},
+		{ID: 20},
+		{ID: 30},
+	}
+
+	rCan := j.GetSteps()[0].ResourceCanonical()
+
+	s.Jobs.EXPECT().Find(ctx, tc, ppn, jn).Return(j, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, tc, ppn, rCan).Return(versions, nil)
+
+	m := queue.Body{
+		TeamCanonical:     tc,
+		PipelineName:      ppn,
+		JobName:           jn,
+		ResourceCanonical: rCan,
+		VersionID:         30,
+	}
+	mb, err := json.Marshal(m)
+	require.NoError(t, err)
+
+	s.Topic.EXPECT().Send(ctx, &pubsub.Message{Body: mb}).Return(nil)
+
+	err = s.S.TriggerPipelineJob(ctx, tc, ppn, jn)
+	require.NoError(t, err)
 }

--- a/pikoci/mysql/resource.go
+++ b/pikoci/mysql/resource.go
@@ -317,6 +317,7 @@ func (r *ResourceRepository) FilterVersions(ctx context.Context, tc, pn, rCan st
 		JOIN teams AS t
 			ON p.team_id = t.id
 		WHERE t.canonical = ? AND p.name = ? AND r.canonical = ?
+		ORDER BY rv.id ASC
 	`, tc, pn, rCan)
 	if err != nil {
 		return nil, fmt.Errorf("failed to filter Resources: %w", err)

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -410,15 +410,26 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 	graph.SetStrict(true)
 	graph.AddAttr(pn, string(gographviz.RankDir), "LR")
 
+	// Collect resources referenced by get steps
+	referencedResources := make(map[string]bool)
+	for _, j := range pp.Jobs {
+		for _, g := range j.GetSteps() {
+			referencedResources[g.ResourceCanonical()] = true
+		}
+	}
+
 	resourceBorders := make(map[string]string)
 	// Print all the resources
 	for _, r := range pp.Resources {
-		vurl := fmt.Sprintf(`"/teams/%s/pipelines/%s/resources/%s/versions"`, tc, pp.Name, r.Canonical)
 		borderColor := colorResourceBorder
 		if r.Logs != "" {
 			borderColor = colorError
 		}
 		resourceBorders[r.Canonical] = borderColor
+		if !referencedResources[r.Canonical] {
+			continue
+		}
+		vurl := fmt.Sprintf(`"/teams/%s/pipelines/%s/resources/%s/versions"`, tc, pp.Name, r.Canonical)
 		err = graph.AddNode(pn, fmt.Sprintf(`"%s"`, r.Canonical), map[string]string{
 			string(gographviz.Margin):    "0.2",
 			string(gographviz.Shape):     "cds",

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -2,11 +2,13 @@ package pikoci_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/xescugc/pikoci/pikoci/build"
 	"github.com/xescugc/pikoci/pikoci/job"
 	"github.com/xescugc/pikoci/pikoci/pipeline"
 	"github.com/xescugc/pikoci/pikoci/resource"
@@ -1096,4 +1098,104 @@ job "deploy" {
 	pp, err := s.S.CreatePipeline(ctx, "main", "hooks-on-put", hclConfig, nil)
 	require.NoError(t, err)
 	require.NotNil(t, pp)
+}
+
+func TestGetPipelineImage_HidesUnlinkedResources(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	// Pipeline with two resources: one used in a get step, one only in a hook put step.
+	pp := &pipeline.Pipeline{
+		Name: "my-pipeline",
+		Resources: []resource.Resource{
+			{ID: 1, Canonical: "cron.timer"},
+			{ID: 2, Canonical: "github-check.ci"},
+		},
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "build",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeGet,
+						Get:  &job.GetStep{Type: "cron", Name: "timer", Trigger: true},
+					},
+					{
+						Type: job.StepTypeTask,
+					},
+				},
+				OnSuccess: []job.HookStep{
+					{
+						Type: job.StepTypePut,
+						Put:  &job.PutStep{Type: "github-check", Name: "ci"},
+					},
+				},
+			},
+		},
+	}
+
+	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
+	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "build").Return([]*build.Build{}, nil)
+
+	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot")
+	require.NoError(t, err)
+
+	dot := string(img)
+	// The get-step resource should appear as a primary node
+	assert.True(t, strings.Contains(dot, `"cron.timer"`), "linked resource should appear in graph")
+	// The hook-only resource should NOT appear as a primary node (only as a put output node)
+	// A primary node would be just "github-check.ci"; the put output node is "build-github-check.ci-out"
+	lines := strings.Split(dot, "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		// Skip edges and put output nodes
+		if strings.Contains(trimmed, "->") || strings.Contains(trimmed, "-out") {
+			continue
+		}
+		if strings.Contains(trimmed, `"github-check.ci"`) && strings.Contains(trimmed, "shape") {
+			t.Errorf("unlinked resource should not appear as a primary node in graph, got: %s", trimmed)
+		}
+	}
+}
+
+func TestGetPipelineImage_ShowsLinkedResources(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	// Both resources are used in get steps - both should appear.
+	pp := &pipeline.Pipeline{
+		Name: "my-pipeline",
+		Resources: []resource.Resource{
+			{ID: 1, Canonical: "cron.timer"},
+			{ID: 2, Canonical: "git.repo"},
+		},
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "test",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeGet,
+						Get:  &job.GetStep{Type: "cron", Name: "timer", Trigger: true},
+					},
+					{
+						Type: job.StepTypeGet,
+						Get:  &job.GetStep{Type: "git", Name: "repo"},
+					},
+				},
+			},
+		},
+	}
+
+	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
+	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "test").Return([]*build.Build{}, nil)
+
+	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot")
+	require.NoError(t, err)
+
+	dot := string(img)
+	assert.True(t, strings.Contains(dot, `"cron.timer"`), "first linked resource should appear")
+	assert.True(t, strings.Contains(dot, `"git.repo"`), "second linked resource should appear")
 }

--- a/worker/service.go
+++ b/worker/service.go
@@ -684,10 +684,12 @@ func (w *Worker) triggerDownstreamJobs(ctx context.Context, m queue.Body, b *bui
 				}
 				mb, err := json.Marshal(qb)
 				if err != nil {
-					w.failBuild(ctx, m, *b, fmt.Errorf("failed to marshal trigger body: %w", err))
-					return
+					w.logger.Error("failed to marshal downstream trigger body", "error", err)
+					continue
 				}
-				w.topic.Send(ctx, &pubsub.Message{Body: mb})
+				if err := w.topic.Send(ctx, &pubsub.Message{Body: mb}); err != nil {
+					w.logger.Error("failed to send downstream trigger message", "job", nj.Name, "error", err)
+				}
 			}
 		}
 	}
@@ -889,9 +891,11 @@ func (w *Worker) triggerResourceJobs(ctx context.Context, m queue.Body, pp *pipe
 				mb, err := json.Marshal(qb)
 				if err != nil {
 					w.logger.Error("failed to marshal trigger body", "error", err)
-					return
+					continue
 				}
-				w.topic.Send(ctx, &pubsub.Message{Body: mb})
+				if err := w.topic.Send(ctx, &pubsub.Message{Body: mb}); err != nil {
+					w.logger.Error("failed to send trigger message", "job", j.Name, "error", err)
+				}
 			}
 		}
 	}

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -1932,5 +1932,57 @@ func TestFetchSecrets_RawFormat(t *testing.T) {
 	assert.Equal(t, pemContent, result["secret_content"], "raw format should return trimmed file content under 'content' key")
 }
 
+func TestTriggerResourceJobs_MultipleJobsSameResource(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, _, topic := newTestWorker(ctrl)
+
+	ctx := context.Background()
+
+	r := resource.Resource{
+		ID:        1,
+		Name:      "my-repo",
+		Type:      "git",
+		Canonical: "git.my-repo",
+	}
+	cv := &resource.Version{ID: 42}
+
+	pp := &pipeline.Pipeline{
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "lint",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "git", Name: "my-repo", Trigger: true}},
+				},
+			},
+			{
+				ID:   2,
+				Name: "test-mock",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "git", Name: "my-repo", Trigger: true}},
+				},
+			},
+			{
+				ID:   3,
+				Name: "test-integration",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "git", Name: "my-repo", Trigger: true}},
+				},
+			},
+		},
+	}
+
+	m := queue.Body{
+		TeamCanonical: "tc",
+		PipelineName:  "test-pipeline",
+	}
+
+	// Expect Send to be called 3 times, once for each job
+	topic.EXPECT().Send(ctx, gomock.Any()).Times(3).Return(nil)
+
+	w.triggerResourceJobs(ctx, m, pp, r, cv)
+}
+
 // Silence the unused import warnings
 var _ = time.Now


### PR DESCRIPTION
## Summary

- Manual trigger (`TriggerPipelineJob`) now pins the latest resource version at trigger time instead of deferring to execution time.
- `triggerResourceJobs` and `triggerDownstreamJobs` no longer abort the loop on a single marshal error — remaining jobs still get triggered.
- Added `ORDER BY` to `FilterVersions` SQL query for deterministic ordering.
- Added tests for multi-job trigger and version pinning.

Closes #255