### PR TITLE
Add graceful shutdown with SIGQUIT/SIGTERM/SIGINT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add graceful shutdown with `SIGQUIT`: stops accepting new jobs, waits for in-flight jobs to finish, then exits cleanly. `SIGTERM`/`SIGINT` still exit immediately. Enables zero-downtime self-deploy via systemd `Restart=always` and a deploy pipeline job ([#281](https://github.com/xescugc/pikoci/issues/281))
 - Fix browser back navigation from build page: use `replace: true` when updating the URL on build tab clicks and auto-selection so the history stack doesn't accumulate build IDs ([#263](https://github.com/xescugc/pikoci/issues/263))
 - Fix secret fetch commands running from build temp directory instead of server working directory, causing relative file paths in secret type configs to fail
 - Stream build logs live: switch from `CombinedOutput()` to streaming stdout/stderr with periodic 2s DB flushes, so the frontend shows incremental output while steps are running. Running steps auto-expand and auto-scroll in the UI ([#13](https://github.com/xescugc/pikoci/issues/13))

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -8,7 +9,9 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
+	"time"
 
 	"github.com/cycloidio/sqlr"
 	"github.com/golang-jwt/jwt/v5"
@@ -25,6 +28,7 @@ import (
 	tshttp "github.com/xescugc/pikoci/pikoci/transport/http"
 	"github.com/xescugc/pikoci/pikoci/unitwork"
 	"github.com/xescugc/pikoci/pikoci/user"
+	"github.com/xescugc/pikoci/worker"
 	"gocloud.dev/pubsub"
 
 	"gocloud.dev/pubsub/mempubsub"
@@ -44,7 +48,8 @@ var serverCmd = &cobra.Command{
 	Use:   "server",
 	Short: "Starts the PikoCI server",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := cmd.Context()
+		ctx, cancel := context.WithCancel(cmd.Context())
+		defer cancel()
 
 		// Load config file if provided
 		cfgFile, _ := cmd.Flags().GetString("config")
@@ -156,25 +161,24 @@ var serverCmd = &cobra.Command{
 			Handler: handlers.CombinedLoggingHandler(os.Stdout, mux),
 		}
 
-		errs := make(chan error)
-
-		go func() {
-			c := make(chan os.Signal, 1)
-			signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
-			errs <- fmt.Errorf("%s", <-c)
-		}()
+		errs := make(chan error, 1)
 
 		go func() {
 			logger.Info("starting HTTP transport", "port", cfg.Port)
 			errs <- svr.ListenAndServe()
 		}()
 
+		var workers []*worker.Worker
+		var wg *sync.WaitGroup
 		if cfg.RunWorker {
 			logger.Info("Starting Worker ...")
-			go func() {
-				err := runWorker(ctx, cfg.PubSubSystem, topic, svc, cfg.Concurrency, cfg.LogLevel)
-				errs <- fmt.Errorf("worker failed to start: %w", err)
-			}()
+			var werr error
+			var workerCleanup func()
+			workers, wg, workerCleanup, werr = runWorker(ctx, cfg.PubSubSystem, topic, svc, cfg.Concurrency, cfg.LogLevel)
+			if werr != nil {
+				return fmt.Errorf("worker failed to start: %w", werr)
+			}
+			defer workerCleanup()
 		}
 
 		pipelineName := serverViper.GetString("pipeline-name")
@@ -201,7 +205,46 @@ var serverCmd = &cobra.Command{
 			}
 		}
 
-		logger.Error("exit", "error", <-errs)
+		quit := make(chan os.Signal, 1)
+		stop := make(chan os.Signal, 1)
+		signal.Notify(quit, syscall.SIGQUIT)
+		signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
+
+		select {
+		case sig := <-quit:
+			logger.Info("received signal, starting graceful shutdown", "signal", sig)
+
+			if cfg.RunWorker && workers != nil {
+				for _, w := range workers {
+					w.Drain()
+				}
+				logger.Info("workers draining, waiting for in-flight jobs to finish...")
+
+				done := make(chan struct{})
+				go func() { wg.Wait(); close(done) }()
+
+				select {
+				case <-done:
+					logger.Info("all workers finished")
+				case <-time.After(10 * time.Minute):
+					logger.Warn("graceful shutdown timed out, forcing exit")
+				}
+			}
+
+			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer shutdownCancel()
+			svr.Shutdown(shutdownCtx)
+
+		case sig := <-stop:
+			logger.Info("received signal, shutting down immediately", "signal", sig)
+			cancel()
+			svr.Close()
+
+		case err := <-errs:
+			logger.Error("component failed", "error", err)
+			cancel()
+			svr.Close()
+		}
 
 		return nil
 	},

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -205,6 +205,11 @@ var serverCmd = &cobra.Command{
 			}
 		}
 
+		drainTimeout, err := time.ParseDuration(cfg.DrainTimeout)
+		if err != nil {
+			return fmt.Errorf("invalid drain-timeout %q: %w", cfg.DrainTimeout, err)
+		}
+
 		quit := make(chan os.Signal, 1)
 		stop := make(chan os.Signal, 1)
 		signal.Notify(quit, syscall.SIGQUIT)
@@ -218,7 +223,7 @@ var serverCmd = &cobra.Command{
 				for _, w := range workers {
 					w.Drain()
 				}
-				logger.Info("workers draining, waiting for in-flight jobs to finish...")
+				logger.Info("workers draining, waiting for in-flight jobs to finish...", "timeout", drainTimeout)
 
 				done := make(chan struct{})
 				go func() { wg.Wait(); close(done) }()
@@ -226,7 +231,7 @@ var serverCmd = &cobra.Command{
 				select {
 				case <-done:
 					logger.Info("all workers finished")
-				case <-time.After(10 * time.Minute):
+				case <-time.After(drainTimeout):
 					logger.Warn("graceful shutdown timed out, forcing exit")
 				}
 			}
@@ -265,6 +270,7 @@ func init() {
 	serverCmd.Flags().Bool("run-migrations", true, "Flag to know if migrations should be ran")
 	serverCmd.Flags().Bool("run-worker", true, "Runs a worker with PikoCI server")
 	serverCmd.Flags().Int("concurrency", 1, "Number of workers to start in one instance")
+	serverCmd.Flags().String("drain-timeout", "10m", "Maximum time to wait for in-flight jobs to finish during graceful shutdown (SIGQUIT)")
 	serverCmd.Flags().String("pubsub-system", mempubsub.Scheme, "Which PubSub system to use (mem, nats, rabbit, kafka). Env vars: NATS_SERVER_URL, RABBIT_SERVER_URL, KAFKA_BROKERS")
 	serverCmd.Flags().String("log-level", "info", "Sets the log level ('debug', 'info', 'warn', 'error')")
 	serverCmd.Flags().String("team-canonical", mainTeamCanonical, "Team Canonical to scope the action")

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -67,6 +67,11 @@ var workerCmd = &cobra.Command{
 		}
 		defer topic.Shutdown(ctx)
 
+		drainTimeout, err := time.ParseDuration(cfg.DrainTimeout)
+		if err != nil {
+			return fmt.Errorf("invalid drain-timeout %q: %w", cfg.DrainTimeout, err)
+		}
+
 		workers, wg, cleanup, err := runWorker(ctx, cfg.PubSubSystem, topic, c, cfg.Concurrency, cfg.LogLevel)
 		if err != nil {
 			return fmt.Errorf("failed to start worker: %w", err)
@@ -90,7 +95,7 @@ var workerCmd = &cobra.Command{
 			for _, w := range workers {
 				w.Drain()
 			}
-			logger.Info("workers draining, waiting for in-flight jobs to finish...")
+			logger.Info("workers draining, waiting for in-flight jobs to finish...", "timeout", drainTimeout)
 
 			done := make(chan struct{})
 			go func() { wg.Wait(); close(done) }()
@@ -98,7 +103,7 @@ var workerCmd = &cobra.Command{
 			select {
 			case <-done:
 				logger.Info("all workers finished")
-			case <-time.After(10 * time.Minute):
+			case <-time.After(drainTimeout):
 				logger.Warn("graceful shutdown timed out, forcing exit")
 			}
 
@@ -122,6 +127,7 @@ func init() {
 	workerCmd.Flags().StringP("pikoci-url", "u", "localhost:8080", "URL to the PikoCI server")
 	workerCmd.Flags().String("pubsub-system", mempubsub.Scheme, "Which PubSub system to use (mem, nats, rabbit, kafka). Env vars: NATS_SERVER_URL, RABBIT_SERVER_URL, KAFKA_BROKERS")
 	workerCmd.Flags().Int("concurrency", 1, "Number of workers to start in one instance")
+	workerCmd.Flags().String("drain-timeout", "10m", "Maximum time to wait for in-flight jobs to finish during graceful shutdown (SIGQUIT)")
 	workerCmd.Flags().String("log-level", "info", "Sets the log level ('debug', 'info', 'warn', 'error')")
 	workerCmd.Flags().String("jwt-secret", "", "JWT secret (must match the server's --jwt-secret)")
 

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -5,8 +5,11 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/signal"
 	"strings"
 	"sync"
+	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -29,7 +32,8 @@ var workerCmd = &cobra.Command{
 	Use:   "worker",
 	Short: "Starts a PikoCI Worker",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := cmd.Context()
+		ctx, cancel := context.WithCancel(cmd.Context())
+		defer cancel()
 
 		// Load config file if provided
 		cfgFile, _ := cmd.Flags().GetString("config")
@@ -44,6 +48,8 @@ var workerCmd = &cobra.Command{
 		if err := workerViper.Unmarshal(&cfg); err != nil {
 			return fmt.Errorf("error unmarshalling config: %v", err)
 		}
+
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: parseSlogLevel(cfg.LogLevel)}))
 
 		if cfg.JWTSecret == "" {
 			return fmt.Errorf("required flag \"jwt-secret\" not set")
@@ -61,7 +67,51 @@ var workerCmd = &cobra.Command{
 		}
 		defer topic.Shutdown(ctx)
 
-		runWorker(ctx, cfg.PubSubSystem, topic, c, cfg.Concurrency, cfg.LogLevel)
+		workers, wg, cleanup, err := runWorker(ctx, cfg.PubSubSystem, topic, c, cfg.Concurrency, cfg.LogLevel)
+		if err != nil {
+			return fmt.Errorf("failed to start worker: %w", err)
+		}
+		defer cleanup()
+
+		quit := make(chan os.Signal, 1)
+		stop := make(chan os.Signal, 1)
+		signal.Notify(quit, syscall.SIGQUIT)
+		signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
+
+		errs := make(chan error, 1)
+		go func() {
+			wg.Wait()
+			errs <- nil
+		}()
+
+		select {
+		case sig := <-quit:
+			logger.Info("received signal, starting graceful shutdown", "signal", sig)
+			for _, w := range workers {
+				w.Drain()
+			}
+			logger.Info("workers draining, waiting for in-flight jobs to finish...")
+
+			done := make(chan struct{})
+			go func() { wg.Wait(); close(done) }()
+
+			select {
+			case <-done:
+				logger.Info("all workers finished")
+			case <-time.After(10 * time.Minute):
+				logger.Warn("graceful shutdown timed out, forcing exit")
+			}
+
+		case sig := <-stop:
+			logger.Info("received signal, shutting down immediately", "signal", sig)
+			cancel()
+
+		case err := <-errs:
+			if err != nil {
+				logger.Error("worker failed", "error", err)
+				return err
+			}
+		}
 
 		return nil
 	},
@@ -81,31 +131,33 @@ func init() {
 	workerViper.AutomaticEnv()
 }
 
-func runWorker(ctx context.Context, sy string, t queue.Topic, s pikoci.Service, c int, llvl string) error {
+func runWorker(ctx context.Context, sy string, t queue.Topic, s pikoci.Service, c int, llvl string) ([]*worker.Worker, *sync.WaitGroup, func(), error) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: parseSlogLevel(llvl)}))
 	logger = logger.With("service", "worker")
 	// Create a subscription connected to that topic.
 	subscription, err := pubsub.OpenSubscription(ctx, getSubscriptionURL(sy))
 	if err != nil {
-		return fmt.Errorf("failed to OpenSubscription: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to OpenSubscription: %w", err)
 	}
-	defer subscription.Shutdown(ctx)
 
+	cleanup := func() { subscription.Shutdown(context.Background()) }
+
+	var workers []*worker.Worker
 	var wg sync.WaitGroup
 	for i := range c {
 		wg.Add(1)
 		nlogger := logger.With("num", i+1)
 		nlogger.Info(fmt.Sprintf("Starting Worker %d", i+1))
 		w := worker.New(s, t, subscription, nlogger)
+		workers = append(workers, w)
 
 		go func() {
-			err = w.Run(ctx)
+			defer wg.Done()
+			err := w.Run(ctx)
 			if err != nil {
 				logger.Error("failed to Run worker", "error", err)
 			}
-			wg.Done()
 		}()
 	}
-	wg.Wait()
-	return nil
+	return workers, &wg, cleanup, nil
 }

--- a/deploy/pikoci.service
+++ b/deploy/pikoci.service
@@ -10,7 +10,7 @@ ExecStart=/usr/local/bin/pikoci server
 EnvironmentFile=/etc/pikoci/pikoci.env
 Environment=HOME=/var/lib/pikoci
 WorkingDirectory=/var/lib/pikoci
-Restart=on-failure
+Restart=always
 RestartSec=5
 
 # Hardening

--- a/deploy/pipeline.hcl
+++ b/deploy/pipeline.hcl
@@ -149,6 +149,27 @@ job "build-latest" {
   }
 }
 
+job "deploy" {
+  get "git" "pikoci_master" {
+    trigger = true
+    passed  = ["build-latest"]
+  }
+  task "deploy" {
+    run "exec" {
+      path = "/bin/sh"
+      args = [
+        "-ec",
+        <<-EOT
+        cd ${var.git_name}
+        GOOS=linux GOARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') go build -o /tmp/pikoci-new .
+        sudo cp /tmp/pikoci-new /usr/local/bin/pikoci
+        sudo kill -QUIT $(pidof pikoci)
+        EOT
+      ]
+    }
+  }
+}
+
 job "build-release" {
   get "git" "pikoci_tag" {
     trigger = true

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -178,10 +178,36 @@ It downloads the binary (or builds it with `--build`), copies it and all configs
 
 ## Self-deploy pipeline
 
-PikoCI can deploy itself. A basic pipeline would:
+PikoCI can deploy itself using graceful shutdown. The included `deploy/pipeline.hcl` has a `deploy` job that:
 
-1. Watch the git repo for new commits
-2. Build the binary
-3. Copy it to the server and restart the service
+1. Waits for the `build-latest` Docker image job to pass
+2. Builds a new binary from master
+3. Copies it to `/usr/local/bin/pikoci`
+4. Sends `SIGQUIT` to the running process
 
-See [Pipeline Reference](Pipeline) for how to set up git resources and task steps.
+`SIGQUIT` triggers a graceful shutdown: PikoCI finishes the deploy job itself, then exits cleanly. Because the systemd unit uses `Restart=always`, systemd automatically restarts PikoCI with the new binary.
+
+```hcl
+job "deploy" {
+  get "git" "pikoci_master" {
+    trigger = true
+    passed  = ["build-latest"]
+  }
+  task "deploy" {
+    run "exec" {
+      path = "/bin/sh"
+      args = [
+        "-ec",
+        <<-EOT
+        cd ${var.git_name}
+        GOOS=linux GOARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') go build -o /tmp/pikoci-new .
+        sudo cp /tmp/pikoci-new /usr/local/bin/pikoci
+        sudo kill -QUIT $(pidof pikoci)
+        EOT
+      ]
+    }
+  }
+}
+```
+
+See [Server Configuration — Signal handling](Server#signal-handling) for details on `SIGQUIT` vs `SIGTERM` behavior.

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -112,4 +112,25 @@ PikoCI supports running multiple server instances concurrently when using Postgr
 
 SQLite and in-memory backends are single-instance only (no locking support).
 
+## Signal handling
+
+PikoCI supports two shutdown modes:
+
+| Signal | Behavior |
+|--------|----------|
+| `SIGQUIT` | **Graceful shutdown.** Stops accepting new jobs, waits for in-flight jobs to finish (up to 10 minutes), then gracefully shuts down the HTTP server. |
+| `SIGTERM` / `SIGINT` | **Immediate shutdown.** Cancels all running jobs and exits. |
+
+Graceful shutdown (`SIGQUIT`) is designed for zero-downtime self-deploys: a pipeline job builds the new binary, copies it, and sends `SIGQUIT`. The running job finishes, PikoCI exits cleanly, and systemd restarts with the new binary.
+
+When `--run-worker=false` (external workers), the server shuts down the HTTP server immediately on `SIGQUIT` since workers are separate processes.
+
+```bash
+# Graceful shutdown (finish running jobs first)
+kill -QUIT $(pidof pikoci)
+
+# Immediate shutdown
+kill -TERM $(pidof pikoci)
+```
+
 See also: [Database Backends](Database) · [Queue Backends](Queue) · [Running Workers Separately](Workers)

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -22,6 +22,7 @@ pikoci server [flags]
 | `--run-migrations` | | `true` | no | Run database migrations on startup |
 | `--run-worker` | | `true` | no | Run an embedded worker |
 | `--concurrency` | | `1` | no | Number of worker goroutines |
+| `--drain-timeout` | | `10m` | no | Max time to wait for in-flight jobs during graceful shutdown (`SIGQUIT`) |
 | `--pubsub-system` | | `mem` | no | Queue backend: `mem`, `nats`, `rabbit`, `kafka` |
 | `--log-level` | | `info` | no | Log level: `debug`, `info`, `warn`, `error` |
 | `--config` | `-c` | | no | Path to a config file |
@@ -118,7 +119,7 @@ PikoCI supports two shutdown modes:
 
 | Signal | Behavior |
 |--------|----------|
-| `SIGQUIT` | **Graceful shutdown.** Stops accepting new jobs, waits for in-flight jobs to finish (up to 10 minutes), then gracefully shuts down the HTTP server. |
+| `SIGQUIT` | **Graceful shutdown.** Stops accepting new jobs, waits for in-flight jobs to finish (up to `--drain-timeout`, default 10m), then gracefully shuts down the HTTP server. |
 | `SIGTERM` / `SIGINT` | **Immediate shutdown.** Cancels all running jobs and exits. |
 
 Graceful shutdown (`SIGQUIT`) is designed for zero-downtime self-deploys: a pipeline job builds the new binary, copies it, and sends `SIGQUIT`. The running job finishes, PikoCI exits cleanly, and systemd restarts with the new binary.

--- a/docs/Workers.md
+++ b/docs/Workers.md
@@ -84,3 +84,20 @@ pikoci worker --pikoci-url http://server:8080 --pubsub-system nats --jwt-secret 
 # Machine B
 pikoci worker --pikoci-url http://server:8080 --pubsub-system nats --jwt-secret my-secret --concurrency 4
 ```
+
+## Signal handling
+
+Standalone workers support the same two shutdown modes as the server:
+
+| Signal | Behavior |
+|--------|----------|
+| `SIGQUIT` | Stop accepting new jobs, wait for in-flight jobs to finish (up to 10 minutes), then exit. |
+| `SIGTERM` / `SIGINT` | Cancel running jobs and exit immediately. |
+
+```bash
+# Graceful shutdown
+kill -QUIT $(pidof pikoci)
+
+# Immediate shutdown
+kill -TERM $(pidof pikoci)
+```

--- a/docs/Workers.md
+++ b/docs/Workers.md
@@ -58,6 +58,7 @@ pikoci worker \
 | `--pikoci-url` | `-u` | `localhost:8080` | no | PikoCI server URL |
 | `--pubsub-system` | | `mem` | no | Queue backend (must match server) |
 | `--concurrency` | | `1` | no | Number of parallel job goroutines |
+| `--drain-timeout` | | `10m` | no | Max time to wait for in-flight jobs during graceful shutdown (`SIGQUIT`) |
 | `--log-level` | | `info` | no | Log level: `debug`, `info`, `warn`, `error` |
 | `--jwt-secret` | | | **yes** | Must match the server's `--jwt-secret` |
 | `--config` | `-c` | | no | Path to a config file |
@@ -91,7 +92,7 @@ Standalone workers support the same two shutdown modes as the server:
 
 | Signal | Behavior |
 |--------|----------|
-| `SIGQUIT` | Stop accepting new jobs, wait for in-flight jobs to finish (up to 10 minutes), then exit. |
+| `SIGQUIT` | Stop accepting new jobs, wait for in-flight jobs to finish (up to `--drain-timeout`, default 10m), then exit. |
 | `SIGTERM` / `SIGINT` | Cancel running jobs and exit immediately. |
 
 ```bash

--- a/pikoci/config/config.go
+++ b/pikoci/config/config.go
@@ -16,8 +16,9 @@ type Config struct {
 	DBPassword string `mapstructure:"db-password"`
 	DBName     string `mapstructure:"db-name"`
 
-	RunWorker   bool `mapstructure:"run-worker"`
-	Concurrency int  `mapstructure:"concurrency"`
+	RunWorker    bool   `mapstructure:"run-worker"`
+	Concurrency  int    `mapstructure:"concurrency"`
+	DrainTimeout string `mapstructure:"drain-timeout"`
 
 	PubSubSystem string `mapstructure:"pubsub-system"`
 

--- a/worker/config/config.go
+++ b/worker/config/config.go
@@ -5,6 +5,7 @@ type Config struct {
 	JWTSecret string `mapstructure:"jwt-secret"`
 
 	Concurrency  int    `mapstructure:"concurrency"`
+	DrainTimeout string `mapstructure:"drain-timeout"`
 	PubSubSystem string `mapstructure:"pubsub-system"`
 
 	LogLevel string `mapstructure:"log-level"`

--- a/worker/service.go
+++ b/worker/service.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/adrg/xdg"
@@ -38,7 +39,8 @@ type Worker struct {
 	pikoci       pikoci.Service
 	subscription queue.Subscription
 
-	logger *slog.Logger
+	draining atomic.Bool
+	logger   *slog.Logger
 }
 
 func New(s pikoci.Service, t queue.Topic, ss queue.Subscription, l *slog.Logger) *Worker {
@@ -50,9 +52,17 @@ func New(s pikoci.Service, t queue.Topic, ss queue.Subscription, l *slog.Logger)
 	}
 }
 
+func (w *Worker) Drain() {
+	w.draining.Store(true)
+}
+
 func (w *Worker) Run(ctx context.Context) error {
 	w.logger.Info("Worker waiting for messages...")
 	for {
+		if w.draining.Load() {
+			w.logger.Info("Worker draining, stopping message receive")
+			return nil
+		}
 		msg, err := w.subscription.Receive(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to receive message: %w", err)


### PR DESCRIPTION
## Summary

- **SIGQUIT** triggers graceful shutdown: stops accepting new jobs, waits for in-flight jobs to finish (10min hard timeout), gracefully drains the HTTP server, then exits cleanly
- **SIGTERM/SIGINT** triggers immediate shutdown: cancels context, kills running jobs, force-closes HTTP server
- Enables zero-downtime self-deploy: systemd `Restart=always` + deploy pipeline job builds new binary and sends `SIGQUIT`

### Key changes
- `worker/service.go`: `draining atomic.Bool` + `Drain()` method — worker finishes current job then stops
- `cmd/server.go`: Two-mode signal handler with `context.WithCancel`, `svr.Shutdown()` / `svr.Close()`
- `cmd/worker.go`: `runWorker` returns workers + WaitGroup + cleanup func; standalone worker gets same signal handling
- `deploy/pikoci.service`: `Restart=always` so clean SIGQUIT exits trigger restart
- `deploy/pipeline.hcl`: Self-deploy job (build → copy → SIGQUIT)

Closes #281