### PR TITLE
Escape HCL interpolation in builtin service definitions

### DIFF
--- a/pikoci/builtin/services/kafka.hcl
+++ b/pikoci/builtin/services/kafka.hcl
@@ -4,26 +4,26 @@ service_type "kafka" {
   start "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-${BUILD_PIPELINE_NAME}-${BUILD_JOB_NAME}-kafka"
+      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-kafka"
       docker rm -f $NAME 2>/dev/null || true
       docker run -d --name $NAME \
-        -p ${param_port}:9092 \
+        -p $${param_port}:9092 \
         -e KAFKA_NODE_ID=0 \
         -e KAFKA_PROCESS_ROLES=controller,broker \
         -e KAFKA_CONTROLLER_QUORUM_VOTERS=0@localhost:9093 \
         -e KAFKA_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093 \
-        -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:${param_port} \
+        -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:$${param_port} \
         -e KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER \
         -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT \
         -e CLUSTER_ID=MkU3OEVBNTcwNTJENDM2Qk \
-        apache/kafka:${param_version}
+        apache/kafka:$${param_version}
     EOT
     ]
   }
 
   ready_check "exec" {
     path     = "/bin/sh"
-    args     = ["-ec", "nc -z localhost ${param_port}"]
+    args     = ["-ec", "nc -z localhost $${param_port}"]
     interval = "3s"
     timeout  = "60s"
   }
@@ -31,7 +31,7 @@ service_type "kafka" {
   stop "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-${BUILD_PIPELINE_NAME}-${BUILD_JOB_NAME}-kafka"
+      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-kafka"
       docker rm -f $NAME 2>/dev/null || true
     EOT
     ]

--- a/pikoci/builtin/services/mariadb.hcl
+++ b/pikoci/builtin/services/mariadb.hcl
@@ -4,12 +4,12 @@ service_type "mariadb" {
   start "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-${BUILD_PIPELINE_NAME}-${BUILD_JOB_NAME}-mariadb"
+      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-mariadb"
       docker rm -f $NAME 2>/dev/null || true
       docker run -d --name $NAME \
-        -p ${param_port}:3306 \
-        -e MYSQL_ROOT_PASSWORD=${param_root_password} \
-        mariadb:${param_version}
+        -p $${param_port}:3306 \
+        -e MYSQL_ROOT_PASSWORD=$${param_root_password} \
+        mariadb:$${param_version}
     EOT
     ]
   }
@@ -17,8 +17,8 @@ service_type "mariadb" {
   ready_check "exec" {
     path     = "/bin/sh"
     args     = ["-ec", <<-EOT
-      NAME="pikoci-${BUILD_PIPELINE_NAME}-${BUILD_JOB_NAME}-mariadb"
-      docker exec $NAME mariadb -uroot -p${param_root_password} -e 'SELECT 1'
+      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-mariadb"
+      docker exec $NAME mariadb -uroot -p$${param_root_password} -e 'SELECT 1'
     EOT
     ]
     interval = "2s"
@@ -28,7 +28,7 @@ service_type "mariadb" {
   stop "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-${BUILD_PIPELINE_NAME}-${BUILD_JOB_NAME}-mariadb"
+      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-mariadb"
       docker rm -f $NAME 2>/dev/null || true
     EOT
     ]

--- a/pikoci/builtin/services/nats.hcl
+++ b/pikoci/builtin/services/nats.hcl
@@ -4,18 +4,18 @@ service_type "nats" {
   start "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-${BUILD_PIPELINE_NAME}-${BUILD_JOB_NAME}-nats"
+      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-nats"
       docker rm -f $NAME 2>/dev/null || true
       docker run -d --name $NAME \
-        -p ${param_port}:4222 \
-        nats:${param_version}
+        -p $${param_port}:4222 \
+        nats:$${param_version}
     EOT
     ]
   }
 
   ready_check "exec" {
     path     = "/bin/sh"
-    args     = ["-ec", "nc -z localhost ${param_port}"]
+    args     = ["-ec", "nc -z localhost $${param_port}"]
     interval = "1s"
     timeout  = "60s"
   }
@@ -23,7 +23,7 @@ service_type "nats" {
   stop "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-${BUILD_PIPELINE_NAME}-${BUILD_JOB_NAME}-nats"
+      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-nats"
       docker rm -f $NAME 2>/dev/null || true
     EOT
     ]

--- a/pikoci/builtin/services/postgresql.hcl
+++ b/pikoci/builtin/services/postgresql.hcl
@@ -4,12 +4,12 @@ service_type "postgresql" {
   start "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-${BUILD_PIPELINE_NAME}-${BUILD_JOB_NAME}-pg"
+      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-pg"
       docker rm -f $NAME 2>/dev/null || true
       docker run -d --name $NAME \
-        -p ${param_port}:5432 \
-        -e POSTGRES_PASSWORD=${param_password} \
-        postgres:${param_version}
+        -p $${param_port}:5432 \
+        -e POSTGRES_PASSWORD=$${param_password} \
+        postgres:$${param_version}
     EOT
     ]
   }
