### PR TITLE
Add local pipeline execution: pikoci run (#161)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,29 @@ job "gen" {
 ```
 
 
+## Local Execution
+
+Run a single pipeline job locally without starting a server. PikoCI spins up an in-memory database, pubsub, and worker in a single process, executes the job, streams the output, and exits with an appropriate exit code.
+
+```bash
+# Run a job from a pipeline file
+pikoci run -p pipeline.hcl -j my-job
+
+# Override variables
+pikoci run -p pipeline.hcl -j my-job --var db_password=local
+
+# Use a local directory instead of pulling a resource (type.name format)
+pikoci run -p pipeline.hcl -j test --resource git.my-repo=./my-repo
+
+# Load variables from a JSON file
+pikoci run -p pipeline.hcl -j my-job -v vars.json
+```
+
+Resource overrides (`--resource name=path`) copy the local directory into the working directory, skipping the resource type's pull command entirely. This is useful for testing pipeline changes against local code.
+
+See [#161](https://github.com/xescugc/pikoci/issues/161) for more details.
+
+
 ## Examples
 
 The [`examples/`](examples/) folder contains ready-to-run pipelines and a Docker Compose file for one-command evaluation. See the [examples README](examples/README.md) for details.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,4 +23,5 @@ func init() {
 	rootCmd.AddCommand(workerCmd)
 	rootCmd.AddCommand(workerTokenCmd)
 	rootCmd.AddCommand(userPasswordCmd)
+	rootCmd.AddCommand(runCmd)
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,0 +1,338 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/cycloidio/sqlr"
+	"github.com/spf13/cobra"
+	"github.com/xescugc/pikoci/pikoci"
+	"github.com/xescugc/pikoci/pikoci/build"
+	"github.com/xescugc/pikoci/pikoci/mysql"
+	"github.com/lopezator/migrator"
+	"github.com/xescugc/pikoci/pikoci/mysql/migrate"
+	"github.com/xescugc/pikoci/pikoci/resource"
+	"github.com/xescugc/pikoci/pikoci/unitwork"
+	"github.com/xescugc/pikoci/worker"
+	"gocloud.dev/pubsub"
+
+	_ "gocloud.dev/pubsub/mempubsub"
+)
+
+// ExitError wraps an exit code so cobra's RunE can propagate it without
+// calling os.Exit directly (which would bypass deferred cleanup).
+type ExitError struct {
+	Code int
+}
+
+func (e *ExitError) Error() string {
+	return fmt.Sprintf("exit code %d", e.Code)
+}
+
+var runCmd = &cobra.Command{
+	Use:           "run",
+	Short:         "Run a pipeline job locally",
+	Long:          "Execute a single job from a pipeline HCL file directly on the local machine without needing a server.",
+	SilenceErrors: true,
+	SilenceUsage:  true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		pipelineConfig, _ := cmd.Flags().GetString("pipeline-config")
+		jobName, _ := cmd.Flags().GetString("job")
+		varFlags, _ := cmd.Flags().GetStringSlice("var")
+		varsFile, _ := cmd.Flags().GetString("vars")
+		resourceFlags, _ := cmd.Flags().GetStringSlice("resource")
+		logLevel, _ := cmd.Flags().GetString("log-level")
+
+		if pipelineConfig == "" {
+			return fmt.Errorf("required flag \"pipeline-config\" not set")
+		}
+		if jobName == "" {
+			return fmt.Errorf("required flag \"job\" not set")
+		}
+
+		vars, err := buildVars(varFlags, varsFile)
+		if err != nil {
+			return err
+		}
+
+		resourceOverrides, err := parseResourceFlags(resourceFlags)
+		if err != nil {
+			return err
+		}
+
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: parseSlogLevel(logLevel)}))
+
+		exitCode, err := runLocal(cmd.Context(), logger, pipelineConfig, jobName, vars, resourceOverrides)
+		if err != nil {
+			return err
+		}
+		if exitCode != 0 {
+			return &ExitError{Code: exitCode}
+		}
+		return nil
+	},
+}
+
+func init() {
+	runCmd.Flags().StringP("pipeline-config", "p", "", "Path to the pipeline HCL file")
+	runCmd.Flags().StringP("job", "j", "", "Job name to execute")
+	runCmd.Flags().StringSlice("var", nil, "Variable overrides in key=value format (repeatable)")
+	runCmd.Flags().StringP("vars", "v", "", "Path to the Pipeline var file (JSON)")
+	runCmd.Flags().StringSlice("resource", nil, "Resource overrides in type.name=path format (repeatable, e.g. git.my-repo=./local-dir)")
+	runCmd.Flags().String("log-level", "error", "Sets the log level ('debug', 'info', 'warn', 'error')")
+}
+
+func buildVars(varFlags []string, varsFile string) (map[string]interface{}, error) {
+	vars := make(map[string]interface{})
+
+	if varsFile != "" {
+		f, err := os.Open(varsFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open vars file %q: %w", varsFile, err)
+		}
+		defer f.Close()
+		if err := json.NewDecoder(f).Decode(&vars); err != nil {
+			return nil, fmt.Errorf("failed to decode vars file %q: %w", varsFile, err)
+		}
+	}
+
+	for _, v := range varFlags {
+		parts := strings.SplitN(v, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid --var format %q, expected key=value", v)
+		}
+		vars[parts[0]] = parts[1]
+	}
+
+	if len(vars) == 0 {
+		return nil, nil
+	}
+	return vars, nil
+}
+
+func parseResourceFlags(flags []string) (map[string]string, error) {
+	if len(flags) == 0 {
+		return nil, nil
+	}
+	overrides := make(map[string]string)
+	for _, f := range flags {
+		parts := strings.SplitN(f, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid --resource format %q, expected name=path", f)
+		}
+		overrides[parts[0]] = parts[1]
+	}
+	return overrides, nil
+}
+
+func runLocal(ctx context.Context, logger *slog.Logger, pipelineConfig, jobName string, vars map[string]interface{}, resourceOverrides map[string]string) (int, error) {
+	// Read the pipeline HCL file
+	hclBytes, err := os.ReadFile(pipelineConfig)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read pipeline config %q: %w", pipelineConfig, err)
+	}
+
+	// Create in-memory DB
+	db, err := mysql.New("", 0, "", "", mysql.Options{
+		System:          mysql.Mem,
+		MultiStatements: true,
+		ClientFoundRows: true,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to create in-memory database: %w", err)
+	}
+	defer db.Close()
+
+	// Run migrations silently (creates "main" team + "admin" user)
+	nopLogger := migrator.WithLogger(migrator.LoggerFunc(func(string, ...interface{}) {}))
+	if err := migrate.Migrate(db, mysql.Mem, nopLogger); err != nil {
+		return 0, fmt.Errorf("failed to run migrations: %w", err)
+	}
+
+	// Create repositories
+	var querier sqlr.Querier = db
+	ur := mysql.NewUserRepository(querier)
+	tr := mysql.NewTeamRepository(querier)
+	ppr := mysql.NewPipelineRepository(querier)
+	jr := mysql.NewJobRepository(querier)
+	rr := mysql.NewResourceRepository(querier, mysql.Mem)
+	rt := mysql.NewResourceTypeRepository(querier)
+	br := mysql.NewBuildRepository(querier, mysql.Mem)
+	rur := mysql.NewRunnerRepository(querier)
+	str := mysql.NewSecretTypeRepository(querier)
+	tgr := mysql.NewTriggerRepository(querier)
+
+	suow := unitwork.NewStartUnitOfWork(db, mysql.Mem)
+
+	// Create pubsub with a unique topic name to avoid conflicts
+	topicName := fmt.Sprintf("mem://pikoci-run-%s", uuid.New().String())
+	topic, err := pubsub.OpenTopic(ctx, topicName)
+	if err != nil {
+		return 0, fmt.Errorf("failed to open topic: %w", err)
+	}
+	defer topic.Shutdown(ctx)
+
+	subscription, err := pubsub.OpenSubscription(ctx, topicName)
+	if err != nil {
+		return 0, fmt.Errorf("failed to open subscription: %w", err)
+	}
+	defer subscription.Shutdown(ctx)
+
+	// Create service (do NOT start scheduler)
+	jwtSecret := []byte("local-run-secret")
+	svc := pikoci.New(ctx, topic, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, suow, jwtSecret, logger)
+
+	// Create pipeline
+	pp, err := svc.CreatePipeline(ctx, mainTeamCanonical, "local", hclBytes, vars)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create pipeline: %w", err)
+	}
+
+	// Verify the job exists
+	_, err = svc.GetPipelineJob(ctx, mainTeamCanonical, "local", jobName)
+	if err != nil {
+		return 0, fmt.Errorf("job %q not found in pipeline: %w", jobName, err)
+	}
+
+	// Seed synthetic resource versions for each resource so get steps have something to pull
+	for _, r := range pp.Resources {
+		_, err := svc.CreateResourceVersion(ctx, mainTeamCanonical, "local", r.Canonical, resource.Version{
+			Version: map[string]interface{}{"ref": "HEAD"},
+		})
+		if err != nil {
+			return 0, fmt.Errorf("failed to seed resource version for %q: %w", r.Canonical, err)
+		}
+	}
+
+	// Build resource override map: keys must use canonical format (type.name)
+	var workerResourceOverrides map[string]string
+	if len(resourceOverrides) > 0 {
+		workerResourceOverrides = make(map[string]string)
+		for canonical, path := range resourceOverrides {
+			found := false
+			for _, r := range pp.Resources {
+				if r.Canonical == canonical {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return 0, fmt.Errorf("resource %q not found in pipeline (use type.name format, e.g. git.my-repo)", canonical)
+			}
+			workerResourceOverrides[canonical] = path
+		}
+	}
+
+	// Create worker with overrides
+	workerLogger := logger.With("service", "worker")
+	w := worker.New(svc, topic, subscription, workerLogger)
+	w.ResourceOverrides = workerResourceOverrides
+	w.LocalMode = true
+
+	// Start worker in goroutine
+	workerCtx, workerCancel := context.WithCancel(ctx)
+	defer workerCancel()
+
+	workerDone := make(chan error, 1)
+	go func() {
+		workerDone <- w.Run(workerCtx)
+	}()
+
+	// Trigger the job
+	if err := svc.TriggerPipelineJob(ctx, mainTeamCanonical, "local", jobName); err != nil {
+		return 0, fmt.Errorf("failed to trigger job %q: %w", jobName, err)
+	}
+
+	// Poll loop: stream output and wait for terminal status
+	printedSteps := 0
+	printedBytes := make(map[int]int)
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return 1, ctx.Err()
+		case err := <-workerDone:
+			if err != nil {
+				return 1, fmt.Errorf("worker error: %w", err)
+			}
+			// Worker exited cleanly but shouldn't before we're done polling
+			// This can happen if context is cancelled
+			return 1, nil
+		case <-ticker.C:
+			builds, err := svc.ListJobBuilds(ctx, mainTeamCanonical, "local", jobName)
+			if err != nil {
+				continue
+			}
+			if len(builds) == 0 {
+				continue
+			}
+
+			b := builds[0] // most recent build
+
+			// Print incremental log updates for already-seen steps first,
+			// so existing step output completes before new step headers.
+			for i := 0; i < printedSteps && i < len(b.Steps); i++ {
+				step := b.Steps[i]
+				prev := printedBytes[i]
+				if len(step.Logs) > prev {
+					delta := step.Logs[prev:]
+					fmt.Fprint(os.Stdout, delta)
+					if !strings.HasSuffix(delta, "\n") {
+						fmt.Fprintln(os.Stdout)
+					}
+					printedBytes[i] = len(step.Logs)
+				}
+			}
+
+			// Print new steps and their logs
+			for i := printedSteps; i < len(b.Steps); i++ {
+				step := b.Steps[i]
+				fmt.Fprintf(os.Stdout, "==> [%s] %s\n", step.Type, step.Name)
+				if len(step.Logs) > 0 {
+					fmt.Fprint(os.Stdout, step.Logs)
+					if !strings.HasSuffix(step.Logs, "\n") {
+						fmt.Fprintln(os.Stdout)
+					}
+					printedBytes[i] = len(step.Logs)
+				}
+				printedSteps = i + 1
+			}
+
+			// Check if build is terminal
+			if b.Status == build.Succeeded || b.Status == build.Failed || b.Status == build.Cancelled {
+				// Print job-level logs (hooks like on_success, on_failure, ensure)
+				for _, step := range b.Job {
+					fmt.Fprintf(os.Stdout, "==> [%s] %s\n", step.Type, step.Name)
+					if len(step.Logs) > 0 {
+						fmt.Fprint(os.Stdout, step.Logs)
+						if !strings.HasSuffix(step.Logs, "\n") {
+							fmt.Fprintln(os.Stdout)
+						}
+					}
+				}
+
+				workerCancel()
+				switch b.Status {
+				case build.Succeeded:
+					fmt.Fprintf(os.Stdout, "\n✓ job %q succeeded\n", jobName)
+					return 0, nil
+				case build.Failed:
+					fmt.Fprintf(os.Stdout, "\n✗ job %q failed\n", jobName)
+					return 1, nil
+				case build.Cancelled:
+					fmt.Fprintf(os.Stdout, "\n⊘ job %q cancelled\n", jobName)
+					return 1, nil
+				}
+			}
+		}
+	}
+}

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,0 +1,315 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunLocal_BasicExec(t *testing.T) {
+	dir := t.TempDir()
+	hcl := `
+job "hello" {
+  task "echo" {
+    run "exec" {
+      path = "echo"
+      args = ["Hello from local run!"]
+    }
+  }
+}
+`
+	hclPath := filepath.Join(dir, "pipeline.hcl")
+	require.NoError(t, os.WriteFile(hclPath, []byte(hcl), 0644))
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	exitCode, err := runLocal(context.Background(), logger, hclPath, "hello", nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
+}
+
+func TestRunLocal_FailedJob(t *testing.T) {
+	dir := t.TempDir()
+	hcl := `
+job "fail" {
+  task "die" {
+    run "exec" {
+      path = "sh"
+      args = ["-c", "exit 1"]
+    }
+  }
+}
+`
+	hclPath := filepath.Join(dir, "pipeline.hcl")
+	require.NoError(t, os.WriteFile(hclPath, []byte(hcl), 0644))
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	exitCode, err := runLocal(context.Background(), logger, hclPath, "fail", nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, exitCode)
+}
+
+func TestRunLocal_VarOverride(t *testing.T) {
+	dir := t.TempDir()
+	hcl := `
+variable "greeting" {
+  type    = string
+  default = "default"
+}
+
+job "hello" {
+  task "echo" {
+    run "exec" {
+      path = "sh"
+      args = ["-c", "echo ${var.greeting}"]
+    }
+  }
+}
+`
+	hclPath := filepath.Join(dir, "pipeline.hcl")
+	require.NoError(t, os.WriteFile(hclPath, []byte(hcl), 0644))
+
+	vars := map[string]interface{}{"greeting": "overridden"}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	exitCode, err := runLocal(context.Background(), logger, hclPath, "hello", vars, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
+}
+
+func TestRunLocal_VarsFile(t *testing.T) {
+	dir := t.TempDir()
+	hcl := `
+variable "msg" {
+  type    = string
+  default = "none"
+}
+
+job "hello" {
+  task "echo" {
+    run "exec" {
+      path = "sh"
+      args = ["-c", "echo ${var.msg}"]
+    }
+  }
+}
+`
+	hclPath := filepath.Join(dir, "pipeline.hcl")
+	require.NoError(t, os.WriteFile(hclPath, []byte(hcl), 0644))
+
+	varsData := map[string]interface{}{"msg": "from-file"}
+	varsBytes, err := json.Marshal(varsData)
+	require.NoError(t, err)
+	varsFile := filepath.Join(dir, "vars.json")
+	require.NoError(t, os.WriteFile(varsFile, varsBytes, 0644))
+
+	vars, err := buildVars(nil, varsFile)
+	require.NoError(t, err)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	exitCode, err := runLocal(context.Background(), logger, hclPath, "hello", vars, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
+}
+
+func TestRunLocal_SecretVarOverride(t *testing.T) {
+	dir := t.TempDir()
+	hcl := `
+secret_type "env" {
+  source = "pikoci://file"
+  format = "env"
+  path   = "/nonexistent/secrets.env"
+}
+
+variable "my_secret" {
+  type = string
+  secret "env" {
+    key = "MY_SECRET"
+  }
+}
+
+job "hello" {
+  task "echo" {
+    run "exec" {
+      path = "sh"
+      args = ["-c", "echo ${var.my_secret}"]
+    }
+  }
+}
+`
+	hclPath := filepath.Join(dir, "pipeline.hcl")
+	require.NoError(t, os.WriteFile(hclPath, []byte(hcl), 0644))
+
+	// Override the secret-backed variable with --var so secret resolution is not needed
+	vars := map[string]interface{}{"my_secret": "overridden-value"}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	exitCode, err := runLocal(context.Background(), logger, hclPath, "hello", vars, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
+}
+
+func TestRunLocal_ResourceOverride(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a local resource directory with a file
+	resDir := filepath.Join(dir, "my-repo")
+	require.NoError(t, os.MkdirAll(resDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(resDir, "hello.txt"), []byte("hello"), 0644))
+
+	hcl := `
+resource_type "git" {
+  params = ["uri"]
+  check "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo [{\"ref\":\"abc\"}]"]
+  }
+  pull "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo pulling"]
+  }
+}
+
+resource "git" "my-repo" {
+  params {
+    uri = "https://example.com/repo.git"
+  }
+}
+
+job "test" {
+  get "git" "my-repo" {
+    trigger = true
+  }
+  task "check" {
+    run "exec" {
+      path = "sh"
+      args = ["-c", "test -f my-repo/hello.txt"]
+    }
+  }
+}
+`
+	hclPath := filepath.Join(dir, "pipeline.hcl")
+	require.NoError(t, os.WriteFile(hclPath, []byte(hcl), 0644))
+
+	overrides := map[string]string{"git.my-repo": resDir}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	exitCode, err := runLocal(context.Background(), logger, hclPath, "test", nil, overrides)
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
+}
+
+func TestRunLocal_ResourceOverride_MissingPath(t *testing.T) {
+	dir := t.TempDir()
+
+	hcl := `
+resource_type "git" {
+  params = ["uri"]
+  check "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo [{\"ref\":\"abc\"}]"]
+  }
+  pull "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo pulling"]
+  }
+}
+
+resource "git" "my-repo" {
+  params {
+    uri = "https://example.com/repo.git"
+  }
+}
+
+job "test" {
+  get "git" "my-repo" {
+    trigger = true
+  }
+  task "check" {
+    run "exec" {
+      path = "echo"
+      args = ["hello"]
+    }
+  }
+}
+`
+	hclPath := filepath.Join(dir, "pipeline.hcl")
+	require.NoError(t, os.WriteFile(hclPath, []byte(hcl), 0644))
+
+	overrides := map[string]string{"git.my-repo": filepath.Join(dir, "does-not-exist")}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	exitCode, err := runLocal(context.Background(), logger, hclPath, "test", nil, overrides)
+	require.NoError(t, err)
+	assert.Equal(t, 1, exitCode)
+}
+
+func TestRunLocal_InvalidJob(t *testing.T) {
+	dir := t.TempDir()
+	hcl := `
+job "hello" {
+  task "echo" {
+    run "exec" {
+      path = "echo"
+      args = ["hello"]
+    }
+  }
+}
+`
+	hclPath := filepath.Join(dir, "pipeline.hcl")
+	require.NoError(t, os.WriteFile(hclPath, []byte(hcl), 0644))
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	_, err := runLocal(context.Background(), logger, hclPath, "nonexistent", nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nonexistent")
+}
+
+func TestRunLocal_InvalidPipeline(t *testing.T) {
+	dir := t.TempDir()
+	hclPath := filepath.Join(dir, "pipeline.hcl")
+	require.NoError(t, os.WriteFile(hclPath, []byte("this is not valid HCL {{{"), 0644))
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	_, err := runLocal(context.Background(), logger, hclPath, "test", nil, nil)
+	require.Error(t, err)
+}
+
+func TestBuildVars(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		vars, err := buildVars(nil, "")
+		require.NoError(t, err)
+		assert.Nil(t, vars)
+	})
+
+	t.Run("flags only", func(t *testing.T) {
+		vars, err := buildVars([]string{"key=value", "foo=bar"}, "")
+		require.NoError(t, err)
+		assert.Equal(t, map[string]interface{}{"key": "value", "foo": "bar"}, vars)
+	})
+
+	t.Run("invalid flag format", func(t *testing.T) {
+		_, err := buildVars([]string{"no-equals"}, "")
+		require.Error(t, err)
+	})
+}
+
+func TestParseResourceFlags(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		overrides, err := parseResourceFlags(nil)
+		require.NoError(t, err)
+		assert.Nil(t, overrides)
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		overrides, err := parseResourceFlags([]string{"repo=/tmp/repo", "image=/tmp/image"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"repo": "/tmp/repo", "image": "/tmp/image"}, overrides)
+	})
+
+	t.Run("invalid format", func(t *testing.T) {
+		_, err := parseResourceFlags([]string{"no-equals"})
+		require.Error(t, err)
+	})
+}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -190,7 +190,7 @@ var serverCmd = &cobra.Command{
 		pipelineName := serverViper.GetString("pipeline-name")
 		if pipelineName != "" {
 			pipelineConfig := serverViper.GetString("pipeline-config")
-			pipelineVars := serverViper.GetString("pipeline-vars")
+			pipelineVars := serverViper.GetString("vars")
 			teamCanonical := serverViper.GetString("team-canonical")
 			err = createPipeline(ctx, svc, teamCanonical, pipelineName, pipelineConfig, pipelineVars)
 			if err != nil {
@@ -281,7 +281,7 @@ func init() {
 	serverCmd.Flags().String("log-level", "info", "Sets the log level ('debug', 'info', 'warn', 'error')")
 	serverCmd.Flags().String("team-canonical", mainTeamCanonical, "Team Canonical to scope the action")
 	serverCmd.Flags().String("pipeline-config", "", "Path to the Pipeline config file")
-	serverCmd.Flags().StringP("pipeline-vars", "v", "", "Path to the Pipeline var file (JSON)")
+	serverCmd.Flags().StringP("vars", "v", "", "Path to the Pipeline var file (JSON)")
 	serverCmd.Flags().StringP("pipeline-name", "n", "", "Name of the Pipeline")
 
 	// Bind all flags to viper

--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -23,7 +23,7 @@ variable "repo_name" {
 | `type`    | yes      | `string`                           |
 | `default` | no       | Default value if not set via vars file |
 
-Variables without a default must be provided via a JSON vars file (`--vars` / `--pipeline-vars`).
+Variables without a default must be provided via a JSON vars file (`--vars` / `-v`).
 
 ## resource_type
 

--- a/docs/Portability.md
+++ b/docs/Portability.md
@@ -59,7 +59,7 @@ pikoci.db
   --db-name pikoci.db \
   --pipeline-name my-pipeline \
   --pipeline-config pipeline.hcl \
-  --pipeline-vars vars.json
+  --vars vars.json
 ```
 
 ## Cross-platform builds

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -28,7 +28,7 @@ pikoci server [flags]
 | `--config` | `-c` | | no | Path to a config file |
 | `--team-canonical` | | `main` | no | Team to use for `--pipeline-*` flags |
 | `--pipeline-config` | | | no | Load a pipeline config file at startup |
