### PR TITLE
Fix release pipeline: use git describe for tag in task steps

### DIFF
--- a/deploy/release-pipeline.hcl
+++ b/deploy/release-pipeline.hcl
@@ -52,11 +52,12 @@ job "build-release" {
         "-ec",
         <<-EOT
         cd pikoci
+        TAG=$(git describe --tags --exact-match)
 
         echo "${var.docker_password}" | docker login -u "${var.docker_username}" --password-stdin
 
-        docker build -t xescugc/pikoci:$version_tag .
-        docker push xescugc/pikoci:$version_tag
+        docker build -t xescugc/pikoci:$TAG .
+        docker push xescugc/pikoci:$TAG
         EOT
       ]
     }

--- a/docs/Resource-Types.md
+++ b/docs/Resource-Types.md
@@ -247,7 +247,7 @@ When `tag = "true"` is set, the check command lists tags instead of checking for
 [{"ref": "abc123", "tag": "v1.0.0"}, {"ref": "def456", "tag": "v0.9.0"}]
 ```
 
-When a new tag is pushed, PikoCI detects it and triggers the job. The pull step clones the repository at the specific tag. The tag name is available as `$version_tag` in task commands.
+When a new tag is pushed, PikoCI detects it and triggers the job. The pull step clones the repository at the specific tag. Since version variables (`$version_tag`) are only available in pull steps, use `git describe --tags --exact-match` in task steps to retrieve the tag name.
 
 This requires a `token` and is supported on GitHub and GitLab.
 
@@ -331,7 +331,7 @@ job "release" {
   task "build" {
     run "exec" {
       path = "/bin/sh"
-      args = ["-ec", "cd my-repo && docker build -t myorg/my-repo:$version_tag ."]
+      args = ["-ec", "cd my-repo && TAG=$(git describe --tags --exact-match) && docker build -t myorg/my-repo:$TAG ."]
     }
   }
 }


### PR DESCRIPTION
## Summary

- `$version_tag` is only available in pull steps, not task steps — caused `docker build -t xescugc/pikoci: .` (empty tag)
- Use `git describe --tags --exact-match` in task steps instead (works because tag mode clones at the specific tag)
- Update docs to clarify this limitation

## Test plan

- [ ] Deploy and trigger build-release — tag should resolve correctly