### PR TITLE
Allow renaming pipelines via UpdatePipeline

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -116,6 +116,7 @@ func init() {
 	pipelinesCmd.AddCommand(pipelinesGetCmd)
 	pipelinesCmd.AddCommand(pipelinesGraphCmd)
 	pipelinesCmd.AddCommand(pipelinesDeleteCmd)
+	pipelinesCmd.AddCommand(pipelinesRenameCmd)
 }
 
 var pipelinesCreateCmd = &cobra.Command{
@@ -332,6 +333,46 @@ var pipelinesDeleteCmd = &cobra.Command{
 func init() {
 	pipelinesDeleteCmd.Flags().StringP("name", "n", "", "Name of the Pipeline")
 	pipelinesDeleteCmd.MarkFlagRequired("name")
+}
+
+var pipelinesRenameCmd = &cobra.Command{
+	Use:   "rename",
+	Short: "Renames a PikoCI Pipeline",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		tc, _ := cmd.Flags().GetString("team-canonical")
+		name, _ := cmd.Flags().GetString("name")
+		newName, _ := cmd.Flags().GetString("new-name")
+
+		pCan := utils.Canonicalize(name)
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		// Get existing pipeline config, then update with new name
+		existing, err := c.GetPipeline(cmd.Context(), tc, pCan)
+		if err != nil {
+			return fmt.Errorf("failed to get Pipeline %q: %w", name, err)
+		}
+
+		pp, err := c.UpdatePipeline(cmd.Context(), tc, pCan, existing.Raw, nil, newName)
+		if err != nil {
+			return fmt.Errorf("failed to rename Pipeline %q: %w", name, err)
+		}
+
+		fmt.Printf("Pipeline renamed to %q (canonical: %s)\n", pp.Name, pp.Canonical)
+		return nil
+	},
+}
+
+func init() {
+	pipelinesRenameCmd.Flags().StringP("name", "n", "", "Current name of the Pipeline")
+	pipelinesRenameCmd.Flags().String("new-name", "", "New name for the Pipeline")
+	pipelinesRenameCmd.MarkFlagRequired("name")
+	pipelinesRenameCmd.MarkFlagRequired("new-name")
 }
 
 // jobs

--- a/pikoci/mock/service.go
+++ b/pikoci/mock/service.go
@@ -668,18 +668,23 @@ func (mr *ServiceMockRecorder) UpdateJobBuild(ctx, tc, pn, jn, buildNumber, b an
 }
 
 // UpdatePipeline mocks base method.
-func (m *Service) UpdatePipeline(ctx context.Context, tc, pn string, pp []byte, vars map[string]any) (*pipeline.Pipeline, error) {
+func (m *Service) UpdatePipeline(ctx context.Context, tc, pCan string, pp []byte, vars map[string]any, newName ...string) (*pipeline.Pipeline, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdatePipeline", ctx, tc, pn, pp, vars)
+	varargs := []any{ctx, tc, pCan, pp, vars}
+	for _, a := range newName {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdatePipeline", varargs...)
 	ret0, _ := ret[0].(*pipeline.Pipeline)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdatePipeline indicates an expected call of UpdatePipeline.
-func (mr *ServiceMockRecorder) UpdatePipeline(ctx, tc, pn, pp, vars any) *gomock.Call {
+func (mr *ServiceMockRecorder) UpdatePipeline(ctx, tc, pCan, pp, vars any, newName ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePipeline", reflect.TypeOf((*Service)(nil).UpdatePipeline), ctx, tc, pn, pp, vars)
+	varargs := append([]any{ctx, tc, pCan, pp, vars}, newName...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePipeline", reflect.TypeOf((*Service)(nil).UpdatePipeline), varargs...)
 }
 
 // UpdatePipelineResource mocks base method.

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -121,7 +121,7 @@ func (q *PikoCI) CreatePipeline(ctx context.Context, tc, pn string, rpp []byte, 
 	return cp, nil
 }
 
-func (q *PikoCI) UpdatePipeline(ctx context.Context, tc, pCan string, rpp []byte, vars map[string]interface{}) (*pipeline.Pipeline, error) {
+func (q *PikoCI) UpdatePipeline(ctx context.Context, tc, pCan string, rpp []byte, vars map[string]interface{}, newName ...string) (*pipeline.Pipeline, error) {
 	if !utils.ValidateCanonical(tc) {
 		return nil, fmt.Errorf("invalid Team Canonical format %q", tc)
 	} else if !utils.ValidateCanonical(pCan) {
@@ -139,16 +139,28 @@ func (q *PikoCI) UpdatePipeline(ctx context.Context, tc, pCan string, rpp []byte
 		return nil, fmt.Errorf("failed to find Pipeline %q: %w", pCan, err)
 	}
 
-	pp.Name = existingPP.Name
-	pp.Canonical = pCan
+	if len(newName) > 0 && newName[0] != "" {
+		pp.Name = newName[0]
+		pp.Canonical = utils.Canonicalize(newName[0])
+		if !utils.ValidateCanonical(pp.Canonical) {
+			return nil, fmt.Errorf("invalid Pipeline Name format %q", newName[0])
+		}
+	} else {
+		pp.Name = existingPP.Name
+		pp.Canonical = pCan
+	}
 	pp.Raw = rpp
 
+	newCan := pp.Canonical
 	var up *pipeline.Pipeline
 	err = q.StartUoW(ctx, func(uow unitwork.UnitOfWork) error {
 		err := uow.Pipelines().Update(ctx, tc, pCan, *pp)
 		if err != nil {
 			return fmt.Errorf("failed to update Pipeline %q: %w", pCan, err)
 		}
+
+		// After update, use the new canonical for all subsequent operations
+		pCan = newCan
 
 		dbpp, err := uow.Pipelines().Find(ctx, tc, pCan)
 		if err != nil {

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -3,6 +3,7 @@ package pikoci_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -116,6 +117,84 @@ func TestListPipelines_InvalidCanonical(t *testing.T) {
 
 	_, err := s.S.ListPipelines(ctx, "INVALID")
 	require.Error(t, err)
+}
+
+func TestUpdatePipeline_Rename(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+	tc := "main"
+	oldCan := "old-name"
+	newName := "New Name"
+	newCan := "new-name"
+
+	b, err := os.ReadFile("testdata/pipeline.hcl")
+	require.NoError(t, err)
+
+	mvars := map[string]interface{}{
+		"repo_name": "repo",
+	}
+
+	existing := &pipeline.Pipeline{
+		ID: 1, Name: "old-name", Canonical: oldCan,
+		Jobs:      []job.Job{{ID: 1, Name: "gen"}, {ID: 2, Name: "test"}, {ID: 3, Name: "build"}},
+		Resources: []resource.Resource{{ID: 1, Canonical: "git.qid", Name: "qid", Type: "git", Params: &resource.Params{Params: map[string]string{"url": "u", "name": "repo"}}}},
+	}
+
+	s.Pipelines.EXPECT().Find(ctx, tc, oldCan).Return(existing, nil)
+	s.Pipelines.EXPECT().Update(ctx, tc, oldCan, gomock.Any()).Return(nil)
+	// After update, Find uses new canonical (called twice: once to get dbpp, once at end of UoW)
+	renamed := &pipeline.Pipeline{
+		ID: 1, Name: newName, Canonical: newCan,
+		Jobs:      existing.Jobs,
+		Resources: existing.Resources,
+	}
+	s.Pipelines.EXPECT().Find(ctx, tc, newCan).Return(renamed, nil).Times(2)
+	// Jobs: update existing (3 jobs match)
+	s.Jobs.EXPECT().Update(ctx, tc, newCan, "gen", gomock.Any()).Return(nil)
+	s.Jobs.EXPECT().Update(ctx, tc, newCan, "test", gomock.Any()).Return(nil)
+	s.Jobs.EXPECT().Update(ctx, tc, newCan, "build", gomock.Any()).Return(nil)
+	// Resources: update existing (1 resource match)
+	s.Resources.EXPECT().Update(ctx, tc, newCan, "git.qid", gomock.Any()).Return(nil)
+
+	pp, err := s.S.UpdatePipeline(ctx, tc, oldCan, b, mvars, newName)
+	require.NoError(t, err)
+	assert.Equal(t, newName, pp.Name)
+	assert.Equal(t, newCan, pp.Canonical)
+}
+
+func TestUpdatePipeline_PreserveName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+	tc := "main"
+	pCan := "my-pipeline"
+
+	b, err := os.ReadFile("testdata/pipeline.hcl")
+	require.NoError(t, err)
+
+	mvars := map[string]interface{}{
+		"repo_name": "repo",
+	}
+
+	existing := &pipeline.Pipeline{
+		ID: 1, Name: "My Pipeline", Canonical: pCan,
+		Jobs:      []job.Job{{ID: 1, Name: "gen"}, {ID: 2, Name: "test"}, {ID: 3, Name: "build"}},
+		Resources: []resource.Resource{{ID: 1, Canonical: "git.qid", Name: "qid", Type: "git", Params: &resource.Params{Params: map[string]string{"url": "u", "name": "repo"}}}},
+	}
+
+	s.Pipelines.EXPECT().Find(ctx, tc, pCan).Return(existing, nil).Times(3)
+	s.Pipelines.EXPECT().Update(ctx, tc, pCan, gomock.Any()).Return(nil)
+	s.Jobs.EXPECT().Update(ctx, tc, pCan, "gen", gomock.Any()).Return(nil)
+	s.Jobs.EXPECT().Update(ctx, tc, pCan, "test", gomock.Any()).Return(nil)
+	s.Jobs.EXPECT().Update(ctx, tc, pCan, "build", gomock.Any()).Return(nil)
+	s.Resources.EXPECT().Update(ctx, tc, pCan, "git.qid", gomock.Any()).Return(nil)
+
+	// No newName — should preserve existing name
+	pp, err := s.S.UpdatePipeline(ctx, tc, pCan, b, mvars)
+	require.NoError(t, err)
+	assert.Equal(t, "My Pipeline", pp.Name)
+	assert.Equal(t, pCan, pp.Canonical)
 }
 
 func TestDeletePipeline(t *testing.T) {

--- a/pikoci/service.go
+++ b/pikoci/service.go
@@ -41,7 +41,7 @@ type Service interface {
 	DeleteTeamMember(ctx context.Context, tc, mc string) error
 
 	CreatePipeline(ctx context.Context, tc, pn string, pp []byte, vars map[string]interface{}) (*pipeline.Pipeline, error)
-	UpdatePipeline(ctx context.Context, tc, pn string, pp []byte, vars map[string]interface{}) (*pipeline.Pipeline, error)
+	UpdatePipeline(ctx context.Context, tc, pCan string, pp []byte, vars map[string]interface{}, newName ...string) (*pipeline.Pipeline, error)
 	GetPipeline(ctx context.Context, tc, pn string) (*pipeline.Pipeline, error)
 	DeletePipeline(ctx context.Context, tc, pn string) error
 	ListPipelines(ctx context.Context, tc string) ([]*pipeline.Pipeline, error)

--- a/pikoci/transport/http/client/client.go
+++ b/pikoci/transport/http/client/client.go
@@ -308,13 +308,17 @@ func (cl *Client) ListPublicResourceVersions(ctx context.Context, tc, pn, rCan s
 	return cl.ListResourceVersions(ctx, tc, pn, rCan)
 }
 
-func (cl *Client) UpdatePipeline(ctx context.Context, tc, pn string, pp []byte, vars map[string]interface{}) (*pipeline.Pipeline, error) {
+func (cl *Client) UpdatePipeline(ctx context.Context, tc, pn string, pp []byte, vars map[string]interface{}, newName ...string) (*pipeline.Pipeline, error) {
 	var resp thttp.UpdatePipelineResponse
 
-	err := cl.Request(ctx, http.MethodPut, fmt.Sprintf("%s/teams/%s/pipelines/%s", cl.url, tc, pn), thttp.UpdatePipelineRequest{
+	req := thttp.UpdatePipelineRequest{
 		Config: pp,
 		Vars:   vars,
-	}, &resp)
+	}
+	if len(newName) > 0 && newName[0] != "" {
+		req.Name = newName[0]
+	}
+	err := cl.Request(ctx, http.MethodPut, fmt.Sprintf("%s/teams/%s/pipelines/%s", cl.url, tc, pn), req, &resp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to make request: %w", err)
 	}

--- a/pikoci/transport/http/client/client_test.go
+++ b/pikoci/transport/http/client/client_test.go
@@ -267,6 +267,26 @@ func TestUpdatePipeline(t *testing.T) {
 	assert.Equal(t, "mypipe", p.Name)
 }
 
+func TestUpdatePipeline_WithRename(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/{pn}", func(w http.ResponseWriter, req *http.Request) {
+		var body thttp.UpdatePipelineRequest
+		json.NewDecoder(req.Body).Decode(&body)
+		assert.Equal(t, "New Name", body.Name)
+		jsonHandler(w, thttp.UpdatePipelineResponse{Pipeline: &pipeline.Pipeline{Name: "New Name", Canonical: "new-name"}})
+	}).Methods("PUT")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	p, err := c.UpdatePipeline(context.Background(), "team", "old-name", []byte("config"), nil, "New Name")
+	require.NoError(t, err)
+	assert.Equal(t, "New Name", p.Name)
+	assert.Equal(t, "new-name", p.Canonical)
+}
+
 func TestGetPipeline(t *testing.T) {
 	r := mux.NewRouter()
 	r.HandleFunc("/teams/{tc}/pipelines/{pn}", func(w http.ResponseWriter, req *http.Request) {

--- a/pikoci/transport/http/pipelines.go
+++ b/pikoci/transport/http/pipelines.go
@@ -46,6 +46,7 @@ func createPipeline(s pikoci.Service) http.HandlerFunc {
 
 type UpdatePipelineRequest struct {
 	TeamCanonical string                 `json:"team_canonical"`
+	Name          string                 `json:"name,omitempty"`
 	Config        []byte                 `json:"config"`
 	Vars          map[string]interface{} `json:"vars"`
 	Public        *bool                  `json:"public,omitempty"`
@@ -73,20 +74,36 @@ func updatePipeline(s pikoci.Service) http.HandlerFunc {
 		}
 		var pp *pipeline.Pipeline
 		var errs string
+		newCan := pCan
 		if len(req.Config) > 0 {
-			pp, err = s.UpdatePipeline(ctx, req.TeamCanonical, pCan, req.Config, req.Vars)
+			pp, err = s.UpdatePipeline(ctx, req.TeamCanonical, pCan, req.Config, req.Vars, req.Name)
 			if err != nil {
 				errs = err.Error()
+			} else if pp != nil {
+				newCan = pp.Canonical
+			}
+		} else if req.Name != "" {
+			// Name-only update (no config change): re-send existing config
+			existing, gerr := s.GetPipeline(ctx, req.TeamCanonical, pCan)
+			if gerr != nil {
+				encodeResponse(UpdatePipelineResponse{Err: gerr.Error()}, w)
+				return
+			}
+			pp, err = s.UpdatePipeline(ctx, req.TeamCanonical, pCan, existing.Raw, nil, req.Name)
+			if err != nil {
+				errs = err.Error()
+			} else if pp != nil {
+				newCan = pp.Canonical
 			}
 		}
 		if err == nil && req.Public != nil {
-			err = s.SetPipelinePublic(ctx, req.TeamCanonical, pCan, *req.Public)
+			err = s.SetPipelinePublic(ctx, req.TeamCanonical, newCan, *req.Public)
 			if err != nil {
 				errs = err.Error()
 			}
 		}
 		if errs == "" && pp == nil {
-			pp, err = s.GetPipeline(ctx, req.TeamCanonical, pCan)
+			pp, err = s.GetPipeline(ctx, req.TeamCanonical, newCan)
 			if err != nil {
 				errs = err.Error()
 			}

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -302,7 +302,7 @@
         <div class="piko-settings-row mb-3">
           <div class="piko-field">
             <label class="form-label">Name</label>
-            <input type="text" class="form-control" id="name" value="<%- name %>" placeholder="e.g. deploy-production" style="width:280px" <%- id ? "disabled" : ""%>>
+            <input type="text" class="form-control" id="name" value="<%- name %>" placeholder="e.g. deploy-production" style="width:280px">
           </div>
           <div class="piko-checkbox-inline">
             <input type="checkbox" class="form-check-input" id="public" <%- public ? "checked" : "" %>>


### PR DESCRIPTION
## Summary

- `UpdatePipeline` accepts optional `newName` to change pipeline name and canonical in one operation
- UI name field enabled on edit page; navigates to new URL after rename
- CLI: `pikoci client pipelines rename -n old --new-name "New Name"`
- Tests for rename and name preservation at service and client levels