### PR TITLE
Fix service parsing with var.* references

### DIFF
--- a/pikoci/helper.go
+++ b/pikoci/helper.go
@@ -260,14 +260,8 @@ func hclFunctions() map[string]function.Function {
 
 func (q *PikoCI) readPipeline(ctx context.Context, rpp []byte, vars map[string]interface{}) (*pipeline.Pipeline, error) {
 	funcs := hclFunctions()
-	ectx := &hcl.EvalContext{
-		Variables: map[string]cty.Value{
-			"string": cty.StringVal("string"),
-			"number": cty.StringVal("number"),
-			"bool":   cty.StringVal("bool"),
-		},
-		Functions: funcs,
-	}
+	ectx := pipeline.TypeEvalContext()
+	ectx.Functions = funcs
 	var pvars pipeline.Variables
 	err := hclsimple.Decode("pipeline.hcl", rpp, ectx, &pvars)
 	if err != nil {

--- a/pikoci/pipeline/pipeline.go
+++ b/pikoci/pipeline/pipeline.go
@@ -18,6 +18,18 @@ import (
 	"github.com/xescugc/pikoci/pikoci/utils"
 )
 
+// TypeEvalContext returns an HCL eval context with the type pseudo-variables
+// (string, number, bool) needed to parse variable declarations.
+func TypeEvalContext() *hcl.EvalContext {
+	return &hcl.EvalContext{
+		Variables: map[string]cty.Value{
+			"string": cty.StringVal("string"),
+			"number": cty.StringVal("number"),
+			"bool":   cty.StringVal("bool"),
+		},
+	}
+}
+
 type Pipeline struct {
 	ID            uint32                    `json:"id"`
 	Name          string                    `json:"name"`
@@ -142,9 +154,14 @@ func ParseServicesFromRaw(ctx context.Context, raw []byte) ([]service.Service, e
 		return nil, nil
 	}
 
+	ectx, err := buildVarEvalContext(raw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve variables for service parsing: %w", err)
+	}
+
 	// Parse top-level service blocks
 	var hp hclPipelineServices
-	err := hclsimple.Decode("pipeline.hcl", raw, nil, &hp)
+	err = hclsimple.Decode("pipeline.hcl", raw, ectx, &hp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse services from raw HCL: %w", err)
 	}
@@ -219,13 +236,7 @@ func ParseSecretVarsFromRaw(raw []byte, vars map[string]interface{}) (map[string
 		return nil, nil
 	}
 
-	ectx := &hcl.EvalContext{
-		Variables: map[string]cty.Value{
-			"string": cty.StringVal("string"),
-			"number": cty.StringVal("number"),
-			"bool":   cty.StringVal("bool"),
-		},
-	}
+	ectx := TypeEvalContext()
 
 	var pv hclPipelineVariables
 	err := hclsimple.Decode("pipeline.hcl", raw, ectx, &pv)
@@ -247,5 +258,62 @@ func ParseSecretVarsFromRaw(raw []byte, vars map[string]interface{}) (map[string
 		return nil, nil
 	}
 	return secretVars, nil
+}
+
+// buildVarEvalContext parses variable declarations from raw HCL and builds
+// an hcl.EvalContext with their default values, so that other blocks
+// (e.g. service_type) referencing var.* can be decoded.
+func buildVarEvalContext(raw []byte) (*hcl.EvalContext, error) {
+	typeCtx := TypeEvalContext()
+
+	var pvars Variables
+	if err := hclsimple.Decode("pipeline.hcl", raw, typeCtx, &pvars); err != nil {
+		return nil, fmt.Errorf("failed to parse variables: %w", err)
+	}
+
+	ecvars := make(map[string]cty.Value)
+	for _, v := range pvars.Variables {
+		if v.Secret != nil {
+			placeholder := fmt.Sprintf("__pikoci_secret:%s:%s:%s__",
+				v.Secret.Type, v.Secret.Path, v.Secret.Key)
+			ecvars[v.Name] = cty.StringVal(placeholder)
+			continue
+		}
+		a, ok := v.Default.(*hcl.Attribute)
+		if !ok {
+			switch v.Type {
+			case "number":
+				ecvars[v.Name] = cty.NumberIntVal(0)
+			case "bool":
+				ecvars[v.Name] = cty.False
+			default:
+				ecvars[v.Name] = cty.StringVal("")
+			}
+			continue
+		}
+		ctyv, diags := a.Expr.Value(typeCtx)
+		if diags.HasErrors() {
+			switch v.Type {
+			case "number":
+				ecvars[v.Name] = cty.NumberIntVal(0)
+			case "bool":
+				ecvars[v.Name] = cty.False
+			default:
+				ecvars[v.Name] = cty.StringVal("")
+			}
+			continue
+		}
+		ecvars[v.Name] = ctyv
+	}
+
+	// TODO: include HCL standard functions (format, join, etc.) once
+	// hclFunctions() is extracted from the pikoci package to avoid a
+	// circular import. For now, service blocks using HCL functions in
+	// attribute values will fail to parse.
+	return &hcl.EvalContext{
+		Variables: map[string]cty.Value{
+			"var": cty.ObjectVal(ecvars),
+		},
+	}, nil
 }
 

--- a/pikoci/pipeline/pipeline_test.go
+++ b/pikoci/pipeline/pipeline_test.go
@@ -1,9 +1,11 @@
 package pipeline_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/xescugc/pikoci/pikoci/pipeline"
 	"github.com/xescugc/pikoci/pikoci/resource"
 	"github.com/xescugc/pikoci/pikoci/restype"
@@ -122,4 +124,95 @@ func TestPipeline_Runner(t *testing.T) {
 		_, ok := pp.Runner("unknown")
 		assert.False(t, ok)
 	})
+}
+
+func TestParseServicesFromRaw_WithVarReferences(t *testing.T) {
+	raw := []byte(`
+variable "timeout" {
+  type    = string
+  default = "5m"
+}
+
+service_type "mydb" {
+  start "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "docker run -d mydb"]
+  }
+  ready_check "exec" {
+    path     = "/bin/sh"
+    args     = ["-ec", "echo ready"]
+    interval = "2s"
+    timeout  = var.timeout
+  }
+  stop "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "docker rm -f mydb"]
+  }
+}
+`)
+
+	svcs, err := pipeline.ParseServicesFromRaw(context.Background(), raw)
+	require.NoError(t, err)
+	require.Len(t, svcs, 1)
+	assert.Equal(t, "mydb", svcs[0].Name)
+	require.NotNil(t, svcs[0].ReadyCheck)
+	assert.Equal(t, "5m", svcs[0].ReadyCheck.Timeout)
+}
+
+func TestParseServicesFromRaw_NoVariables(t *testing.T) {
+	raw := []byte(`
+service_type "simple" {
+  start "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo start"]
+  }
+  stop "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo stop"]
+  }
+}
+`)
+
+	svcs, err := pipeline.ParseServicesFromRaw(context.Background(), raw)
+	require.NoError(t, err)
+	require.Len(t, svcs, 1)
+	assert.Equal(t, "simple", svcs[0].Name)
+}
+
+func TestParseServicesFromRaw_SecretVariable(t *testing.T) {
+	raw := []byte(`
+secret_type "env" {
+  source = "pikoci://file"
+  path   = "/etc/test.env"
+}
+
+variable "db_pass" {
+  type = string
+  secret "env" {
+    key = "DB_PASSWORD"
+  }
+}
+
+service_type "db" {
+  start "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "docker run -e PASS=${var.db_pass} mydb"]
+  }
+  stop "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "docker rm -f mydb"]
+  }
+}
+`)
+
+	svcs, err := pipeline.ParseServicesFromRaw(context.Background(), raw)
+	require.NoError(t, err)
+	require.Len(t, svcs, 1)
+	assert.Equal(t, "db", svcs[0].Name)
+}
+
+func TestParseServicesFromRaw_EmptyRaw(t *testing.T) {
+	svcs, err := pipeline.ParseServicesFromRaw(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Nil(t, svcs)
 }


### PR DESCRIPTION
Resolve pipeline variables before parsing `service_type` blocks from raw HCL in the worker. Previously `ParseServicesFromRaw` passed `nil` eval context, failing on any `var.*` reference.

Closes #267