-| `--pipeline-vars` | `-v` | | no | Path to a JSON vars file for the startup pipeline |
+| `--vars` | `-v` | | no | Path to a JSON vars file for the startup pipeline |
 | `--pipeline-name` | `-n` | | no | Name for the startup pipeline |
 
 ## Environment variables
@@ -106,7 +106,7 @@ pikoci server \
   --jwt-secret my-secret \
   --pipeline-name my-pipeline \
   --pipeline-config pipeline.hcl \
-  --pipeline-vars vars.json
+  --vars vars.json
 ```
 
 ## Horizontal scaling

--- a/docs/Variables.md
+++ b/docs/Variables.md
@@ -38,7 +38,7 @@ Pass the file when creating or updating a pipeline:
 pikoci client pipelines create -n my-pipeline -c pipeline.hcl -v vars.json
 
 # At server startup
-pikoci server --pipeline-name my-pipeline --pipeline-config pipeline.hcl --pipeline-vars vars.json
+pikoci server --pipeline-name my-pipeline --pipeline-config pipeline.hcl --vars vars.json
 ```
 
 ## Using variables
@@ -98,7 +98,7 @@ At **runtime** (every resource check, get, task, or put execution), the worker r
 ### Precedence
 
 ```
-vars file (--pipeline-vars) > secret block > default
+vars file (--vars) > secret block > default
 ```
 
 - If the variable is provided via vars file → use it, skip secret resolution

