### PR TITLE
Port all API operations to the CLI (#58)

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -12,7 +12,9 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/spf13/cobra"
 	"github.com/xescugc/pikoci/pikoci"
+	"github.com/xescugc/pikoci/pikoci/team"
 	"github.com/xescugc/pikoci/pikoci/transport/http/client"
+	"github.com/xescugc/pikoci/pikoci/user"
 )
 
 var (
@@ -48,6 +50,11 @@ func init() {
 	clientCmd.AddCommand(loginCmd)
 	clientCmd.AddCommand(pipelinesCmd)
 	clientCmd.AddCommand(jobsCmd)
+	clientCmd.AddCommand(usersCmd)
+	clientCmd.AddCommand(teamsCmd)
+	clientCmd.AddCommand(buildsCmd)
+	clientCmd.AddCommand(resourcesCmd)
+	clientCmd.AddCommand(triggersCmd)
 }
 
 // login
@@ -437,4 +444,725 @@ func createPipeline(ctx context.Context, svc pikoci.Service, tc, name, config, v
 	}
 
 	return nil
+}
+
+// users
+var usersCmd = &cobra.Command{
+	Use:   "users",
+	Short: "Interacts with PikoCI Users",
+}
+
+func init() {
+	usersCmd.AddCommand(usersCreateCmd)
+	usersCmd.AddCommand(usersListCmd)
+}
+
+var usersCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Creates a new User",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		username, _ := cmd.Flags().GetString("username")
+		password, _ := cmd.Flags().GetString("password")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		// isHash=false because the CLI receives a plain-text password
+		u, err := c.CreateUser(cmd.Context(), user.User{
+			Username: username,
+			Password: password,
+		}, false)
+		if err != nil {
+			return fmt.Errorf("failed to create User %q: %w", username, err)
+		}
+
+		spew.Dump(u)
+		return nil
+	},
+}
+
+func init() {
+	usersCreateCmd.Flags().String("username", "", "Username for the new User")
+	usersCreateCmd.Flags().String("password", "", "Password for the new User")
+	usersCreateCmd.MarkFlagRequired("username")
+	usersCreateCmd.MarkFlagRequired("password")
+}
+
+var usersListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Lists all Users",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		users, err := c.ListUsers(cmd.Context())
+		if err != nil {
+			return fmt.Errorf("failed to list Users: %w", err)
+		}
+
+		spew.Dump(users)
+		return nil
+	},
+}
+
+// teams
+var teamsCmd = &cobra.Command{
+	Use:   "teams",
+	Short: "Interacts with PikoCI Teams",
+}
+
+func init() {
+	teamsCmd.AddCommand(teamsCreateCmd)
+	teamsCmd.AddCommand(teamsListCmd)
+	teamsCmd.AddCommand(teamsGetCmd)
+	teamsCmd.AddCommand(teamsUpdateCmd)
+	teamsCmd.AddCommand(teamsDeleteCmd)
+	teamsCmd.AddCommand(teamsMembersCmd)
+}
+
+var teamsCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Creates a new Team",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		name, _ := cmd.Flags().GetString("name")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		t, err := c.CreateTeam(cmd.Context(), "", team.Team{Name: name})
+		if err != nil {
+			return fmt.Errorf("failed to create Team %q: %w", name, err)
+		}
+
+		spew.Dump(t)
+		return nil
+	},
+}
+
+func init() {
+	teamsCreateCmd.Flags().String("name", "", "Name of the Team")
+	teamsCreateCmd.MarkFlagRequired("name")
+}
+
+var teamsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Lists all Teams",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		teams, err := c.ListTeams(cmd.Context(), "")
+		if err != nil {
+			return fmt.Errorf("failed to list Teams: %w", err)
+		}
+
+		spew.Dump(teams)
+		return nil
+	},
+}
+
+var teamsGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Gets a Team",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		canonical, _ := cmd.Flags().GetString("canonical")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		t, err := c.GetTeam(cmd.Context(), canonical)
+		if err != nil {
+			return fmt.Errorf("failed to get Team %q: %w", canonical, err)
+		}
+
+		spew.Dump(t)
+		return nil
+	},
+}
+
+func init() {
+	teamsGetCmd.Flags().String("canonical", "", "Canonical of the Team")
+	teamsGetCmd.MarkFlagRequired("canonical")
+}
+
+var teamsUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Updates a Team",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		canonical, _ := cmd.Flags().GetString("canonical")
+		name, _ := cmd.Flags().GetString("name")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		t, err := c.UpdateTeam(cmd.Context(), canonical, team.Team{Name: name})
+		if err != nil {
+			return fmt.Errorf("failed to update Team %q: %w", canonical, err)
+		}
+
+		spew.Dump(t)
+		return nil
+	},
+}
+
+func init() {
+	teamsUpdateCmd.Flags().String("canonical", "", "Canonical of the Team")
+	teamsUpdateCmd.Flags().String("name", "", "New name for the Team")
+	teamsUpdateCmd.MarkFlagRequired("canonical")
+	teamsUpdateCmd.MarkFlagRequired("name")
+}
+
+var teamsDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Deletes a Team",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		canonical, _ := cmd.Flags().GetString("canonical")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		err = c.DeleteTeam(cmd.Context(), canonical)
+		if err != nil {
+			return fmt.Errorf("failed to delete Team %q: %w", canonical, err)
+		}
+
+		fmt.Println("Team deleted successfully")
+		return nil
+	},
+}
+
+func init() {
+	teamsDeleteCmd.Flags().String("canonical", "", "Canonical of the Team")
+	teamsDeleteCmd.MarkFlagRequired("canonical")
+}
+
+// team members
+var teamsMembersCmd = &cobra.Command{
+	Use:   "members",
+	Short: "Interacts with Team Members",
+}
+
+func init() {
+	teamsMembersCmd.PersistentFlags().String("team-canonical", "", "Team Canonical to scope the action")
+	teamsMembersCmd.MarkPersistentFlagRequired("team-canonical")
+
+	teamsMembersCmd.AddCommand(teamsMembersCreateCmd)
+	teamsMembersCmd.AddCommand(teamsMembersUpdateCmd)
+	teamsMembersCmd.AddCommand(teamsMembersDeleteCmd)
+}
+
+var teamsMembersCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Adds a Member to a Team",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		tc, _ := cmd.Flags().GetString("team-canonical")
+		username, _ := cmd.Flags().GetString("username")
+		admin, _ := cmd.Flags().GetBool("admin")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		m, err := c.CreateTeamMember(cmd.Context(), tc, team.Member{
+			Admin: admin,
+			User:  user.User{Username: username},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to add member %q to team %q: %w", username, tc, err)
+		}
+
+		spew.Dump(m)
+		return nil
+	},
+}
+
+func init() {
+	teamsMembersCreateCmd.Flags().String("username", "", "Username of the member to add")
+	teamsMembersCreateCmd.Flags().Bool("admin", false, "Whether the member is a team admin")
+	teamsMembersCreateCmd.MarkFlagRequired("username")
+}
+
+var teamsMembersUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Updates a Team Member",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		tc, _ := cmd.Flags().GetString("team-canonical")
+		username, _ := cmd.Flags().GetString("username")
+		admin, _ := cmd.Flags().GetBool("admin")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		m, err := c.UpdateTeamMember(cmd.Context(), tc, username, team.Member{
+			Admin: admin,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to update member %q in team %q: %w", username, tc, err)
+		}
+
+		spew.Dump(m)
+		return nil
+	},
+}
+
+func init() {
+	teamsMembersUpdateCmd.Flags().String("username", "", "Username of the member to update")
+	teamsMembersUpdateCmd.Flags().Bool("admin", false, "Whether the member is a team admin")
+	teamsMembersUpdateCmd.MarkFlagRequired("username")
+}
+
+var teamsMembersDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Removes a Member from a Team",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		tc, _ := cmd.Flags().GetString("team-canonical")
+		username, _ := cmd.Flags().GetString("username")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		err = c.DeleteTeamMember(cmd.Context(), tc, username)
+		if err != nil {
+			return fmt.Errorf("failed to remove member %q from team %q: %w", username, tc, err)
+		}
+
+		fmt.Println("Team member removed successfully")
+		return nil
+	},
+}
+
+func init() {
+	teamsMembersDeleteCmd.Flags().String("username", "", "Username of the member to remove")
+	teamsMembersDeleteCmd.MarkFlagRequired("username")
+}
+
+// builds
+var buildsCmd = &cobra.Command{
+	Use:   "builds",
+	Short: "Interacts with PikoCI Builds",
+}
+
+func init() {
+	buildsCmd.PersistentFlags().String("team-canonical", "", "Team Canonical to scope the action")
+	buildsCmd.PersistentFlags().String("pipeline-name", "", "Name of the Pipeline")
+	buildsCmd.PersistentFlags().String("job-name", "", "Name of the Job")
+	buildsCmd.MarkPersistentFlagRequired("team-canonical")
+	buildsCmd.MarkPersistentFlagRequired("pipeline-name")
+	buildsCmd.MarkPersistentFlagRequired("job-name")
+
+	buildsCmd.AddCommand(buildsListCmd)
+	buildsCmd.AddCommand(buildsGetCmd)
+	buildsCmd.AddCommand(buildsDeleteCmd)
+	buildsCmd.AddCommand(buildsCancelCmd)
+	buildsCmd.AddCommand(buildsRetryCmd)
+}
+
+var buildsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Lists all Builds for a Job",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		tc, _ := cmd.Flags().GetString("team-canonical")
+		pn, _ := cmd.Flags().GetString("pipeline-name")
+		jn, _ := cmd.Flags().GetString("job-name")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		builds, err := c.ListJobBuilds(cmd.Context(), tc, pn, jn)
+		if err != nil {
+			return fmt.Errorf("failed to list builds for job %q: %w", jn, err)
+		}
+
+		spew.Dump(builds)
+		return nil
+	},
+}
+
+var buildsGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Gets a Build",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		tc, _ := cmd.Flags().GetString("team-canonical")
+		pn, _ := cmd.Flags().GetString("pipeline-name")
+		jn, _ := cmd.Flags().GetString("job-name")
+		bn, _ := cmd.Flags().GetString("build-number")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		b, err := c.GetJobBuild(cmd.Context(), tc, pn, jn, bn)
+		if err != nil {
+			return fmt.Errorf("failed to get build %q: %w", bn, err)
+		}
+
+		spew.Dump(b)
+		return nil
+	},
+}
+
+func init() {
+	buildsGetCmd.Flags().String("build-number", "", "Number of the Build")
+	buildsGetCmd.MarkFlagRequired("build-number")
+}
+
+var buildsDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Deletes a Build",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		tc, _ := cmd.Flags().GetString("team-canonical")
+		pn, _ := cmd.Flags().GetString("pipeline-name")
+		jn, _ := cmd.Flags().GetString("job-name")
+		bn, _ := cmd.Flags().GetString("build-number")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		err = c.DeleteJobBuild(cmd.Context(), tc, pn, jn, bn)
+		if err != nil {
+			return fmt.Errorf("failed to delete build %q: %w", bn, err)
+		}
+
+		fmt.Println("Build deleted successfully")
+		return nil
+	},
+}
+
+func init() {
+	buildsDeleteCmd.Flags().String("build-number", "", "Number of the Build")
+	buildsDeleteCmd.MarkFlagRequired("build-number")
+}
+
+var buildsCancelCmd = &cobra.Command{
+	Use:   "cancel",
+	Short: "Cancels a Build",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		tc, _ := cmd.Flags().GetString("team-canonical")
+		pn, _ := cmd.Flags().GetString("pipeline-name")
+		jn, _ := cmd.Flags().GetString("job-name")
+		bn, _ := cmd.Flags().GetString("build-number")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		err = c.CancelJobBuild(cmd.Context(), tc, pn, jn, bn)
+		if err != nil {
+			return fmt.Errorf("failed to cancel build %q: %w", bn, err)
+		}
+
+		fmt.Println("Build cancelled successfully")
+		return nil
+	},
+}
+
+func init() {
+	buildsCancelCmd.Flags().String("build-number", "", "Number of the Build")
+	buildsCancelCmd.MarkFlagRequired("build-number")
+}
+
+var buildsRetryCmd = &cobra.Command{
+	Use:   "retry",
+	Short: "Retries a Build",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		tc, _ := cmd.Flags().GetString("team-canonical")
+		pn, _ := cmd.Flags().GetString("pipeline-name")
+		jn, _ := cmd.Flags().GetString("job-name")
+		bn, _ := cmd.Flags().GetString("build-number")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		err = c.RetryJobBuild(cmd.Context(), tc, pn, jn, bn)
+		if err != nil {
+			return fmt.Errorf("failed to retry build %q: %w", bn, err)
+		}
+
+		fmt.Println("Build retried successfully")
+		return nil
+	},
+}
+
+func init() {
+	buildsRetryCmd.Flags().String("build-number", "", "Number of the Build")
+	buildsRetryCmd.MarkFlagRequired("build-number")
+}
+
+// resources
+var resourcesCmd = &cobra.Command{
+	Use:   "resources",
+	Short: "Interacts with PikoCI Resources",
+}
+
+func init() {
+	resourcesCmd.PersistentFlags().String("team-canonical", "", "Team Canonical to scope the action")
+	resourcesCmd.PersistentFlags().String("pipeline-name", "", "Name of the Pipeline")
+	resourcesCmd.MarkPersistentFlagRequired("team-canonical")
+	resourcesCmd.MarkPersistentFlagRequired("pipeline-name")
+
+	resourcesCmd.AddCommand(resourcesGetCmd)
+	resourcesCmd.AddCommand(resourcesTriggerCmd)
+	resourcesCmd.AddCommand(resourcesVersionsCmd)
+	resourcesCmd.AddCommand(resourcesWebhookRegenerateCmd)
+}
+
+var resourcesGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Gets a Pipeline Resource",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		tc, _ := cmd.Flags().GetString("team-canonical")
+		pn, _ := cmd.Flags().GetString("pipeline-name")
+		rCan, _ := cmd.Flags().GetString("resource-canonical")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		r, err := c.GetPipelineResource(cmd.Context(), tc, pn, rCan)
+		if err != nil {
+			return fmt.Errorf("failed to get resource %q: %w", rCan, err)
+		}
+
+		spew.Dump(r)
+		return nil
+	},
+}
+
+func init() {
+	resourcesGetCmd.Flags().String("resource-canonical", "", "Canonical of the Resource")
+	resourcesGetCmd.MarkFlagRequired("resource-canonical")
+}
+
+var resourcesTriggerCmd = &cobra.Command{
+	Use:   "trigger",
+	Short: "Triggers a Pipeline Resource check",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		tc, _ := cmd.Flags().GetString("team-canonical")
+		pn, _ := cmd.Flags().GetString("pipeline-name")
+		rCan, _ := cmd.Flags().GetString("resource-canonical")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		err = c.TriggerPipelineResource(cmd.Context(), tc, pn, rCan)
+		if err != nil {
+			return fmt.Errorf("failed to trigger resource %q: %w", rCan, err)
+		}
+
+		fmt.Println("Resource triggered successfully")
+		return nil
+	},
+}
+
+func init() {
+	resourcesTriggerCmd.Flags().String("resource-canonical", "", "Canonical of the Resource")
+	resourcesTriggerCmd.MarkFlagRequired("resource-canonical")
+}
+
+var resourcesVersionsCmd = &cobra.Command{
+	Use:   "versions",
+	Short: "Lists versions of a Pipeline Resource",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		tc, _ := cmd.Flags().GetString("team-canonical")
+		pn, _ := cmd.Flags().GetString("pipeline-name")
+		rCan, _ := cmd.Flags().GetString("resource-canonical")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		versions, err := c.ListResourceVersions(cmd.Context(), tc, pn, rCan)
+		if err != nil {
+			return fmt.Errorf("failed to list versions for resource %q: %w", rCan, err)
+		}
+
+		spew.Dump(versions)
+		return nil
+	},
+}
+
+func init() {
+	resourcesVersionsCmd.Flags().String("resource-canonical", "", "Canonical of the Resource")
+	resourcesVersionsCmd.MarkFlagRequired("resource-canonical")
+}
+
+var resourcesWebhookRegenerateCmd = &cobra.Command{
+	Use:   "webhook-regenerate",
+	Short: "Regenerates the webhook token for a Pipeline Resource",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		tc, _ := cmd.Flags().GetString("team-canonical")
+		pn, _ := cmd.Flags().GetString("pipeline-name")
+		rCan, _ := cmd.Flags().GetString("resource-canonical")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		token, err := c.RegenerateWebhookToken(cmd.Context(), tc, pn, rCan)
+		if err != nil {
+			return fmt.Errorf("failed to regenerate webhook token for resource %q: %w", rCan, err)
+		}
+
+		fmt.Println(token)
+		return nil
+	},
+}
+
+func init() {
+	resourcesWebhookRegenerateCmd.Flags().String("resource-canonical", "", "Canonical of the Resource")
+	resourcesWebhookRegenerateCmd.MarkFlagRequired("resource-canonical")
+}
+
+// triggers
+var triggersCmd = &cobra.Command{
+	Use:   "triggers",
+	Short: "Interacts with PikoCI Triggers",
+}
+
+func init() {
+	triggersCmd.PersistentFlags().String("team-canonical", "", "Team Canonical to scope the action")
+	triggersCmd.MarkPersistentFlagRequired("team-canonical")
+
+	triggersCmd.AddCommand(triggersCreateCmd)
+	triggersCmd.AddCommand(triggersListCmd)
+}
+
+var triggersCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Creates a new Trigger",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		tc, _ := cmd.Flags().GetString("team-canonical")
+		name, _ := cmd.Flags().GetString("name")
+		versionStr, _ := cmd.Flags().GetString("version")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		var version map[string]interface{}
+		if err := json.Unmarshal([]byte(versionStr), &version); err != nil {
+			return fmt.Errorf("failed to parse version JSON: %w", err)
+		}
+
+		t, err := c.CreateTrigger(cmd.Context(), tc, name, version)
+		if err != nil {
+			return fmt.Errorf("failed to create trigger %q: %w", name, err)
+		}
+
+		spew.Dump(t)
+		return nil
+	},
+}
+
+func init() {
+	triggersCreateCmd.Flags().String("name", "", "Name of the Trigger")
+	triggersCreateCmd.Flags().String("version", "", "Version data as a JSON string")
+	triggersCreateCmd.MarkFlagRequired("name")
+	triggersCreateCmd.MarkFlagRequired("version")
+}
+
+var triggersListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Lists Triggers",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		tc, _ := cmd.Flags().GetString("team-canonical")
+		name, _ := cmd.Flags().GetString("name")
+		after, _ := cmd.Flags().GetUint32("after")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		triggers, err := c.ListTriggersAfter(cmd.Context(), tc, name, after)
+		if err != nil {
+			return fmt.Errorf("failed to list triggers %q: %w", name, err)
+		}
+
+		spew.Dump(triggers)
+		return nil
+	},
+}
+
+func init() {
+	triggersListCmd.Flags().String("name", "", "Name of the Trigger")
+	triggersListCmd.Flags().Uint32("after", 0, "List triggers after this ID")
+	triggersListCmd.MarkFlagRequired("name")
 }

