### PR TITLE
Add last build timestamp to pipeline card footer

### DIFF
--- a/integration/pikoci_test.go
+++ b/integration/pikoci_test.go
@@ -10,6 +10,7 @@ import (
 	"image/png"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -406,8 +407,32 @@ job "gen" {
 			}, 5*time.Second)
 
 		})
+		t.Run("Pipeline Card Last Build Timestamp", func(t *testing.T) {
+			// Navigate to pipelines list
+			ppsBtn, err := wd.FindElement(selenium.ByLinkText, "Pipelines")
+			require.NoError(t, err)
+
+			err = ppsBtn.Click()
+			require.NoError(t, err)
+
+			waitFor(t, wd, eqText(selenium.ByCSSSelector, "#breadcrumb", "Teams\nMain\nPipelines"), 5*time.Second)
+
+			// Wait for the card status to include a relative timestamp
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				el, err := wd.FindElement(selenium.ByCSSSelector, ".piko-card-status")
+				if err != nil {
+					return false
+				}
+				txt, err := el.Text()
+				if err != nil {
+					return false
+				}
+				// After builds have run, the card footer should contain "ago"
+				return containsString(txt, "ago") || containsString(txt, "just now")
+			}, 10*time.Second)
+		})
 		t.Run("Delete Pipeline", func(t *testing.T) {
-			ppBtn, err := wd.FindElement(selenium.ByLinkText, "cron")
+			ppBtn, err := wd.FindElement(selenium.ByCSSSelector, ".card")
 			require.NoError(t, err)
 
 			err = ppBtn.Click()
@@ -880,6 +905,10 @@ func eqText(by, value, txt string) waitForFn {
 
 		return weTxt == txt
 	}
+}
+
+func containsString(s, substr string) bool {
+	return strings.Contains(s, substr)
 }
 
 func screenshot(t *testing.T, wd selenium.WebDriver) {

--- a/pikoci/build/repository.go
+++ b/pikoci/build/repository.go
@@ -1,6 +1,9 @@
 package build
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 //go:generate go tool mockgen -destination=../mock/build_repository.go -mock_names=Repository=BuildRepository -package mock github.com/xescugc/pikoci/pikoci/build Repository
 
@@ -12,4 +15,5 @@ type Repository interface {
 	Delete(ctx context.Context, tc, pn, jn string, bID uint32) error
 	InsertGetVersion(ctx context.Context, tc, pn, jn string, buildID uint32, stepName string, versionID uint32) error
 	FindReadyDownstreamVersion(ctx context.Context, tc, pn string, upstreamJobs []string, downstreamJob string, stepName string, upstreamCount int) (uint32, bool, error)
+	LastBuildAtByPipeline(ctx context.Context, tc string) (map[uint32]time.Time, error)
 }

--- a/pikoci/mock/build_repository.go
+++ b/pikoci/mock/build_repository.go
@@ -12,6 +12,7 @@ package mock
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	build "github.com/xescugc/pikoci/pikoci/build"
 	gomock "go.uber.org/mock/gomock"
@@ -128,6 +129,21 @@ func (m *BuildRepository) InsertGetVersion(ctx context.Context, tc, pn, jn strin
 func (mr *BuildRepositoryMockRecorder) InsertGetVersion(ctx, tc, pn, jn, buildID, stepName, versionID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertGetVersion", reflect.TypeOf((*BuildRepository)(nil).InsertGetVersion), ctx, tc, pn, jn, buildID, stepName, versionID)
+}
+
+// LastBuildAtByPipeline mocks base method.
+func (m *BuildRepository) LastBuildAtByPipeline(ctx context.Context, tc string) (map[uint32]time.Time, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LastBuildAtByPipeline", ctx, tc)
+	ret0, _ := ret[0].(map[uint32]time.Time)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LastBuildAtByPipeline indicates an expected call of LastBuildAtByPipeline.
+func (mr *BuildRepositoryMockRecorder) LastBuildAtByPipeline(ctx, tc any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastBuildAtByPipeline", reflect.TypeOf((*BuildRepository)(nil).LastBuildAtByPipeline), ctx, tc)
 }
 
 // Update mocks base method.

--- a/pikoci/mysql/build.go
+++ b/pikoci/mysql/build.go
@@ -274,12 +274,27 @@ func (r *BuildRepository) LastBuildAtByPipeline(ctx context.Context, tc string) 
 	result := make(map[uint32]time.Time)
 	for rows.Next() {
 		var pipelineID uint32
-		var startedAt sql.NullTime
-		if err := rows.Scan(&pipelineID, &startedAt); err != nil {
+		var startedAtStr sql.NullString
+		if err := rows.Scan(&pipelineID, &startedAtStr); err != nil {
 			return nil, fmt.Errorf("failed to scan last build timestamp: %w", err)
 		}
-		if startedAt.Valid {
-			result[pipelineID] = startedAt.Time
+		if startedAtStr.Valid && startedAtStr.String != "" {
+			var t time.Time
+			var parseErr error
+			for _, layout := range []string{
+				time.RFC3339,
+				"2006-01-02 15:04:05 -0700 MST",
+				"2006-01-02 15:04:05",
+				"2006-01-02T15:04:05Z",
+			} {
+				t, parseErr = time.Parse(layout, startedAtStr.String)
+				if parseErr == nil {
+					break
+				}
+			}
+			if parseErr == nil {
+				result[pipelineID] = t
+			}
 		}
 	}
 	if err := rows.Err(); err != nil {

--- a/pikoci/mysql/build.go
+++ b/pikoci/mysql/build.go
@@ -256,6 +256,39 @@ func (r *BuildRepository) FindReadyDownstreamVersion(ctx context.Context, tc, pn
 	return versionID, true, nil
 }
 
+func (r *BuildRepository) LastBuildAtByPipeline(ctx context.Context, tc string) (map[uint32]time.Time, error) {
+	rows, err := r.querier.QueryContext(ctx, `
+		SELECT p.id, MAX(b.started_at)
+		FROM builds AS b
+		JOIN jobs AS j ON b.job_id = j.id
+		JOIN pipelines AS p ON j.pipeline_id = p.id
+		JOIN teams AS t ON p.team_id = t.id
+		WHERE t.canonical = ?
+		GROUP BY p.id
+	`, tc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query last build timestamps: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[uint32]time.Time)
+	for rows.Next() {
+		var pipelineID uint32
+		var startedAt sql.NullTime
+		if err := rows.Scan(&pipelineID, &startedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan last build timestamp: %w", err)
+		}
+		if startedAt.Valid {
+			result[pipelineID] = startedAt.Time
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate last build timestamps: %w", err)
+	}
+
+	return result, nil
+}
+
 func scanBuild(s sqlr.Scanner) (*build.Build, error) {
 	var b dbBuild
 

--- a/pikoci/mysql/build_test.go
+++ b/pikoci/mysql/build_test.go
@@ -3,6 +3,7 @@ package mysql_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,6 +43,76 @@ func TestInsertGetVersion(t *testing.T) {
 	err = db.QueryRowContext(ctx, `SELECT version_id FROM build_get_versions WHERE build_id = ? AND step_name = ?`, buildID, "repo").Scan(&versionID)
 	require.NoError(t, err)
 	assert.Equal(t, 42, versionID)
+}
+
+func TestLastBuildAtByPipeline(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	// Create two pipelines
+	res, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name) VALUES (1, 'lba-pipe-a')`)
+	require.NoError(t, err)
+	ppAID, _ := res.LastInsertId()
+
+	res, err = db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name) VALUES (1, 'lba-pipe-b')`)
+	require.NoError(t, err)
+	ppBID, _ := res.LastInsertId()
+
+	// Pipeline A has two jobs with builds
+	res, err = db.ExecContext(ctx, `INSERT INTO jobs (pipeline_id, name) VALUES (?, 'lint')`, ppAID)
+	require.NoError(t, err)
+	jobAID, _ := res.LastInsertId()
+
+	t1 := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
+	t2 := time.Date(2025, 3, 2, 12, 0, 0, 0, time.UTC)
+
+	_, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, started_at) VALUES (?, 'succeeded', ?)`, jobAID, t1)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, started_at) VALUES (?, 'failed', ?)`, jobAID, t2)
+	require.NoError(t, err)
+
+	// Pipeline B has no builds — only a job
+	_, err = db.ExecContext(ctx, `INSERT INTO jobs (pipeline_id, name) VALUES (?, 'test')`, ppBID)
+	require.NoError(t, err)
+
+	br := mysql.NewBuildRepository(db)
+	result, err := br.LastBuildAtByPipeline(ctx, "main")
+	require.NoError(t, err)
+
+	// Pipeline A should have the latest build time
+	assert.Contains(t, result, uint32(ppAID))
+	assert.Equal(t, t2, result[uint32(ppAID)])
+
+	// Pipeline B should not be in the map (no builds)
+	assert.NotContains(t, result, uint32(ppBID))
+}
+
+func TestLastBuildAtByPipeline_NoBuildsDifferentTeam(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	// Create a pipeline under a different team
+	res, err := db.ExecContext(ctx, `INSERT INTO teams (name, canonical) VALUES ('other-team', 'other')`)
+	require.NoError(t, err)
+	otherTeamID, _ := res.LastInsertId()
+
+	res, err = db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name) VALUES (?, 'lba-other')`, otherTeamID)
+	require.NoError(t, err)
+	ppID, _ := res.LastInsertId()
+
+	res, err = db.ExecContext(ctx, `INSERT INTO jobs (pipeline_id, name) VALUES (?, 'build')`, ppID)
+	require.NoError(t, err)
+	jobID, _ := res.LastInsertId()
+
+	_, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, started_at) VALUES (?, 'succeeded', ?)`, jobID, time.Now())
+	require.NoError(t, err)
+
+	br := mysql.NewBuildRepository(db)
+
+	// Querying for "main" team should return empty map
+	result, err := br.LastBuildAtByPipeline(ctx, "main")
+	require.NoError(t, err)
+	assert.NotContains(t, result, uint32(ppID))
 }
 
 func TestFindReadyDownstreamVersion_BasicCase(t *testing.T) {

--- a/pikoci/pipeline/pipeline.go
+++ b/pikoci/pipeline/pipeline.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsimple"
@@ -49,6 +50,7 @@ type Pipeline struct {
 	SecretVars    map[string]VariableSecret `json:"secret_vars,omitempty"`
 	Remain        hcl.Body                  `json:"-" hcl:",remain"`
 	Raw           []byte                    `json:"raw"`
+	LastBuildAt   *time.Time                `json:"last_build_at,omitempty"`
 }
 
 type Variables struct {

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -331,6 +331,18 @@ func (q *PikoCI) ListPipelines(ctx context.Context, tc string) ([]*pipeline.Pipe
 		return nil, fmt.Errorf("failed to filter Pipelines: %w", err)
 	}
 
+	lastBuilds, err := q.Builds.LastBuildAtByPipeline(ctx, tc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get last build timestamps: %w", err)
+	}
+
+	for _, pp := range pps {
+		if t, ok := lastBuilds[pp.ID]; ok {
+			t := t
+			pp.LastBuildAt = &t
+		}
+	}
+
 	return pps, nil
 }
 

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -2,6 +2,7 @@ package pikoci_test
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -56,10 +57,55 @@ func TestListPipelines(t *testing.T) {
 		{ID: 2, Name: "pipeline-b"},
 	}
 	s.Pipelines.EXPECT().Filter(ctx, "main").Return(expected, nil)
+	s.Builds.EXPECT().LastBuildAtByPipeline(ctx, "main").Return(map[uint32]time.Time{}, nil)
 
 	pps, err := s.S.ListPipelines(ctx, "main")
 	require.NoError(t, err)
 	assert.Len(t, pps, 2)
+}
+
+func TestListPipelines_WithLastBuildAt(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	pipelines := []*pipeline.Pipeline{
+		{ID: 1, Name: "pipeline-a"},
+		{ID: 2, Name: "pipeline-b"},
+		{ID: 3, Name: "pipeline-c"},
+	}
+	buildTime := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+	lastBuilds := map[uint32]time.Time{
+		1: buildTime,
+		3: buildTime.Add(-time.Hour),
+	}
+	s.Pipelines.EXPECT().Filter(ctx, "main").Return(pipelines, nil)
+	s.Builds.EXPECT().LastBuildAtByPipeline(ctx, "main").Return(lastBuilds, nil)
+
+	pps, err := s.S.ListPipelines(ctx, "main")
+	require.NoError(t, err)
+	require.Len(t, pps, 3)
+
+	require.NotNil(t, pps[0].LastBuildAt)
+	assert.Equal(t, buildTime, *pps[0].LastBuildAt)
+
+	assert.Nil(t, pps[1].LastBuildAt)
+
+	require.NotNil(t, pps[2].LastBuildAt)
+	assert.Equal(t, buildTime.Add(-time.Hour), *pps[2].LastBuildAt)
+}
+
+func TestListPipelines_LastBuildAtError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Pipelines.EXPECT().Filter(ctx, "main").Return([]*pipeline.Pipeline{{ID: 1}}, nil)
+	s.Builds.EXPECT().LastBuildAtByPipeline(ctx, "main").Return(nil, fmt.Errorf("db error"))
+
+	_, err := s.S.ListPipelines(ctx, "main")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "last build timestamps")
 }
 
 func TestListPipelines_InvalidCanonical(t *testing.T) {

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -1240,12 +1240,21 @@
               if (fill === "#00a83a") hasSucceeded = true
             })
             var html = ''
