### PR TITLE
Add concurrency on jobs (#187)

### DIFF
--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -192,6 +192,24 @@ The `ready_check` block accepts `interval` (default `"1s"`) and `timeout` (defau
 
 Jobs contain a plan of steps executed in order. Each step is one of `get`, `task`, `put`, or `service`.
 
+The optional `concurrency` attribute limits how many builds of the job can run simultaneously. When the limit is reached, new builds are re-queued and wait until a slot frees up. The default value `0` means unlimited.
+
+```hcl
+job "deploy" {
+  concurrency = 1
+
+  get "git" "my_repo" {
+    trigger = true
+  }
+
+  task "deploy" {
+    run "exec" {
+      path = "./deploy.sh"
+    }
+  }
+}
+```
+
 ```hcl
 job "build" {
   get "git" "my_repo" {

--- a/pikoci/build/repository.go
+++ b/pikoci/build/repository.go
@@ -18,4 +18,5 @@ type Repository interface {
 	FindGetVersions(ctx context.Context, buildID uint32) (map[string]uint32, error)
 	FindReadyDownstreamVersion(ctx context.Context, tc, pn string, upstreamJobs []string, downstreamJob string, stepName string, upstreamCount int) (uint32, bool, error)
 	LastBuildAtByPipeline(ctx context.Context, tc string) (map[uint32]time.Time, error)
+	CountRunning(ctx context.Context, tc, pn, jn string) (int, error)
 }

--- a/pikoci/builds.go
+++ b/pikoci/builds.go
@@ -3,6 +3,7 @@ package pikoci
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -10,9 +11,12 @@ import (
 
 	"github.com/xescugc/pikoci/pikoci/build"
 	"github.com/xescugc/pikoci/pikoci/queue"
+	"github.com/xescugc/pikoci/pikoci/unitwork"
 	"github.com/xescugc/pikoci/pikoci/utils"
 	"gocloud.dev/pubsub"
 )
+
+var ErrConcurrencyLimit = errors.New("concurrency limit reached")
 
 func (q *PikoCI) CreateJobBuild(ctx context.Context, tc, pn, jn string, b build.Build) (*build.Build, error) {
 	if !utils.ValidateCanonical(tc) {
@@ -23,13 +27,23 @@ func (q *PikoCI) CreateJobBuild(ctx context.Context, tc, pn, jn string, b build.
 		return nil, fmt.Errorf("invalid Job Name format %q", jn)
 	}
 
-	id, buildNumber, err := q.Builds.Create(ctx, tc, pn, jn, b)
-	if err != nil {
-		return nil, fmt.Errorf("failed to Create Build: %w", err)
-	}
+	err := q.StartUoW(ctx, func(uow unitwork.UnitOfWork) error {
+		if err := checkConcurrencyLimit(ctx, uow, tc, pn, jn); err != nil {
+			return err
+		}
 
-	b.ID = id
-	b.BuildNumber = buildNumber
+		id, buildNumber, err := uow.Builds().Create(ctx, tc, pn, jn, b)
+		if err != nil {
+			return fmt.Errorf("failed to Create Build: %w", err)
+		}
+
+		b.ID = id
+		b.BuildNumber = buildNumber
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
 
 	return &b, nil
 }
@@ -204,13 +218,23 @@ func (q *PikoCI) CreateRetryJobBuild(ctx context.Context, tc, pn, jn, parentBuil
 		return nil, fmt.Errorf("invalid Job Name format %q", jn)
 	}
 
-	id, buildNumber, err := q.Builds.CreateRetry(ctx, tc, pn, jn, parentBuildNumber, b)
-	if err != nil {
-		return nil, fmt.Errorf("failed to Create Retry Build: %w", err)
-	}
+	err := q.StartUoW(ctx, func(uow unitwork.UnitOfWork) error {
+		if err := checkConcurrencyLimit(ctx, uow, tc, pn, jn); err != nil {
+			return err
+		}
 
-	b.ID = id
-	b.BuildNumber = buildNumber
+		id, buildNumber, err := uow.Builds().CreateRetry(ctx, tc, pn, jn, parentBuildNumber, b)
+		if err != nil {
+			return fmt.Errorf("failed to Create Retry Build: %w", err)
+		}
+
+		b.ID = id
+		b.BuildNumber = buildNumber
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
 
 	return &b, nil
 }
@@ -225,4 +249,21 @@ func (q *PikoCI) FindBuildGetVersions(ctx context.Context, tc, pn, jn string, bu
 	}
 
 	return q.Builds.FindGetVersions(ctx, buildID)
+}
+
+func checkConcurrencyLimit(ctx context.Context, uow unitwork.UnitOfWork, tc, pn, jn string) error {
+	j, err := uow.Jobs().Find(ctx, tc, pn, jn)
+	if err != nil {
+		return fmt.Errorf("failed to find job: %w", err)
+	}
+	if j.Concurrency > 0 {
+		running, err := uow.Builds().CountRunning(ctx, tc, pn, jn)
+		if err != nil {
+			return fmt.Errorf("failed to count running builds: %w", err)
+		}
+		if running >= j.Concurrency {
+			return ErrConcurrencyLimit
+		}
+	}
+	return nil
 }

--- a/pikoci/builds_test.go
+++ b/pikoci/builds_test.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/xescugc/pikoci/pikoci"
 	"github.com/xescugc/pikoci/pikoci/build"
+	"github.com/xescugc/pikoci/pikoci/job"
 	"go.uber.org/mock/gomock"
 	"gocloud.dev/pubsub"
 )
@@ -16,6 +18,7 @@ func TestCreateJobBuild(t *testing.T) {
 	s := newService(ctrl)
 	ctx := context.TODO()
 
+	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "my-job").Return(&job.Job{Name: "my-job"}, nil)
 	s.Builds.EXPECT().Create(ctx, "main", "my-pipeline", "my-job", gomock.Any()).Return(uint32(1), "1", nil)
 
 	b, err := s.S.CreateJobBuild(ctx, "main", "my-pipeline", "my-job", build.Build{Status: build.Started})
@@ -137,6 +140,7 @@ func TestCreateRetryJobBuild(t *testing.T) {
 	s := newService(ctrl)
 	ctx := context.TODO()
 
+	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "my-job").Return(&job.Job{Name: "my-job"}, nil)
 	s.Builds.EXPECT().CreateRetry(ctx, "main", "my-pipeline", "my-job", "3", gomock.Any()).
 		Return(uint32(8), "3.1", nil)
 
@@ -144,6 +148,44 @@ func TestCreateRetryJobBuild(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint32(8), b.ID)
 	assert.Equal(t, "3.1", b.BuildNumber)
+}
+
+func TestCreateJobBuild_ConcurrencyLimit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "my-job").Return(&job.Job{Name: "my-job", Concurrency: 1}, nil)
+	s.Builds.EXPECT().CountRunning(ctx, "main", "my-pipeline", "my-job").Return(1, nil)
+
+	_, err := s.S.CreateJobBuild(ctx, "main", "my-pipeline", "my-job", build.Build{Status: build.Started})
+	require.ErrorIs(t, err, pikoci.ErrConcurrencyLimit)
+}
+
+func TestCreateJobBuild_ConcurrencyAllowed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "my-job").Return(&job.Job{Name: "my-job", Concurrency: 2}, nil)
+	s.Builds.EXPECT().CountRunning(ctx, "main", "my-pipeline", "my-job").Return(1, nil)
+	s.Builds.EXPECT().Create(ctx, "main", "my-pipeline", "my-job", gomock.Any()).Return(uint32(1), "1", nil)
+
+	b, err := s.S.CreateJobBuild(ctx, "main", "my-pipeline", "my-job", build.Build{Status: build.Started})
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), b.ID)
+}
+
+func TestCreateRetryJobBuild_ConcurrencyLimit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "my-job").Return(&job.Job{Name: "my-job", Concurrency: 1}, nil)
+	s.Builds.EXPECT().CountRunning(ctx, "main", "my-pipeline", "my-job").Return(1, nil)
+
+	_, err := s.S.CreateRetryJobBuild(ctx, "main", "my-pipeline", "my-job", "3", build.Build{Status: build.Started})
+	require.ErrorIs(t, err, pikoci.ErrConcurrencyLimit)
 }
 
 func TestFindBuildGetVersions(t *testing.T) {

--- a/pikoci/helper.go
+++ b/pikoci/helper.go
@@ -66,11 +66,12 @@ type hclPutStep struct {
 
 // hclJob is the intermediate HCL-decoded job with separate get/task/put arrays.
 type hclJob struct {
-	Name    string           `hcl:"name,label"`
-	Get     []hclGetStep     `hcl:"get,block"`
-	Task    []hclTaskStep    `hcl:"task,block"`
-	Put     []hclPutStep     `hcl:"put,block"`
-	Service []hclServiceRef  `hcl:"service,block"`
+	Name        string          `hcl:"name,label"`
+	Concurrency int             `hcl:"concurrency,optional"`
+	Get         []hclGetStep    `hcl:"get,block"`
+	Task        []hclTaskStep   `hcl:"task,block"`
+	Put         []hclPutStep    `hcl:"put,block"`
+	Service     []hclServiceRef `hcl:"service,block"`
 
 	Remain hcl.Body `hcl:",remain"` // absorbs hook blocks; parsed by parseHooks from AST
 }
@@ -496,13 +497,17 @@ func (q *PikoCI) readPipeline(ctx context.Context, rpp []byte, vars map[string]i
 	}
 
 	for _, hj := range hp.Jobs {
+		if hj.Concurrency < 0 {
+			return nil, fmt.Errorf("job %q: concurrency must be >= 0", hj.Name)
+		}
 		jh := jobHooksMap[hj.Name]
 		j := job.Job{
-			Name:      hj.Name,
-			Plan:      jobPlans[hj.Name],
-			OnSuccess: jh.OnSuccess,
-			OnFailure: jh.OnFailure,
-			Ensure:    jh.Ensure,
+			Name:        hj.Name,
+			Concurrency: hj.Concurrency,
+			Plan:        jobPlans[hj.Name],
+			OnSuccess:   jh.OnSuccess,
+			OnFailure:   jh.OnFailure,
+			Ensure:      jh.Ensure,
 		}
 		pp.Jobs = append(pp.Jobs, j)
 	}

--- a/pikoci/job/job.go
+++ b/pikoci/job/job.go
@@ -25,9 +25,10 @@ type HookStep struct {
 }
 
 type Job struct {
-	ID   uint32 `json:"id"`
-	Name string `json:"name" hcl:"name,label"`
-	Plan []PlanStep `json:"plan"`
+	ID          uint32     `json:"id"`
+	Name        string     `json:"name" hcl:"name,label"`
+	Concurrency int        `json:"concurrency,omitempty"`
+	Plan        []PlanStep `json:"plan"`
 
 	OnSuccess []HookStep `json:"on_success,omitempty"`
 	OnFailure []HookStep `json:"on_failure,omitempty"`

--- a/pikoci/mock/build_repository.go
+++ b/pikoci/mock/build_repository.go
@@ -42,6 +42,21 @@ func (m *BuildRepository) EXPECT() *BuildRepositoryMockRecorder {
 	return m.recorder
 }
 
+// CountRunning mocks base method.
+func (m *BuildRepository) CountRunning(ctx context.Context, tc, pn, jn string) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountRunning", ctx, tc, pn, jn)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountRunning indicates an expected call of CountRunning.
+func (mr *BuildRepositoryMockRecorder) CountRunning(ctx, tc, pn, jn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountRunning", reflect.TypeOf((*BuildRepository)(nil).CountRunning), ctx, tc, pn, jn)
+}
+
 // Create mocks base method.
 func (m *BuildRepository) Create(ctx context.Context, tc, pn, jn string, b build.Build) (uint32, string, error) {
 	m.ctrl.T.Helper()

--- a/pikoci/mysql/build.go
+++ b/pikoci/mysql/build.go
@@ -436,6 +436,23 @@ func (r *BuildRepository) LastBuildAtByPipeline(ctx context.Context, tc string) 
 	return result, nil
 }
 
+func (r *BuildRepository) CountRunning(ctx context.Context, tc, pn, jn string) (int, error) {
+	var count int
+	err := r.querier.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM builds AS b
+		JOIN jobs AS j ON b.job_id = j.id
+		JOIN pipelines AS p ON j.pipeline_id = p.id
+		JOIN teams AS t ON p.team_id = t.id
+		WHERE t.canonical = ? AND p.name = ? AND j.name = ?
+		  AND b.status = 'started'
+	`, tc, pn, jn).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count running builds: %w", err)
+	}
+	return count, nil
+}
+
 func scanBuild(s sqlr.Scanner) (*build.Build, error) {
 	var b dbBuild
 

--- a/pikoci/mysql/job.go
+++ b/pikoci/mysql/job.go
@@ -21,12 +21,13 @@ func NewJobRepository(db sqlr.Querier) *JobRepository {
 }
 
 type dbJob struct {
-	ID        sql.NullInt64
-	Name      sql.NullString
-	Plan      sql.NullString
-	OnSuccess sql.NullString
-	OnFailure sql.NullString
-	Ensure    sql.NullString
+	ID          sql.NullInt64
+	Name        sql.NullString
+	Plan        sql.NullString
+	OnSuccess   sql.NullString
+	OnFailure   sql.NullString
+	Ensure      sql.NullString
+	Concurrency sql.NullInt64
 }
 
 func newDBJob(p job.Job) dbJob {
@@ -35,18 +36,20 @@ func newDBJob(p job.Job) dbJob {
 	f, _ := json.Marshal(p.OnFailure)
 	e, _ := json.Marshal(p.Ensure)
 	return dbJob{
-		Name:      toNullString(p.Name),
-		Plan:      toNullString(string(pl)),
-		OnSuccess: toNullString(string(s)),
-		OnFailure: toNullString(string(f)),
-		Ensure:    toNullString(string(e)),
+		Name:        toNullString(p.Name),
+		Plan:        toNullString(string(pl)),
+		OnSuccess:   toNullString(string(s)),
+		OnFailure:   toNullString(string(f)),
+		Ensure:      toNullString(string(e)),
+		Concurrency: sql.NullInt64{Int64: int64(p.Concurrency), Valid: true},
 	}
 }
 
 func (dbp *dbJob) toDomainEntity() *job.Job {
 	j := &job.Job{
-		ID:   uint32(dbp.ID.Int64),
-		Name: dbp.Name.String,
+		ID:          uint32(dbp.ID.Int64),
+		Name:        dbp.Name.String,
+		Concurrency: int(dbp.Concurrency.Int64),
 	}
 
 	_ = json.Unmarshal([]byte(dbp.Plan.String), &j.Plan)
@@ -60,8 +63,8 @@ func (dbp *dbJob) toDomainEntity() *job.Job {
 func (r *JobRepository) Create(ctx context.Context, tc, pn string, j job.Job) (uint32, error) {
 	dbj := newDBJob(j)
 	res, err := r.querier.ExecContext(ctx, `
-		INSERT INTO jobs(name, plan, on_success, on_failure, ensure, pipeline_id)
-		VALUES (?, ?, ?, ?, ?,
+		INSERT INTO jobs(name, plan, on_success, on_failure, ensure, concurrency, pipeline_id)
+		VALUES (?, ?, ?, ?, ?, ?,
 			-- pipeline_id
 			(
 				SELECT p.id
@@ -69,7 +72,7 @@ func (r *JobRepository) Create(ctx context.Context, tc, pn string, j job.Job) (u
 				JOIN teams AS t
 					ON p.team_id = t.id
 				WHERE t.canonical = ? AND p.name = ?
-			))`, dbj.Name, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.Ensure, tc, pn)
+			))`, dbj.Name, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.Ensure, dbj.Concurrency, tc, pn)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -86,7 +89,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 	dbj := newDBJob(j)
 	res, err := r.querier.ExecContext(ctx, `
 		UPDATE jobs AS j
-		SET name = ?, plan = ?, on_success = ?, on_failure = ?, ensure = ?
+		SET name = ?, plan = ?, on_success = ?, on_failure = ?, ensure = ?, concurrency = ?
 		FROM (
 			SELECT j.id
 			FROM jobs AS j
@@ -97,7 +100,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 			WHERE t.canonical = ? AND p.name = ? AND j.name = ?
 		) AS jj
 		WHERE jj.id = j.id
-	`, dbj.Name, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.Ensure, tc, pn, jn)
+	`, dbj.Name, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.Ensure, dbj.Concurrency, tc, pn, jn)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -112,7 +115,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 
 func (r *JobRepository) Find(ctx context.Context, tc, pn, jn string) (*job.Job, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT j.id, j.name, j.plan, j.on_success, j.on_failure, j.ensure
+		SELECT j.id, j.name, j.plan, j.on_success, j.on_failure, j.ensure, j.concurrency
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -131,7 +134,7 @@ func (r *JobRepository) Find(ctx context.Context, tc, pn, jn string) (*job.Job, 
 
 func (r *JobRepository) Filter(ctx context.Context, tc, pn string) ([]*job.Job, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT j.id, j.name, j.plan, j.on_success, j.on_failure, j.ensure
+		SELECT j.id, j.name, j.plan, j.on_success, j.on_failure, j.ensure, j.concurrency
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -187,6 +190,7 @@ func scanJob(s sqlr.Scanner) (*job.Job, error) {
 		&j.OnSuccess,
 		&j.OnFailure,
 		&j.Ensure,
+		&j.Concurrency,
 	)
 
 	if err != nil {

--- a/pikoci/mysql/migrate/migrations/V18Concurrency.go
+++ b/pikoci/mysql/migrate/migrations/V18Concurrency.go
@@ -1,0 +1,7 @@
+package migrations
+
+// V18Concurrency adds a concurrency column to the jobs table.
+var V18Concurrency = Migration{
+	Name: "Concurrency",
+	SQL:  `ALTER TABLE jobs ADD COLUMN concurrency INTEGER NOT NULL DEFAULT 0;`,
+}

--- a/pikoci/mysql/migrate/migrations/migrations.go
+++ b/pikoci/mysql/migrate/migrations/migrations.go
@@ -12,7 +12,7 @@ type Migration struct {
 // in compilation time if some order is wrong
 // if it where to have more than one person working
 // on it
-var Migrations = [18]Migration{
+var Migrations = [19]Migration{
 	V0Initial,
 	V1ResourceCheckInterval,
 	V2JobsAndBuilds,
@@ -31,4 +31,5 @@ var Migrations = [18]Migration{
 	V15SecretTypeConfig,
 	V16BuildGetVersions,
 	V17BuildNumber,
+	V18Concurrency,
 }

--- a/pikoci/transport/http/client/client.go
+++ b/pikoci/transport/http/client/client.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/xescugc/pikoci/pikoci"
 	"github.com/xescugc/pikoci/pikoci/build"
 	"github.com/xescugc/pikoci/pikoci/job"
 	"github.com/xescugc/pikoci/pikoci/pipeline"
@@ -444,6 +445,9 @@ func (cl *Client) CreateJobBuild(ctx context.Context, tc, pn, jn string, b build
 	}
 
 	if resp.Err != "" {
+		if resp.Err == pikoci.ErrConcurrencyLimit.Error() {
+			return nil, pikoci.ErrConcurrencyLimit
+		}
 		return nil, fmt.Errorf("error from request: %s", resp.Err)
 	}
 
@@ -539,6 +543,9 @@ func (cl *Client) CreateRetryJobBuild(ctx context.Context, tc, pn, jn, parentBui
 	}
 
 	if resp.Err != "" {
+		if resp.Err == pikoci.ErrConcurrencyLimit.Error() {
+			return nil, pikoci.ErrConcurrencyLimit
+		}
 		return nil, fmt.Errorf("error from request: %s", resp.Err)
 	}
 

--- a/worker/service.go
+++ b/worker/service.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -164,6 +165,17 @@ func (w *Worker) processJob(ctx context.Context, m queue.Body, cwd string, pp *p
 		nb, err = w.pikoci.CreateJobBuild(ctx, m.TeamCanonical, m.PipelineName, m.JobName, b)
 	}
 	if err != nil {
+		if errors.Is(err, pikoci.ErrConcurrencyLimit) {
+			w.logger.Info("job at concurrency limit, re-queuing",
+				"pipeline", m.PipelineName, "job", m.JobName)
+			mb, _ := json.Marshal(m)
+			if err := w.topic.Send(ctx, &pubsub.Message{Body: mb}); err != nil {
+				w.logger.Error("failed to re-queue concurrency-limited build",
+					"pipeline", m.PipelineName, "job", m.JobName, "error", err)
+			}
+			time.Sleep(2 * time.Second)
+			return
+		}
 		w.logger.Error("failed create build", "pipeline", m.PipelineName, "job", m.JobName, "error", err)
 		return
 	}


### PR DESCRIPTION
## Summary

- Add per-job `concurrency` attribute to limit how many builds run simultaneously (default `0` = unlimited)
- Server-side enforcement via `ErrConcurrencyLimit` sentinel error within a DB transaction (no TOCTOU race)
- Worker re-queues builds that hit the limit with a 2s delay
- V18 migration adds `concurrency` column to `jobs` table

Closes #187