### PR TITLE
Fix double-trigger: ack pubsub message before processing (#297)

### DIFF
--- a/worker/service.go
+++ b/worker/service.go
@@ -77,14 +77,17 @@ func (w *Worker) Run(ctx context.Context) error {
 			continue
 		}
 
+		// Ack immediately to prevent re-delivery while the job runs.
+		// Jobs can take minutes (e.g. docker builds), which exceeds
+		// the pubsub ack deadline and causes duplicate triggers.
+		msg.Ack()
+
 		cwd, err := w.createWorkDir()
 		if err != nil {
 			return err
 		}
 
 		w.processMessage(ctx, m, cwd)
-
-		msg.Ack()
 		os.RemoveAll(cwd)
 	}
 }


### PR DESCRIPTION
## Summary

- Root cause: the worker acked messages *after* `processMessage` completed. Long-running jobs (docker builds taking minutes) exceeded the pubsub ack deadline, causing the broker to re-deliver the same message and create a duplicate build.
- Fix: ack the message immediately after unmarshalling, before processing. This is safe because job processing is idempotent-ish (creates a new build), and we prefer at-most-once delivery over duplicate builds.

Evidence from server logs: build #196 created at 19:06:27, identical message re-delivered 61s later creating build #197 for the same version_id=54, with no corresponding "sending trigger message" log.

Closes #297