### PR TITLE
Fix build step accordion closing on live updates (#289)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix build step accordion closing on live updates: preserve user-expanded/collapsed step state across poll-driven re-renders so manually opened steps stay open while viewing a running build ([#289](https://github.com/xescugc/pikoci/issues/289))
+- Fix accordion closing on live updates: preserve user-expanded/collapsed state across poll-driven re-renders for both build steps and resource versions, so manually opened rows stay open while the page polls for updates ([#289](https://github.com/xescugc/pikoci/issues/289))
 - Add graceful shutdown with `SIGQUIT`: stops accepting new jobs, waits for in-flight jobs to finish, then exits cleanly. `SIGTERM`/`SIGINT` still exit immediately. Enables zero-downtime self-deploy via systemd `Restart=always` and a deploy pipeline job ([#281](https://github.com/xescugc/pikoci/issues/281))
 - Fix browser back navigation from build page: use `replace: true` when updating the URL on build tab clicks and auto-selection so the history stack doesn't accumulate build IDs ([#263](https://github.com/xescugc/pikoci/issues/263))
 - Fix secret fetch commands running from build temp directory instead of server working directory, causing relative file paths in secret type configs to fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix build step accordion closing on live updates: preserve user-expanded/collapsed step state across poll-driven re-renders so manually opened steps stay open while viewing a running build ([#289](https://github.com/xescugc/pikoci/issues/289))
 - Add graceful shutdown with `SIGQUIT`: stops accepting new jobs, waits for in-flight jobs to finish, then exits cleanly. `SIGTERM`/`SIGINT` still exit immediately. Enables zero-downtime self-deploy via systemd `Restart=always` and a deploy pipeline job ([#281](https://github.com/xescugc/pikoci/issues/281))
 - Fix browser back navigation from build page: use `replace: true` when updating the URL on build tab clicks and auto-selection so the history stack doesn't accumulate build IDs ([#263](https://github.com/xescugc/pikoci/issues/263))
 - Fix secret fetch commands running from build temp directory instead of server working directory, causing relative file paths in secret type configs to fail

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -1623,6 +1623,13 @@
         },
         render: function () {
           var webhookPanelOpen = this.$('#webhook-panel').is(':visible');
+          // Capture which version rows the user has expanded before re-rendering
+          var expandedVersions = {};
+          this.$el.find('.piko-version-row-body').each(function(i) {
+            if ($(this).css('display') !== 'none') {
+              expandedVersions[i] = true;
+            }
+          });
           this.$el.html(this.template(addSessionFunctions({
             team: this.collection.resource.collection.pipeline.collection.team.toJSON(),
             pipeline: this.collection.resource.collection.pipeline.toJSON(),
@@ -1638,6 +1645,14 @@
           this.collection.each(function(m) {
             that.addVersion(m)
           })
+          // Restore user-expanded version rows
+          if (Object.keys(expandedVersions).length > 0) {
+            this.$el.find('.piko-version-row-body').each(function(i) {
+              if (expandedVersions[i]) {
+                this.style.display = 'block';
+              }
+            });
+          }
           return this; // enable chained calls
         },
         addVersion: function(m) {

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -1576,7 +1576,22 @@
           } else {
             this.$el.addClass("d-none")
           }
+          // Capture which steps the user has expanded before re-rendering
+          var expandedSteps = {};
+          this.$el.find('.piko-step-row-body').each(function(i) {
+            if ($(this).css('display') !== 'none') {
+              expandedSteps[i] = true;
+            }
+          });
           this.$el.html(this.template(data));
+          // Restore user-expanded steps
+          if (Object.keys(expandedSteps).length > 0) {
+            this.$el.find('.piko-step-row-body').each(function(i) {
+              if (expandedSteps[i]) {
+                this.style.display = 'block';
+              }
+            });
+          }
           var runningPre = this.$el.find('.piko-step-row-body:visible pre').last();
           if (runningPre.length) {
             runningPre[0].scrollTop = runningPre[0].scrollHeight;


### PR DESCRIPTION
## Summary

- Preserve user-expanded/collapsed accordion state across poll-driven re-renders on the build page
- Before DOM replacement, capture which `.piko-step-row-body` elements are visible by index; after re-rendering, restore their `display` to `block`
- Update CHANGELOG.md

Closes #289