--- a/cmd/client_test.go
+++ b/cmd/client_test.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func findSubcommand(parent *cobra.Command, name string) *cobra.Command {
+	for _, c := range parent.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	return nil
+}
+
+func TestCommandTree(t *testing.T) {
+	tests := []struct {
+		parent      *cobra.Command
+		parentName  string
+		subcommands []string
+	}{
+		{clientCmd, "client", []string{"login", "pipelines", "jobs", "users", "teams", "builds", "resources", "triggers"}},
+		{usersCmd, "users", []string{"create", "list"}},
+		{teamsCmd, "teams", []string{"create", "list", "get", "update", "delete", "members"}},
+		{teamsMembersCmd, "members", []string{"create", "update", "delete"}},
+		{buildsCmd, "builds", []string{"list", "get", "delete", "cancel", "retry"}},
+		{resourcesCmd, "resources", []string{"get", "trigger", "versions", "webhook-regenerate"}},
+		{triggersCmd, "triggers", []string{"create", "list"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.parentName, func(t *testing.T) {
+			for _, name := range tt.subcommands {
+				sub := findSubcommand(tt.parent, name)
+				assert.NotNilf(t, sub, "expected subcommand %q under %q", name, tt.parentName)
+			}
+		})
+	}
+}
+
+func TestRequiredFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmd      *cobra.Command
+		required []string
+	}{
+		{"users create", usersCreateCmd, []string{"username", "password"}},
+		{"teams create", teamsCreateCmd, []string{"name"}},
+		{"teams get", teamsGetCmd, []string{"canonical"}},
+		{"teams update", teamsUpdateCmd, []string{"canonical", "name"}},
+		{"teams delete", teamsDeleteCmd, []string{"canonical"}},
+		{"members create", teamsMembersCreateCmd, []string{"username"}},
+		{"members update", teamsMembersUpdateCmd, []string{"username"}},
+		{"members delete", teamsMembersDeleteCmd, []string{"username"}},
+		{"builds get", buildsGetCmd, []string{"build-number"}},
+		{"builds delete", buildsDeleteCmd, []string{"build-number"}},
+		{"builds cancel", buildsCancelCmd, []string{"build-number"}},
+		{"builds retry", buildsRetryCmd, []string{"build-number"}},
+		{"resources get", resourcesGetCmd, []string{"resource-canonical"}},
+		{"resources trigger", resourcesTriggerCmd, []string{"resource-canonical"}},
+		{"resources versions", resourcesVersionsCmd, []string{"resource-canonical"}},
+		{"resources webhook-regenerate", resourcesWebhookRegenerateCmd, []string{"resource-canonical"}},
+		{"triggers create", triggersCreateCmd, []string{"name", "version"}},
+		{"triggers list", triggersListCmd, []string{"name"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, flagName := range tt.required {
+				f := tt.cmd.Flags().Lookup(flagName)
+				require.NotNilf(t, f, "flag %q not found on %q", flagName, tt.name)
+				ann := tt.cmd.Flags().Lookup(flagName).Annotations
+				_, isRequired := ann[cobra.BashCompOneRequiredFlag]
+				assert.Truef(t, isRequired, "flag %q on %q should be required", flagName, tt.name)
+			}
+		})
+	}
+}
+
+func TestPersistentFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		parent  *cobra.Command
+		child   *cobra.Command
+		flags   []string
+	}{
+		{"builds persistent flags", buildsCmd, buildsListCmd, []string{"team-canonical", "pipeline-name", "job-name"}},
+		{"resources persistent flags", resourcesCmd, resourcesGetCmd, []string{"team-canonical", "pipeline-name"}},
+		{"triggers persistent flags", triggersCmd, triggersCreateCmd, []string{"team-canonical"}},
+		{"members persistent flags", teamsMembersCmd, teamsMembersCreateCmd, []string{"team-canonical"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, flagName := range tt.flags {
+				f := tt.parent.PersistentFlags().Lookup(flagName)
+				require.NotNilf(t, f, "persistent flag %q not found on parent %q", flagName, tt.name)
+				// Verify child inherits the flag
+				inherited := tt.child.InheritedFlags().Lookup(flagName)
+				assert.NotNilf(t, inherited, "child should inherit persistent flag %q from parent", flagName)
+			}
+		})
+	}
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -141,6 +141,253 @@ pikoci client -u localhost:8080 jobs trigger -tc main -pn my-pipeline -n my-job
 |------|-------|----------|-------------|
 | `--job-name` | `-n`, `-jn` | **yes** | Job name |
 