--- a/main.go
+++ b/main.go
@@ -1,13 +1,19 @@
 package main
 
 import (
+	"errors"
 	"log"
+	"os"
 
 	"github.com/xescugc/pikoci/cmd"
 )
 
 func main() {
 	if err := cmd.Execute(); err != nil {
+		var exitErr *cmd.ExitError
+		if errors.As(err, &exitErr) {
+			os.Exit(exitErr.Code)
+		}
 		log.Fatal(err)
 	}
 }

--- a/pikoci/config/config.go
+++ b/pikoci/config/config.go
@@ -27,5 +27,5 @@ type Config struct {
 	TeamCanonical       string `mapstructure:"team-canonical"`
 	PipelineDisplayName string `mapstructure:"pipeline-name"`
 	PipelineConfig      string `mapstructure:"pipeline-config"`
-	PipelineVars        string `mapstructure:"pipeline-vars"`
+	PipelineVars        string `mapstructure:"vars"`
 }

--- a/pikoci/mysql/migrate/migrate.go
+++ b/pikoci/mysql/migrate/migrate.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Migrate runs the migrations on the provided db
-func Migrate(db *sql.DB, system string) error {
+func Migrate(db *sql.DB, system string, opts ...migrator.Option) error {
 	ms := make([]interface{}, 0, len(migrations.Migrations))
 	for _, m := range migrations.Migrations {
 		val := m
@@ -27,7 +27,10 @@ func Migrate(db *sql.DB, system string) error {
 		})
 	}
 
-	m, err := migrator.New(migrator.Migrations(ms...))
+	allOpts := []migrator.Option{migrator.Migrations(ms...)}
+	allOpts = append(allOpts, opts...)
+
+	m, err := migrator.New(allOpts...)
 	if err != nil {
 		return fmt.Errorf("error while creating the migration: %w", err)
 	}

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -477,38 +477,46 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 		color := colorDefault
 		borderColor := colorDefaultBorder
 
-		// cb: latest main build (no retry suffix) for fill color
+		// cb: latest completed build (including retries) for fill color.
+		//     For the most recent main build number, if a retry succeeded
+		//     the color should reflect that success, not the original failure.
 		// rb: any running build (including retries) for dashed outline
 		var (
 			cb *build.Build
 			rb *build.Build
 		)
+		// Find the latest main build number first
+		var latestMain string
 		for _, b := range builds {
 			if b.Status == build.Started && rb == nil {
 				rb = b
 			}
-			if !strings.Contains(b.BuildNumber, ".") && cb == nil {
-				cb = b
+			if !strings.Contains(b.BuildNumber, ".") && latestMain == "" {
+				latestMain = b.BuildNumber
 			}
-			if cb != nil && rb != nil {
-				break
+		}
+		// Find the latest terminal build in that group (main + retries)
+		if latestMain != "" {
+			for _, b := range builds {
+				if b.BuildNumber == latestMain || strings.HasPrefix(b.BuildNumber, latestMain+".") {
+					if b.Status != build.Started {
+						cb = b
+						break
+					}
+				}
+			}
+			// If all builds in the group are running, fall back to previous main build
+			if cb == nil {
+				for _, b := range builds {
+					if b.Status != build.Started && !strings.Contains(b.BuildNumber, ".") && b.BuildNumber != latestMain {
+						cb = b
+						break
+					}
+				}
 			}
 		}
 
-		// If the latest main build is running, use the previous main build for color
-		if cb != nil && cb.Status == build.Started {
-			for _, b := range builds {
-				if b != cb && !strings.Contains(b.BuildNumber, ".") {
-					if c, ok := jobColors[b.Status]; ok {
-						color = c
-					}
-					if c, ok := jobBorderColors[b.Status]; ok {
-						borderColor = c
-					}
-					break
-				}
-			}
-		} else if cb != nil {
+		if cb != nil {
 			if c, ok := jobColors[cb.Status]; ok {
 				color = c
 			}

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -1443,12 +1443,12 @@ func TestGetPipelineImage_JobStatusColors(t *testing.T) {
 			wantDashedStyle: true,
 		},
 		{
-			name: "retry succeeded - latest main build color unchanged",
+			name: "retry succeeded - color reflects retry success",
 			builds: []*build.Build{
 				{ID: 1, BuildNumber: "1", Status: build.Failed},
 				{ID: 2, BuildNumber: "1.1", Status: build.Succeeded},
 			},
-			wantFillColor:   colorFailed,
+			wantFillColor:   colorSucceeded,
 			wantDashedStyle: false,
 		},
 		{

--- a/worker/service.go
+++ b/worker/service.go
@@ -42,6 +42,14 @@ type Worker struct {
 
 	draining atomic.Bool
 	logger   *slog.Logger
+
+	// ResourceOverrides maps resource canonical names to local directory paths.
+	// When set, get steps for these resources will copy the local directory
+	// instead of running the resource type's pull command.
+	ResourceOverrides map[string]string
+	// LocalMode enables local execution behavior: skips passed-constraints,
+	// version-availability checks, put steps, and secret resolution.
+	LocalMode bool
 }
 
 func New(s pikoci.Service, t queue.Topic, ss queue.Subscription, l *slog.Logger) *Worker {
@@ -197,7 +205,9 @@ func (w *Worker) processJob(ctx context.Context, m queue.Body, cwd string, pp *p
 	}
 
 	var resolvedVersions map[string]uint32
-	if m.RetryBuildNumber != "" && m.RetryBuildID != 0 {
+	if w.LocalMode {
+		resolvedVersions = make(map[string]uint32)
+	} else if m.RetryBuildNumber != "" && m.RetryBuildID != 0 {
 		// Look up versions from the retried build
 		stepVersions, err := w.pikoci.FindBuildGetVersions(ctx, m.TeamCanonical, m.PipelineCanonical, m.JobName, m.RetryBuildID)
 		if err != nil {
@@ -250,6 +260,12 @@ func (w *Worker) processJob(ctx context.Context, m queue.Body, cwd string, pp *p
 		}
 		w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.OnSuccess, "on_success", resolved, "succeeded")
 	} else {
+		// Ensure local b reflects the Failed status set by failBuild (which
+		// operates on a copy) so that any subsequent updateBuild calls from
+		// hooks don't overwrite the DB status back to Started.
+		if b.Status != build.Failed {
+			b.Status = build.Failed
+		}
 		w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.OnFailure, "on_failure", resolved, "failed")
 	}
 	status := "succeeded"
@@ -438,6 +454,12 @@ func (w *Worker) runGetStep(ctx context.Context, m queue.Body, b *build.Build, c
 		secretResolved = resolved[0]
 	}
 	rCan := g.ResourceCanonical()
+
+	if w.ResourceOverrides != nil {
+		if localPath, ok := w.ResourceOverrides[rCan]; ok {
+			return w.runGetStepLocal(ctx, m, b, cwd, pp, g, ps, localPath)
+		}
+	}
 	r, ok := pp.Resource(rCan)
 	if !ok {
 		return false
@@ -562,6 +584,60 @@ func (w *Worker) runGetStep(ctx context.Context, m queue.Body, b *build.Build, c
 	return false
 }
 
+// runGetStepLocal handles a get step by copying a local directory into the
+// working directory instead of running the resource type's pull command. This
+// is used for local execution with --resource overrides. A real copy is used
+// instead of a symlink because symlinks break with Docker volume mounts (the
+// container can't resolve host-side symlink targets).
+// Returns true if the step failed.
+func (w *Worker) runGetStepLocal(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, g job.GetStep, ps job.PlanStep, localPath string) bool {
+	absPath, err := filepath.Abs(localPath)
+	if err != nil {
+		b.Steps = append(b.Steps, build.Step{Type: "get", Name: g.Name, Logs: fmt.Sprintf("failed to resolve path %q: %s", localPath, err), Status: build.Failed})
+		b.Status = build.Failed
+		w.failBuild(ctx, m, *b, nil)
+		return true
+	}
+
+	if _, err := os.Stat(absPath); os.IsNotExist(err) {
+		b.Steps = append(b.Steps, build.Step{Type: "get", Name: g.Name, Logs: fmt.Sprintf("local resource override path does not exist: %s", absPath), Status: build.Failed})
+		b.Status = build.Failed
+		w.failBuild(ctx, m, *b, nil)
+		return true
+	}
+
+	// Use the resource's "name" param as the directory name if available,
+	// matching the behavior of resource type pull commands (e.g. git clone
+	// into $param_name). Fall back to the step name.
+	dirName := g.Name
+	if pp != nil {
+		rCan := g.ResourceCanonical()
+		if r, ok := pp.Resource(rCan); ok && r.Params != nil {
+			if n, ok := r.Params.Params["name"]; ok && n != "" {
+				dirName = n
+			}
+		}
+	}
+
+	dst := filepath.Join(cwd, dirName)
+	// Use cp -a to copy preserving permissions. This works with all runners
+	// including Docker, unlike symlinks which break across mount boundaries.
+	cpCmd := exec.CommandContext(ctx, "cp", "-a", absPath, dst)
+	if out, err := cpCmd.CombinedOutput(); err != nil {
+		b.Steps = append(b.Steps, build.Step{Type: "get", Name: g.Name, Logs: fmt.Sprintf("failed to copy %s -> %s: %s\n%s", absPath, dst, err, string(out)), Status: build.Failed})
+		b.Status = build.Failed
+		w.failBuild(ctx, m, *b, nil)
+		return true
+	}
+
+	logMsg := fmt.Sprintf("using local resource override: %s -> %s", absPath, dirName)
+	b.Steps = append(b.Steps, build.Step{Type: "get", Name: g.Name, Logs: logMsg, Status: build.Succeeded})
+	w.updateBuild(ctx, m, *b)
+	w.runHooks(ctx, m, b, &b.Steps, cwd, nil, g.Name, ps.OnSuccess, "on_success", nil)
+	w.runHooks(ctx, m, b, &b.Steps, cwd, nil, g.Name, ps.Ensure, "ensure", nil)
+	return false
+}
+
 // runTaskStep runs a single task step.
 // Returns true if the step failed.
 func (w *Worker) runTaskStep(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, t job.TaskStep, ps job.PlanStep, resolved ...map[string]string) bool {
@@ -679,6 +755,14 @@ func (w *Worker) runTaskStep(ctx context.Context, m queue.Body, b *build.Build, 
 // runPutStep runs a single put step (resource push).
 // Returns true if the step failed.
 func (w *Worker) runPutStep(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, p job.PutStep, ps job.PlanStep, resolved ...map[string]string) bool {
+	if w.LocalMode {
+		rCan := utils.ResourceCanonical(p.Type, p.Name)
+		logMsg := fmt.Sprintf("skipping put step (local execution): %s", rCan)
+		b.Steps = append(b.Steps, build.Step{Type: "put", Name: p.Name, Logs: logMsg, Status: build.Succeeded})
+		w.updateBuild(ctx, m, *b)
+		return false
+	}
+
 	var secretResolved map[string]string
 	if len(resolved) > 0 {
 		secretResolved = resolved[0]
@@ -1716,6 +1800,9 @@ func (w *Worker) stopServices(m queue.Body, b *build.Build, cwd string, pp *pipe
 // the same secret type and path are batched into a single fetch call.
 func (w *Worker) resolveSecretVars(ctx context.Context, cwd string, pp *pipeline.Pipeline) (map[string]string, error) {
 	if len(pp.SecretVars) == 0 {
+		return nil, nil
+	}
+	if w.LocalMode {
 		return nil, nil
 	}
 

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -2966,5 +2966,83 @@ func TestProcessJob_Cancellation_RunsOnCancelNotOnFailure(t *testing.T) {
 	assert.True(t, os.IsNotExist(err), "on_failure hook should NOT run on cancellation (marker file should not exist)")
 }
 
+func TestRunGetStepLocal_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	dir := t.TempDir()
+	// Create a local resource directory
+	resDir := filepath.Join(dir, "my-resource")
+	require.NoError(t, os.MkdirAll(resDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(resDir, "test.txt"), []byte("content"), 0644))
+
+	cwd := filepath.Join(dir, "workdir")
+	require.NoError(t, os.MkdirAll(cwd, 0755))
+
+	m := queue.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "test-job",
+	}
+	b := build.Build{
+		ID:          1,
+		BuildNumber: "1",
+		Status:      build.Started,
+		Steps:       []build.Step{},
+	}
+	g := job.GetStep{Type: "git", Name: "my-repo"}
+	ps := job.PlanStep{Type: job.StepTypeGet, Get: &g}
+
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), "main", "test-pipeline", "test-job", "1", gomock.Any()).Return(nil).AnyTimes()
+
+	failed := w.runGetStepLocal(context.Background(), m, &b, cwd, nil, g, ps, resDir)
+	assert.False(t, failed)
+	assert.Equal(t, 1, len(b.Steps))
+	assert.Equal(t, build.Succeeded, b.Steps[0].Status)
+	assert.Contains(t, b.Steps[0].Logs, "using local resource override")
+
+	// Verify directory was copied
+	dst := filepath.Join(cwd, "my-repo")
+	info, err := os.Stat(dst)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir(), "expected directory")
+	// Verify file contents were copied
+	content, err := os.ReadFile(filepath.Join(dst, "test.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "content", string(content))
+}
+
+func TestRunGetStepLocal_MissingPath(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	dir := t.TempDir()
+	cwd := filepath.Join(dir, "workdir")
+	require.NoError(t, os.MkdirAll(cwd, 0755))
+
+	m := queue.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "test-job",
+	}
+	b := build.Build{
+		ID:          1,
+		BuildNumber: "1",
+		Status:      build.Started,
+		Steps:       []build.Step{},
+	}
+	g := job.GetStep{Type: "git", Name: "my-repo"}
+	ps := job.PlanStep{Type: job.StepTypeGet, Get: &g}
+
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), "main", "test-pipeline", "test-job", "1", gomock.Any()).Return(nil).AnyTimes()
+
+	missingPath := filepath.Join(dir, "does-not-exist")
+	failed := w.runGetStepLocal(context.Background(), m, &b, cwd, nil, g, ps, missingPath)
+	assert.True(t, failed)
+	assert.Equal(t, 1, len(b.Steps))
+	assert.Equal(t, build.Failed, b.Steps[0].Status)
+	assert.Contains(t, b.Steps[0].Logs, "does not exist")
+}
+
 // Silence the unused import warnings
 var _ = time.Now


### PR DESCRIPTION
## Summary

- Add `pikoci run` command to execute a single pipeline job locally without a server
- Spins up in-memory SQLite + pubsub + worker in one process, reusing all existing execution logic
- Supports `--resource type.name=path` to copy local directories instead of pulling resources
- Supports `--var key=value` and `--vars`/`-v` for variable overrides
- Skips put steps, secret resolution, and passed-constraints in local mode (`Worker.LocalMode`)
- Fix pre-existing bug: `processJob` now sets `b.Status=Failed` before on_failure hooks (failBuild operates on a copy)
- Unify `--pipeline-vars` to `--vars`/`-v` across server, client, run commands and docs
- Silent migrations for the run command via `migrator.WithLogger` (backward-compatible variadic opts)
- `ExitError` type for clean exit code propagation through cobra