@@ -17,7 +17,7 @@ service_type "postgresql" {
   ready_check "exec" {
     path     = "/bin/sh"
     args     = ["-ec", <<-EOT
-      NAME="pikoci-${BUILD_PIPELINE_NAME}-${BUILD_JOB_NAME}-pg"
+      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-pg"
       docker exec $NAME pg_isready
     EOT
     ]
@@ -28,7 +28,7 @@ service_type "postgresql" {
   stop "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-${BUILD_PIPELINE_NAME}-${BUILD_JOB_NAME}-pg"
+      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-pg"
       docker rm -f $NAME 2>/dev/null || true
     EOT
     ]

--- a/pikoci/builtin/services/rabbitmq.hcl
+++ b/pikoci/builtin/services/rabbitmq.hcl
@@ -4,19 +4,19 @@ service_type "rabbitmq" {
   start "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-${BUILD_PIPELINE_NAME}-${BUILD_JOB_NAME}-rabbit"
+      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-rabbit"
       docker rm -f $NAME 2>/dev/null || true
       docker run -d --name $NAME \
-        -p ${param_port}:5672 \
+        -p $${param_port}:5672 \
         -e RABBITMQ_NODENAME=rabbit \
-        rabbitmq:${param_version}
+        rabbitmq:$${param_version}
     EOT
     ]
   }
 
   ready_check "exec" {
     path     = "/bin/sh"
-    args     = ["-ec", "nc -z localhost ${param_port}"]
+    args     = ["-ec", "nc -z localhost $${param_port}"]
     interval = "3s"
     timeout  = "60s"
   }
@@ -24,7 +24,7 @@ service_type "rabbitmq" {
   stop "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-${BUILD_PIPELINE_NAME}-${BUILD_JOB_NAME}-rabbit"
+      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-rabbit"
       docker rm -f $NAME 2>/dev/null || true
     EOT
     ]

--- a/pikoci/builtin/services/redis.hcl
+++ b/pikoci/builtin/services/redis.hcl
@@ -4,18 +4,18 @@ service_type "redis" {
   start "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-${BUILD_PIPELINE_NAME}-${BUILD_JOB_NAME}-redis"
+      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-redis"
       docker rm -f $NAME 2>/dev/null || true
       docker run -d --name $NAME \
-        -p ${param_port}:6379 \
-        redis:${param_version}
+        -p $${param_port}:6379 \
+        redis:$${param_version}
     EOT
     ]
   }
 
   ready_check "exec" {
     path     = "/bin/sh"
-    args     = ["-ec", "redis-cli -p ${param_port} ping"]
+    args     = ["-ec", "redis-cli -p $${param_port} ping"]
     interval = "1s"
     timeout  = "30s"
   }
@@ -23,7 +23,7 @@ service_type "redis" {
   stop "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-${BUILD_PIPELINE_NAME}-${BUILD_JOB_NAME}-redis"
+      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-redis"
       docker rm -f $NAME 2>/dev/null || true
     EOT
     ]

--- a/pikoci/builtin/services/vault.hcl
+++ b/pikoci/builtin/services/vault.hcl
@@ -4,22 +4,22 @@ service_type "vault" {
   start "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-${BUILD_PIPELINE_NAME}-${BUILD_JOB_NAME}-vault"
+      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-vault"
       docker rm -f $NAME 2>/dev/null || true
       docker run -d --name $NAME \
-        -p ${param_port}:8200 \
-        -e VAULT_DEV_ROOT_TOKEN_ID=${param_root_token} \
+        -p $${param_port}:8200 \
+        -e VAULT_DEV_ROOT_TOKEN_ID=$${param_root_token} \
         -e VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200 \
         -e SKIP_SETCAP=1 \
         --cap-add IPC_LOCK \
-        hashicorp/vault:${param_version}
+        hashicorp/vault:$${param_version}
     EOT
     ]
   }
 
   ready_check "exec" {
     path     = "/bin/sh"
-    args     = ["-ec", "curl -sf http://127.0.0.1:${param_port}/v1/sys/health"]
+    args     = ["-ec", "curl -sf http://127.0.0.1:$${param_port}/v1/sys/health"]
     interval = "2s"
     timeout  = "60s"
   }
@@ -27,7 +27,7 @@ service_type "vault" {
   stop "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-${BUILD_PIPELINE_NAME}-${BUILD_JOB_NAME}-vault"
+      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-vault"
       docker rm -f $NAME 2>/dev/null || true
     EOT
     ]


### PR DESCRIPTION
- Service HCL files used ${param_*} and ${BUILD_*} inside heredocs, which HCL interprets as variable interpolation and fails during source resolution
- Changed to $${...} so HCL produces literal ${...} for shell expansion at runtime
- This matches the pattern already used by the git resource type ($param_url, not ${param_url})
- Fixes all 7 builtin services: mariadb, postgresql, nats, rabbitmq, kafka, vault, redis

Follow-up to #284 which fixed the HCL struct decoding but didn't fix the interpolation issue in the HCL files themselves.