### PR TITLE
Pipeline editor: scroll to top and show resource type.label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - User management: Profile page, admin Users page, CLI commands, force password change on default `admin/admin123`, and `--users` flag preserves UI/CLI password changes ([#237](https://github.com/PikoCI/pikoci/issues/237))
 
+### Changed
+
+- Build detail and resource views now show relative timestamps ("5m ago") with absolute time on hover ([#344](https://github.com/PikoCI/pikoci/issues/344))
+
 ## [0.1.0] - 2026-05-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Build detail and resource views now show relative timestamps ("5m ago") with absolute time on hover ([#344](https://github.com/PikoCI/pikoci/issues/344))
+- Pipeline editor: clicking a block or graph node now scrolls it to the top of the viewport, and resource blocks in the sidebar show `type.label` (e.g., `git.pikoci_pr`) instead of just the type ([#336](https://github.com/PikoCI/pikoci/issues/336))
 
 ## [0.1.0] - 2026-05-23
 

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -2298,11 +2298,14 @@
           var html = ''
           var errorLines = this._errorLines || {}
           app.blockTypes.forEach(function(bt) {
-            var re = new RegExp(bt.type + '\\s+"([^"]+)"', 'g')
+            var re = bt.type === 'resource'
+              ? new RegExp(bt.type + '\\s+"([^"]+)"\\s+"([^"]+)"', 'g')
+              : new RegExp(bt.type + '\\s+"([^"]+)"', 'g')
             var matches = []
             var m
             while ((m = re.exec(doc)) !== null) {
-              matches.push({name: m[1], pos: m.index})
+              var displayName = bt.type === 'resource' ? m[1] + '.' + m[2] : m[1]
+              matches.push({name: displayName, pos: m.index})
             }
             if (matches.length === 0) return
             html += '<div class="piko-blocks-section">'
@@ -2324,9 +2327,10 @@
           if (isNaN(pos) || !this.editor) return
           this.$el.find('.piko-blocks-item').removeClass('active')
           $(e.currentTarget).addClass('active')
+          var CM = window.PikoCM
           this.editor.dispatch({
             selection: {anchor: pos},
-            scrollIntoView: true,
+            effects: CM.EditorView.scrollIntoView(pos, {y: 'start'}),
           })
           this.editor.focus()
         },
@@ -2357,12 +2361,22 @@
           var name = textEl.text().trim()
           if (!name) return
           var doc = this.editor.state.doc.toString()
-          var re = new RegExp('(?:job|resource|resource_type|runner_type|secret_type|service_type)\\s+"' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '"')
+          // Resource nodes use "type.label" format in the graph; split and match both quoted strings
+          var dotIdx = name.indexOf('.')
+          var re
+          if (dotIdx !== -1) {
+            var rType = name.substring(0, dotIdx).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+            var rLabel = name.substring(dotIdx + 1).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+            re = new RegExp('resource\\s+"' + rType + '"\\s+"' + rLabel + '"')
+          } else {
+            re = new RegExp('(?:job|resource|resource_type|runner_type|secret_type|service_type)\\s+"' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '"')
+          }
           var match = re.exec(doc)
           if (match) {
+            var CM = window.PikoCM
             this.editor.dispatch({
               selection: {anchor: match.index, head: match.index + match[0].length},
-              scrollIntoView: true,
+              effects: CM.EditorView.scrollIntoView(match.index, {y: 'start'}),
             })
             this.editor.focus()
           }

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -447,7 +447,7 @@
           </div>
         <% } %>
         <div class="piko-build-meta">
-          <span><span class="piko-build-label">Started</span> <%- new Date(started_at).toLocaleString() %></span>
+          <span><span class="piko-build-label">Started</span> <span class="piko-time-ago" data-time="<%= started_at %>" title="<%= new Date(started_at).toLocaleString() %>"><%= pikoTimeAgo(started_at) %></span></span>
           <% if (status === "started" && duration === 0) { %>
             <span><span class="piko-build-label">Duration</span> <span class="piko-elapsed" data-started="<%= started_at %>"></span></span>
           <% } else if (duration !== 0) { %>
@@ -586,7 +586,7 @@
         </div>
       </div>
       <div class="piko-resource-info">
-        <span class="piko-build-label">Last checked</span> (<%- resource.check_interval||"@every 1m" %>) at: <span style="color: var(--text-primary);"><%- new Date(resource.last_check).toLocaleString() %></span>
+        <span class="piko-build-label">Last checked</span> (<%- resource.check_interval||"@every 1m" %>) at: <span class="piko-time-ago" data-time="<%= resource.last_check %>" title="<%= new Date(resource.last_check).toLocaleString() %>" style="color: var(--text-primary);"><%= pikoTimeAgo(resource.last_check) %></span>
       </div>
       <div id="resource-versions">
       </div>
@@ -772,6 +772,15 @@
       var app = {};
       var fetchInterval = 2000
       var isLogin = true
+
+      function pikoTimeAgo(dateStr) {
+        if (!dateStr) return ''
+        var seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000)
+        if (seconds < 60) return 'just now'
+        if (seconds < 3600) return Math.floor(seconds / 60) + 'm ago'
+        if (seconds < 86400) return Math.floor(seconds / 3600) + 'h ago'
+        return Math.floor(seconds / 86400) + 'd ago'
+      }
 
       var durationToString = function(duration) {
         if (duration === 0) {
@@ -1860,11 +1869,7 @@
             var timeAgo = ''
             var lastBuildAt = that.model.get('last_build_at')
             if (lastBuildAt) {
-              var seconds = Math.floor((Date.now() - new Date(lastBuildAt).getTime()) / 1000)
-              if (seconds < 60) timeAgo = ' · just now'
-              else if (seconds < 3600) timeAgo = ' · ' + Math.floor(seconds / 60) + 'm ago'
-              else if (seconds < 86400) timeAgo = ' · ' + Math.floor(seconds / 3600) + 'h ago'
-              else timeAgo = ' · ' + Math.floor(seconds / 86400) + 'd ago'
+              timeAgo = ' · ' + pikoTimeAgo(lastBuildAt)
             }
             if (hasFailed) {
               html = '<span class="piko-card-status-dot" style="background:#FF004D;"></span> Last build failed' + timeAgo
@@ -2694,6 +2699,11 @@
               if (m > 0 || h > 0) text += m + 'm ';
               text += s + 's';
               $(this).text('(' + text + ')');
+            });
+            that.$el.find('.piko-time-ago').each(function() {
+              var t = $(this).data('time');
+              if (!t) return;
+              $(this).text(pikoTimeAgo(t));
             });
           };
           update();


### PR DESCRIPTION
## Summary
- Clicking a block in the sidebar or a graph node now scrolls it to the **top** of the editor viewport instead of the bottom.
- Resource blocks in the sidebar display `type.label` (e.g., `git.pikoci_pr`) instead of just the type.
- Clicking a resource graph node correctly matches the two-label HCL format (`resource "type" "label"`).

Closes #336