### PR TITLE
Add user management: Profile, admin Users page, CLI, and force password change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- User management: Profile page, admin Users page, CLI commands, force password change on default `admin/admin123`, and `--users` flag preserves UI/CLI password changes ([#237](https://github.com/PikoCI/pikoci/issues/237))
+
 ## [0.1.0] - 2026-05-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ The fastest way to get started. Pass a pipeline config directly at launch. When 
   --pipeline-config pipeline.hcl
 ```
 
-Open [http://localhost:8080](http://localhost:8080) and log in with the default user `admin` and password `admin123`.
+Open [http://localhost:8080](http://localhost:8080) and log in with the default user `admin` and password `admin123`. On first login with the default password, you will be redirected to the Profile page to set a new password.
 
-> **Users:** pass `--users 'username:hashed-password'` to add or update users at startup. If a user already exists, their password is updated. Use `pikoci user-password` to generate password hashes.
+> **Users:** pass `--users 'username:hashed-password'` to create users or override the default password at startup. Users who have changed their password via the UI/CLI are not affected. Use `pikoci user-password` to generate password hashes.
 
 ### Example pipeline
 

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -534,6 +534,9 @@ var usersCmd = &cobra.Command{
 func init() {
 	usersCmd.AddCommand(usersCreateCmd)
 	usersCmd.AddCommand(usersListCmd)
+	usersCmd.AddCommand(usersUpdateCmd)
+	usersCmd.AddCommand(usersDeleteCmd)
+	usersCmd.AddCommand(usersChangePasswordCmd)
 }
 
 var usersCreateCmd = &cobra.Command{
@@ -591,6 +594,104 @@ var usersListCmd = &cobra.Command{
 		spew.Dump(users)
 		return nil
 	},
+}
+
+var usersUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Updates an existing User",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		username, _ := cmd.Flags().GetString("username")
+		password, _ := cmd.Flags().GetString("password")
+		fullName, _ := cmd.Flags().GetString("full-name")
+		admin, _ := cmd.Flags().GetBool("admin")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		u, err := c.UpdateUser(cmd.Context(), username, user.User{
+			FullName: fullName,
+			Username: username,
+			Password: password,
+			Admin:    admin,
+		}, false)
+		if err != nil {
+			return fmt.Errorf("failed to update User %q: %w", username, err)
+		}
+
+		spew.Dump(u)
+		return nil
+	},
+}
+
+func init() {
+	usersUpdateCmd.Flags().String("username", "", "Username of the User to update")
+	usersUpdateCmd.Flags().String("password", "", "New password for the User")
+	usersUpdateCmd.Flags().String("full-name", "", "Full name for the User")
+	usersUpdateCmd.Flags().Bool("admin", false, "Whether the User is an admin")
+	usersUpdateCmd.MarkFlagRequired("username")
+}
+
+var usersDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Deletes a User",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		username, _ := cmd.Flags().GetString("username")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		err = c.DeleteUser(cmd.Context(), username)
+		if err != nil {
+			return fmt.Errorf("failed to delete User %q: %w", username, err)
+		}
+
+		fmt.Printf("User %q deleted successfully\n", username)
+		return nil
+	},
+}
+
+func init() {
+	usersDeleteCmd.Flags().String("username", "", "Username of the User to delete")
+	usersDeleteCmd.MarkFlagRequired("username")
+}
+
+var usersChangePasswordCmd = &cobra.Command{
+	Use:   "change-password",
+	Short: "Changes the password of the current User",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		oldPassword, _ := cmd.Flags().GetString("old-password")
+		newPassword, _ := cmd.Flags().GetString("new-password")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		err = c.ChangePassword(cmd.Context(), "", oldPassword, newPassword)
+		if err != nil {
+			return fmt.Errorf("failed to change password: %w", err)
+		}
+
+		fmt.Println("Password changed successfully")
+		return nil
+	},
+}
+
+func init() {
+	usersChangePasswordCmd.Flags().String("old-password", "", "Current password")
+	usersChangePasswordCmd.Flags().String("new-password", "", "New password")
+	usersChangePasswordCmd.MarkFlagRequired("old-password")
+	usersChangePasswordCmd.MarkFlagRequired("new-password")
 }
 
 // teams

--- a/cmd/client_test.go
+++ b/cmd/client_test.go
@@ -24,7 +24,7 @@ func TestCommandTree(t *testing.T) {
 		subcommands []string
 	}{
 		{clientCmd, "client", []string{"login", "pipelines", "jobs", "users", "teams", "builds", "resources", "triggers"}},
-		{usersCmd, "users", []string{"create", "list"}},
+		{usersCmd, "users", []string{"create", "list", "update", "delete", "change-password"}},
 		{teamsCmd, "teams", []string{"create", "list", "get", "update", "delete", "members"}},
 		{teamsMembersCmd, "members", []string{"create", "update", "delete"}},
 		{buildsCmd, "builds", []string{"list", "get", "delete", "cancel", "retry"}},
@@ -49,6 +49,9 @@ func TestRequiredFlags(t *testing.T) {
 		required []string
 	}{
 		{"users create", usersCreateCmd, []string{"username", "password"}},
+		{"users update", usersUpdateCmd, []string{"username"}},
+		{"users delete", usersDeleteCmd, []string{"username"}},
+		{"users change-password", usersChangePasswordCmd, []string{"old-password", "new-password"}},
 		{"teams create", teamsCreateCmd, []string{"name"}},
 		{"teams get", teamsGetCmd, []string{"canonical"}},
 		{"teams update", teamsUpdateCmd, []string{"canonical", "name"}},

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -266,7 +266,7 @@ func init() {
 
 	serverCmd.Flags().IntP("port", "p", 8080, "Port in which to start the server")
 	serverCmd.Flags().String("jwt-secret", "", "Declares the Secret used to sign the JWT when user login")
-	serverCmd.Flags().StringSlice("users", nil, "List of Users which will have 'USERNAME:HASH-PASSWORD', you can use the 'user-password' command to help you")
+	serverCmd.Flags().StringSlice("users", nil, "List of Users as 'USERNAME:HASH-PASSWORD' to create at startup or override default passwords. Use the 'user-password' command to generate hashes")
 	serverCmd.Flags().String("db-system", mysql.Mem, "Which DB system to use (mem, sqlite, mysql, postgresql)")
 	serverCmd.Flags().String("db-host", "", "Database Host")
 	serverCmd.Flags().Int("db-port", 0, "Database Port")

--- a/deploy/pikoci.env.example
+++ b/deploy/pikoci.env.example
@@ -22,7 +22,7 @@ RUN_WORKER=true
 # Log level (debug, info, warn, error)
 # LOG_LEVEL=info
 
-# Users: override the default admin password
+# Users: create users or override default password at startup
 # Generate hashes with: pikoci user-password -u admin -p your-password
 # USERS=admin:$2a$10$...
 

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -66,7 +66,7 @@ The initial database migration seeds a default user: `admin` / `admin123`. On fi
 ./pikoci server --jwt-secret my-secret --users 'admin:$2a$10$...' --users 'deploy:$2a$10$...'
 ```
 
-The `--users` flag is safe to pass on every restart. It will set the password for users that still have the default `admin123` password, but will not overwrite passwords that have been changed via the UI or CLI.
+The `--users` flag is safe to pass on every restart. It will set the password for the `admin` user if it still has the default `admin` / `admin123` credentials, but will not overwrite passwords that have been changed via the UI or CLI.
 
 ## Examples
 

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -50,10 +50,10 @@ export PUBSUB_SYSTEM=nats
 
 ## Default user
 
-The initial database migration seeds a default user: `admin` / `admin123`. Use the `--users` flag to add new users or update existing users' passwords. If a user already exists, their password is updated; otherwise a new user is created.
+The initial database migration seeds a default user: `admin` / `admin123`. On first login with the default password, the UI will redirect to the Profile page and require a password change before continuing. Use the `--users` flag to create users or override the default password at startup.
 
 ```bash
-# Change the default admin password
+# Override the default admin password
 ./pikoci user-password -u admin -p new-secure-password
 # Output: admin:$2a$10$...
 
@@ -66,7 +66,7 @@ The initial database migration seeds a default user: `admin` / `admin123`. Use t
 ./pikoci server --jwt-secret my-secret --users 'admin:$2a$10$...' --users 'deploy:$2a$10$...'
 ```
 
-The `--users` flag is idempotent and safe to pass on every restart.
+The `--users` flag is safe to pass on every restart. It will set the password for users that still have the default `admin123` password, but will not overwrite passwords that have been changed via the UI or CLI.
 
 ## Examples
 

--- a/integration/pikoci_test.go
+++ b/integration/pikoci_test.go
@@ -52,7 +52,7 @@ func TestPikoCI(t *testing.T) {
 			require.NoError(t, err)
 
 			// Default admin123 triggers forced password change — handle it
-			waitFor(t, wd, eqText(selenium.ByCSSSelector, "h1", "Profile"), 5*time.Second)
+			waitFor(t, wd, eqText(selenium.ByCSSSelector, "h1", "Profile"), 10*time.Second)
 
 			curPass, err := wd.FindElement(selenium.ByCSSSelector, "#current_password")
 			require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestPikoCI(t *testing.T) {
 			err = changeBtn.Click()
 			require.NoError(t, err)
 
-			waitFor(t, wd, eqText(selenium.ByCSSSelector, ".alert-success", "Password changed successfully"), 5*time.Second)
+			waitFor(t, wd, eqText(selenium.ByCSSSelector, ".alert-success", "Password changed successfully"), 15*time.Second)
 
 			// Navigate to teams
 			wd.Get(pikoURL + "/")

--- a/integration/pikoci_test.go
+++ b/integration/pikoci_test.go
@@ -51,6 +51,30 @@ func TestPikoCI(t *testing.T) {
 			err = login.Click()
 			require.NoError(t, err)
 
+			// Default admin123 triggers forced password change — handle it
+			waitFor(t, wd, eqText(selenium.ByCSSSelector, "h1", "Profile"), 5*time.Second)
+
+			curPass, err := wd.FindElement(selenium.ByCSSSelector, "#current_password")
+			require.NoError(t, err)
+			curPass.SendKeys("admin123")
+
+			newPass, err := wd.FindElement(selenium.ByCSSSelector, "#new_password")
+			require.NoError(t, err)
+			newPass.SendKeys("newadmin123")
+
+			confirmPass, err := wd.FindElement(selenium.ByCSSSelector, "#confirm_password")
+			require.NoError(t, err)
+			confirmPass.SendKeys("newadmin123")
+
+			changeBtn, err := wd.FindElement(selenium.ByCSSSelector, "#change-password-form button[type=submit]")
+			require.NoError(t, err)
+			err = changeBtn.Click()
+			require.NoError(t, err)
+
+			waitFor(t, wd, eqText(selenium.ByCSSSelector, ".alert-success", "Password changed successfully"), 5*time.Second)
+
+			// Navigate to teams
+			wd.Get(pikoURL + "/")
 			waitFor(t, wd, eqText(selenium.ByCSSSelector, "#breadcrumb", "Teams"), 5*time.Second)
 		})
 
@@ -794,7 +818,7 @@ job "gen" {
 		// Set pipeline public via admin HTTP API
 		loginBody, _ := json.Marshal(thttp.UserLoginRequest{
 			Username: "admin",
-			Password: "admin123",
+			Password: "newadmin123",
 		})
 		loginReq, err := http.NewRequest(http.MethodPost, pikoURL+"/login.json", bytes.NewReader(loginBody))
 		require.NoError(t, err)
@@ -899,7 +923,7 @@ job "gen" {
 		// Step 1: Get admin JWT via HTTP
 		loginBody, _ := json.Marshal(thttp.UserLoginRequest{
 			Username: "admin",
-			Password: "admin123",
+			Password: "newadmin123",
 		})
 		loginReq, err := http.NewRequest(http.MethodPost, pikoURL+"/login.json", bytes.NewReader(loginBody))
 		require.NoError(t, err)

--- a/pikoci/mock/service.go
+++ b/pikoci/mock/service.go
@@ -61,6 +61,20 @@ func (mr *ServiceMockRecorder) CancelJobBuild(ctx, tc, pn, jn, buildNumber any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelJobBuild", reflect.TypeOf((*Service)(nil).CancelJobBuild), ctx, tc, pn, jn, buildNumber)
 }
 
+// ChangePassword mocks base method.
+func (m *Service) ChangePassword(ctx context.Context, un, oldPassword, newPassword string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ChangePassword", ctx, un, oldPassword, newPassword)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ChangePassword indicates an expected call of ChangePassword.
+func (mr *ServiceMockRecorder) ChangePassword(ctx, un, oldPassword, newPassword any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangePassword", reflect.TypeOf((*Service)(nil).ChangePassword), ctx, un, oldPassword, newPassword)
+}
+
 // CreateJobBuild mocks base method.
 func (m *Service) CreateJobBuild(ctx context.Context, tc, pn, jn string, b build.Build) (*build.Build, error) {
 	m.ctrl.T.Helper()
@@ -250,6 +264,20 @@ func (m *Service) DeleteTeamMember(ctx context.Context, tc, mc string) error {
 func (mr *ServiceMockRecorder) DeleteTeamMember(ctx, tc, mc any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTeamMember", reflect.TypeOf((*Service)(nil).DeleteTeamMember), ctx, tc, mc)
+}
+
+// DeleteUser mocks base method.
+func (m *Service) DeleteUser(ctx context.Context, un string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteUser", ctx, un)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteUser indicates an expected call of DeleteUser.
+func (mr *ServiceMockRecorder) DeleteUser(ctx, un any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUser", reflect.TypeOf((*Service)(nil).DeleteUser), ctx, un)
 }
 
 // FindBuildGetVersions mocks base method.
@@ -701,6 +729,21 @@ func (mr *ServiceMockRecorder) UpdatePipelineResource(ctx, tc, pn, rCan, r any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePipelineResource", reflect.TypeOf((*Service)(nil).UpdatePipelineResource), ctx, tc, pn, rCan, r)
 }
 
+// UpdateProfile mocks base method.
+func (m *Service) UpdateProfile(ctx context.Context, un, fullName, newUsername string) (*user.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateProfile", ctx, un, fullName, newUsername)
+	ret0, _ := ret[0].(*user.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateProfile indicates an expected call of UpdateProfile.
+func (mr *ServiceMockRecorder) UpdateProfile(ctx, un, fullName, newUsername any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateProfile", reflect.TypeOf((*Service)(nil).UpdateProfile), ctx, un, fullName, newUsername)
+}
+
 // UpdateTeam mocks base method.
 func (m *Service) UpdateTeam(ctx context.Context, tc string, t team.Team) (*team.WithMembers, error) {
 	m.ctrl.T.Helper()
@@ -729,6 +772,21 @@ func (m *Service) UpdateTeamMember(ctx context.Context, tc, mc string, tm team.M
 func (mr *ServiceMockRecorder) UpdateTeamMember(ctx, tc, mc, tm any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTeamMember", reflect.TypeOf((*Service)(nil).UpdateTeamMember), ctx, tc, mc, tm)
+}
+
+// UpdateUser mocks base method.
+func (m *Service) UpdateUser(ctx context.Context, un string, u user.User, isHash bool) (*user.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateUser", ctx, un, u, isHash)
+	ret0, _ := ret[0].(*user.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateUser indicates an expected call of UpdateUser.
+func (mr *ServiceMockRecorder) UpdateUser(ctx, un, u, isHash any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUser", reflect.TypeOf((*Service)(nil).UpdateUser), ctx, un, u, isHash)
 }
 
 // UserLogin mocks base method.

--- a/pikoci/service.go
+++ b/pikoci/service.go
@@ -29,6 +29,10 @@ type Service interface {
 	GetUser(ctx context.Context, un string) (*user.WithMemberships, error)
 	CreateUser(ctx context.Context, u user.User, isHash bool) (*user.User, error)
 	ListUsers(ctx context.Context) ([]*user.User, error)
+	UpdateUser(ctx context.Context, un string, u user.User, isHash bool) (*user.User, error)
+	DeleteUser(ctx context.Context, un string) error
+	ChangePassword(ctx context.Context, un, oldPassword, newPassword string) error
+	UpdateProfile(ctx context.Context, un string, fullName, newUsername string) (*user.User, error)
 
 	CreateTeam(ctx context.Context, un string, t team.Team) (*team.WithMembers, error)
 	ListTeams(ctx context.Context, un string) ([]*team.WithMembers, error)

--- a/pikoci/transport/http/authorization.go
+++ b/pikoci/transport/http/authorization.go
@@ -16,6 +16,11 @@ var (
 
 		CreateUser: admin,
 		ListUsers:  admin,
+		GetUser:    admin,
+		UpdateUser: admin,
+		DeleteUser: admin,
+		ChangePassword: member,
+		UpdateProfile:  member,
 
 		CreateTeam: admin,
 		ListTeams:  member,

--- a/pikoci/transport/http/client/client.go
+++ b/pikoci/transport/http/client/client.go
@@ -84,8 +84,22 @@ func (cl *Client) RefreshToken(ctx context.Context, un string) (*user.WithMember
 }
 
 func (cl *Client) GetUser(ctx context.Context, un string) (*user.WithMemberships, error) {
-	// No server-side endpoint for GetUser; it's only used internally for authorization
-	return nil, fmt.Errorf("GetUser is not exposed via HTTP")
+	var resp thttp.GetUserResponse
+
+	err := cl.Request(ctx, http.MethodGet, fmt.Sprintf("%s/users/%s", cl.url, un), nil, &resp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make request: %w", err)
+	}
+
+	if resp.Err != "" {
+		return nil, fmt.Errorf("error from request: %s", resp.Err)
+	}
+
+	if resp.User == nil {
+		return nil, fmt.Errorf("user not found")
+	}
+
+	return &user.WithMemberships{User: *resp.User}, nil
 }
 
 func (cl *Client) CreateUser(ctx context.Context, u user.User, isHash bool) (*user.User, error) {
@@ -120,6 +134,78 @@ func (cl *Client) ListUsers(ctx context.Context) ([]*user.User, error) {
 	}
 
 	return resp.Users, nil
+}
+
+func (cl *Client) UpdateUser(ctx context.Context, un string, u user.User, isHash bool) (*user.User, error) {
+	var resp thttp.UpdateUserResponse
+
+	err := cl.Request(ctx, http.MethodPut, fmt.Sprintf("%s/users/%s", cl.url, un), thttp.UpdateUserRequest{
+		FullName: u.FullName,
+		Username: u.Username,
+		Password: u.Password,
+		Admin:    u.Admin,
+		IsHash:   isHash,
+	}, &resp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make request: %w", err)
+	}
+
+	if resp.Err != "" {
+		return nil, fmt.Errorf("error from request: %s", resp.Err)
+	}
+
+	return resp.User, nil
+}
+
+func (cl *Client) DeleteUser(ctx context.Context, un string) error {
+	var resp thttp.DeleteUserResponse
+
+	err := cl.Request(ctx, http.MethodDelete, fmt.Sprintf("%s/users/%s", cl.url, un), nil, &resp)
+	if err != nil {
+		return fmt.Errorf("failed to make request: %w", err)
+	}
+
+	if resp.Err != "" {
+		return fmt.Errorf("error from request: %s", resp.Err)
+	}
+
+	return nil
+}
+
+func (cl *Client) ChangePassword(ctx context.Context, un, oldPassword, newPassword string) error {
+	var resp thttp.ChangePasswordResponse
+
+	err := cl.Request(ctx, http.MethodPost, fmt.Sprintf("%s/users/change-password", cl.url), thttp.ChangePasswordRequest{
+		OldPassword: oldPassword,
+		NewPassword: newPassword,
+	}, &resp)
+	if err != nil {
+		return fmt.Errorf("failed to make request: %w", err)
+	}
+
+	if resp.Err != "" {
+		return fmt.Errorf("error from request: %s", resp.Err)
+	}
+
+	return nil
+}
+
+func (cl *Client) UpdateProfile(ctx context.Context, un string, fullName, newUsername string) (*user.User, error) {
+	var resp thttp.UpdateProfileResponse
+
+	err := cl.Request(ctx, http.MethodPut, fmt.Sprintf("%s/profile", cl.url), thttp.UpdateProfileRequest{
+		FullName: fullName,
+		Username: newUsername,
+	}, &resp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make request: %w", err)
+	}
+
+	if resp.Err != "" {
+		return nil, fmt.Errorf("error from request: %s", resp.Err)
+	}
+
+	return resp.User, nil
 }
 
 func (cl *Client) CreateTeam(ctx context.Context, un string, t team.Team) (*team.WithMembers, error) {

--- a/pikoci/transport/http/client/client_test.go
+++ b/pikoci/transport/http/client/client_test.go
@@ -108,6 +108,94 @@ func TestListUsers(t *testing.T) {
 	assert.Len(t, users, 2)
 }
 
+func TestGetUser(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/users/{username}", func(w http.ResponseWriter, req *http.Request) {
+		vars := mux.Vars(req)
+		jsonHandler(w, thttp.GetUserResponse{User: &user.User{Username: vars["username"], FullName: "Admin"}})
+	}).Methods("GET")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	u, err := c.GetUser(context.Background(), "admin")
+	require.NoError(t, err)
+	assert.Equal(t, "admin", u.Username)
+	assert.Equal(t, "Admin", u.FullName)
+}
+
+func TestUpdateUser(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/users/{username}", func(w http.ResponseWriter, req *http.Request) {
+		var ur thttp.UpdateUserRequest
+		json.NewDecoder(req.Body).Decode(&ur)
+		vars := mux.Vars(req)
+		jsonHandler(w, thttp.UpdateUserResponse{User: &user.User{Username: vars["username"], FullName: ur.FullName, Admin: ur.Admin}})
+	}).Methods("PUT")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	u, err := c.UpdateUser(context.Background(), "admin", user.User{FullName: "New Name", Admin: true}, false)
+	require.NoError(t, err)
+	assert.Equal(t, "admin", u.Username)
+	assert.Equal(t, "New Name", u.FullName)
+	assert.True(t, u.Admin)
+}
+
+func TestDeleteUser(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/users/{username}", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.DeleteUserResponse{})
+	}).Methods("DELETE")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	err = c.DeleteUser(context.Background(), "pepito")
+	require.NoError(t, err)
+}
+
+func TestChangePassword(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/users/change-password", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.ChangePasswordResponse{})
+	}).Methods("POST")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	err = c.ChangePassword(context.Background(), "admin", "oldpass", "newpass")
+	require.NoError(t, err)
+}
+
+func TestUpdateProfile(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/profile", func(w http.ResponseWriter, req *http.Request) {
+		var pr thttp.UpdateProfileRequest
+		json.NewDecoder(req.Body).Decode(&pr)
+		jsonHandler(w, thttp.UpdateProfileResponse{User: &user.User{Username: pr.Username, FullName: pr.FullName}})
+	}).Methods("PUT")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	u, err := c.UpdateProfile(context.Background(), "admin", "New Name", "admin")
+	require.NoError(t, err)
+	assert.Equal(t, "admin", u.Username)
+	assert.Equal(t, "New Name", u.FullName)
+}
+
 func TestCreateTeam(t *testing.T) {
 	r := mux.NewRouter()
 	r.HandleFunc("/teams", func(w http.ResponseWriter, req *http.Request) {

--- a/pikoci/transport/http/handler.go
+++ b/pikoci/transport/http/handler.go
@@ -192,6 +192,11 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger) http.Handler {
 
 	api.Methods(http.MethodGet).Path("/users").Name(ListUsers.String()).Handler(listUsers(s))
 	api.Methods(http.MethodPost).Path("/users").Name(CreateUser.String()).Handler(createUser(s))
+	api.Methods(http.MethodPost).Path("/users/change-password").Name(ChangePassword.String()).Handler(changePassword(s))
+	api.Methods(http.MethodGet).Path("/users/{username}").Name(GetUser.String()).Handler(getUser(s))
+	api.Methods(http.MethodPut).Path("/users/{username}").Name(UpdateUser.String()).Handler(updateUser(s))
+	api.Methods(http.MethodDelete).Path("/users/{username}").Name(DeleteUser.String()).Handler(deleteUser(s))
+	api.Methods(http.MethodPut).Path("/profile").Name(UpdateProfile.String()).Handler(updateProfile(s))
 	api.Methods(http.MethodPost).Path("/teams").Name(CreateTeam.String()).Handler(createTeam(s))
 
 	api.Methods(http.MethodGet).Path("/teams").Name(ListTeams.String()).Handler(listTeams(s))

--- a/pikoci/transport/http/route_names.go
+++ b/pikoci/transport/http/route_names.go
@@ -10,6 +10,11 @@ const (
 
 	CreateUser
 	ListUsers
+	GetUser
+	UpdateUser
+	DeleteUser
+	ChangePassword
+	UpdateProfile
 
 	CreateTeam
 	ListTeams

--- a/pikoci/transport/http/route_names_string.go
+++ b/pikoci/transport/http/route_names_string.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _RouteNameName = "user_loginrefresh_tokencreate_userlist_userscreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionswebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_after"
+const _RouteNameName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionswebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_after"
 
-var _RouteNameIndex = [...]uint16{0, 10, 23, 34, 44, 55, 65, 73, 84, 95, 113, 131, 149, 164, 179, 191, 206, 220, 238, 259, 279, 295, 311, 333, 349, 365, 380, 404, 427, 440, 456, 471, 492, 516, 541, 564, 586, 601, 625, 639, 658}
+var _RouteNameIndex = [...]uint16{0, 10, 23, 34, 44, 52, 63, 74, 89, 103, 114, 124, 132, 143, 154, 172, 190, 208, 223, 238, 250, 265, 279, 297, 318, 338, 354, 370, 392, 408, 424, 439, 463, 486, 499, 515, 530, 551, 575, 600, 623, 645, 660, 684, 698, 717}
 
-const _RouteNameLowerName = "user_loginrefresh_tokencreate_userlist_userscreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionswebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_after"
+const _RouteNameLowerName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionswebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_after"
 
 func (i RouteName) String() string {
 	if i < 0 || i >= RouteName(len(_RouteNameIndex)-1) {
@@ -28,45 +28,50 @@ func _RouteNameNoOp() {
 	_ = x[RefreshToken-(1)]
 	_ = x[CreateUser-(2)]
 	_ = x[ListUsers-(3)]
-	_ = x[CreateTeam-(4)]
-	_ = x[ListTeams-(5)]
-	_ = x[GetTeam-(6)]
-	_ = x[UpdateTeam-(7)]
-	_ = x[DeleteTeam-(8)]
-	_ = x[CreateTeamMember-(9)]
-	_ = x[UpdateTeamMember-(10)]
-	_ = x[DeleteTeamMember-(11)]
-	_ = x[CreatePipeline-(12)]
-	_ = x[UpdatePipeline-(13)]
-	_ = x[GetPipeline-(14)]
-	_ = x[DeletePipeline-(15)]
-	_ = x[ListPipelines-(16)]
-	_ = x[GetPipelineImage-(17)]
-	_ = x[CreatePipelineImage-(18)]
-	_ = x[TriggerPipelineJob-(19)]
-	_ = x[GetPipelineJob-(20)]
-	_ = x[CreateJobBuild-(21)]
-	_ = x[CreateRetryJobBuild-(22)]
-	_ = x[UpdateJobBuild-(23)]
-	_ = x[DeleteJobBuild-(24)]
-	_ = x[ListJobBuilds-(25)]
-	_ = x[InsertBuildGetVersion-(26)]
-	_ = x[FindBuildGetVersions-(27)]
-	_ = x[GetJobBuild-(28)]
-	_ = x[CancelJobBuild-(29)]
-	_ = x[RetryJobBuild-(30)]
-	_ = x[GetPipelineResource-(31)]
-	_ = x[UpdatePipelineResource-(32)]
-	_ = x[TriggerPipelineResource-(33)]
-	_ = x[CreateResourceVersion-(34)]
-	_ = x[ListResourceVersions-(35)]
-	_ = x[WebhookTrigger-(36)]
-	_ = x[RegenerateWebhookToken-(37)]
-	_ = x[CreateTrigger-(38)]
-	_ = x[ListTriggersAfter-(39)]
+	_ = x[GetUser-(4)]
+	_ = x[UpdateUser-(5)]
+	_ = x[DeleteUser-(6)]
+	_ = x[ChangePassword-(7)]
+	_ = x[UpdateProfile-(8)]
+	_ = x[CreateTeam-(9)]
+	_ = x[ListTeams-(10)]
+	_ = x[GetTeam-(11)]
+	_ = x[UpdateTeam-(12)]
+	_ = x[DeleteTeam-(13)]
+	_ = x[CreateTeamMember-(14)]
+	_ = x[UpdateTeamMember-(15)]
+	_ = x[DeleteTeamMember-(16)]
+	_ = x[CreatePipeline-(17)]
+	_ = x[UpdatePipeline-(18)]
+	_ = x[GetPipeline-(19)]
+	_ = x[DeletePipeline-(20)]
+	_ = x[ListPipelines-(21)]
+	_ = x[GetPipelineImage-(22)]
+	_ = x[CreatePipelineImage-(23)]
+	_ = x[TriggerPipelineJob-(24)]
+	_ = x[GetPipelineJob-(25)]
+	_ = x[CreateJobBuild-(26)]
+	_ = x[CreateRetryJobBuild-(27)]
+	_ = x[UpdateJobBuild-(28)]
+	_ = x[DeleteJobBuild-(29)]
+	_ = x[ListJobBuilds-(30)]
+	_ = x[InsertBuildGetVersion-(31)]
+	_ = x[FindBuildGetVersions-(32)]
+	_ = x[GetJobBuild-(33)]
+	_ = x[CancelJobBuild-(34)]
+	_ = x[RetryJobBuild-(35)]
+	_ = x[GetPipelineResource-(36)]
+	_ = x[UpdatePipelineResource-(37)]
+	_ = x[TriggerPipelineResource-(38)]
+	_ = x[CreateResourceVersion-(39)]
+	_ = x[ListResourceVersions-(40)]
+	_ = x[WebhookTrigger-(41)]
+	_ = x[RegenerateWebhookToken-(42)]
+	_ = x[CreateTrigger-(43)]
+	_ = x[ListTriggersAfter-(44)]
 }
 
-var _RouteNameValues = []RouteName{UserLogin, RefreshToken, CreateUser, ListUsers, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, GetPipelineJob, CreateJobBuild, CreateRetryJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, InsertBuildGetVersion, FindBuildGetVersions, GetJobBuild, CancelJobBuild, RetryJobBuild, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions, WebhookTrigger, RegenerateWebhookToken, CreateTrigger, ListTriggersAfter}
+var _RouteNameValues = []RouteName{UserLogin, RefreshToken, CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser, ChangePassword, UpdateProfile, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, GetPipelineJob, CreateJobBuild, CreateRetryJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, InsertBuildGetVersion, FindBuildGetVersions, GetJobBuild, CancelJobBuild, RetryJobBuild, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions, WebhookTrigger, RegenerateWebhookToken, CreateTrigger, ListTriggersAfter}
 
 var _RouteNameNameToValueMap = map[string]RouteName{
 	_RouteNameName[0:10]:         UserLogin,
@@ -77,78 +82,88 @@ var _RouteNameNameToValueMap = map[string]RouteName{
 	_RouteNameLowerName[23:34]:   CreateUser,
 	_RouteNameName[34:44]:        ListUsers,
 	_RouteNameLowerName[34:44]:   ListUsers,
-	_RouteNameName[44:55]:        CreateTeam,
-	_RouteNameLowerName[44:55]:   CreateTeam,
-	_RouteNameName[55:65]:        ListTeams,
-	_RouteNameLowerName[55:65]:   ListTeams,
-	_RouteNameName[65:73]:        GetTeam,
-	_RouteNameLowerName[65:73]:   GetTeam,
-	_RouteNameName[73:84]:        UpdateTeam,
-	_RouteNameLowerName[73:84]:   UpdateTeam,
-	_RouteNameName[84:95]:        DeleteTeam,
-	_RouteNameLowerName[84:95]:   DeleteTeam,
-	_RouteNameName[95:113]:       CreateTeamMember,
-	_RouteNameLowerName[95:113]:  CreateTeamMember,
-	_RouteNameName[113:131]:      UpdateTeamMember,
-	_RouteNameLowerName[113:131]: UpdateTeamMember,
-	_RouteNameName[131:149]:      DeleteTeamMember,
-	_RouteNameLowerName[131:149]: DeleteTeamMember,
-	_RouteNameName[149:164]:      CreatePipeline,
-	_RouteNameLowerName[149:164]: CreatePipeline,
-	_RouteNameName[164:179]:      UpdatePipeline,
-	_RouteNameLowerName[164:179]: UpdatePipeline,
-	_RouteNameName[179:191]:      GetPipeline,
-	_RouteNameLowerName[179:191]: GetPipeline,
-	_RouteNameName[191:206]:      DeletePipeline,
-	_RouteNameLowerName[191:206]: DeletePipeline,
-	_RouteNameName[206:220]:      ListPipelines,
-	_RouteNameLowerName[206:220]: ListPipelines,
-	_RouteNameName[220:238]:      GetPipelineImage,
-	_RouteNameLowerName[220:238]: GetPipelineImage,
-	_RouteNameName[238:259]:      CreatePipelineImage,
-	_RouteNameLowerName[238:259]: CreatePipelineImage,
-	_RouteNameName[259:279]:      TriggerPipelineJob,
-	_RouteNameLowerName[259:279]: TriggerPipelineJob,
-	_RouteNameName[279:295]:      GetPipelineJob,
-	_RouteNameLowerName[279:295]: GetPipelineJob,
-	_RouteNameName[295:311]:      CreateJobBuild,
-	_RouteNameLowerName[295:311]: CreateJobBuild,
-	_RouteNameName[311:333]:      CreateRetryJobBuild,
-	_RouteNameLowerName[311:333]: CreateRetryJobBuild,
-	_RouteNameName[333:349]:      UpdateJobBuild,
-	_RouteNameLowerName[333:349]: UpdateJobBuild,
-	_RouteNameName[349:365]:      DeleteJobBuild,
-	_RouteNameLowerName[349:365]: DeleteJobBuild,
-	_RouteNameName[365:380]:      ListJobBuilds,
-	_RouteNameLowerName[365:380]: ListJobBuilds,
-	_RouteNameName[380:404]:      InsertBuildGetVersion,
-	_RouteNameLowerName[380:404]: InsertBuildGetVersion,
-	_RouteNameName[404:427]:      FindBuildGetVersions,
-	_RouteNameLowerName[404:427]: FindBuildGetVersions,
-	_RouteNameName[427:440]:      GetJobBuild,
-	_RouteNameLowerName[427:440]: GetJobBuild,
-	_RouteNameName[440:456]:      CancelJobBuild,
-	_RouteNameLowerName[440:456]: CancelJobBuild,
-	_RouteNameName[456:471]:      RetryJobBuild,
-	_RouteNameLowerName[456:471]: RetryJobBuild,
-	_RouteNameName[471:492]:      GetPipelineResource,
-	_RouteNameLowerName[471:492]: GetPipelineResource,
-	_RouteNameName[492:516]:      UpdatePipelineResource,
-	_RouteNameLowerName[492:516]: UpdatePipelineResource,
-	_RouteNameName[516:541]:      TriggerPipelineResource,
-	_RouteNameLowerName[516:541]: TriggerPipelineResource,
-	_RouteNameName[541:564]:      CreateResourceVersion,
-	_RouteNameLowerName[541:564]: CreateResourceVersion,
-	_RouteNameName[564:586]:      ListResourceVersions,
-	_RouteNameLowerName[564:586]: ListResourceVersions,
-	_RouteNameName[586:601]:      WebhookTrigger,
-	_RouteNameLowerName[586:601]: WebhookTrigger,
-	_RouteNameName[601:625]:      RegenerateWebhookToken,
-	_RouteNameLowerName[601:625]: RegenerateWebhookToken,
-	_RouteNameName[625:639]:      CreateTrigger,
-	_RouteNameLowerName[625:639]: CreateTrigger,
-	_RouteNameName[639:658]:      ListTriggersAfter,
-	_RouteNameLowerName[639:658]: ListTriggersAfter,
+	_RouteNameName[44:52]:        GetUser,
+	_RouteNameLowerName[44:52]:   GetUser,
+	_RouteNameName[52:63]:        UpdateUser,
+	_RouteNameLowerName[52:63]:   UpdateUser,
+	_RouteNameName[63:74]:        DeleteUser,
+	_RouteNameLowerName[63:74]:   DeleteUser,
+	_RouteNameName[74:89]:        ChangePassword,
+	_RouteNameLowerName[74:89]:   ChangePassword,
+	_RouteNameName[89:103]:       UpdateProfile,
+	_RouteNameLowerName[89:103]:  UpdateProfile,
+	_RouteNameName[103:114]:      CreateTeam,
+	_RouteNameLowerName[103:114]: CreateTeam,
+	_RouteNameName[114:124]:      ListTeams,
+	_RouteNameLowerName[114:124]: ListTeams,
+	_RouteNameName[124:132]:      GetTeam,
+	_RouteNameLowerName[124:132]: GetTeam,
+	_RouteNameName[132:143]:      UpdateTeam,
+	_RouteNameLowerName[132:143]: UpdateTeam,
+	_RouteNameName[143:154]:      DeleteTeam,
+	_RouteNameLowerName[143:154]: DeleteTeam,
+	_RouteNameName[154:172]:      CreateTeamMember,
+	_RouteNameLowerName[154:172]: CreateTeamMember,
+	_RouteNameName[172:190]:      UpdateTeamMember,
+	_RouteNameLowerName[172:190]: UpdateTeamMember,
+	_RouteNameName[190:208]:      DeleteTeamMember,
+	_RouteNameLowerName[190:208]: DeleteTeamMember,
+	_RouteNameName[208:223]:      CreatePipeline,
+	_RouteNameLowerName[208:223]: CreatePipeline,
+	_RouteNameName[223:238]:      UpdatePipeline,
+	_RouteNameLowerName[223:238]: UpdatePipeline,
+	_RouteNameName[238:250]:      GetPipeline,
+	_RouteNameLowerName[238:250]: GetPipeline,
+	_RouteNameName[250:265]:      DeletePipeline,
+	_RouteNameLowerName[250:265]: DeletePipeline,
+	_RouteNameName[265:279]:      ListPipelines,
+	_RouteNameLowerName[265:279]: ListPipelines,
+	_RouteNameName[279:297]:      GetPipelineImage,
+	_RouteNameLowerName[279:297]: GetPipelineImage,
+	_RouteNameName[297:318]:      CreatePipelineImage,
+	_RouteNameLowerName[297:318]: CreatePipelineImage,
+	_RouteNameName[318:338]:      TriggerPipelineJob,
+	_RouteNameLowerName[318:338]: TriggerPipelineJob,
+	_RouteNameName[338:354]:      GetPipelineJob,
+	_RouteNameLowerName[338:354]: GetPipelineJob,
+	_RouteNameName[354:370]:      CreateJobBuild,
+	_RouteNameLowerName[354:370]: CreateJobBuild,
+	_RouteNameName[370:392]:      CreateRetryJobBuild,
+	_RouteNameLowerName[370:392]: CreateRetryJobBuild,
+	_RouteNameName[392:408]:      UpdateJobBuild,
+	_RouteNameLowerName[392:408]: UpdateJobBuild,
+	_RouteNameName[408:424]:      DeleteJobBuild,
+	_RouteNameLowerName[408:424]: DeleteJobBuild,
+	_RouteNameName[424:439]:      ListJobBuilds,
+	_RouteNameLowerName[424:439]: ListJobBuilds,
+	_RouteNameName[439:463]:      InsertBuildGetVersion,
+	_RouteNameLowerName[439:463]: InsertBuildGetVersion,
+	_RouteNameName[463:486]:      FindBuildGetVersions,
+	_RouteNameLowerName[463:486]: FindBuildGetVersions,
+	_RouteNameName[486:499]:      GetJobBuild,
+	_RouteNameLowerName[486:499]: GetJobBuild,
+	_RouteNameName[499:515]:      CancelJobBuild,
+	_RouteNameLowerName[499:515]: CancelJobBuild,
+	_RouteNameName[515:530]:      RetryJobBuild,
+	_RouteNameLowerName[515:530]: RetryJobBuild,
+	_RouteNameName[530:551]:      GetPipelineResource,
+	_RouteNameLowerName[530:551]: GetPipelineResource,
+	_RouteNameName[551:575]:      UpdatePipelineResource,
+	_RouteNameLowerName[551:575]: UpdatePipelineResource,
+	_RouteNameName[575:600]:      TriggerPipelineResource,
+	_RouteNameLowerName[575:600]: TriggerPipelineResource,
+	_RouteNameName[600:623]:      CreateResourceVersion,
+	_RouteNameLowerName[600:623]: CreateResourceVersion,
+	_RouteNameName[623:645]:      ListResourceVersions,
+	_RouteNameLowerName[623:645]: ListResourceVersions,
+	_RouteNameName[645:660]:      WebhookTrigger,
+	_RouteNameLowerName[645:660]: WebhookTrigger,
+	_RouteNameName[660:684]:      RegenerateWebhookToken,
+	_RouteNameLowerName[660:684]: RegenerateWebhookToken,
+	_RouteNameName[684:698]:      CreateTrigger,
+	_RouteNameLowerName[684:698]: CreateTrigger,
+	_RouteNameName[698:717]:      ListTriggersAfter,
+	_RouteNameLowerName[698:717]: ListTriggersAfter,
 }
 
 var _RouteNameNames = []string{
@@ -156,42 +171,47 @@ var _RouteNameNames = []string{
 	_RouteNameName[10:23],
 	_RouteNameName[23:34],
 	_RouteNameName[34:44],
-	_RouteNameName[44:55],
-	_RouteNameName[55:65],
-	_RouteNameName[65:73],
-	_RouteNameName[73:84],
-	_RouteNameName[84:95],
-	_RouteNameName[95:113],
-	_RouteNameName[113:131],
-	_RouteNameName[131:149],
-	_RouteNameName[149:164],
-	_RouteNameName[164:179],
-	_RouteNameName[179:191],
-	_RouteNameName[191:206],
-	_RouteNameName[206:220],
-	_RouteNameName[220:238],
-	_RouteNameName[238:259],
-	_RouteNameName[259:279],
-	_RouteNameName[279:295],
-	_RouteNameName[295:311],
-	_RouteNameName[311:333],
-	_RouteNameName[333:349],
-	_RouteNameName[349:365],
-	_RouteNameName[365:380],
-	_RouteNameName[380:404],
-	_RouteNameName[404:427],
-	_RouteNameName[427:440],
-	_RouteNameName[440:456],
-	_RouteNameName[456:471],
-	_RouteNameName[471:492],
-	_RouteNameName[492:516],
-	_RouteNameName[516:541],
-	_RouteNameName[541:564],
-	_RouteNameName[564:586],
-	_RouteNameName[586:601],
-	_RouteNameName[601:625],
-	_RouteNameName[625:639],
-	_RouteNameName[639:658],
+	_RouteNameName[44:52],
+	_RouteNameName[52:63],
+	_RouteNameName[63:74],
+	_RouteNameName[74:89],
+	_RouteNameName[89:103],
+	_RouteNameName[103:114],
+	_RouteNameName[114:124],
+	_RouteNameName[124:132],
+	_RouteNameName[132:143],
+	_RouteNameName[143:154],
+	_RouteNameName[154:172],
+	_RouteNameName[172:190],
+	_RouteNameName[190:208],
+	_RouteNameName[208:223],
+	_RouteNameName[223:238],
+	_RouteNameName[238:250],
+	_RouteNameName[250:265],
+	_RouteNameName[265:279],
+	_RouteNameName[279:297],
+	_RouteNameName[297:318],
+	_RouteNameName[318:338],
+	_RouteNameName[338:354],
+	_RouteNameName[354:370],
+	_RouteNameName[370:392],
+	_RouteNameName[392:408],
+	_RouteNameName[408:424],
+	_RouteNameName[424:439],
+	_RouteNameName[439:463],
+	_RouteNameName[463:486],
+	_RouteNameName[486:499],
+	_RouteNameName[499:515],
+	_RouteNameName[515:530],
+	_RouteNameName[530:551],
+	_RouteNameName[551:575],
+	_RouteNameName[575:600],
+	_RouteNameName[600:623],
+	_RouteNameName[623:645],
+	_RouteNameName[645:660],
+	_RouteNameName[660:684],
+	_RouteNameName[684:698],
+	_RouteNameName[698:717],
 }
 
 // RouteNameString retrieves an enum value from the enum constants string name.

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -1530,6 +1530,10 @@
               }
               app.apiNotice.setSuccess("Password changed successfully");
             },
+            error: function(response) {
+              var msg = (response.responseJSON && response.responseJSON.error) || response.statusText || "Unknown error";
+              app.apiNotice.set({error: msg});
+            },
           });
         },
       })

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -26,7 +26,7 @@
       <header>
       </header>
       <main class="container">
-        <div id="error"></div>
+        <div id="notice"></div>
         <div id="breadcrumb"></div>
         <div id="main"></div>
       </main>
@@ -56,6 +56,11 @@
                   </a>
                 </li>
                 <li><hr class="dropdown-divider"></li>
+                <li><a class="dropdown-item" id="nav-profile" href="/profile"><i class="bi bi-person"></i> Profile</a></li>
+                <% if (session.user.admin) { %>
+                  <li><a class="dropdown-item" id="nav-users" href="/users"><i class="bi bi-people"></i> Users <span class="badge bg-secondary ms-1">Admin</span></a></li>
+                <% } %>
+                <li><hr class="dropdown-divider"></li>
                 <li><a class="dropdown-item" id="logout" href="/logout"><i class="bi bi-box-arrow-right"></i> Logout</a></li>
               </ul>
             </div>
@@ -64,11 +69,16 @@
       </nav>
     </script>
 
-    <script type="text/template" id="error-view">
+    <script type="text/template" id="notice-view">
       <div>
         <% if (error) { %>
           <div class="alert alert-danger" role="alert">
             <%- error %>
+          </div>
+        <% } %>
+        <% if (success) { %>
+          <div class="alert alert-success" role="alert">
+            <%- success %>
           </div>
         <% } %>
       </div>
@@ -607,6 +617,126 @@
       </div>
     </script>
 
+    <script type="text/template" id="users-list-view">
+      <div class="d-flex align-items-center justify-content-between mb-3">
+        <h1 class="h4 fw-bold mb-0">Users</h1>
+        <a type="button" id="user-new" class="btn btn-success" href="/users/new"><i class="bi bi-plus"></i> New User</a>
+      </div>
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Username</th>
+            <th>Full Name</th>
+            <th>Role</th>
+          </tr>
+        </thead>
+        <tbody id="users-table-body">
+        </tbody>
+      </table>
+    </script>
+
+    <script type="text/template" id="users-row-view">
+      <td><a href="/users/<%- username %>"><%- username %></a></td>
+      <td><%- full_name %></td>
+      <td><% if (admin) { %><span class="badge bg-primary">Admin</span><% } else { %><span class="badge bg-secondary">Member</span><% } %></td>
+    </script>
+
+    <script type="text/template" id="user-show-view">
+      <div class="d-flex align-items-center justify-content-between mb-3">
+        <h1 class="h4 fw-bold mb-0">Edit User: <%- username %></h1>
+      </div>
+      <form id="user-form">
+        <div class="mb-3">
+          <label for="full_name" class="form-label">Full Name</label>
+          <input type="text" class="form-control" id="full_name" value="<%- full_name %>">
+        </div>
+        <div class="mb-3">
+          <label for="username" class="form-label">Username</label>
+          <input type="text" class="form-control" id="username" value="<%- username %>">
+        </div>
+        <div class="mb-3 form-check">
+          <input type="checkbox" class="form-check-input" id="admin" <% if (admin) { %>checked<% } %>>
+          <label class="form-check-label" for="admin">Admin</label>
+        </div>
+        <button type="submit" class="btn btn-primary">Save Changes</button>
+      </form>
+      <hr style="border-color: var(--border); margin: 1.5rem 0;">
+      <h3 class="h5 fw-bold mb-3">Reset Password</h3>
+      <form id="reset-password-form">
+        <div class="mb-3">
+          <label for="new_password" class="form-label">New Password</label>
+          <input type="password" class="form-control" id="new_password" placeholder="Enter new password">
+        </div>
+        <button type="submit" class="btn btn-warning">Reset Password</button>
+      </form>
+      <hr style="border-color: var(--border); margin: 1.5rem 0;">
+      <button type="button" id="delete-user" class="btn btn-danger"><i class="bi bi-trash"></i> Delete User</button>
+    </script>
+
+    <script type="text/template" id="users-new-view">
+      <div class="mb-3">
+        <h1 class="h4 fw-bold">New User</h1>
+      </div>
+      <form id="user-create-form">
+        <div class="mb-3">
+          <label for="username" class="form-label">Username</label>
+          <input type="text" class="form-control" id="username" placeholder="Enter username">
+        </div>
+        <div class="mb-3">
+          <label for="full_name" class="form-label">Full Name</label>
+          <input type="text" class="form-control" id="full_name" placeholder="Enter full name">
+        </div>
+        <div class="mb-3">
+          <label for="password" class="form-label">Password</label>
+          <input type="password" class="form-control" id="password" placeholder="Enter password">
+        </div>
+        <div class="mb-3 form-check">
+          <input type="checkbox" class="form-check-input" id="admin">
+          <label class="form-check-label" for="admin">Admin</label>
+        </div>
+        <button type="submit" class="btn btn-primary">Create User</button>
+      </form>
+    </script>
+
+    <script type="text/template" id="profile-view">
+      <div class="d-flex align-items-center justify-content-between mb-3">
+        <h1 class="h4 fw-bold mb-0">Profile</h1>
+      </div>
+      <% if (mustChangePassword) { %>
+        <div class="alert alert-warning" id="must-change-password-banner" role="alert">
+          <i class="bi bi-exclamation-triangle"></i> Please change your default password before continuing.
+        </div>
+      <% } %>
+      <form id="profile-form">
+        <div class="mb-3">
+          <label for="full_name" class="form-label">Full Name</label>
+          <input type="text" class="form-control" id="full_name" value="<%- fullName %>">
+        </div>
+        <div class="mb-3">
+          <label for="username" class="form-label">Username</label>
+          <input type="text" class="form-control" id="username" value="<%- currentUsername %>">
+        </div>
+        <button type="submit" class="btn btn-primary">Save Changes</button>
+      </form>
+      <hr style="border-color: var(--border); margin: 1.5rem 0;">
+      <h3 class="h5 fw-bold mb-3">Change Password</h3>
+      <form id="change-password-form">
+        <div class="mb-3">
+          <label for="current_password" class="form-label">Current Password</label>
+          <input type="password" class="form-control" id="current_password" placeholder="Enter current password">
+        </div>
+        <div class="mb-3">
+          <label for="new_password" class="form-label">New Password</label>
+          <input type="password" class="form-control" id="new_password" placeholder="Enter new password">
+        </div>
+        <div class="mb-3">
+          <label for="confirm_password" class="form-label">Confirm New Password</label>
+          <input type="password" class="form-control" id="confirm_password" placeholder="Confirm new password">
+        </div>
+        <button type="submit" class="btn btn-warning">Change Password</button>
+      </form>
+    </script>
+
     <script type = "text/javascript">
       'use strict';
 
@@ -748,9 +878,25 @@
           id: null,
           full_name: null,
           username: null,
-          admin: null,
+          admin: false,
         },
         idAttribute: "username",
+        url: function() {
+          return "/users/" + this.get("username")
+        },
+        parse: function(response) {
+          if (response.data) {
+            return response.data
+          }
+          return response
+        },
+      });
+      app.UsersCollection = Backbone.Collection.extend({
+        model: app.User,
+        url: "/users",
+        parse: function(response) {
+          return response.data
+        },
       });
       app.Team = Backbone.Model.extend({
         idAttribute: "canonical",
@@ -851,12 +997,25 @@
           return response;
         }
       });
-      app.APIError = Backbone.Model.extend({
+      app.APINotice = Backbone.Model.extend({
+        defaults: {
+          error: "",
+          success: "",
+        },
         clear: function(){
-          this.set({error: ""})
+          Backbone.Model.prototype.set.call(this, {error: "", success: ""})
+        },
+        set: function(attrs, options) {
+          if (attrs.error && attrs.error !== "") {
+            attrs.success = ""
+          }
+          return Backbone.Model.prototype.set.call(this, attrs, options)
+        },
+        setSuccess: function(msg){
+          this.set({error: "", success: msg})
         }
       })
-      app.apiError = new app.APIError()
+      app.apiNotice = new app.APINotice()
 
       //--------------
       // Collections
@@ -994,7 +1153,7 @@
         initialize: function () {
           this.render();
           this.header = new app.HeaderView({ el: 'header' });
-          this.error = new app.ErrorView({ el: '#error', model: app.apiError });
+          this.notice = new app.NoticeView({ el: '#notice', model: app.apiNotice });
         },
         render: function () {
           this.$el.html(this.template());
@@ -1010,6 +1169,8 @@
         events: {
           'click a#logo': 'clickLogo',
           'click a#logout': 'clickLogout',
+          'click a#nav-profile': 'clickNavLink',
+          'click a#nav-users': 'clickNavLink',
         },
         clickLogo: function(event) {
           event.preventDefault();
@@ -1024,6 +1185,12 @@
           var url = new URL(event.target.href)
           app.router.navigate(url.pathname, { trigger: true });
         },
+        clickNavLink: function(event) {
+          event.preventDefault();
+          var target = event.target.closest('a');
+          var url = new URL(target.href)
+          app.router.navigate(url.pathname, { trigger: true });
+        },
         render: function () {
           var sjson 
           if (!app.session.isEmpty()) {
@@ -1034,8 +1201,8 @@
           return this; // enable chained calls
         }
       })
-      app.ErrorView = Backbone.View.extend({
-        template: _.template($('#error-view').html()),
+      app.NoticeView = Backbone.View.extend({
+        template: _.template($('#notice-view').html()),
         initialize: function() {
           this.listenTo(this.model, "change", this.render)
         },
@@ -1097,9 +1264,273 @@
               app.session.unset("password")
               app.session.unset("username")
               window.localStorage.setItem(userSessionKey, JSON.stringify(app.session.toJSON()))
-              app.router.navigate('', { trigger: true });
+              var u = app.session.get("user");
+              if (u && u.must_change_password) {
+                app.router.navigate('profile', { trigger: true });
+              } else {
+                app.router.navigate('', { trigger: true });
+              }
             },
           })
+        },
+      })
+      app.UsersListView = Backbone.View.extend({
+        template: _.template($('#users-list-view').html()),
+        initialize: function() {
+          this.listenTo(this.collection, "add", this.addUser)
+          this.listenTo(this.collection, "destroy", this.render)
+          this.collection.fetch()
+        },
+        events: {
+          'click a': 'clickLink',
+        },
+        render: function() {
+          this.$el.html(this.template());
+          var that = this
+          this.collection.each(function(m) {
+            that.addUser(m)
+          })
+          return this;
+        },
+        addUser: function(m) {
+          var view = new app.UsersRowView({model: m});
+          this.$('#users-table-body').append(view.render().el);
+        },
+        clickLink: function(event) {
+          event.preventDefault();
+          var target = event.target.closest('a');
+          var url = new URL(target.href)
+          app.router.navigate(url.pathname, { trigger: true });
+        },
+      })
+      app.UsersRowView = Backbone.View.extend({
+        template: _.template($('#users-row-view').html()),
+        tagName: "tr",
+        events: {
+          'click a': 'clickLink',
+        },
+        render: function() {
+          this.$el.html(this.template(this.model.toJSON()));
+          return this;
+        },
+        clickLink: function(event) {
+          event.preventDefault();
+          var url = new URL(event.target.href)
+          app.router.navigate(url.pathname, { trigger: true });
+        },
+      })
+      app.UserShowView = Backbone.View.extend({
+        template: _.template($('#user-show-view').html()),
+        events: {
+          'submit #user-form': 'submitForm',
+          'submit #reset-password-form': 'resetPassword',
+          'click #delete-user': 'deleteUser',
+        },
+        render: function() {
+          this.$el.html(this.template(this.model.toJSON()));
+          return this;
+        },
+        submitForm: function(event) {
+          event.preventDefault();
+          var fullName = this.$('#full_name').val();
+          var username = this.$('#username').val();
+          var admin = this.$('#admin').is(':checked');
+          var originalUsername = this.model.get("username");
+          var that = this;
+
+          $.ajax({
+            url: '/users/' + originalUsername + '.json',
+            type: 'PUT',
+            headers: {
+              'Authorization': 'Bearer ' + app.session.get("jwt"),
+              'Content-Type': 'application/json',
+            },
+            data: JSON.stringify({full_name: fullName, username: username, admin: admin}),
+            success: function(resp) {
+              if (resp.error) {
+                app.apiNotice.set({error: resp.error});
+                return;
+              }
+              if (username !== originalUsername) {
+                app.router.navigate('users/' + username, { trigger: true });
+              } else {
+                that.model.set(resp.data);
+                that.render();
+              }
+            },
+          });
+        },
+        resetPassword: function(event) {
+          event.preventDefault();
+          var newPassword = this.$('#new_password').val();
+          if (!newPassword) return;
+          var username = this.model.get("username");
+
+          $.ajax({
+            url: '/users/' + username + '.json',
+            type: 'PUT',
+            headers: {
+              'Authorization': 'Bearer ' + app.session.get("jwt"),
+              'Content-Type': 'application/json',
+            },
+            data: JSON.stringify({password: newPassword, admin: this.model.get("admin")}),
+            success: function(resp) {
+              if (resp.error) {
+                app.apiNotice.set({error: resp.error});
+                return;
+              }
+              app.apiNotice.setSuccess("Password reset successfully");
+            },
+          });
+        },
+        deleteUser: function(event) {
+          event.preventDefault();
+          var username = this.model.get("username");
+          if (!confirm("Are you sure you want to delete user '" + username + "'?")) return;
+
+          $.ajax({
+            url: '/users/' + username + '.json',
+            type: 'DELETE',
+            headers: {
+              'Authorization': 'Bearer ' + app.session.get("jwt"),
+              'Content-Type': 'application/json',
+            },
+            success: function(resp) {
+              if (resp.error) {
+                app.apiNotice.set({error: resp.error});
+                return;
+              }
+              app.router.navigate('users', { trigger: true });
+            },
+          });
+        },
+      })
+      app.UsersNewView = Backbone.View.extend({
+        template: _.template($('#users-new-view').html()),
+        events: {
+          'submit #user-create-form': 'submitForm',
+        },
+        render: function() {
+          this.$el.html(this.template());
+          return this;
+        },
+        submitForm: function(event) {
+          event.preventDefault();
+          var username = this.$('#username').val();
+          var fullName = this.$('#full_name').val();
+          var password = this.$('#password').val();
+          var admin = this.$('#admin').is(':checked');
+
+          $.ajax({
+            url: '/users.json',
+            type: 'POST',
+            headers: {
+              'Authorization': 'Bearer ' + app.session.get("jwt"),
+              'Content-Type': 'application/json',
+            },
+            data: JSON.stringify({username: username, password: password, full_name: fullName, admin: admin}),
+            success: function(resp) {
+              if (resp.error) {
+                app.apiNotice.set({error: resp.error});
+                return;
+              }
+              app.router.navigate('users/' + username, { trigger: true });
+            },
+          });
+        },
+      })
+      app.ProfileView = Backbone.View.extend({
+        template: _.template($('#profile-view').html()),
+        initialize: function(opts) {
+          this.mustChangePassword = opts.mustChangePassword || false;
+        },
+        events: {
+          'submit #profile-form': 'submitProfile',
+          'submit #change-password-form': 'changePassword',
+        },
+        render: function() {
+          var u = app.session.get("user");
+          this.$el.html(this.template({
+            fullName: u.full_name || '',
+            currentUsername: u.username || '',
+            mustChangePassword: this.mustChangePassword,
+          }));
+          return this;
+        },
+        submitProfile: function(event) {
+          event.preventDefault();
+          var fullName = this.$('#full_name').val();
+          var username = this.$('#username').val();
+
+          $.ajax({
+            url: '/profile.json',
+            type: 'PUT',
+            headers: {
+              'Authorization': 'Bearer ' + app.session.get("jwt"),
+              'Content-Type': 'application/json',
+            },
+            data: JSON.stringify({full_name: fullName, username: username}),
+            success: function(resp) {
+              if (resp.error) {
+                app.apiNotice.set({error: resp.error});
+                return;
+              }
+              // Refresh token to get updated user info
+              $.ajax({
+                url: '/refresh-token.json',
+                type: 'POST',
+                headers: {
+                  'Authorization': 'Bearer ' + app.session.get("jwt"),
+                  'Content-Type': 'application/json',
+                },
+                success: function(refreshResp) {
+                  if (refreshResp.data && refreshResp.data.jwt) {
+                    app.session.set({jwt: refreshResp.data.jwt, user: refreshResp.data.user});
+                    window.localStorage.setItem(userSessionKey, JSON.stringify(app.session.toJSON()));
+                  }
+                },
+              });
+              app.apiNotice.setSuccess("Profile updated successfully");
+            },
+          });
+        },
+        changePassword: function(event) {
+          event.preventDefault();
+          var currentPassword = this.$('#current_password').val();
+          var newPassword = this.$('#new_password').val();
+          var confirmPassword = this.$('#confirm_password').val();
+
+          if (newPassword !== confirmPassword) {
+            app.apiNotice.set({error: "New passwords do not match"});
+            return;
+          }
+
+          var that = this;
+          $.ajax({
+            url: '/users/change-password.json',
+            type: 'POST',
+            headers: {
+              'Authorization': 'Bearer ' + app.session.get("jwt"),
+              'Content-Type': 'application/json',
+            },
+            data: JSON.stringify({old_password: currentPassword, new_password: newPassword}),
+            success: function(resp) {
+              if (resp.error) {
+                app.apiNotice.set({error: resp.error});
+                return;
+              }
+              that.mustChangePassword = false;
+              that.$('#must-change-password-banner').remove();
+              // Clear the must_change_password flag from session
+              var u = app.session.get("user");
+              if (u) {
+                u.must_change_password = false;
+                app.session.set({user: u});
+                window.localStorage.setItem(userSessionKey, JSON.stringify(app.session.toJSON()));
+              }
+              app.apiNotice.setSuccess("Password changed successfully");
+            },
+          });
         },
       })
       app.TeamsView = Backbone.View.extend({
@@ -2019,7 +2450,7 @@
           try{
             var vars = JSON.parse(rvars)
           } catch (error){
-            app.apiError.set({error: "Error parsing Vars: "+error})
+            app.apiNotice.set({error: "Error parsing Vars: "+error})
             return
           }
           var data = [];
@@ -2052,7 +2483,7 @@
           try{
             var vars = JSON.parse(rvars)
           } catch (error){
-            app.apiError.set({error: "Error parsing Vars: "+error})
+            app.apiNotice.set({error: "Error parsing Vars: "+error})
             return
           }
           var data = [];
@@ -2474,6 +2905,12 @@
           'teams/:tc/pipelines/:pn/jobs/:jn/builds/:bid':   'jobBuilds',
 
           'teams/:tn/pipelines/:pn/resources/:rCan/versions': 'resourceVersions',
+
+          'users':          'usersIndex',
+          'users/new':      'usersNew',
+          'users/:username': 'usersShow',
+          'profile':        'profile',
+
           '*notFound': 'notFound',
         },
         sessionNew: function() {
@@ -2713,10 +3150,63 @@
             }
           })
         },
+        usersIndex: function() {
+          if (!this.setup(!isLogin)) {
+            return
+          }
+          if (!app.session.isAdmin()) {
+            app.router.navigate('', { trigger: true });
+            return
+          }
+          var users = new app.UsersCollection();
+          this.contentView = new app.UsersListView({collection: users});
+          $('#main').html(this.contentView.render().el)
+          $('#breadcrumb').html(new app.BreadcrumbView().render().el)
+        },
+        usersNew: function() {
+          if (!this.setup(!isLogin)) {
+            return
+          }
+          if (!app.session.isAdmin()) {
+            app.router.navigate('', { trigger: true });
+            return
+          }
+          this.contentView = new app.UsersNewView();
+          $('#main').html(this.contentView.render().el)
+          $('#breadcrumb').html(new app.BreadcrumbView().render().el)
+        },
+        usersShow: function(username) {
+          if (!this.setup(!isLogin)) {
+            return
+          }
+          if (!app.session.isAdmin()) {
+            app.router.navigate('', { trigger: true });
+            return
+          }
+          var u = new app.User({username: username});
+          var that = this;
+          u.fetch({
+            success: function() {
+              that.contentView = new app.UserShowView({model: u});
+              $('#main').html(that.contentView.render().el)
+              $('#breadcrumb').html(new app.BreadcrumbView().render().el)
+            },
+          });
+        },
+        profile: function() {
+          if (!this.setup(!isLogin, false, true)) {
+            return
+          }
+          var u = app.session.get("user");
+          var mustChange = u && u.must_change_password;
+          this.contentView = new app.ProfileView({mustChangePassword: mustChange});
+          $('#main').html(this.contentView.render().el)
+          $('#breadcrumb').html(new app.BreadcrumbView().render().el)
+        },
         notFound: function() {
           app.router.navigate('', { trigger: true });
         },
-        setup: function(isLogin, allowPublic) {
+        setup: function(isLogin, allowPublic, isProfile) {
           if (!this.mainView) {
             this.mainView = new app.MainView({ el: '#app' });
           }
@@ -2725,8 +3215,17 @@
             return false
           } else if (!app.session.isEmpty() && isLogin) {
             app.router.navigate("", { trigger: true });
-            return true 
-          } else if (this.contentView) {
+            return true
+          }
+          // Force redirect to profile if user must change their default password
+          if (!isProfile && !app.session.isEmpty()) {
+            var u = app.session.get("user");
+            if (u && u.must_change_password) {
+              app.router.navigate("profile", { trigger: true });
+              return false
+            }
+          }
+          if (this.contentView) {
             // TODO: Recheck this
             //// COMPLETELY UNBIND THE VIEW
             this.contentView.undelegateEvents();
@@ -2756,7 +3255,7 @@
         var optError = options.error
         options.error = function(response){
           var msg = (response.responseJSON && response.responseJSON.error) || response.statusText || "Unknown error";
-          app.apiError.set({error: msg})
+          app.apiNotice.set({error: msg})
           if (optError) {
             optError(response)
           }
@@ -2764,7 +3263,7 @@
         var optSuccess = options.success
         options.success = function(response, textStatus, jqXHR){
           if (!options.isInterval) {
-            app.apiError.clear()
+            app.apiNotice.clear()
           }
           if (jqXHR && jqXHR.getResponseHeader('X-Refresh-Token') === 'true') {
             $.ajax({

--- a/pikoci/transport/http/users.go
+++ b/pikoci/transport/http/users.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/gorilla/mux"
 	"github.com/xescugc/pikoci/pikoci"
 	"github.com/xescugc/pikoci/pikoci/user"
 )
@@ -123,6 +124,8 @@ func listUsers(s pikoci.Service) http.HandlerFunc {
 type CreateUserRequest struct {
 	Username string `json:"username"`
 	Password string `json:"password"`
+	FullName string `json:"full_name"`
+	Admin    bool   `json:"admin"`
 	IsHash   bool   `json:"is_hash"`
 }
 type CreateUserResponse struct {
@@ -145,11 +148,183 @@ func createUser(s pikoci.Service) http.HandlerFunc {
 			encodeResponse(CreateUserResponse{Err: err.Error()}, w)
 			return
 		}
-		u, err := s.CreateUser(ctx, user.User{Username: req.Username, Password: req.Password}, req.IsHash)
+		u, err := s.CreateUser(ctx, user.User{Username: req.Username, Password: req.Password, FullName: req.FullName, Admin: req.Admin}, req.IsHash)
 		var errs string
 		if err != nil {
 			errs = err.Error()
 		}
 		encodeResponse(CreateUserResponse{User: u, Err: errs}, w)
+	}
+}
+
+type GetUserResponse struct {
+	User *user.User `json:"data,omitempty"`
+	Err  string     `json:"error,omitempty"`
+}
+
+func (r GetUserResponse) Error() string {
+	return r.Err
+}
+
+func getUser(s pikoci.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		vars := mux.Vars(r)
+		un := vars["username"]
+
+		um, err := s.GetUser(ctx, un)
+		var errs string
+		if err != nil {
+			errs = err.Error()
+			encodeResponse(GetUserResponse{Err: errs}, w)
+			return
+		}
+		encodeResponse(GetUserResponse{User: &um.User, Err: errs}, w)
+	}
+}
+
+type UpdateUserRequest struct {
+	FullName string `json:"full_name"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Admin    bool   `json:"admin"`
+	IsHash   bool   `json:"is_hash"`
+}
+type UpdateUserResponse struct {
+	User *user.User `json:"data,omitempty"`
+	Err  string     `json:"error,omitempty"`
+}
+
+func (r UpdateUserResponse) Error() string {
+	return r.Err
+}
+
+func updateUser(s pikoci.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var (
+			req UpdateUserRequest
+			ctx = r.Context()
+		)
+		vars := mux.Vars(r)
+		un := vars["username"]
+
+		err := json.NewDecoder(r.Body).Decode(&req)
+		if err != nil {
+			encodeResponse(UpdateUserResponse{Err: err.Error()}, w)
+			return
+		}
+		u, err := s.UpdateUser(ctx, un, user.User{
+			FullName: req.FullName,
+			Username: req.Username,
+			Password: req.Password,
+			Admin:    req.Admin,
+		}, req.IsHash)
+		var errs string
+		if err != nil {
+			errs = err.Error()
+		}
+		encodeResponse(UpdateUserResponse{User: u, Err: errs}, w)
+	}
+}
+
+type DeleteUserResponse struct {
+	Err string `json:"error,omitempty"`
+}
+
+func (r DeleteUserResponse) Error() string {
+	return r.Err
+}
+
+func deleteUser(s pikoci.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		vars := mux.Vars(r)
+		un := vars["username"]
+
+		err := s.DeleteUser(ctx, un)
+		var errs string
+		if err != nil {
+			errs = err.Error()
+		}
+		encodeResponse(DeleteUserResponse{Err: errs}, w)
+	}
+}
+
+type ChangePasswordRequest struct {
+	OldPassword string `json:"old_password"`
+	NewPassword string `json:"new_password"`
+}
+type ChangePasswordResponse struct {
+	Err string `json:"error,omitempty"`
+}
+
+func (r ChangePasswordResponse) Error() string {
+	return r.Err
+}
+
+func changePassword(s pikoci.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var (
+			req ChangePasswordRequest
+			ctx = r.Context()
+		)
+		un, _ := ctx.Value(UsernameContextKey).(string)
+		if un == "" {
+			encodeResponse(ChangePasswordResponse{Err: "missing username"}, w)
+			return
+		}
+
+		err := json.NewDecoder(r.Body).Decode(&req)
+		if err != nil {
+			encodeResponse(ChangePasswordResponse{Err: err.Error()}, w)
+			return
+		}
+
+		err = s.ChangePassword(ctx, un, req.OldPassword, req.NewPassword)
+		var errs string
+		if err != nil {
+			errs = err.Error()
+		}
+		encodeResponse(ChangePasswordResponse{Err: errs}, w)
+	}
+}
+
+type UpdateProfileRequest struct {
+	FullName string `json:"full_name"`
+	Username string `json:"username"`
+}
+type UpdateProfileResponse struct {
+	User *user.User `json:"data,omitempty"`
+	Err  string     `json:"error,omitempty"`
+}
+
+func (r UpdateProfileResponse) Error() string {
+	return r.Err
+}
+
+func updateProfile(s pikoci.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var (
+			req UpdateProfileRequest
+			ctx = r.Context()
+		)
+		un, _ := ctx.Value(UsernameContextKey).(string)
+		if un == "" {
+			encodeResponse(UpdateProfileResponse{Err: "missing username"}, w)
+			return
+		}
+
+		err := json.NewDecoder(r.Body).Decode(&req)
+		if err != nil {
+			encodeResponse(UpdateProfileResponse{Err: err.Error()}, w)
+			return
+		}
+
+		u, err := s.UpdateProfile(ctx, un, req.FullName, req.Username)
+		var errs string
+		if err != nil {
+			errs = err.Error()
+		}
+		encodeResponse(UpdateProfileResponse{User: u, Err: errs}, w)
 	}
 }

--- a/pikoci/user/user.go
+++ b/pikoci/user/user.go
@@ -11,7 +11,8 @@ type User struct {
 type WithMemberships struct {
 	User
 
-	Memberships []Member `json:"memberships"`
+	Memberships        []Member `json:"memberships"`
+	MustChangePassword bool     `json:"must_change_password,omitempty"`
 }
 
 type Member struct {

--- a/pikoci/users.go
+++ b/pikoci/users.go
@@ -10,6 +10,11 @@ import (
 	"github.com/xescugc/pikoci/pikoci/utils"
 )
 
+// defaultAdminUsername and defaultAdmin123Hash identify the migration-seeded
+// default user (admin / admin123). Both must match to trigger force-password-change.
+const defaultAdminUsername = "admin"
+const defaultAdmin123Hash = "$2a$14$FoV/2Z0CRgQyiDJLMcErd.cC/DtWCKMWtxZEaL6HQd/rrtU2DZpAu"
+
 func (q *PikoCI) UserLogin(ctx context.Context, un, pass string) (*user.WithMemberships, string, error) {
 	if !utils.ValidateCanonical(un) {
 		return nil, "", fmt.Errorf("invalid Username format %q", un)
@@ -22,6 +27,11 @@ func (q *PikoCI) UserLogin(ctx context.Context, un, pass string) (*user.WithMemb
 	ok := utils.CheckPasswordHash(pass, um.Password)
 	if !ok {
 		return nil, "", fmt.Errorf("username or password is wrong")
+	}
+
+	// Flag if user is the migration-seeded admin with the default password
+	if um.Username == defaultAdminUsername && um.Password == defaultAdmin123Hash {
+		um.MustChangePassword = true
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
@@ -92,9 +102,10 @@ func (q *PikoCI) CreateUser(ctx context.Context, u user.User, isHash bool) (*use
 	return &u, nil
 }
 
-// CreateOrUpdateUser finds a user by username and updates their password if they exist,
-// or creates them if they don't. This is only intended for startup user seeding (--users flag),
-// not for the HTTP API.
+// CreateOrUpdateUser creates a user if they don't exist, or updates their password
+// only if they still have the migration-seeded default password (admin123).
+// This is only intended for startup user seeding (--users flag), not for the HTTP API.
+// Users who have already changed their password via the UI/CLI are not modified.
 func (q *PikoCI) CreateOrUpdateUser(ctx context.Context, u user.User, isHash bool) (*user.User, error) {
 	if !utils.ValidateCanonical(u.Username) {
 		return nil, fmt.Errorf("invalid Username format %q", u.Username)
@@ -112,6 +123,12 @@ func (q *PikoCI) CreateOrUpdateUser(ctx context.Context, u user.User, isHash boo
 
 	existing, err := q.Users.Find(ctx, u.Username)
 	if err == nil && existing != nil {
+		// Only update if this is the migration-seeded admin with the default password.
+		// This allows --users to set the admin password on first setup but
+		// won't overwrite passwords changed via the UI/CLI.
+		if !(existing.Username == defaultAdminUsername && existing.Password == defaultAdmin123Hash) {
+			return existing, nil
+		}
 		existing.Password = u.Password
 		if u.FullName != "" {
 			existing.FullName = u.FullName
@@ -139,4 +156,151 @@ func (q *PikoCI) ListUsers(ctx context.Context) ([]*user.User, error) {
 	}
 
 	return us, nil
+}
+
+func (q *PikoCI) UpdateUser(ctx context.Context, un string, u user.User, isHash bool) (*user.User, error) {
+	existing, err := q.Users.Find(ctx, un)
+	if err != nil {
+		return nil, fmt.Errorf("failed to Find User: %w", err)
+	}
+
+	if u.FullName != "" {
+		existing.FullName = u.FullName
+	}
+	if u.Username != "" && u.Username != un {
+		if !utils.ValidateCanonical(u.Username) {
+			return nil, fmt.Errorf("invalid Username format %q", u.Username)
+		}
+		existing.Username = u.Username
+	}
+	if u.Password != "" {
+		if !isHash {
+			hash, err := utils.HashPassword(u.Password)
+			if err != nil {
+				return nil, fmt.Errorf("failed to hash Password: %w", err)
+			}
+			existing.Password = hash
+		} else {
+			existing.Password = u.Password
+		}
+	}
+
+	// Prevent demoting the last admin
+	if existing.Admin && !u.Admin {
+		all, err := q.Users.Filter(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list users: %w", err)
+		}
+		adminCount := 0
+		for _, a := range all {
+			if a.Admin {
+				adminCount++
+			}
+		}
+		if adminCount <= 1 {
+			return nil, fmt.Errorf("cannot demote the last admin user")
+		}
+	}
+	existing.Admin = u.Admin
+
+	err = q.Users.Update(ctx, un, *existing)
+	if err != nil {
+		return nil, fmt.Errorf("failed to Update User: %w", err)
+	}
+
+	return existing, nil
+}
+
+func (q *PikoCI) DeleteUser(ctx context.Context, un string) error {
+	if !utils.ValidateCanonical(un) {
+		return fmt.Errorf("invalid Username format %q", un)
+	}
+
+	existing, err := q.Users.Find(ctx, un)
+	if err != nil {
+		return fmt.Errorf("failed to Find User: %w", err)
+	}
+
+	if existing.Admin {
+		all, err := q.Users.Filter(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to list users: %w", err)
+		}
+		adminCount := 0
+		for _, a := range all {
+			if a.Admin {
+				adminCount++
+			}
+		}
+		if adminCount <= 1 {
+			return fmt.Errorf("cannot delete the last admin user")
+		}
+	}
+
+	err = q.Users.Delete(ctx, un)
+	if err != nil {
+		return fmt.Errorf("failed to Delete User: %w", err)
+	}
+
+	return nil
+}
+
+func (q *PikoCI) ChangePassword(ctx context.Context, un, oldPassword, newPassword string) error {
+	if !utils.ValidateCanonical(un) {
+		return fmt.Errorf("invalid Username format %q", un)
+	}
+
+	existing, err := q.Users.Find(ctx, un)
+	if err != nil {
+		return fmt.Errorf("failed to Find User: %w", err)
+	}
+
+	if !utils.CheckPasswordHash(oldPassword, existing.Password) {
+		return fmt.Errorf("current password is incorrect")
+	}
+
+	if newPassword == "" {
+		return fmt.Errorf("new password cannot be empty")
+	}
+
+	hash, err := utils.HashPassword(newPassword)
+	if err != nil {
+		return fmt.Errorf("failed to hash Password: %w", err)
+	}
+	existing.Password = hash
+
+	err = q.Users.Update(ctx, un, *existing)
+	if err != nil {
+		return fmt.Errorf("failed to Update User: %w", err)
+	}
+
+	return nil
+}
+
+func (q *PikoCI) UpdateProfile(ctx context.Context, un string, fullName, newUsername string) (*user.User, error) {
+	if !utils.ValidateCanonical(un) {
+		return nil, fmt.Errorf("invalid Username format %q", un)
+	}
+
+	existing, err := q.Users.Find(ctx, un)
+	if err != nil {
+		return nil, fmt.Errorf("failed to Find User: %w", err)
+	}
+
+	if fullName != "" {
+		existing.FullName = fullName
+	}
+	if newUsername != "" && newUsername != un {
+		if !utils.ValidateCanonical(newUsername) {
+			return nil, fmt.Errorf("invalid Username format %q", newUsername)
+		}
+		existing.Username = newUsername
+	}
+
+	err = q.Users.Update(ctx, un, *existing)
+	if err != nil {
+		return nil, fmt.Errorf("failed to Update User: %w", err)
+	}
+
+	return existing, nil
 }

--- a/pikoci/users_test.go
+++ b/pikoci/users_test.go
@@ -59,12 +59,13 @@ func TestCreateOrUpdateUser_CreatesNew(t *testing.T) {
 	assert.True(t, utils.CheckPasswordHash("secret", u.Password))
 }
 
-func TestCreateOrUpdateUser_UpdatesExisting(t *testing.T) {
+func TestCreateOrUpdateUser_UpdatesExistingWithDefaultPassword(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := newService(ctrl)
 	ctx := context.TODO()
 
-	existing := &user.User{ID: 1, Username: "admin", Password: "old-hash", FullName: "Admin", Admin: true}
+	// User still has the default admin123 hash — should be updated
+	existing := &user.User{ID: 1, Username: "admin", Password: "$2a$14$FoV/2Z0CRgQyiDJLMcErd.cC/DtWCKMWtxZEaL6HQd/rrtU2DZpAu", FullName: "Admin", Admin: true}
 	s.Users.EXPECT().Find(ctx, "admin").Return(existing, nil)
 	s.Users.EXPECT().Update(ctx, "admin", gomock.Any()).Return(nil)
 
@@ -75,6 +76,23 @@ func TestCreateOrUpdateUser_UpdatesExisting(t *testing.T) {
 	assert.Equal(t, newHash, u.Password)
 	assert.True(t, u.Admin)
 	assert.Equal(t, "Admin", u.FullName)
+}
+
+func TestCreateOrUpdateUser_SkipsExistingWithChangedPassword(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	// User already changed their password — should NOT be updated
+	customHash, _ := utils.HashPassword("custom-password")
+	existing := &user.User{ID: 1, Username: "admin", Password: customHash, FullName: "Admin", Admin: true}
+	s.Users.EXPECT().Find(ctx, "admin").Return(existing, nil)
+
+	newHash, _ := utils.HashPassword("newsecret")
+	u, err := s.P.CreateOrUpdateUser(ctx, user.User{Username: "admin", Password: newHash}, true)
+	require.NoError(t, err)
+	// Password should NOT be changed
+	assert.Equal(t, customHash, u.Password)
 }
 
 func TestCreateUser_InvalidUsername(t *testing.T) {
@@ -166,4 +184,145 @@ func TestUserLogin_WrongPassword(t *testing.T) {
 	_, _, err := s.S.UserLogin(ctx, "admin", "wrong")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "wrong")
+}
+
+func TestUserLogin_DefaultPassword(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	// Use the actual default admin123 hash from migration
+	um := &user.WithMemberships{
+		User: user.User{ID: 1, Username: "admin", Password: "$2a$14$FoV/2Z0CRgQyiDJLMcErd.cC/DtWCKMWtxZEaL6HQd/rrtU2DZpAu"},
+	}
+	s.Users.EXPECT().FindWithMemberships(ctx, "admin").Return(um, nil)
+
+	u, jwt, err := s.S.UserLogin(ctx, "admin", "admin123")
+	require.NoError(t, err)
+	require.NotNil(t, u)
+	assert.NotEmpty(t, jwt)
+	assert.True(t, u.MustChangePassword)
+}
+
+func TestUserLogin_DefaultPassword_OtherUser(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	// A non-admin user with the same hash should NOT be flagged
+	um := &user.WithMemberships{
+		User: user.User{ID: 2, Username: "pepito", Password: "$2a$14$FoV/2Z0CRgQyiDJLMcErd.cC/DtWCKMWtxZEaL6HQd/rrtU2DZpAu"},
+	}
+	s.Users.EXPECT().FindWithMemberships(ctx, "pepito").Return(um, nil)
+
+	u, jwt, err := s.S.UserLogin(ctx, "pepito", "admin123")
+	require.NoError(t, err)
+	require.NotNil(t, u)
+	assert.NotEmpty(t, jwt)
+	assert.False(t, u.MustChangePassword)
+}
+
+func TestUpdateUser(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	existing := &user.User{ID: 1, Username: "admin", FullName: "Admin", Admin: true, Password: "old-hash"}
+	s.Users.EXPECT().Find(ctx, "admin").Return(existing, nil)
+	s.Users.EXPECT().Update(ctx, "admin", gomock.Any()).Return(nil)
+
+	u, err := s.S.UpdateUser(ctx, "admin", user.User{
+		FullName: "New Name",
+		Admin:    true,
+	}, false)
+	require.NoError(t, err)
+	assert.Equal(t, "New Name", u.FullName)
+	assert.True(t, u.Admin)
+}
+
+func TestUpdateUser_LastAdmin(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	existing := &user.User{ID: 1, Username: "admin", Admin: true, Password: "hash"}
+	s.Users.EXPECT().Find(ctx, "admin").Return(existing, nil)
+	s.Users.EXPECT().Filter(ctx).Return([]*user.User{
+		{ID: 1, Username: "admin", Admin: true},
+	}, nil)
+
+	_, err := s.S.UpdateUser(ctx, "admin", user.User{Admin: false}, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot demote the last admin")
+}
+
+func TestDeleteUser(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	existing := &user.User{ID: 2, Username: "pepito", Admin: false}
+	s.Users.EXPECT().Find(ctx, "pepito").Return(existing, nil)
+	s.Users.EXPECT().Delete(ctx, "pepito").Return(nil)
+
+	err := s.S.DeleteUser(ctx, "pepito")
+	require.NoError(t, err)
+}
+
+func TestDeleteUser_LastAdmin(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	existing := &user.User{ID: 1, Username: "admin", Admin: true}
+	s.Users.EXPECT().Find(ctx, "admin").Return(existing, nil)
+	s.Users.EXPECT().Filter(ctx).Return([]*user.User{
+		{ID: 1, Username: "admin", Admin: true},
+	}, nil)
+
+	err := s.S.DeleteUser(ctx, "admin")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot delete the last admin")
+}
+
+func TestChangePassword(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hash, _ := utils.HashPassword("oldpass")
+	existing := &user.User{ID: 1, Username: "admin", Password: hash}
+	s.Users.EXPECT().Find(ctx, "admin").Return(existing, nil)
+	s.Users.EXPECT().Update(ctx, "admin", gomock.Any()).Return(nil)
+
+	err := s.S.ChangePassword(ctx, "admin", "oldpass", "newpass")
+	require.NoError(t, err)
+}
+
+func TestChangePassword_WrongOld(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hash, _ := utils.HashPassword("oldpass")
+	existing := &user.User{ID: 1, Username: "admin", Password: hash}
+	s.Users.EXPECT().Find(ctx, "admin").Return(existing, nil)
+
+	err := s.S.ChangePassword(ctx, "admin", "wrongpass", "newpass")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "current password is incorrect")
+}
+
+func TestUpdateProfile(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	existing := &user.User{ID: 1, Username: "admin", FullName: "Admin", Password: "hash"}
+	s.Users.EXPECT().Find(ctx, "admin").Return(existing, nil)
+	s.Users.EXPECT().Update(ctx, "admin", gomock.Any()).Return(nil)
+
+	u, err := s.S.UpdateProfile(ctx, "admin", "New Name", "admin")
+	require.NoError(t, err)
+	assert.Equal(t, "New Name", u.FullName)
 }


### PR DESCRIPTION
## Summary

- Profile page for all users: change full name, username, and password (requires current password)
- Admin Users page: list, create, edit, and delete users with admin toggle and password reset
- CLI commands: `users update`, `users delete`, `users change-password`
- Force password change on first login with default `admin/admin123` credentials
- `--users` startup flag preserves passwords changed via UI/CLI, only overrides the default migration password
- Header dropdown with Profile and Users (admin-only) links

Closes #237