### PR TITLE
Fix job status display on pipeline view (#323)

### DIFF
--- a/pikoci/mysql/build.go
+++ b/pikoci/mysql/build.go
@@ -246,6 +246,7 @@ func (r *BuildRepository) Filter(ctx context.Context, tc, pn, jn string) ([]*bui
 		JOIN teams AS t
 			ON p.team_id = t.id
 		WHERE t.canonical = ? AND p.name = ? AND j.name = ?
+		ORDER BY b.id ASC
 	`, tc, pn, jn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to filter builds: %w", err)

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -468,24 +468,39 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 		slices.Reverse(builds)
 		color := colorDefault
 		borderColor := colorDefaultBorder
+
+		// cb: latest main build (no retry suffix) for fill color
+		// rb: any running build (including retries) for dashed outline
 		var (
 			cb *build.Build
-			pb *build.Build
+			rb *build.Build
 		)
-		if len(builds) != 0 {
-			cb = builds[0]
-			if len(builds) > 1 && cb.Status == build.Started {
-				pb = builds[1]
-				if c, ok := jobColors[pb.Status]; ok {
-					color = c
-				}
-				if c, ok := jobBorderColors[pb.Status]; ok {
-					borderColor = c
-				}
+		for _, b := range builds {
+			if b.Status == build.Started && rb == nil {
+				rb = b
+			}
+			if !strings.Contains(b.BuildNumber, ".") && cb == nil {
+				cb = b
+			}
+			if cb != nil && rb != nil {
+				break
 			}
 		}
 
-		if pb == nil && cb != nil && cb.Status != build.Started {
+		// If the latest main build is running, use the previous main build for color
+		if cb != nil && cb.Status == build.Started {
+			for _, b := range builds {
+				if b != cb && !strings.Contains(b.BuildNumber, ".") {
+					if c, ok := jobColors[b.Status]; ok {
+						color = c
+					}
+					if c, ok := jobBorderColors[b.Status]; ok {
+						borderColor = c
+					}
+					break
+				}
+			}
+		} else if cb != nil {
 			if c, ok := jobColors[cb.Status]; ok {
 				color = c
 			}
@@ -495,7 +510,7 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 		}
 
 		style := "invis"
-		if cb != nil && cb.Status == build.Started {
+		if rb != nil {
 			style = `"dashed,bold"`
 		}
 

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -1359,3 +1359,143 @@ func TestGetPipelineImage_ShowsLinkedResources(t *testing.T) {
 	assert.True(t, strings.Contains(dot, `"cron.timer"`), "first linked resource should appear")
 	assert.True(t, strings.Contains(dot, `"git.repo"`), "second linked resource should appear")
 }
+
+func TestGetPipelineImage_JobStatusColors(t *testing.T) {
+	// Helper to build a simple pipeline with one job triggered by a cron resource.
+	makePipeline := func() *pipeline.Pipeline {
+		return &pipeline.Pipeline{
+			Name: "p",
+			Resources: []resource.Resource{
+				{ID: 1, Canonical: "cron.tick"},
+			},
+			Jobs: []job.Job{
+				{
+					ID:   1,
+					Name: "j",
+					Plan: []job.PlanStep{
+						{
+							Type: job.StepTypeGet,
+							Get:  &job.GetStep{Type: "cron", Name: "tick", Trigger: true},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	// Color constants matching pipelines.go
+	colorSucceeded := `"#00A83A"`
+	colorFailed := `"#FF004D"`
+	colorDefault := `"#83769C"`
+	colorStartedBorder := `"#CC8200"`
+
+	tests := []struct {
+		name            string
+		builds          []*build.Build
+		wantFillColor   string
+		wantDashedStyle bool
+	}{
+		{
+			name:            "no builds - default color, no outline",
+			builds:          []*build.Build{},
+			wantFillColor:   colorDefault,
+			wantDashedStyle: false,
+		},
+		{
+			name: "latest main build succeeded",
+			builds: []*build.Build{
+				{ID: 1, BuildNumber: "1", Status: build.Failed},
+				{ID: 2, BuildNumber: "2", Status: build.Succeeded},
+			},
+			wantFillColor:   colorSucceeded,
+			wantDashedStyle: false,
+		},
+		{
+			name: "latest main build failed",
+			builds: []*build.Build{
+				{ID: 1, BuildNumber: "1", Status: build.Succeeded},
+				{ID: 2, BuildNumber: "2", Status: build.Failed},
+			},
+			wantFillColor:   colorFailed,
+			wantDashedStyle: false,
+		},
+		{
+			name: "latest main build running - shows previous color with dashed outline",
+			builds: []*build.Build{
+				{ID: 1, BuildNumber: "1", Status: build.Succeeded},
+				{ID: 2, BuildNumber: "2", Status: build.Started},
+			},
+			wantFillColor:   colorSucceeded,
+			wantDashedStyle: true,
+		},
+		{
+			name: "retry running - latest main build color with dashed outline",
+			builds: []*build.Build{
+				{ID: 1, BuildNumber: "1", Status: build.Failed},
+				{ID: 2, BuildNumber: "1.1", Status: build.Started},
+			},
+			wantFillColor:   colorFailed,
+			wantDashedStyle: true,
+		},
+		{
+			name: "retry succeeded - latest main build color unchanged",
+			builds: []*build.Build{
+				{ID: 1, BuildNumber: "1", Status: build.Failed},
+				{ID: 2, BuildNumber: "1.1", Status: build.Succeeded},
+			},
+			wantFillColor:   colorFailed,
+			wantDashedStyle: false,
+		},
+		{
+			name: "only build is running - default color with dashed outline",
+			builds: []*build.Build{
+				{ID: 1, BuildNumber: "1", Status: build.Started},
+			},
+			wantFillColor:   colorDefault,
+			wantDashedStyle: true,
+		},
+		{
+			name: "multiple main builds with retries - latest main build wins",
+			builds: []*build.Build{
+				{ID: 1, BuildNumber: "1", Status: build.Succeeded},
+				{ID: 2, BuildNumber: "1.1", Status: build.Succeeded},
+				{ID: 3, BuildNumber: "2", Status: build.Failed},
+				{ID: 4, BuildNumber: "2.1", Status: build.Started},
+			},
+			wantFillColor:   colorFailed,
+			wantDashedStyle: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			s := newService(ctrl)
+			ctx := context.TODO()
+
+			pp := makePipeline()
+			s.Pipelines.EXPECT().Find(ctx, "main", "p").Return(pp, nil)
+			s.Builds.EXPECT().Filter(ctx, "main", "p", "j").Return(tt.builds, nil)
+
+			img, err := s.S.GetPipelineImage(ctx, "main", "p", "dot")
+			require.NoError(t, err)
+
+			dot := string(img)
+
+			// Check fill color on the job node
+			assert.Contains(t, dot, fmt.Sprintf("fillcolor=%s", tt.wantFillColor),
+				"expected fill color %s", tt.wantFillColor)
+
+			// Check dashed outline on the subgraph cluster
+			if tt.wantDashedStyle {
+				assert.Contains(t, dot, fmt.Sprintf("color=%s", colorStartedBorder),
+					"expected running border color on subgraph")
+				assert.Contains(t, dot, `style="dashed,bold"`,
+					"expected dashed style on subgraph when build is running")
+			} else {
+				assert.Contains(t, dot, "style=invis",
+					"expected invisible style on subgraph when no build is running")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `ORDER BY b.id ASC` to `BuildRepository.Filter()` so builds are returned in deterministic order — without it, `slices.Reverse` produced arbitrary ordering, causing jobs to show wrong colors
- Determine job fill color from the latest **main** build (excluding retries like `3.1`), so retrying an old build doesn't change the displayed status
- Show the dashed yellow running outline when **any** build (including retries) is running
- Add table-driven tests covering 8 scenarios for the new status logic
