### PR TITLE
Make web UI mobile-friendly (#350)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Make web UI mobile-friendly: viewport meta tag, hamburger menu, responsive CSS for graphs, logs, tables, and touch targets; login page centered without scroll ([#350](https://github.com/PikoCI/pikoci/issues/350))
 - Build detail and resource views now show relative timestamps ("5m ago") with absolute time on hover ([#344](https://github.com/PikoCI/pikoci/issues/344))
 - Pipeline editor: clicking a block or graph node now scrolls it to the top of the viewport, and resource blocks in the sidebar show `type.label` (e.g., `git.pikoci_pr`) instead of just the type ([#336](https://github.com/PikoCI/pikoci/issues/336))
 

--- a/pikoci/transport/http/assets/css/pikoci.css
+++ b/pikoci/transport/http/assets/css/pikoci.css
@@ -719,11 +719,13 @@ textarea.form-control {
    LOGIN PAGE
    ============================================================ */
 .piko-login-wrapper {
-  min-height: 100vh;
+  height: calc(100vh - 60px);
+  height: calc(100dvh - 60px);
   display: flex;
   align-items: center;
   justify-content: center;
   background: var(--bg-body);
+  overflow: hidden;
 }
 .piko-login-box {
   background: var(--bg-surface);
@@ -967,3 +969,141 @@ body.piko-fullscreen .btn-primary { display: none; }
 .piko-graph-strip-header.open + .piko-graph-strip-body { display: flex; }
 /* Graph nodes clickable */
 .piko-graph-strip-body svg g.node { cursor: pointer; }
+
+/* ===== MOBILE ===== */
+@media (max-width: 767.98px) {
+  /* 3a. Navbar toggler */
+  .navbar-toggler {
+    border-color: rgba(255,255,255,0.25);
+    padding: 0.25rem 0.5rem;
+  }
+  .navbar-toggler-icon {
+    filter: invert(1);
+  }
+  .navbar-collapse {
+    margin-top: 0.5rem;
+  }
+  .navbar .dropdown {
+    width: 100%;
+  }
+
+  /* 3b. Breadcrumbs — horizontal scroll */
+  .breadcrumb {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    white-space: nowrap;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* 3c. Pipeline graph — horizontal scroll */
+  .piko-graph-container {
+    padding: 0.75rem;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+  .piko-graph-container svg {
+    min-width: 500px;
+  }
+
+  /* 3d. Build logs — wrap lines + larger touch targets */
+  .piko-step-row-body pre {
+    white-space: pre-wrap;
+    word-break: break-all;
+    font-size: 0.7rem;
+    max-height: 50vh;
+  }
+  .piko-step-row-header {
+    min-height: 44px;
+  }
+  .piko-copy-logs-header-btn {
+    min-height: 32px;
+    min-width: 32px;
+    padding: 4px 10px;
+  }
+  .piko-goto-bottom-btn {
+    min-height: 36px;
+    padding: 6px 12px;
+  }
+
+  /* 3e. Build meta — flex-wrap */
+  .piko-build-meta {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  /* 3f. Tables — responsive overflow */
+  .table {
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* 3g. Action buttons — touch targets */
+  .btn {
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+  }
+  .piko-team-actions .btn {
+    min-height: 36px;
+  }
+
+  /* 3h. Page headers — stack vertically */
+  .d-flex.justify-content-between.mb-3 {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  /* 3i. Team rows — stack */
+  .piko-team-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+  .piko-team-actions {
+    flex-wrap: wrap;
+    width: 100%;
+  }
+
+  /* 3j. Version rows — adjust padding */
+  .piko-version-row-header {
+    padding: 0.5rem 0.75rem;
+    flex-wrap: wrap;
+  }
+  .piko-version-kv {
+    word-break: break-all;
+  }
+
+  /* 3k. Build tabs — smooth scroll */
+  .piko-build-tabs {
+    -webkit-overflow-scrolling: touch;
+  }
+  .piko-build-tab {
+    padding: 0.4rem 0.75rem;
+  }
+
+  /* 3l. Misc spacing */
+  .container {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+  .navbar {
+    padding: 0.55rem 0.75rem;
+  }
+  .piko-build-content {
+    padding: 0.75rem;
+  }
+  .piko-graph-legend {
+    gap: 0.75rem;
+    font-size: 0.7rem;
+  }
+  .piko-login-wrapper {
+    height: calc(100vh - 52px);
+    height: calc(100dvh - 52px);
+  }
+  .piko-login-box {
+    padding: 1.5rem 1.25rem;
+    margin: 0 12px;
+  }
+}

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <title>PikoCI</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
@@ -35,34 +36,39 @@
     </script>
 
     <script type="text/template" id="header-view">
-      <nav class="navbar">
+      <nav class="navbar navbar-expand-md">
         <div class="container-fluid">
           <a class="navbar-brand" id="logo" href="/">
             <img src="/images/logo.svg" alt="PikoCI" width="25" height="25" class="d-inline-block align-text-top">
             PikoCI
           </a>
           <% if (session) { %>
-            <div class="dropdown">
-              <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
-                <%- session.user.full_name %>
-              </a>
-              <ul class="dropdown-menu dropdown-menu-end">
-                <li>
-                  <a class="dropdown-item d-flex align-items-center justify-content-between" href="#" onclick="event.preventDefault(); event.stopPropagation(); toggleTheme();">
-                    <span>Dark Mode</span>
-                    <span class="piko-toggle" id="theme-toggle">
-                      <span class="piko-toggle-thumb"></span>
-                    </span>
-                  </a>
-                </li>
-                <li><hr class="dropdown-divider"></li>
-                <li><a class="dropdown-item" id="nav-profile" href="/profile"><i class="bi bi-person"></i> Profile</a></li>
-                <% if (session.user.admin) { %>
-                  <li><a class="dropdown-item" id="nav-users" href="/users"><i class="bi bi-people"></i> Users <span class="badge bg-secondary ms-1">Admin</span></a></li>
-                <% } %>
-                <li><hr class="dropdown-divider"></li>
-                <li><a class="dropdown-item" id="logout" href="/logout"><i class="bi bi-box-arrow-right"></i> Logout</a></li>
-              </ul>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarContent" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
+              <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse justify-content-end" id="navbarContent">
+              <div class="dropdown">
+                <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
+                  <%- session.user.full_name %>
+                </a>
+                <ul class="dropdown-menu dropdown-menu-end">
+                  <li>
+                    <a class="dropdown-item d-flex align-items-center justify-content-between" href="#" onclick="event.preventDefault(); event.stopPropagation(); toggleTheme();">
+                      <span>Dark Mode</span>
+                      <span class="piko-toggle" id="theme-toggle">
+                        <span class="piko-toggle-thumb"></span>
+                      </span>
+                    </a>
+                  </li>
+                  <li><hr class="dropdown-divider"></li>
+                  <li><a class="dropdown-item" id="nav-profile" href="/profile"><i class="bi bi-person"></i> Profile</a></li>
+                  <% if (session.user.admin) { %>
+                    <li><a class="dropdown-item" id="nav-users" href="/users"><i class="bi bi-people"></i> Users <span class="badge bg-secondary ms-1">Admin</span></a></li>
+                  <% } %>
+                  <li><hr class="dropdown-divider"></li>
+                  <li><a class="dropdown-item" id="logout" href="/logout"><i class="bi bi-box-arrow-right"></i> Logout</a></li>
+                </ul>
+              </div>
             </div>
           <% } %>
         </div>


### PR DESCRIPTION
## Summary

- Add `<meta name="viewport">` and Bootstrap hamburger menu for mobile navigation
- Append ~120 lines of responsive CSS (`@media max-width: 767.98px`) for horizontal-scrolling graphs/breadcrumbs/tables, pre-wrap build logs, 44px touch targets, and stacked layouts
- Center login page vertically using `100dvh` and prevent scroll on all screen sizes
- Desktop layout unchanged — all mobile styles scoped inside the media query

Closes #350