### PR TITLE
Add on_cancel hook for jobs (#321)

### DIFF
--- a/integration/pikoci_test.go
+++ b/integration/pikoci_test.go
@@ -906,11 +906,13 @@ func containsString(s, substr string) bool {
 func setEditorContent(t *testing.T, wd selenium.WebDriver, content string) {
 	t.Helper()
 	_, err := wd.ExecuteScript(`
-		var editor = document.querySelector('.cm-content');
-		if (editor && editor.cmView && editor.cmView.view) {
-			var view = editor.cmView.view;
+		var view = window._pikoEditor;
+		if (view) {
 			view.dispatch({changes: {from: 0, to: view.state.doc.length, insert: arguments[0]}});
 		}
+		// Also sync hidden textarea as fallback
+		var ta = document.getElementById('pipeline');
+		if (ta) { ta.value = arguments[0]; }
 	`, []interface{}{content})
 	require.NoError(t, err)
 }

--- a/integration/pikoci_test.go
+++ b/integration/pikoci_test.go
@@ -254,10 +254,7 @@ func TestPikoCI(t *testing.T) {
 			name, err := wd.FindElement(selenium.ByCSSSelector, "#name")
 			require.NoError(t, err)
 
-			pipeline, err := wd.FindElement(selenium.ByCSSSelector, ".cm-content")
-			require.NoError(t, err)
-
-			pipeline.SendKeys(`
+			setEditorContent(t, wd, `
 resource "cron" "my_cron" {
   check_interval = "@every 1m"
 }
@@ -276,7 +273,7 @@ job "gen" {
 			name.SendKeys("cron")
 
 			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
-				_, err := wd.FindElement(selenium.ByCSSSelector, "div#pipeline-graph>svg")
+				_, err := wd.FindElement(selenium.ByCSSSelector, "#graph svg")
 
 				return err == nil
 			}, 5*time.Second)
@@ -298,13 +295,7 @@ job "gen" {
 
 			waitFor(t, wd, eqText(selenium.ByCSSSelector, "h1", "Update Pipeline"), 5*time.Second)
 
-			pipeline, err := wd.FindElement(selenium.ByCSSSelector, ".cm-content")
-			require.NoError(t, err)
-			// Select all and delete to clear CodeMirror editor
-			pipeline.SendKeys(selenium.ControlKey + "a")
-			pipeline.SendKeys(selenium.DeleteKey)
-
-			pipeline.SendKeys(`
+			setEditorContent(t, wd, `
 resource "cron" "my_cron_edit" {
   check_interval = "@every 1m"
 }
@@ -466,10 +457,7 @@ job "gen" {
 				name, err := wd.FindElement(selenium.ByCSSSelector, "#name")
 				require.NoError(t, err)
 
-				pipeline, err := wd.FindElement(selenium.ByCSSSelector, ".cm-content")
-				require.NoError(t, err)
-
-				pipeline.SendKeys(`
+				setEditorContent(t, wd, `
 resource "cron" "my_cron" {
   check_interval = "@every 1m"
 }
@@ -488,7 +476,7 @@ job "gen" {
 				name.SendKeys("cron")
 
 				waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
-					_, err := wd.FindElement(selenium.ByCSSSelector, "div#pipeline-graph>svg")
+					_, err := wd.FindElement(selenium.ByCSSSelector, "#graph svg")
 
 					return err == nil
 				}, 5*time.Second)
@@ -911,6 +899,20 @@ func eqText(by, value, txt string) waitForFn {
 
 func containsString(s, substr string) bool {
 	return strings.Contains(s, substr)
+}
+
+// setEditorContent sets the CodeMirror editor content via JavaScript,
+// bypassing contenteditable issues with Selenium WebDriver.
+func setEditorContent(t *testing.T, wd selenium.WebDriver, content string) {
+	t.Helper()
+	_, err := wd.ExecuteScript(`
+		var editor = document.querySelector('.cm-content');
+		if (editor && editor.cmView && editor.cmView.view) {
+			var view = editor.cmView.view;
+			view.dispatch({changes: {from: 0, to: view.state.doc.length, insert: arguments[0]}});
+		}
+	`, []interface{}{content})
+	require.NoError(t, err)
 }
 
 func screenshot(t *testing.T, wd selenium.WebDriver) {

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -1566,7 +1566,7 @@
       // HCL stream language for CodeMirror
       app.hclLanguage = function() {
         var CM = window.PikoCM
-        var keywords = 'job resource resource_type runner_type secret_type service_type variable get put task service plan params start stop ready_check secret on_success on_failure ensure concurrency'
+        var keywords = 'job resource resource_type runner_type secret_type service_type variable get put task service plan params start stop ready_check secret on_success on_failure on_cancel ensure concurrency'
         var keywordSet = {}
         keywords.split(' ').forEach(function(k){ keywordSet[k] = true })
         var atoms = {true:true, false:true, null:true}

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -1796,6 +1796,8 @@
             }),
             parent: this.$el.find('#pipeline-editor')[0],
           })
+          // Expose editor for integration tests
+          window._pikoEditor = this.editor
           this._themeObserver = new MutationObserver(function() {
             var dark = document.documentElement.getAttribute('data-theme') === 'dark'
             that.editor.dispatch({

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -2846,6 +2847,124 @@ func TestProcessJob_Retry_FailsOnVersionLookupError(t *testing.T) {
 		}).AnyTimes()
 
 	w.processJob(ctx, m, cwd, pp)
+}
+
+func TestProcessJob_Cancellation_RunsOnCancelNotOnFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	svc := mock.NewService(ctrl)
+	topic := mock.NewTopic(ctrl)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	svc.EXPECT().InsertBuildGetVersion(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	w := &Worker{
+		pikoci: svc,
+		topic:  topic,
+		logger: logger,
+	}
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical: "main",
+		PipelineName:  "test-pipeline",
+		JobName:       "cancel-hook-job",
+	}
+
+	cancelMarker := filepath.Join(t.TempDir(), "on_cancel_ran")
+	failureMarker := filepath.Join(t.TempDir(), "on_failure_ran")
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "cancel-hook-job",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "long-task",
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Args:   []string{"60"},
+								Params: map[string]string{"path": "sleep"},
+							},
+						},
+					},
+				},
+				OnCancel: []job.HookStep{
+					{
+						Type: job.StepTypeRunner,
+						Runner: &utils.RunnerCommand{
+							Runner: "exec",
+							Args:   []string{"-ec", fmt.Sprintf("touch %s", cancelMarker)},
+							Params: map[string]string{"path": "/bin/sh"},
+						},
+					},
+				},
+				OnFailure: []job.HookStep{
+					{
+						Type: job.StepTypeRunner,
+						Runner: &utils.RunnerCommand{
+							Runner: "exec",
+							Args:   []string{"-ec", fmt.Sprintf("touch %s", failureMarker)},
+							Params: map[string]string{"path": "/bin/sh"},
+						},
+					},
+				},
+				Ensure: []job.HookStep{},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().CreateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineName, m.JobName, gomock.Any()).
+		Return(&build.Build{ID: 800, BuildNumber: "800"}, nil)
+	svc.EXPECT().GetPipelineJob(gomock.Any(), m.TeamCanonical, m.PipelineName, m.JobName).
+		Return(&pp.Jobs[0], nil)
+
+	// GetJobBuild: return Started first, then Cancelled on subsequent calls
+	callCount := 0
+	svc.EXPECT().GetJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineName, m.JobName, "800").
+		DoAndReturn(func(ctx context.Context, tc, pn, jn string, bID string) (*build.Build, error) {
+			callCount++
+			if callCount <= 1 {
+				return &build.Build{ID: 800, BuildNumber: "800", Status: build.Started}, nil
+			}
+			return &build.Build{ID: 800, BuildNumber: "800", Status: build.Cancelled}, nil
+		}).AnyTimes()
+
+	var capturedBuild build.Build
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineName, m.JobName, "800", gomock.Any()).
+		DoAndReturn(func(ctx context.Context, tc, pn, jn string, bID string, b build.Build) error {
+			capturedBuild = b
+			return nil
+		}).AnyTimes()
+
+	done := make(chan struct{})
+	go func() {
+		w.processJob(ctx, m, cwd, pp)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("processJob did not finish in time")
+	}
+
+	assert.Equal(t, build.Cancelled, capturedBuild.Status)
+
+	// on_cancel hook should have run
+	_, err := os.Stat(cancelMarker)
+	assert.NoError(t, err, "on_cancel hook should have run (marker file should exist)")
+
+	// on_failure hook should NOT have run
+	_, err = os.Stat(failureMarker)
+	assert.True(t, os.IsNotExist(err), "on_failure hook should NOT run on cancellation (marker file should not exist)")
 }
 
 // Silence the unused import warnings


### PR DESCRIPTION
## Summary

- Add `on_cancel` hook that runs when a build is cancelled
- Follows Concourse CI semantics: each outcome maps to exactly one hook
- `on_failure` no longer runs on cancellation (breaking change)
- Supported at both job-level and step-level
- Added `on_cancel` as a keyword in the HCL editor syntax highlighting

Closes #321