### PR TITLE
Pipeline editor: scroll to top and show resource type.label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Build detail and resource views now show relative timestamps ("5m ago") with absolute time on hover ([#344](https://github.com/PikoCI/pikoci/issues/344))
+- Pipeline editor: clicking a block or graph node now scrolls it to the top of the viewport, and resource blocks in the sidebar show `type.label` (e.g., `git.pikoci_pr`) instead of just the type ([#336](https://github.com/PikoCI/pikoci/issues/336))
 
 ## [0.1.0] - 2026-05-23
 

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -2298,11 +2298,14 @@
           var html = ''
           var errorLines = this._errorLines || {}
           app.blockTypes.forEach(function(bt) {
-            var re = new RegExp(bt.type + '\\s+"([^"]+)"', 'g')
+            var re = bt.type === 'resource'
+              ? new RegExp(bt.type + '\\s+"([^"]+)"\\s+"([^"]+)"', 'g')
+              : new RegExp(bt.type + '\\s+"([^"]+)"', 'g')
             var matches = []
             var m
             while ((m = re.exec(doc)) !== null) {
-              matches.push({name: m[1], pos: m.index})
+              var displayName = bt.type === 'resource' ? m[1] + '.' + m[2] : m[1]
+              matches.push({name: displayName, pos: m.index})
             }
             if (matches.length === 0) return
             html += '<div class="piko-blocks-section">'
@@ -2324,9 +2327,10 @@
           if (isNaN(pos) || !this.editor) return
           this.$el.find('.piko-blocks-item').removeClass('active')
           $(e.currentTarget).addClass('active')
+          var CM = window.PikoCM
           this.editor.dispatch({
             selection: {anchor: pos},
-            scrollIntoView: true,
+            effects: CM.EditorView.scrollIntoView(pos, {y: 'start'}),
           })
           this.editor.focus()
         },
@@ -2357,12 +2361,22 @@
           var name = textEl.text().trim()
           if (!name) return
           var doc = this.editor.state.doc.toString()
-          var re = new RegExp('(?:job|resource|resource_type|runner_type|secret_type|service_type)\\s+"' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '"')
+          // Resource nodes use "type.label" format in the graph; split and match both quoted strings
+          var dotIdx = name.indexOf('.')
+          var re
+          if (dotIdx !== -1) {
+            var rType = name.substring(0, dotIdx).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+            var rLabel = name.substring(dotIdx + 1).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+            re = new RegExp('resource\\s+"' + rType + '"\\s+"' + rLabel + '"')
+          } else {
+            re = new RegExp('(?:job|resource|resource_type|runner_type|secret_type|service_type)\\s+"' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '"')
+          }
           var match = re.exec(doc)
           if (match) {
+            var CM = window.PikoCM
             this.editor.dispatch({
               selection: {anchor: match.index, head: match.index + match[0].length},
-              scrollIntoView: true,
+              effects: CM.EditorView.scrollIntoView(match.index, {y: 'start'}),
             })
             this.editor.focus()
           }


### PR DESCRIPTION
## Summary
- Clicking a block in the sidebar or a graph node now scrolls it to the **top** of the editor viewport instead of the bottom.
- Resource blocks in the sidebar display `type.label` (e.g., `git.pikoci_pr`) instead of just the type.
- Clicking a resource graph node correctly matches the two-label HCL format (`resource "type" "label"`).

Closes #336