+### users
+
+User management commands.
+
+#### users create
+
+```bash
+pikoci client users create --username newuser --password secret123
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--username` | **yes** | Username for the new User |
+| `--password` | **yes** | Password for the new User |
+
+#### users list
+
+```bash
+pikoci client users list
+```
+
+### teams
+
+Team management commands.
+
+#### teams create
+
+```bash
+pikoci client teams create --name my-team
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--name` | **yes** | Name of the Team |
+
+#### teams list
+
+```bash
+pikoci client teams list
+```
+
+#### teams get
+
+```bash
+pikoci client teams get --canonical my-team
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--canonical` | **yes** | Canonical of the Team |
+
+#### teams update
+
+```bash
+pikoci client teams update --canonical my-team --name new-name
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--canonical` | **yes** | Canonical of the Team |
+| `--name` | **yes** | New name for the Team |
+
+#### teams delete
+
+```bash
+pikoci client teams delete --canonical my-team
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--canonical` | **yes** | Canonical of the Team |
+
+#### teams members
+
+Team member management. All subcommands require `--team-canonical`.
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--team-canonical` | **yes** | Team scope |
+
+##### teams members create
+
+```bash
+pikoci client teams members create --team-canonical my-team --username user1 --admin
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--username` | **yes** | Username of the member to add |
+| `--admin` | no | Whether the member is a team admin |
+
+##### teams members update
+
+```bash
+pikoci client teams members update --team-canonical my-team --username user1 --admin
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--username` | **yes** | Username of the member to update |
+| `--admin` | no | Whether the member is a team admin |
+
+##### teams members delete
+
+```bash
+pikoci client teams members delete --team-canonical my-team --username user1
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--username` | **yes** | Username of the member to remove |
+
+### builds
+
+Build management commands. All require `--team-canonical`, `--pipeline-name`, and `--job-name`.
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--team-canonical` | **yes** | Team scope |
+| `--pipeline-name` | **yes** | Pipeline name |
+| `--job-name` | **yes** | Job name |
+
+#### builds list
+
+```bash
+pikoci client builds list --team-canonical main --pipeline-name my-pipeline --job-name my-job
+```
+
+#### builds get
+
+```bash
+pikoci client builds get --team-canonical main --pipeline-name my-pipeline --job-name my-job --build-number 1
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--build-number` | **yes** | Number of the Build |
+
+#### builds delete
+
+```bash
+pikoci client builds delete --team-canonical main --pipeline-name my-pipeline --job-name my-job --build-number 1
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--build-number` | **yes** | Number of the Build |
+
+#### builds cancel
+
+```bash
+pikoci client builds cancel --team-canonical main --pipeline-name my-pipeline --job-name my-job --build-number 1
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--build-number` | **yes** | Number of the Build |
+
+#### builds retry
+
+```bash
+pikoci client builds retry --team-canonical main --pipeline-name my-pipeline --job-name my-job --build-number 1
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--build-number` | **yes** | Number of the Build |
+
+### resources
+
+Resource management commands. All require `--team-canonical` and `--pipeline-name`.
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--team-canonical` | **yes** | Team scope |
+| `--pipeline-name` | **yes** | Pipeline name |
+
+#### resources get
+
+```bash
+pikoci client resources get --team-canonical main --pipeline-name my-pipeline --resource-canonical my-resource
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--resource-canonical` | **yes** | Canonical of the Resource |
+
+#### resources trigger
+
+```bash
+pikoci client resources trigger --team-canonical main --pipeline-name my-pipeline --resource-canonical my-resource
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--resource-canonical` | **yes** | Canonical of the Resource |
+
+#### resources versions
+
+```bash
+pikoci client resources versions --team-canonical main --pipeline-name my-pipeline --resource-canonical my-resource
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--resource-canonical` | **yes** | Canonical of the Resource |
+
+#### resources webhook-regenerate
+
+```bash
+pikoci client resources webhook-regenerate --team-canonical main --pipeline-name my-pipeline --resource-canonical my-resource
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--resource-canonical` | **yes** | Canonical of the Resource |
+
+### triggers
+
+Trigger management commands. All require `--team-canonical`.
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--team-canonical` | **yes** | Team scope |
+
+#### triggers create
+
+```bash
+pikoci client triggers create --team-canonical main --name my-trigger --version '{"ref": "abc123"}'
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--name` | **yes** | Name of the Trigger |
+| `--version` | **yes** | Version data as a JSON string |
+
+#### triggers list
+
+```bash
+pikoci client triggers list --team-canonical main --name my-trigger --after 0
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--name` | **yes** | Name of the Trigger |
+| `--after` | no | List triggers after this ID (default: 0) |
+
 ## user-password
 
 Generate a `USERNAME:HASHED_PASSWORD` string for the server's `--users` flag.


### PR DESCRIPTION
## Summary

- Adds 21 new CLI commands across 6 command groups: `users`, `teams`, `teams members`, `builds`, `resources`, and `triggers`
- Creates `cmd/client_test.go` with tests for command tree structure, required flag enforcement, and persistent flag inheritance
- Updates `docs/CLI.md` with documentation and examples for all new commands

Closes #58