### PR TITLE
Fix last_build_at timestamp not showing on pipeline cards

### DIFF
--- a/pikoci/mysql/build.go
+++ b/pikoci/mysql/build.go
@@ -279,15 +279,21 @@ func (r *BuildRepository) LastBuildAtByPipeline(ctx context.Context, tc string) 
 			return nil, fmt.Errorf("failed to scan last build timestamp: %w", err)
 		}
 		if startedAtStr.Valid && startedAtStr.String != "" {
+			s := startedAtStr.String
+			// Strip Go monotonic clock suffix (e.g. " m=+123.456")
+			if idx := strings.Index(s, " m="); idx != -1 {
+				s = strings.TrimSpace(s[:idx])
+			}
 			var t time.Time
 			var parseErr error
 			for _, layout := range []string{
 				time.RFC3339,
+				"2006-01-02 15:04:05.999999999 +0000 UTC",
 				"2006-01-02 15:04:05 -0700 MST",
 				"2006-01-02 15:04:05",
 				"2006-01-02T15:04:05Z",
 			} {
-				t, parseErr = time.Parse(layout, startedAtStr.String)
+				t, parseErr = time.Parse(layout, s)
 				if parseErr == nil {
 					break
 				}

--- a/pikoci/mysql/build_test.go
+++ b/pikoci/mysql/build_test.go
@@ -87,6 +87,32 @@ func TestLastBuildAtByPipeline(t *testing.T) {
 	assert.NotContains(t, result, uint32(ppBID))
 }
 
+func TestLastBuildAtByPipeline_GoMonotonicFormat(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	res, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name) VALUES (1, 'lba-mono')`)
+	require.NoError(t, err)
+	ppID, _ := res.LastInsertId()
+
+	res, err = db.ExecContext(ctx, `INSERT INTO jobs (pipeline_id, name) VALUES (?, 'build')`, ppID)
+	require.NoError(t, err)
+	jobID, _ := res.LastInsertId()
+
+	// Insert with Go's time.Time.String() format including monotonic clock suffix
+	_, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, started_at) VALUES (?, 'succeeded', ?)`,
+		jobID, "2026-05-20 11:16:14.81137605 +0000 UTC m=+630.364992545")
+	require.NoError(t, err)
+
+	br := mysql.NewBuildRepository(db)
+	result, err := br.LastBuildAtByPipeline(ctx, "main")
+	require.NoError(t, err)
+	assert.Contains(t, result, uint32(ppID))
+	assert.Equal(t, 2026, result[uint32(ppID)].Year())
+	assert.Equal(t, time.May, result[uint32(ppID)].Month())
+	assert.Equal(t, 20, result[uint32(ppID)].Day())
+}
+
 func TestLastBuildAtByPipeline_NoBuildsDifferentTeam(t *testing.T) {
 	db := setupTestDB(t)
 	ctx := context.Background()

--- a/worker/service.go
+++ b/worker/service.go
@@ -145,7 +145,7 @@ func (w *Worker) processJob(ctx context.Context, m queue.Body, cwd string, pp *p
 	b := build.Build{
 		Status:    build.Started,
 		Steps:     []build.Step{},
-		StartedAt: time.Now(),
+		StartedAt: time.Now().Round(0),
 	}
 	nb, err := w.pikoci.CreateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, b)
 	if err != nil {


### PR DESCRIPTION
- SQLite stores `time.Time` using Go's `String()` format which includes the monotonic clock suffix (e.g. `m=+630.364`)
- `LastBuildAtByPipeline` uses `MAX(started_at)` which returns a string in SQLite, and none of the parse layouts matched this format
- The timestamp was silently dropped, so pipeline cards showed "Last build failed" without a time
- Fix: strip the `m=+...` suffix before parsing, add the Go time format layout
- Also strip monotonic clock at the source via `time.Now().Round(0)` for new builds
- Added test for Go monotonic format parsing