### PR TITLE
Fix cancellation follow-ups from #306

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,20 +59,24 @@ lint: ## Runs staticcheck linter
 	GOFLAGS=-buildvcs=false go tool staticcheck ./...
 
 .PHONY: test
-test: test-mock test-integration test-backends ## Runs all tests
+test: test-mock test-backends-lite test-backends ## Runs all tests
 
 .PHONY: test-mock
 test-mock: ## Runs unit/mock tests (no services needed)
 	go test ./... -timeout 120s
 
 .PHONY: test-integration
-test-integration: ## Runs integration tests with in-memory backends (no services needed)
+test-integration: ## Runs UI integration tests via Selenium (requires geckodriver + Xvfb)
+	go test -tags integration ./integration/... -timeout 120s
+
+.PHONY: test-backends-lite
+test-backends-lite: ## Runs backend integration tests with mem+sqlite (no services needed)
 	@PIKOCI_TEST_DB_SYSTEMS=$${PIKOCI_TEST_DB_SYSTEMS:-mem,sqlite} \
 	PIKOCI_TEST_PUBSUB_SYSTEMS=$${PIKOCI_TEST_PUBSUB_SYSTEMS:-mem} \
 	go test -tags integration ./integration/backends/... -timeout 120s
 
 .PHONY: test-backends
-test-backends: ## Runs integration tests with all backends (requires test-services-up)
+test-backends: ## Runs backend integration tests with all backends (requires test-services-up)
 	@PIKOCI_TEST_DB_SYSTEMS=mem,sqlite,mysql,postgresql \
 	PIKOCI_TEST_PUBSUB_SYSTEMS=mem,nats \
 	PIKOCI_TEST_VAULT=1 \

--- a/deploy/pipeline.hcl
+++ b/deploy/pipeline.hcl
@@ -46,7 +46,7 @@ job "test-mock" {
   }
 }
 
