### PR TITLE
Build multi-arch Docker images with cross-compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM golang:1.25.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.1 AS builder
+ARG TARGETOS TARGETARCH
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -o /pikoci .
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /pikoci .
 
 FROM alpine:3.21
 RUN apk add --no-cache ca-certificates git jq curl openssl docker-cli

--- a/deploy/pipeline.hcl
+++ b/deploy/pipeline.hcl
@@ -141,8 +141,8 @@ job "build-latest" {
 
         echo "${var.docker_password}" | docker login -u "${var.docker_username}" --password-stdin
 
-        docker build -t xescugc/pikoci:latest .
-        docker push xescugc/pikoci:latest
+        docker buildx create --use --name pikoci-builder 2>/dev/null || docker buildx use pikoci-builder
+        docker buildx build --platform linux/amd64,linux/arm64 -t xescugc/pikoci:latest --push .
         EOT
       ]
     }
@@ -197,8 +197,8 @@ job "build-release" {
 
         echo "${var.docker_password}" | docker login -u "${var.docker_username}" --password-stdin
 
-        docker build -t xescugc/pikoci:$TAG .
-        docker push xescugc/pikoci:$TAG
+        docker buildx create --use --name pikoci-builder 2>/dev/null || docker buildx use pikoci-builder
+        docker buildx build --platform linux/amd64,linux/arm64 -t xescugc/pikoci:$TAG --push .
         EOT
       ]
     }


### PR DESCRIPTION
- Go 1.25 crashes under QEMU user-mode emulation with `taggedPointerPack` error when building amd64 on arm64
- Use `--platform=$BUILDPLATFORM` in Dockerfile builder stage so Go runs natively
- Cross-compile with `TARGETOS`/`TARGETARCH` env vars instead of emulating the target arch
- Use `docker buildx` in both `build-latest` and `build-release` pipeline jobs for `linux/amd64,linux/arm64`
- Fixes `docker compose up` failing with "no matching manifest for linux/amd64"