### PR TITLE
Add inputs and outputs on task steps (#177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `inputs` and `outputs` on task steps: declarative filesystem checks that validate required paths exist before a task runs (inputs) and after it finishes (outputs), providing clear error messages instead of confusing script failures ([#177](https://github.com/xescugc/pikoci/issues/177))
 - Add live status toggle on pipelines list view: a "Live" toggle next to the heading enables periodic polling of pipeline graph images so status dots update without reloading the page. Toggle state persists via localStorage ([#282](https://github.com/xescugc/pikoci/issues/282))
 - Add "Pipelines" link button to the team manage/edit page heading for quick navigation to the team's pipelines ([#265](https://github.com/xescugc/pikoci/issues/265))
 - Add Bootstrap Icons library and icons across the UI (buttons, navigation, step type labels) with a copy-to-clipboard button on build step logs ([#254](https://github.com/xescugc/pikoci/issues/254))

--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -267,7 +267,24 @@ task "test" {
 | `name`     | yes      | Label on the block                             |
 | `timeout`  | no       | Maximum duration for the step (e.g. `"10m"`, `"1h"`) |
 | `attempts` | no       | Maximum number of times to try the step (default `1`, no retry) |
+| `inputs`   | no       | List of paths that must exist before the task runs |
+| `outputs`  | no       | List of paths that must exist after the task finishes |
 | `secrets`  | no       | Map of secret_type name to path (e.g. `{"vault" = "secret/data/db"}`) |
+
+Example with inputs and outputs:
+
+```hcl
+task "build" {
+  inputs  = ["pikoci/"]
+  outputs = ["bin/pikoci"]
+  run "exec" {
+    path = "make"
+    args = ["build"]
+  }
+}
+```
+
+Paths are checked with `os.Stat` relative to `$WORKDIR` and work for both files and directories. If an input is missing, the task fails immediately with a clear error. If an output is missing after the task finishes, the build fails with a descriptive message.
 
 ### put
 

--- a/pikoci/helper.go
+++ b/pikoci/helper.go
@@ -44,6 +44,8 @@ type hclTaskStep struct {
 	Name     string              `json:"name" hcl:"name,label"`
 	Timeout  string              `json:"timeout" hcl:"timeout,optional"`
 	Attempts int                 `json:"attempts" hcl:"attempts,optional"`
+	Inputs   []string            `json:"inputs" hcl:"inputs,optional"`
+	Outputs  []string            `json:"outputs" hcl:"outputs,optional"`
 	Run      utils.RunnerCommand `json:"run" hcl:"run,block"`
 
 	Remain hcl.Body `hcl:",remain"` // absorbs hook blocks; parsed by parseHooks from AST
@@ -714,8 +716,10 @@ func parseJobPlans(rpp []byte, ectx *hcl.EvalContext, hclJobs []hclJob, services
 					Timeout:  timeout,
 					Attempts: t.Attempts,
 					Task: &job.TaskStep{
-						Name: t.Name,
-						Run:  t.Run,
+						Name:    t.Name,
+						Run:     t.Run,
+						Inputs:  t.Inputs,
+						Outputs: t.Outputs,
 					},
 					OnSuccess: parseHooks(innerBlock, ectx, "on_success"),
 					OnFailure: parseHooks(innerBlock, ectx, "on_failure"),

--- a/pikoci/job/job.go
+++ b/pikoci/job/job.go
@@ -117,8 +117,10 @@ func (g *GetStep) ResourceCanonical() string {
 }
 
 type TaskStep struct {
-	Name string              `json:"name" hcl:"name,label"`
-	Run  utils.RunnerCommand `json:"run" hcl:"run,block"`
+	Name    string              `json:"name" hcl:"name,label"`
+	Run     utils.RunnerCommand `json:"run" hcl:"run,block"`
+	Inputs  []string            `json:"inputs,omitempty"`
+	Outputs []string            `json:"outputs,omitempty"`
 }
 
 type PutStep struct {

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -441,6 +441,84 @@ job "test" {
 	require.NoError(t, err)
 }
 
+func TestCreatePipeline_WithInputsOutputs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "test" {
+  get "cron" "timer" {
+    trigger = true
+  }
+  task "build" {
+    inputs  = ["src/"]
+    outputs = ["bin/app"]
+    run "exec" {
+      path = "make"
+      args = ["build"]
+    }
+  }
+}
+`)
+
+	s.Pipelines.EXPECT().Create(ctx, "main", gomock.Any()).Return(uint32(1), nil)
+	s.Jobs.EXPECT().Create(ctx, "main", "inputs-outputs-pipeline", gomock.Any()).DoAndReturn(
+		func(ctx context.Context, tc, pn string, j job.Job) (uint32, error) {
+			require.Len(t, j.Plan, 2)
+			assert.Equal(t, []string{"src/"}, j.Plan[1].Task.Inputs)
+			assert.Equal(t, []string{"bin/app"}, j.Plan[1].Task.Outputs)
+			return uint32(1), nil
+		})
+	s.Resources.EXPECT().Create(ctx, "main", "inputs-outputs-pipeline", gomock.Any()).Return(uint32(1), nil)
+	s.Pipelines.EXPECT().Find(ctx, "main", "inputs-outputs-pipeline").Return(&pipeline.Pipeline{ID: 1, Name: "inputs-outputs-pipeline"}, nil)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "inputs-outputs-pipeline", hclConfig, nil)
+	require.NoError(t, err)
+}
+
+func TestCreatePipeline_WithoutInputsOutputs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "test" {
+  get "cron" "timer" {
+    trigger = true
+  }
+  task "build" {
+    run "exec" {
+      path = "echo"
+      args = ["building"]
+    }
+  }
+}
+`)
+
+	s.Pipelines.EXPECT().Create(ctx, "main", gomock.Any()).Return(uint32(1), nil)
+	s.Jobs.EXPECT().Create(ctx, "main", "no-io-pipeline", gomock.Any()).DoAndReturn(
+		func(ctx context.Context, tc, pn string, j job.Job) (uint32, error) {
+			require.Len(t, j.Plan, 2)
+			assert.Nil(t, j.Plan[1].Task.Inputs)
+			assert.Nil(t, j.Plan[1].Task.Outputs)
+			return uint32(1), nil
+		})
+	s.Resources.EXPECT().Create(ctx, "main", "no-io-pipeline", gomock.Any()).Return(uint32(1), nil)
+	s.Pipelines.EXPECT().Find(ctx, "main", "no-io-pipeline").Return(&pipeline.Pipeline{ID: 1, Name: "no-io-pipeline"}, nil)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "no-io-pipeline", hclConfig, nil)
+	require.NoError(t, err)
+}
+
 func TestCreatePipeline_InvalidAttempts(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := newService(ctrl)

--- a/worker/service.go
+++ b/worker/service.go
@@ -524,6 +524,18 @@ func (w *Worker) runTaskStep(ctx context.Context, m queue.Body, b *build.Build, 
 		t.Run.Params[k] = v
 	}
 
+	for _, input := range t.Inputs {
+		if _, err := os.Stat(filepath.Join(cwd, input)); err != nil {
+			errMsg := fmt.Sprintf("input %q does not exist", input)
+			b.Steps = append(b.Steps, build.Step{Type: "task", Name: t.Name, Logs: errMsg, Status: build.Failed})
+			b.Status = build.Failed
+			w.failBuild(ctx, m, *b, nil)
+			w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.OnFailure, "on_failure", secretResolved)
+			w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.Ensure, "ensure", secretResolved)
+			return true
+		}
+	}
+
 	maxAttempts := ps.Attempts
 	if maxAttempts <= 0 {
 		maxAttempts = 1
@@ -582,6 +594,19 @@ func (w *Worker) runTaskStep(ctx context.Context, m queue.Body, b *build.Build, 
 	}
 
 	b.Steps[stepIdx] = build.Step{Type: "task", Name: t.Name, Logs: out, Duration: d, Status: build.Succeeded}
+
+	for _, output := range t.Outputs {
+		if _, err := os.Stat(filepath.Join(cwd, output)); err != nil {
+			errMsg := fmt.Sprintf("task finished but output %q was not produced", output)
+			b.Steps[stepIdx] = build.Step{Type: "task", Name: t.Name, Logs: out + "\n" + errMsg, Duration: d, Status: build.Failed}
+			b.Status = build.Failed
+			w.failBuild(ctx, m, *b, nil)
+			w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.OnFailure, "on_failure", secretResolved)
+			w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.Ensure, "ensure", secretResolved)
+			return true
+		}
+	}
+
 	if err := w.updateBuild(ctx, m, *b); err != nil {
 		return true
 	}

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -2304,5 +2304,325 @@ func TestTriggerResourceJobs_MultipleJobsSameResource(t *testing.T) {
 	w.triggerResourceJobs(ctx, m, pp, r, cv)
 }
 
+func TestProcessJob_TaskInputMissing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical: "main",
+		PipelineName:  "test-pipeline",
+		JobName:       "input-job",
+	}
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "input-job",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name:   "build",
+							Inputs: []string{"nonexistent/"},
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Args:   []string{"hello"},
+								Params: map[string]string{
+									"path": "echo",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().CreateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, gomock.Any()).
+		Return(&build.Build{ID: 200}, nil)
+	svc.EXPECT().GetPipelineJob(ctx, m.TeamCanonical, m.PipelineName, m.JobName).
+		Return(&pp.Jobs[0], nil)
+
+	var capturedBuild build.Build
+	svc.EXPECT().UpdateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, uint32(200), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, tc, pn, jn string, bID uint32, b build.Build) error {
+			capturedBuild = b
+			return nil
+		}).AnyTimes()
+
+	w.processJob(ctx, m, cwd, pp)
+
+	assert.Equal(t, build.Failed, capturedBuild.Status)
+	require.NotEmpty(t, capturedBuild.Steps)
+	assert.Contains(t, capturedBuild.Steps[0].Logs, `input "nonexistent/" does not exist`)
+}
+
+func TestProcessJob_TaskOutputMissing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical: "main",
+		PipelineName:  "test-pipeline",
+		JobName:       "output-job",
+	}
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "output-job",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name:    "build",
+							Outputs: []string{"missing-file"},
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Args:   []string{"somefile"},
+								Params: map[string]string{
+									"path": "touch",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().CreateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, gomock.Any()).
+		Return(&build.Build{ID: 300}, nil)
+	svc.EXPECT().GetPipelineJob(ctx, m.TeamCanonical, m.PipelineName, m.JobName).
+		Return(&pp.Jobs[0], nil)
+
+	var capturedBuild build.Build
+	svc.EXPECT().UpdateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, uint32(300), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, tc, pn, jn string, bID uint32, b build.Build) error {
+			capturedBuild = b
+			return nil
+		}).AnyTimes()
+
+	w.processJob(ctx, m, cwd, pp)
+
+	assert.Equal(t, build.Failed, capturedBuild.Status)
+	require.NotEmpty(t, capturedBuild.Steps)
+	assert.Contains(t, capturedBuild.Steps[0].Logs, `task finished but output "missing-file" was not produced`)
+}
+
+func TestProcessJob_TaskInputsOutputs_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical: "main",
+		PipelineName:  "test-pipeline",
+		JobName:       "io-job",
+	}
+
+	cwd := t.TempDir()
+
+	// Create the input files that will be checked
+	os.MkdirAll(fmt.Sprintf("%s/src", cwd), 0755)
+	os.WriteFile(fmt.Sprintf("%s/src/main.go", cwd), []byte("package main"), 0644)
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "io-job",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name:    "build",
+							Inputs:  []string{"src/"},
+							Outputs: []string{"src/main.go"},
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Args:   []string{"building"},
+								Params: map[string]string{
+									"path": "echo",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+
+	svc.EXPECT().CreateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, gomock.Any()).
+		Return(&build.Build{ID: 400}, nil)
+	svc.EXPECT().GetPipelineJob(ctx, m.TeamCanonical, m.PipelineName, m.JobName).
+		Return(&pp.Jobs[0], nil)
+
+	var capturedBuild build.Build
+	svc.EXPECT().UpdateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, uint32(400), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, tc, pn, jn string, bID uint32, b build.Build) error {
+			capturedBuild = b
+			return nil
+		}).AnyTimes()
+
+	w.processJob(ctx, m, cwd, pp)
+
+	assert.Equal(t, build.Succeeded, capturedBuild.Status)
+	require.NotEmpty(t, capturedBuild.Steps)
+	assert.Equal(t, build.Succeeded, capturedBuild.Steps[0].Status)
+}
+
+func TestProcessJob_TaskMultipleInputs_FailsOnFirst(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical: "main",
+		PipelineName:  "test-pipeline",
+		JobName:       "multi-input-job",
+	}
+
+	cwd := t.TempDir()
+
+	// Create only the first input, second will be missing
+	os.MkdirAll(fmt.Sprintf("%s/dir1", cwd), 0755)
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "multi-input-job",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name:   "build",
+							Inputs: []string{"dir1/", "file2"},
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Args:   []string{"hello"},
+								Params: map[string]string{
+									"path": "echo",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+
+	svc.EXPECT().CreateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, gomock.Any()).
+		Return(&build.Build{ID: 500}, nil)
+	svc.EXPECT().GetPipelineJob(ctx, m.TeamCanonical, m.PipelineName, m.JobName).
+		Return(&pp.Jobs[0], nil)
+
+	var capturedBuild build.Build
+	svc.EXPECT().UpdateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, uint32(500), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, tc, pn, jn string, bID uint32, b build.Build) error {
+			capturedBuild = b
+			return nil
+		}).AnyTimes()
+
+	w.processJob(ctx, m, cwd, pp)
+
+	assert.Equal(t, build.Failed, capturedBuild.Status)
+	require.NotEmpty(t, capturedBuild.Steps)
+	// Should fail on "file2" (first missing input), not "dir1/" which exists
+	assert.Contains(t, capturedBuild.Steps[0].Logs, `input "file2" does not exist`)
+	assert.NotContains(t, capturedBuild.Steps[0].Logs, `input "dir1/" does not exist`)
+}
+
+func TestProcessJob_TaskMultipleOutputs_FailsOnFirst(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical: "main",
+		PipelineName:  "test-pipeline",
+		JobName:       "multi-output-job",
+	}
+
+	cwd := t.TempDir()
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "multi-output-job",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name:    "build",
+							Outputs: []string{"somefile", "missing-output"},
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Args:   []string{"somefile"},
+								Params: map[string]string{
+									"path": "touch",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+
+	svc.EXPECT().CreateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, gomock.Any()).
+		Return(&build.Build{ID: 600}, nil)
+	svc.EXPECT().GetPipelineJob(ctx, m.TeamCanonical, m.PipelineName, m.JobName).
+		Return(&pp.Jobs[0], nil)
+
+	var capturedBuild build.Build
+	svc.EXPECT().UpdateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, uint32(600), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, tc, pn, jn string, bID uint32, b build.Build) error {
+			capturedBuild = b
+			return nil
+		}).AnyTimes()
+
+	w.processJob(ctx, m, cwd, pp)
+
+	assert.Equal(t, build.Failed, capturedBuild.Status)
+	require.NotEmpty(t, capturedBuild.Steps)
+	// "somefile" was created by touch, so it should fail on "missing-output"
+	assert.Contains(t, capturedBuild.Steps[0].Logs, `task finished but output "missing-output" was not produced`)
+	assert.NotContains(t, capturedBuild.Steps[0].Logs, `task finished but output "somefile" was not produced`)
+}
+
 // Silence the unused import warnings
 var _ = time.Now


### PR DESCRIPTION
## Summary

- Add `inputs` and `outputs` optional fields to task steps for declarative filesystem validation
- `inputs` are checked with `os.Stat` before the task runs — missing input fails the build immediately with a clear error
- `outputs` are checked after the task finishes — missing output fails the build with a descriptive message
- Paths are relative to `$WORKDIR` and work for both files and directories


Closes #177