-job "test-integration" {
+job "test-backends-lite" {
   get "git" "pikoci_pr" {
     trigger = true
   }
@@ -54,7 +54,7 @@ job "test-integration" {
   task "make" {
     run "docker" {
       image = "golang:1.25.1"
-      cmd   = "cd ${var.git_name} && make test-integration"
+      cmd   = "cd ${var.git_name} && make test-backends-lite"
       args  = [
         "-v", "pikoci-go-mod:/go/pkg/mod",
         "-v", "pikoci-build:/root/.cache/go-build",
@@ -72,7 +72,7 @@ job "test-integration" {
 job "test-backends" {
   get "git" "pikoci_pr" {
     trigger = true
-    passed  = ["lint", "test-mock", "test-integration"]
+    passed  = ["lint", "test-mock", "test-backends-lite"]
   }
 
   put "github-check" "ci" { status = "in_progress" }

--- a/pikoci/mysql/build.go
+++ b/pikoci/mysql/build.go
@@ -98,7 +98,7 @@ func (r *BuildRepository) Find(ctx context.Context, tc, pn, jn string, bID uint3
 			ON j.pipeline_id = p.id
 		JOIN teams AS t
 			ON p.team_id = t.id
-		WHERE tc.canonical = ? AND p.name = ? AND j.name = ? AND b.id = ?
+		WHERE t.canonical = ? AND p.name = ? AND j.name = ? AND b.id = ?
 	`, tc, pn, jn, bID)
 
 	j, err := scanBuild(row)

--- a/pikoci/mysql/build_test.go
+++ b/pikoci/mysql/build_test.go
@@ -10,6 +10,31 @@ import (
 	"github.com/xescugc/pikoci/pikoci/mysql"
 )
 
+func TestFind(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	res, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name) VALUES (1, 'find-pipe')`)
+	require.NoError(t, err)
+	ppID, _ := res.LastInsertId()
+
+	res, err = db.ExecContext(ctx, `INSERT INTO jobs (pipeline_id, name) VALUES (?, 'build')`, ppID)
+	require.NoError(t, err)
+	jobID, _ := res.LastInsertId()
+
+	now := time.Now().Round(0).UTC()
+	res, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, started_at) VALUES (?, 'started', ?)`, jobID, now)
+	require.NoError(t, err)
+	buildID, _ := res.LastInsertId()
+
+	br := mysql.NewBuildRepository(db)
+
+	b, err := br.Find(ctx, "main", "find-pipe", "build", uint32(buildID))
+	require.NoError(t, err)
+	assert.Equal(t, uint32(buildID), b.ID)
+	assert.Equal(t, "started", b.Status.String())
+}
+
 func TestInsertGetVersion(t *testing.T) {
 	db := setupTestDB(t)
 	ctx := context.Background()

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -366,13 +366,13 @@ var (
 		build.Started:   `"#FFA300"`,
 		build.Failed:    `"#FF004D"`,
 		build.Succeeded: `"#00A83A"`,
-		build.Cancelled: `"#83769C"`,
+		build.Cancelled: `"#AB5236"`,
 	}
 	jobBorderColors = map[build.Status]string{
 		build.Started:   `"#CC8200"`,
 		build.Failed:    `"#CC003E"`,
 		build.Succeeded: `"#008030"`,
-		build.Cancelled: `"#5F574F"`,
+		build.Cancelled: `"#8A3F2B"`,
 	}
 	colorResource       = `"#83769C"`
 	colorResourceBorder = `"#5F574F"`

--- a/pikoci/testdata/cron.hcl
+++ b/pikoci/testdata/cron.hcl
@@ -25,6 +25,12 @@ job "gen" {
   get "cron" "my_cron" {
     trigger = true
   }
+  task "sleep" {
+    run "exec" {
+      path = "sleep"
+      args = ["60"]
+    }
+  }
   task "echo" {
     run "exec" {
       path = "echo"

--- a/pikoci/transport/http/assets/css/pikoci.css
+++ b/pikoci/transport/http/assets/css/pikoci.css
@@ -31,7 +31,7 @@
   --status-succeeded: #00A83A;
   --status-failed:    #FF004D;
   --status-started:   #FFA300;
-  --status-cancelled: #83769C;
+  --status-cancelled: #AB5236;
   --status-pending:   #83769C;
 
   --font-body:     'Plus Jakarta Sans', system-ui, sans-serif;
@@ -646,11 +646,11 @@ textarea.form-control {
 .piko-badge-succeeded { background: #d0f5d8; color: #007a2b; }
 .piko-badge-failed { background: #ffe0e8; color: #cc003e; }
 .piko-badge-started { background: #fff0d0; color: #9a7000; }
-.piko-badge-cancelled { background: #e8e0f0; color: #5F574F; }
+.piko-badge-cancelled { background: #f5e6df; color: #8A3F2B; }
 [data-theme="dark"] .piko-badge-succeeded { background: rgba(0,168,58,0.15); color: #00E436; }
 [data-theme="dark"] .piko-badge-failed { background: rgba(255,0,77,0.15); color: #FF77A8; }
 [data-theme="dark"] .piko-badge-started { background: rgba(255,163,0,0.15); color: #FFA300; }
-[data-theme="dark"] .piko-badge-cancelled { background: rgba(131,118,156,0.15); color: #AB9FC7; }
+[data-theme="dark"] .piko-badge-cancelled { background: rgba(171,82,54,0.15); color: #D4845E; }
 
 /* ============================================================
    VERSION ROWS (Resource versions)
@@ -682,7 +682,7 @@ textarea.form-control {
 .status-succeeded { background-color: #00A83A !important; }
 .status-failed    { background-color: #FF004D !important; }
 .status-started   { background-color: #FFA300 !important; }
-.status-cancelled { background-color: #83769C !important; }
+.status-cancelled { background-color: #AB5236 !important; }
 
 /* ============================================================
    LOGIN PAGE

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -279,6 +279,10 @@
           Running
         </span>
         <span class="piko-graph-legend-item">
+          <span class="piko-graph-legend-swatch" style="background:var(--status-cancelled);"></span>
+          Cancelled
+        </span>
+        <span class="piko-graph-legend-item">
           <span class="piko-graph-legend-swatch" style="background:#83769C;"></span>
           No builds
         </span>
@@ -399,7 +403,7 @@
             <span class="piko-badge piko-badge-cancelled">Cancelled</span>
           <% } %>
           <% if (status === "started") { %>
-            <button type="button" class="btn btn-sm btn-outline-danger piko-cancel-build" data-build-id="<%- id %>">
+            <button type="button" class="btn btn-sm btn-outline-danger piko-cancel-build" style="margin-left:auto;" data-build-id="<%- id %>">
               <i class="bi bi-x-circle"></i> Cancel
             </button>
           <% } %>


### PR DESCRIPTION
## Summary

Follow-up fixes for the job cancellation PR (#306):

- Fix SQL typo in `BuildRepository.Find` (`tc.canonical` -> `t.canonical`) that broke cancellation polling on SQLite/MySQL
- Add test for `BuildRepository.Find`
- Change cancelled status color from grey/lavender to brown (PICO-8 `#AB5236`), so cancelled builds are visually distinct from pending/no-builds. Matches Concourse CI's aborted style
- Add "Cancelled" entry to pipeline graph legend
- Move cancel button to the right side of build meta row
- Add sleep task to cron testdata for manual cancel testing