+            var timeAgo = ''
+            var lastBuildAt = that.model.get('last_build_at')
+            if (lastBuildAt) {
+              var seconds = Math.floor((Date.now() - new Date(lastBuildAt).getTime()) / 1000)
+              if (seconds < 60) timeAgo = ' · just now'
+              else if (seconds < 3600) timeAgo = ' · ' + Math.floor(seconds / 60) + 'm ago'
+              else if (seconds < 86400) timeAgo = ' · ' + Math.floor(seconds / 3600) + 'h ago'
+              else timeAgo = ' · ' + Math.floor(seconds / 86400) + 'd ago'
+            }
             if (hasFailed) {
-              html = '<span class="piko-card-status-dot" style="background:#FF004D;"></span> Last build failed'
+              html = '<span class="piko-card-status-dot" style="background:#FF004D;"></span> Last build failed' + timeAgo
             } else if (hasRunning) {
-              html = '<span class="piko-card-status-dot" style="background:#FFA300;"></span> Running'
+              html = '<span class="piko-card-status-dot" style="background:#FFA300;"></span> Running' + timeAgo
             } else if (hasSucceeded) {
-              html = '<span class="piko-card-status-dot" style="background:#00A83A;"></span> Last build passed'
+              html = '<span class="piko-card-status-dot" style="background:#00A83A;"></span> Last build passed' + timeAgo
             } else {
               html = '<span style="color:var(--text-muted);">No builds</span>'
             }


### PR DESCRIPTION
## Summary

- Adds relative timestamp (e.g. "2m ago", "1h ago") to pipeline card footer showing when the last build ran
- New `LastBuildAtByPipeline` repository method fetches `MAX(started_at)` per pipeline in a single query
- `ListPipelines` populates the new `LastBuildAt` field on each pipeline struct
- Frontend formats relative time client-side from the ISO timestamp

Closes #134