### PR TITLE
Fix pipeline graph: show retry status instead of original build status

### DIFF
--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -477,38 +477,46 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 		color := colorDefault
 		borderColor := colorDefaultBorder
 
-		// cb: latest main build (no retry suffix) for fill color
+		// cb: latest completed build (including retries) for fill color.
+		//     For the most recent main build number, if a retry succeeded
+		//     the color should reflect that success, not the original failure.
 		// rb: any running build (including retries) for dashed outline
 		var (
 			cb *build.Build
 			rb *build.Build
 		)
+		// Find the latest main build number first
+		var latestMain string
 		for _, b := range builds {
 			if b.Status == build.Started && rb == nil {
 				rb = b
 			}
-			if !strings.Contains(b.BuildNumber, ".") && cb == nil {
-				cb = b
+			if !strings.Contains(b.BuildNumber, ".") && latestMain == "" {
+				latestMain = b.BuildNumber
 			}
-			if cb != nil && rb != nil {
-				break
+		}
+		// Find the latest terminal build in that group (main + retries)
+		if latestMain != "" {
+			for _, b := range builds {
+				if b.BuildNumber == latestMain || strings.HasPrefix(b.BuildNumber, latestMain+".") {
+					if b.Status != build.Started {
+						cb = b
+						break
+					}
+				}
+			}
+			// If all builds in the group are running, fall back to previous main build
+			if cb == nil {
+				for _, b := range builds {
+					if b.Status != build.Started && !strings.Contains(b.BuildNumber, ".") && b.BuildNumber != latestMain {
+						cb = b
+						break
+					}
+				}
 			}
 		}
 
-		// If the latest main build is running, use the previous main build for color
-		if cb != nil && cb.Status == build.Started {
-			for _, b := range builds {
-				if b != cb && !strings.Contains(b.BuildNumber, ".") {
-					if c, ok := jobColors[b.Status]; ok {
-						color = c
-					}
-					if c, ok := jobBorderColors[b.Status]; ok {
-						borderColor = c
-					}
-					break
-				}
-			}
-		} else if cb != nil {
+		if cb != nil {
 			if c, ok := jobColors[cb.Status]; ok {
 				color = c
 			}

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -1443,12 +1443,12 @@ func TestGetPipelineImage_JobStatusColors(t *testing.T) {
 			wantDashedStyle: true,
 		},
 		{
-			name: "retry succeeded - latest main build color unchanged",
+			name: "retry succeeded - color reflects retry success",
 			builds: []*build.Build{
 				{ID: 1, BuildNumber: "1", Status: build.Failed},
 				{ID: 2, BuildNumber: "1.1", Status: build.Succeeded},
 			},
-			wantFillColor:   colorFailed,
+			wantFillColor:   colorSucceeded,
 			wantDashedStyle: false,
 		},
 		{


### PR DESCRIPTION
When a build fails and is retried successfully, the pipeline graph now
reflects the retry outcome. Previously it always showed the status of
the original (main) build number, so a successful retry would still
show red.

Now the graph picks the latest terminal build in the group (main +
retries) for the fill color. For example, if build 6 failed but
retry 6.1 succeeded, the job shows green.