### PR TITLE
Fix self-deploy pipeline: build in Docker, atomic binary replace

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -138,6 +138,7 @@ ssh "$SSH_HOST" 'systemctl stop pikoci 2>/dev/null || true'
 
 echo "==> Copying binary to $SSH_HOST..."
 scp "$BINARY" "$SSH_HOST":/usr/local/bin/pikoci
+ssh "$SSH_HOST" 'chown pikoci:pikoci /usr/local/bin/pikoci'
 
 # --- Sync deploy configs ---
 # Creates directories and the pikoci system user on first run.

--- a/deploy/pikoci.service
+++ b/deploy/pikoci.service
@@ -17,7 +17,7 @@ RestartSec=5
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true
-ReadWritePaths=/var/lib/pikoci
+ReadWritePaths=/var/lib/pikoci /usr/local/bin /tmp
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/pipeline.hcl
+++ b/deploy/pipeline.hcl
@@ -154,16 +154,28 @@ job "deploy" {
     trigger = true
     passed  = ["build-latest"]
   }
-  task "deploy" {
+  task "build-and-replace" {
+    run "docker" {
+      image = "golang:1.25.1"
+      cmd   = <<-EOT
+        cd ${var.git_name}
+        GOOS=linux GOARCH=arm64 go build -buildvcs=false -o /tmp/pikoci-new .
+        mv /tmp/pikoci-new /hostbin/pikoci
+      EOT
+      args = [
+        "-v", "pikoci-go-mod:/go/pkg/mod",
+        "-v", "pikoci-build:/root/.cache/go-build",
+        "-v", "/usr/local/bin:/hostbin",
+      ]
+    }
+  }
+  task "restart" {
     run "exec" {
       path = "/bin/sh"
       args = [
         "-ec",
         <<-EOT
-        cd ${var.git_name}
-        GOOS=linux GOARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') go build -o /tmp/pikoci-new .
-        sudo cp /tmp/pikoci-new /usr/local/bin/pikoci
-        sudo kill -QUIT $(pidof pikoci)
+        kill -QUIT $(pidof pikoci)
         EOT
       ]
     }


### PR DESCRIPTION
- Build binary inside `golang:1.25.1` Docker image (Go not installed on host)
- Add `-buildvcs=false` (container can't read VCS info from mounted workdir)
- Mount `/usr/local/bin` into container as `/hostbin` so root can replace the binary directly (avoids "Text file busy", permission denied, and read-only FS errors from `ProtectSystem=strict`)
- Remove `sudo` from deploy task (blocked by `NoNewPrivileges=true` in systemd unit)
- Add `/usr/local/bin` and `/tmp` to `ReadWritePaths` in systemd unit
- Set `pikoci` ownership on binary in deploy script