### PR TITLE
Fix resource trigger: continue on duplicate version instead of aborting

### DIFF
--- a/docs/Database.md
+++ b/docs/Database.md
@@ -24,6 +24,8 @@ pikoci server --jwt-secret my-secret --db-system sqlite --db-name pikoci.db
 |------|-------------|
 | `--db-name` | Path to the SQLite database file |
 
+PikoCI automatically enables [WAL mode](https://www.sqlite.org/wal.html) and a 5-second `busy_timeout` on file-backed SQLite connections. WAL allows concurrent reads during writes, and `busy_timeout` prevents immediate `SQLITE_BUSY` errors when multiple workers access the database simultaneously. In-memory databases (`mem`) only use `busy_timeout` since WAL requires a file on disk.
+
 ## mysql
 
 MySQL or MariaDB.

--- a/pikoci/mysql/new.go
+++ b/pikoci/mysql/new.go
@@ -68,11 +68,15 @@ func New(host string, port int, user, password string, ops Options) (*sql.DB, er
 		// In-memory SQLite with shared cache (so multiple connections see the same data).
 		// _pragma=foreign_keys(1) enables ON DELETE CASCADE on every connection in the pool
 		// (per-connection PRAGMA wouldn't work with sql.DB's connection pool).
-		db, err = sql.Open("sqlite", "file::memory:?cache=shared&_pragma=foreign_keys(1)")
+		// busy_timeout(5000) waits up to 5s before returning SQLITE_BUSY.
+		// Note: WAL is not supported on in-memory databases, only busy_timeout applies here.
+		db, err = sql.Open("sqlite", "file::memory:?cache=shared&_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)")
 	case SQLite:
 		// File-backed SQLite. Data persists across restarts.
 		// _pragma=foreign_keys(1) enables ON DELETE CASCADE on every connection in the pool.
-		db, err = sql.Open("sqlite", ops.DBFile+"?_pragma=foreign_keys(1)")
+		// journal_mode(WAL) allows concurrent reads during writes.
+		// busy_timeout(5000) waits up to 5s before returning SQLITE_BUSY.
+		db, err = sql.Open("sqlite", ops.DBFile+"?_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)")
 	case PostgreSQL:
 		// PostgreSQL has foreign keys enabled by default. sslmode=disable for local/dev setups.
 		dsn := fmt.Sprintf(

--- a/worker/service.go
+++ b/worker/service.go
@@ -921,6 +921,9 @@ func (w *Worker) processResourceCheck(ctx context.Context, m queue.Body, cwd str
 			Version: v,
 		})
 		if err != nil {
+			if isDuplicateKeyError(err) {
+				continue
+			}
 			w.logger.Error("failed to create resource version", "error", err)
 			return
 		}
@@ -1445,4 +1448,12 @@ func createKeyValuePairs(m map[string]string) string {
 		fmt.Fprintf(b, "%s=%s ", key, value)
 	}
 	return b.String()
+}
+
+// isDuplicateKeyError returns true if the error is a unique constraint violation.
+func isDuplicateKeyError(err error) bool {
+	s := err.Error()
+	return strings.Contains(s, "UNIQUE constraint failed") || // SQLite
+		strings.Contains(s, "Duplicate entry") || // MySQL
+		strings.Contains(s, "duplicate key value") // PostgreSQL
 }

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -583,6 +583,93 @@ func TestProcessResourceCheck_NewVersions(t *testing.T) {
 	w.processResourceCheck(ctx, m, cwd, pp)
 }
 
+func TestProcessResourceCheck_DuplicateVersionSkipped_NewVersionTriggered(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, topic := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical:     "main",
+		PipelineName:      "test-pipeline",
+		ResourceCanonical: "git.my-repo",
+	}
+	// Check script returns 2 versions: first already exists, second is new
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "lint",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeGet,
+						Get:  &job.GetStep{Type: "git", Name: "my-repo", Trigger: true},
+					},
+				},
+			},
+			{
+				ID:   2,
+				Name: "test",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeGet,
+						Get:  &job.GetStep{Type: "git", Name: "my-repo", Trigger: true},
+					},
+				},
+			},
+		},
+		Resources: []resource.Resource{
+			{ID: 1, Name: "my-repo", Type: "git", Canonical: "git.my-repo"},
+		},
+		ResourceTypes: []restype.ResourceType{
+			{
+				ID: 1, Name: "git",
+				Check: &utils.RunnerCommand{
+					Runner: "exec",
+					Args:   []string{"-ec", `printf '[{"ref":"old"},{"ref":"new"}]\n'`},
+					Params: map[string]string{"path": "/bin/sh"},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().ListResourceVersions(ctx, m.TeamCanonical, m.PipelineName, "git.my-repo").
+		Return([]*resource.Version{}, nil).AnyTimes()
+
+	// First version: duplicate error (already exists)
+	svc.EXPECT().CreateResourceVersion(ctx, m.TeamCanonical, m.PipelineName, "git.my-repo", gomock.Any()).
+		Return(nil, fmt.Errorf("failed to Create Resource Version: failed to execute query: constraint failed: UNIQUE constraint failed: resource_versions.resource_id, resource_versions.version (2067)"))
+
+	// Second version: new, created successfully
+	svc.EXPECT().CreateResourceVersion(ctx, m.TeamCanonical, m.PipelineName, "git.my-repo", gomock.Any()).
+		Return(&resource.Version{ID: 2, Version: map[string]interface{}{"ref": "new"}}, nil)
+
+	// Should trigger both jobs for the new version only
+	topic.EXPECT().Send(ctx, gomock.Any()).DoAndReturn(func(ctx context.Context, msg *pubsub.Message) error {
+		var body queue.Body
+		err := json.Unmarshal(msg.Body, &body)
+		require.NoError(t, err)
+		assert.Equal(t, "lint", body.JobName)
+		assert.Equal(t, uint32(2), body.VersionID)
+		return nil
+	})
+	topic.EXPECT().Send(ctx, gomock.Any()).DoAndReturn(func(ctx context.Context, msg *pubsub.Message) error {
+		var body queue.Body
+		err := json.Unmarshal(msg.Body, &body)
+		require.NoError(t, err)
+		assert.Equal(t, "test", body.JobName)
+		assert.Equal(t, uint32(2), body.VersionID)
+		return nil
+	})
+
+	w.processResourceCheck(ctx, m, cwd, pp)
+}
+
 func TestCheckPassedConstraints_AllPassed(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	w, svc, _ := newTestWorker(ctrl)


### PR DESCRIPTION
Two fixes for jobs not being triggered when a new resource version is detected:

1. **`return` → `continue` on duplicate version**: When `processResourceCheck` iterates versions from a check script (e.g. git PR check returning multiple open PRs), a UNIQUE constraint error on an already-existing version caused `return`, aborting the entire loop. New versions after the duplicate were never created and their job triggers never fired.

2. **SQLite WAL mode + busy_timeout**: With concurrent workers, SQLite returned SQLITE_BUSY immediately when another connection held a write lock, causing triggered job builds to fail silently. Added `journal_mode=WAL` (concurrent reads during writes) and `busy_timeout=5000` (wait up to 5s before returning BUSY).