### PR TITLE
Worker authentication for non-memory deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `pikoci worker-token` subcommand and `--worker-token` flag on the worker so standalone workers no longer need the raw JWT secret. The server logs a pre-generated worker token on startup when `--run-worker=false`. The `--jwt-secret` flag has been removed from the worker command ([#270](https://github.com/xescugc/pikoci/issues/270))
 - Add job cancellation via DB polling: cancel running builds from the UI or API with `POST .../builds/{id}/cancel`. The worker polls every 5s and cancels the Go context, killing child processes. on_failure and ensure hooks still run after cancellation ([#271](https://github.com/xescugc/pikoci/issues/271))
 - Add `inputs` and `outputs` on task steps: declarative filesystem checks that validate required paths exist before a task runs (inputs) and after it finishes (outputs), providing clear error messages instead of confusing script failures ([#177](https://github.com/xescugc/pikoci/issues/177))
 - Add live status toggle on pipelines list view: a "Live" toggle next to the heading enables periodic polling of pipeline graph images so status dots update without reloading the page. Toggle state persists via localStorage ([#282](https://github.com/xescugc/pikoci/issues/282))

--- a/README.md
+++ b/README.md
@@ -127,11 +127,14 @@ watch -n2 'pikoci client -u localhost:8080 pipelines graph -n my-pipeline | dot 
 For production setups, run the server and workers as separate processes on different machines:
 
 ```bash
-# Server
+# Server (logs a worker token on startup)
 ./pikoci server --db-system mysql --pubsub-system nats --jwt-secret my-secret --run-worker=false
 
+# Generate a worker token (or copy from server logs)
+./pikoci worker-token --jwt-secret my-secret
+
 # Worker, can run anywhere with access to the server
-./pikoci worker --pikoci-url http://your-server:8080 --pubsub-system nats --jwt-secret my-secret
+./pikoci worker --pikoci-url http://your-server:8080 --pubsub-system nats --worker-token <token>
 ```
 
 Full server and worker configuration options are covered in the [documentation](https://github.com/xescugc/pikoci/wiki/Server).

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,5 +21,6 @@ func init() {
 	rootCmd.AddCommand(serverCmd)
 	rootCmd.AddCommand(clientCmd)
 	rootCmd.AddCommand(workerCmd)
+	rootCmd.AddCommand(workerTokenCmd)
 	rootCmd.AddCommand(userPasswordCmd)
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -168,6 +168,11 @@ var serverCmd = &cobra.Command{
 			errs <- svr.ListenAndServe()
 		}()
 
+		if !cfg.RunWorker {
+			wt := generateWorkerJWT(jwtSecret)
+			logger.Info("Worker token for standalone workers", "token", wt)
+		}
+
 		var workers []*worker.Worker
 		var wg *sync.WaitGroup
 		if cfg.RunWorker {

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -51,11 +51,10 @@ var workerCmd = &cobra.Command{
 
 		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: parseSlogLevel(cfg.LogLevel)}))
 
-		if cfg.JWTSecret == "" {
-			return fmt.Errorf("required flag \"jwt-secret\" not set")
+		if cfg.WorkerToken == "" {
+			return fmt.Errorf("required flag \"worker-token\" not set")
 		}
-
-		workerToken := generateWorkerJWT([]byte(cfg.JWTSecret))
+		workerToken := cfg.WorkerToken
 		c, err := client.New(cfg.PikoCIURL, workerToken)
 		if err != nil {
 			return fmt.Errorf("failed to initialize client with url %q: %w", cfg.PikoCIURL, err)
@@ -129,7 +128,7 @@ func init() {
 	workerCmd.Flags().Int("concurrency", 1, "Number of workers to start in one instance")
 	workerCmd.Flags().String("drain-timeout", "10m", "Maximum time to wait for in-flight jobs to finish during graceful shutdown (SIGQUIT)")
 	workerCmd.Flags().String("log-level", "info", "Sets the log level ('debug', 'info', 'warn', 'error')")
-	workerCmd.Flags().String("jwt-secret", "", "JWT secret (must match the server's --jwt-secret)")
+	workerCmd.Flags().String("worker-token", "", "Worker authentication token (from 'pikoci worker-token' or server startup logs)")
 
 	workerViper.BindPFlags(workerCmd.Flags())
 

--- a/cmd/worker_token.go
+++ b/cmd/worker_token.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var workerTokenCmd = &cobra.Command{
+	Use:   "worker-token",
+	Short: "Generate a worker authentication token",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		js, _ := cmd.Flags().GetString("jwt-secret")
+		if js == "" {
+			return fmt.Errorf("--jwt-secret is required")
+		}
+		fmt.Println(generateWorkerJWT([]byte(js)))
+		return nil
+	},
+}
+
+func init() {
+	workerTokenCmd.Flags().String("jwt-secret", "", "JWT secret used by the server")
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,14 +1,15 @@
 # CLI Reference
 
-PikoCI provides three top-level commands: `server`, `worker`, and `client`, plus a utility command `user-password`.
+PikoCI provides three top-level commands: `server`, `worker`, and `client`, plus utility commands `user-password` and `worker-token`.
 
 ## Global structure
 
 ```
-pikoci server   [flags]          # Start the server
-pikoci worker   [flags]          # Start a standalone worker
-pikoci client   [flags] <cmd>    # Interact with the API
-pikoci user-password [flags]     # Generate hashed passwords
+pikoci server       [flags]          # Start the server
+pikoci worker       [flags]          # Start a standalone worker
+pikoci client       [flags] <cmd>    # Interact with the API
+pikoci user-password [flags]         # Generate hashed passwords
+pikoci worker-token  [flags]         # Generate a worker authentication token
 ```
 
 ## client
@@ -153,6 +154,21 @@ pikoci user-password -u myuser -p mypassword
 |------|-------|----------|-------------|
 | `--username` | `-u` | **yes** | Username |
 | `--password` | `-p` | **yes** | Plain-text password |
+
+## worker-token
+
+Generate a pre-signed worker authentication token. This avoids distributing the raw JWT secret to worker machines.
+
+```bash
+pikoci worker-token --jwt-secret my-secret
+# Output: eyJhbG...
+```
+
+| Flag | Default | Required | Description |
+|------|---------|----------|-------------|
+| `--jwt-secret` | | **yes** | JWT secret used by the server |
+
+The server also logs a worker token on startup when `--run-worker=false`.
 
 ## server
 

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -151,6 +151,7 @@ Caddy handles TLS certificates automatically via Let's Encrypt.
 - The `pikoci.env.example` file is a template — never commit actual secrets
 - Generate JWT secrets with: `openssl rand -hex 32`
 - Generate password hashes with: `pikoci user-password -u <user> -p <password>`
+- For standalone workers, generate a worker token with `pikoci worker-token --jwt-secret <secret>` instead of distributing the raw JWT secret. See [Running Workers Separately](Workers)
 
 ## Monitoring
 

--- a/docs/Queue.md
+++ b/docs/Queue.md
@@ -18,7 +18,7 @@ pikoci server --jwt-secret my-secret --pubsub-system mem --run-worker
 export NATS_SERVER_URL="nats://localhost:4222"
 
 pikoci server --jwt-secret my-secret --pubsub-system nats --run-worker=false
-pikoci worker --pikoci-url http://localhost:8080 --pubsub-system nats --jwt-secret my-secret
+pikoci worker --pikoci-url http://localhost:8080 --pubsub-system nats --worker-token <token>
 ```
 
 ## rabbit
@@ -29,7 +29,7 @@ pikoci worker --pikoci-url http://localhost:8080 --pubsub-system nats --jwt-secr
 export RABBIT_SERVER_URL="amqp://guest:guest@localhost:5672/"
 
 pikoci server --jwt-secret my-secret --pubsub-system rabbit --run-worker=false
-pikoci worker --pikoci-url http://localhost:8080 --pubsub-system rabbit --jwt-secret my-secret
+pikoci worker --pikoci-url http://localhost:8080 --pubsub-system rabbit --worker-token <token>
 ```
 
 ## kafka
@@ -40,7 +40,7 @@ pikoci worker --pikoci-url http://localhost:8080 --pubsub-system rabbit --jwt-se
 export KAFKA_BROKERS="localhost:9092"
 
 pikoci server --jwt-secret my-secret --pubsub-system kafka --run-worker=false
-pikoci worker --pikoci-url http://localhost:8080 --pubsub-system kafka --jwt-secret my-secret
+pikoci worker --pikoci-url http://localhost:8080 --pubsub-system kafka --worker-token <token>
 ```
 
 ## Planned

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -97,6 +97,8 @@ pikoci server \
   --run-worker=false
 ```
 
+When `--run-worker=false`, the server logs a pre-generated worker token on startup. Copy this token to configure standalone workers with `--worker-token`. See [Running Workers Separately](Workers).
+
 ### Load a pipeline at startup
 
 ```bash

--- a/docs/Workers.md
+++ b/docs/Workers.md
@@ -22,11 +22,11 @@ The server publishes jobs to a queue. Workers subscribe, execute the jobs, and r
 
 - A non-memory queue backend (`nats`, `rabbit`, or `kafka`). The `mem` backend only works within a single process.
 - Workers must be able to reach the server URL and the queue backend.
-- Workers must use the same `--jwt-secret` as the server.
+- Workers need a worker token for authentication. Generate one with `pikoci worker-token --jwt-secret <secret>` or copy it from the server startup logs.
 
 ## Server setup
 
-Disable the embedded worker:
+Disable the embedded worker. The server logs a worker token on startup that you can copy for worker config:
 
 ```bash
 pikoci server \
@@ -39,6 +39,14 @@ pikoci server \
   --db-name pikoci \
   --pubsub-system nats \
   --run-worker=false
+# Server logs: Worker token for standalone workers token=eyJhbG...
+```
+
+Or generate a token manually:
+
+```bash
+pikoci worker-token --jwt-secret my-secret
+# Output: eyJhbG...
 ```
 
 ## Worker setup
@@ -47,7 +55,7 @@ pikoci server \
 pikoci worker \
   --pikoci-url http://server:8080 \
   --pubsub-system nats \
-  --jwt-secret my-secret \
+  --worker-token eyJhbG... \
   --concurrency 4
 ```
 
@@ -60,7 +68,7 @@ pikoci worker \
 | `--concurrency` | | `1` | no | Number of parallel job goroutines |
 | `--drain-timeout` | | `10m` | no | Max time to wait for in-flight jobs during graceful shutdown (`SIGQUIT`) |
 | `--log-level` | | `info` | no | Log level: `debug`, `info`, `warn`, `error` |
-| `--jwt-secret` | | | **yes** | Must match the server's `--jwt-secret` |
+| `--worker-token` | | | **yes** | Worker authentication token (from `pikoci worker-token` or server startup logs) |
 | `--config` | `-c` | | no | Path to a config file |
 
 ## Environment variables
@@ -70,7 +78,7 @@ Worker flags can be set via environment variables:
 ```bash
 export PIKOCI_URL=http://server:8080
 export PUBSUB_SYSTEM=nats
-export JWT_SECRET=my-secret
+export WORKER_TOKEN=eyJhbG...
 export CONCURRENCY=4
 ```
 
@@ -80,10 +88,10 @@ Run multiple worker instances to increase throughput. Each worker independently 
 
 ```bash
 # Machine A
-pikoci worker --pikoci-url http://server:8080 --pubsub-system nats --jwt-secret my-secret --concurrency 2
+pikoci worker --pikoci-url http://server:8080 --pubsub-system nats --worker-token eyJhbG... --concurrency 2
 
 # Machine B
-pikoci worker --pikoci-url http://server:8080 --pubsub-system nats --jwt-secret my-secret --concurrency 4
+pikoci worker --pikoci-url http://server:8080 --pubsub-system nats --worker-token eyJhbG... --concurrency 4
 ```
 
 ## Signal handling

--- a/worker/config/config.go
+++ b/worker/config/config.go
@@ -1,8 +1,8 @@
 package config
 
 type Config struct {
-	PikoCIURL string `mapstructure:"pikoci-url"`
-	JWTSecret string `mapstructure:"jwt-secret"`
+	PikoCIURL   string `mapstructure:"pikoci-url"`
+	WorkerToken string `mapstructure:"worker-token"`
 
 	Concurrency  int    `mapstructure:"concurrency"`
 	DrainTimeout string `mapstructure:"drain-timeout"`


### PR DESCRIPTION
## Summary

- Add `pikoci worker-token` subcommand that generates a pre-signed worker JWT from `--jwt-secret`
- Add `--worker-token` flag to the worker command; remove `--jwt-secret` from the worker
- Server logs the worker token on startup when `--run-worker=false`
- Update docs: Workers, Queue, CLI, Server, Deployment, README, CHANGELOG

Closes #270