### PR TITLE
Add pipeline graph zoom, pan, and fullscreen controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - User management: Profile page, admin Users page, CLI commands, force password change on default `admin/admin123`, and `--users` flag preserves UI/CLI password changes ([#237](https://github.com/PikoCI/pikoci/issues/237))
+- Pipeline graph zoom, pan, and fullscreen controls: scroll-wheel zoom toward cursor, click-drag pan (including on nodes), zoom buttons, reset, fullscreen overlay with navbar visible, pinch-zoom on mobile, and auto-sizing that prevents small pipelines from appearing oversized ([#338](https://github.com/PikoCI/pikoci/issues/338))
 
 ### Changed
 

--- a/pikoci/transport/http/assets/css/pikoci.css
+++ b/pikoci/transport/http/assets/css/pikoci.css
@@ -529,7 +529,55 @@ textarea.form-control {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 1.5rem;
-  overflow: auto;
+  overflow: hidden;
+  position: relative;
+  cursor: grab;
+  /* Fill remaining viewport height */
+  min-height: calc(100vh - 200px);
+}
+.piko-graph-container.panning { cursor: grabbing; }
+
+/* Graph zoom controls */
+.piko-graph-controls {
+  position: absolute; top: 8px; right: 8px;
+  display: flex; gap: 4px; z-index: 10;
+}
+.piko-graph-controls button {
+  width: 28px; height: 28px; border: none; border-radius: 4px;
+  background: var(--primary); color: #fff; cursor: pointer;
+  font-size: 14px; display: flex; align-items: center; justify-content: center;
+  line-height: 1;
+}
+.piko-graph-controls button:hover { background: var(--primary-hover); }
+
+/* Graph fullscreen overlay */
+.piko-graph-fullscreen {
+  position: fixed; top: 46px; left: 0; right: 0; bottom: 0;
+  z-index: 9999;
+  background: var(--bg-surface);
+  display: flex; flex-direction: column;
+}
+.piko-graph-fullscreen-hint {
+  position: absolute; top: 10px; left: 14px;
+  font-size: 0.75rem; color: var(--text-muted);
+  text-transform: uppercase; letter-spacing: 0.5px;
+}
+.piko-graph-fullscreen-close {
+  position: absolute; top: 8px; right: 8px; z-index: 1;
+}
+.piko-graph-fullscreen-body {
+  flex: 1; display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  overflow: hidden; padding: 48px 16px 16px;
+  cursor: grab;
+}
+.piko-graph-fullscreen-body.panning { cursor: grabbing; }
+.piko-graph-container #pipeline-graph {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 .piko-graph-container svg {
   display: block;
@@ -938,8 +986,10 @@ body.piko-fullscreen .btn-primary { display: none; }
 .piko-graph-bottom-header button:hover { color: var(--text-primary); background: var(--primary-light); }
 .piko-graph-bottom-body {
   padding: 16px 24px; display: flex; align-items: center;
-  justify-content: center; overflow: auto; min-height: 80px;
+  justify-content: center; overflow: hidden; min-height: 80px;
+  position: relative; cursor: grab;
 }
+.piko-graph-bottom-body.panning { cursor: grabbing; }
 
 /* Graph strip (normal mode) */
 .piko-graph-strip {
@@ -965,7 +1015,9 @@ body.piko-fullscreen .btn-primary { display: none; }
 .piko-graph-strip-header.open .piko-graph-chev { transform: rotate(90deg); }
 .piko-graph-strip-body {
   display: none; padding: 24px; min-height: 120px; justify-content: center;
+  position: relative; overflow: hidden; cursor: grab;
 }
+.piko-graph-strip-body.panning { cursor: grabbing; }
 .piko-graph-strip-header.open + .piko-graph-strip-body { display: flex; }
 /* Graph nodes clickable */
 .piko-graph-strip-body svg g.node { cursor: pointer; }
@@ -995,14 +1047,14 @@ body.piko-fullscreen .btn-primary { display: none; }
     -webkit-overflow-scrolling: touch;
   }
 
-  /* 3c. Pipeline graph — horizontal scroll */
+  /* 3c. Pipeline graph — touch-friendly */
   .piko-graph-container {
     padding: 0.75rem;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
+    min-height: 300px;
   }
-  .piko-graph-container svg {
-    min-width: 500px;
+  .piko-graph-controls button {
+    min-width: 36px; min-height: 36px;
+    width: 36px; height: 36px;
   }
 
   /* 3d. Build logs — wrap lines + larger touch targets */

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -1913,12 +1913,22 @@
         },
         render: function () {
           this.$el.html(this.template(addSessionFunctions({ pipeline: this.model.toJSON(), team: this.model.collection.team.toJSON() })));
-          this.$el.find("#graphviz").html(new app.PipelineGraphView({model: this.image}).render().el)
+          var that = this
+          this.graphView = new app.PipelineGraphView({model: this.image, onSVGReady: function(svg) {
+            var container = that.$el.find("#graphviz")[0]
+            if (!container) return
+            if (!that.graphZoom) {
+              that.graphZoom = new app.PikoGraphZoom(container)
+            }
+            that.graphZoom.attachSVG(svg)
+          }})
+          this.$el.find("#graphviz").html(this.graphView.render().el)
           this.image.trigger("change", this.image)
           return this; // enable chained calls
         },
         remove: function() {
           clearInterval(this.intervalID)
+          if (this.graphZoom) { this.graphZoom.destroy() }
           Backbone.View.prototype.remove.call(this);
         },
         clickPipeline: function(event) {
@@ -1943,18 +1953,453 @@
           }
         },
       })
+      // ================================================================
+      // PikoGraphZoom — zoom, pan, fullscreen for pipeline graph SVGs
+      // ================================================================
+      app.PikoGraphZoom = function(containerEl, opts) {
+        opts = opts || {}
+        this.container = containerEl
+        this.svg = null
+        this.baseViewBox = null
+        this.currentViewBox = null
+        this.zoomLevel = 1
+        this.isPanning = false
+        this.panStart = null
+        this.onFullscreenChange = opts.onFullscreenChange || null
+        this._fsOverlay = null
+        this._bound = {}
+        this._injectControls()
+        this._bindContainerEvents()
+      }
+
+      app.PikoGraphZoom.prototype = {
+        MIN_ZOOM: 0.25,
+        MAX_ZOOM: 4,
+        ZOOM_FACTOR: 1.15,
+        DRAG_THRESHOLD: 5,
+
+        _injectControls: function() {
+          var div = document.createElement('div')
+          div.className = 'piko-graph-controls'
+          div.innerHTML =
+            '<button type="button" title="Zoom in" data-action="zoomIn">+</button>' +
+            '<button type="button" title="Zoom out" data-action="zoomOut">&minus;</button>' +
+            '<button type="button" title="Reset" data-action="reset">&#x21BA;</button>' +
+            '<button type="button" title="Fullscreen" data-action="fullscreen">&#x26F6;</button>'
+          this.container.appendChild(div)
+          this._controlsEl = div
+          var that = this
+          div.addEventListener('click', function(e) {
+            var btn = e.target.closest('button')
+            if (!btn) return
+            e.stopPropagation()
+            var action = btn.getAttribute('data-action')
+            if (action === 'zoomIn') that.zoomIn()
+            else if (action === 'zoomOut') that.zoomOut()
+            else if (action === 'reset') that.reset()
+            else if (action === 'fullscreen') that.toggleFullscreen()
+          })
+        },
+
+        _bindContainerEvents: function() {
+          var that = this
+          this._bound.wheel = function(e) { that._onWheel(e) }
+          this._bound.mousedown = function(e) { that._onPanStart(e) }
+          this._bound.mousemove = function(e) { that._onPanMove(e) }
+          this._bound.mouseup = function(e) { that._onPanEnd(e) }
+          this._bound.touchstart = function(e) { that._onTouchStart(e) }
+          this._bound.touchmove = function(e) { that._onTouchMove(e) }
+          this._bound.touchend = function(e) { that._onPanEnd(e) }
+          this._bound.click = function(e) {
+            if (that._suppressClick) {
+              that._suppressClick = false
+              e.preventDefault()
+              e.stopPropagation()
+            }
+          }
+          this.container.addEventListener('wheel', this._bound.wheel, {passive: false})
+          this.container.addEventListener('mousedown', this._bound.mousedown)
+          window.addEventListener('mousemove', this._bound.mousemove)
+          window.addEventListener('mouseup', this._bound.mouseup)
+          this.container.addEventListener('click', this._bound.click, true)
+          this.container.addEventListener('touchstart', this._bound.touchstart, {passive: false})
+          this.container.addEventListener('touchmove', this._bound.touchmove, {passive: false})
+          this.container.addEventListener('touchend', this._bound.touchend)
+        },
+
+        attachSVG: function(svg) {
+          this.svg = svg
+          var w = parseFloat(svg.getAttribute('width'))
+          var h = parseFloat(svg.getAttribute('height'))
+          if (!w || !h) {
+            var vb = svg.getAttribute('viewBox')
+            if (vb) {
+              var parts = vb.split(/[\s,]+/)
+              w = parseFloat(parts[2])
+              h = parseFloat(parts[3])
+            }
+          }
+          var natW = w || 800
+          var natH = h || 400
+          // Expand viewBox to match container so content renders at natural size (not scaled up)
+          var cRect = this.container.getBoundingClientRect()
+          var cW = cRect.width || natW
+          var cH = cRect.height || natH
+          // Scale factor: how much the container is larger than natural SVG
+          var scaleX = cW / natW
+          var scaleY = cH / natH
+          var scale = Math.min(scaleX, scaleY)
+          var vbW, vbH
+          var MAX_SCALE = 1.5  // allow up to 1.5x upscale for comfortable default size
+          if (scale > MAX_SCALE) {
+            // Container much larger than natural — cap at MAX_SCALE
+            vbW = cW / MAX_SCALE
+            vbH = cH / MAX_SCALE
+          } else if (scale > 1) {
+            // Container slightly larger — let it scale up to MAX_SCALE
+            vbW = natW
+            vbH = natH
+          } else {
+            // Container is smaller — use natural dims, SVG scales down via preserveAspectRatio
+            vbW = natW
+            vbH = natH
+          }
+          // Center the natural content within the expanded viewBox
+          var offsetX = -(vbW - natW) / 2
+          var offsetY = -(vbH - natH) / 2
+          this.baseViewBox = {x: offsetX, y: offsetY, w: vbW, h: vbH}
+          // Preserve zoom/pan state across re-renders
+          if (!this.currentViewBox) {
+            this.currentViewBox = {x: offsetX, y: offsetY, w: vbW, h: vbH}
+            this.zoomLevel = 1
+          }
+          svg.setAttribute('viewBox', this.currentViewBox.x + ' ' + this.currentViewBox.y + ' ' + this.currentViewBox.w + ' ' + this.currentViewBox.h)
+          svg.setAttribute('width', '100%')
+          svg.setAttribute('height', '100%')
+          svg.style.maxWidth = 'none'
+          svg.style.maxHeight = 'none'
+        },
+
+        _applyViewBox: function() {
+          if (!this.svg || !this.currentViewBox) return
+          var vb = this.currentViewBox
+          this.svg.setAttribute('viewBox', vb.x + ' ' + vb.y + ' ' + vb.w + ' ' + vb.h)
+        },
+
+        zoomIn: function() {
+          this._zoomAtCenter(this.ZOOM_FACTOR)
+        },
+
+        zoomOut: function() {
+          this._zoomAtCenter(1 / this.ZOOM_FACTOR)
+        },
+
+        // factor > 1 = zoom in (smaller viewBox), factor < 1 = zoom out
+        _zoomAtCenter: function(factor) {
+          if (!this.currentViewBox || !this.baseViewBox) return
+          var newZoom = this.zoomLevel * factor
+          newZoom = Math.max(this.MIN_ZOOM, Math.min(this.MAX_ZOOM, newZoom))
+          var vb = this.currentViewBox
+          var newW = this.baseViewBox.w / newZoom
+          var newH = this.baseViewBox.h / newZoom
+          var cx = vb.x + vb.w / 2
+          var cy = vb.y + vb.h / 2
+          this.currentViewBox = {x: cx - newW / 2, y: cy - newH / 2, w: newW, h: newH}
+          this.zoomLevel = newZoom
+          this._applyViewBox()
+        },
+
+        zoomAtPoint: function(clientX, clientY, factor) {
+          if (!this.svg || !this.currentViewBox || !this.baseViewBox) return
+          var rect = this.svg.getBoundingClientRect()
+          var px = (clientX - rect.left) / rect.width
+          var py = (clientY - rect.top) / rect.height
+          var vb = this.currentViewBox
+          var pointX = vb.x + px * vb.w
+          var pointY = vb.y + py * vb.h
+          var newZoom = this.zoomLevel * factor
+          newZoom = Math.max(this.MIN_ZOOM, Math.min(this.MAX_ZOOM, newZoom))
+          var newW = this.baseViewBox.w / newZoom
+          var newH = this.baseViewBox.h / newZoom
+          this.currentViewBox = {
+            x: pointX - px * newW,
+            y: pointY - py * newH,
+            w: newW,
+            h: newH
+          }
+          this.zoomLevel = newZoom
+          this._applyViewBox()
+        },
+
+        reset: function() {
+          if (!this.baseViewBox) return
+          this.currentViewBox = {x: this.baseViewBox.x, y: this.baseViewBox.y, w: this.baseViewBox.w, h: this.baseViewBox.h}
+          this.zoomLevel = 1
+          this._applyViewBox()
+        },
+
+        _onWheel: function(e) {
+          if (!this.svg) return
+          e.preventDefault()
+          // factor > 1 = zoom in, factor < 1 = zoom out
+          // Scroll up (deltaY < 0) = zoom in, scroll down = zoom out
+          var factor = e.deltaY < 0 ? this.ZOOM_FACTOR : 1 / this.ZOOM_FACTOR
+          this.zoomAtPoint(e.clientX, e.clientY, factor)
+        },
+
+        _getPanTarget: function() {
+          return this._fsOverlay ? this._fsOverlay.querySelector('.piko-graph-fullscreen-body') : this.container
+        },
+
+        _onPanStart: function(e) {
+          if (e.button !== 0) return
+          if (e.target.closest && e.target.closest('.piko-graph-controls')) return
+          this.isPanning = true
+          this.panStart = {x: e.clientX, y: e.clientY, dragged: false}
+          this._getPanTarget().classList.add('panning')
+        },
+
+        _onPanMove: function(e) {
+          if (!this.isPanning || !this.panStart || !this.svg || !this.currentViewBox) return
+          var dx = e.clientX - this.panStart.x
+          var dy = e.clientY - this.panStart.y
+          if (Math.abs(dx) > this.DRAG_THRESHOLD || Math.abs(dy) > this.DRAG_THRESHOLD) {
+            this.panStart.dragged = true
+          }
+          if (!this.panStart.dragged) return
+          var rect = this.svg.getBoundingClientRect()
+          var vb = this.currentViewBox
+          vb.x -= dx / rect.width * vb.w
+          vb.y -= dy / rect.height * vb.h
+          this.panStart.x = e.clientX
+          this.panStart.y = e.clientY
+          this._applyViewBox()
+        },
+
+        _onPanEnd: function(e) {
+          var wasDragged = this.isPanning && this.panStart && this.panStart.dragged
+          if (this.isPanning) {
+            this._getPanTarget().classList.remove('panning')
+          }
+          // If we dragged, suppress the upcoming click so links don't navigate
+          if (wasDragged) {
+            this._suppressClick = true
+          }
+          this.isPanning = false
+          this.panStart = null
+          this._pinchStart = null
+        },
+
+        _onTouchStart: function(e) {
+          if (e.touches.length === 1) {
+            this.isPanning = true
+            this.panStart = {x: e.touches[0].clientX, y: e.touches[0].clientY, dragged: false}
+            this._getPanTarget().classList.add('panning')
+          } else if (e.touches.length === 2) {
+            e.preventDefault()
+            this._pinchStart = this._getPinchDist(e)
+          }
+        },
+
+        _onTouchMove: function(e) {
+          if (e.touches.length === 1 && this.isPanning && this.panStart && this.svg && this.currentViewBox) {
+            var dx = e.touches[0].clientX - this.panStart.x
+            var dy = e.touches[0].clientY - this.panStart.y
+            if (Math.abs(dx) > this.DRAG_THRESHOLD || Math.abs(dy) > this.DRAG_THRESHOLD) {
+              this.panStart.dragged = true
+            }
+            if (!this.panStart.dragged) return
+            e.preventDefault()
+            var rect = this.svg.getBoundingClientRect()
+            var vb = this.currentViewBox
+            vb.x -= dx / rect.width * vb.w
+            vb.y -= dy / rect.height * vb.h
+            this.panStart.x = e.touches[0].clientX
+            this.panStart.y = e.touches[0].clientY
+            this._applyViewBox()
+          } else if (e.touches.length === 2 && this._pinchStart) {
+            e.preventDefault()
+            var dist = this._getPinchDist(e)
+            var factor = dist / this._pinchStart
+            var cx = (e.touches[0].clientX + e.touches[1].clientX) / 2
+            var cy = (e.touches[0].clientY + e.touches[1].clientY) / 2
+            this.zoomAtPoint(cx, cy, factor)
+            this._pinchStart = dist
+          }
+        },
+
+        _getPinchDist: function(e) {
+          var dx = e.touches[0].clientX - e.touches[1].clientX
+          var dy = e.touches[0].clientY - e.touches[1].clientY
+          return Math.sqrt(dx * dx + dy * dy)
+        },
+
+        toggleFullscreen: function() {
+          if (this._fsOverlay) {
+            this._exitFullscreen()
+          } else {
+            this._enterFullscreen()
+          }
+        },
+
+        _enterFullscreen: function() {
+          if (!this.svg) return
+          var overlay = document.createElement('div')
+          overlay.className = 'piko-graph-fullscreen'
+          var hint = document.createElement('span')
+          hint.className = 'piko-graph-fullscreen-hint'
+          hint.textContent = 'Press Esc to exit'
+          overlay.appendChild(hint)
+
+          var closeDiv = document.createElement('div')
+          closeDiv.className = 'piko-graph-fullscreen-close piko-graph-controls'
+          closeDiv.style.position = 'absolute'
+          closeDiv.innerHTML =
+            '<button type="button" title="Zoom in" data-action="zoomIn">+</button>' +
+            '<button type="button" title="Zoom out" data-action="zoomOut">&minus;</button>' +
+            '<button type="button" title="Reset" data-action="reset">&#x21BA;</button>' +
+            '<button type="button" title="Close" data-action="close">&times;</button>'
+          overlay.appendChild(closeDiv)
+
+          var body = document.createElement('div')
+          body.className = 'piko-graph-fullscreen-body'
+          overlay.appendChild(body)
+
+          // Move SVG into fullscreen
+          this._svgParent = this.svg.parentNode
+          this._svgNextSibling = this.svg.nextSibling
+          body.appendChild(this.svg)
+          // Expand SVG to fill the overlay
+          this.svg.style.maxWidth = 'none'
+          this.svg.style.maxHeight = '100%'
+          this.svg.style.width = '100%'
+          this.svg.style.height = '100%'
+
+          // Move legend into fullscreen if exists
+          var legend = this.container.querySelector('.piko-graph-legend')
+          if (!legend) {
+            // Legend might be a sibling of the container
+            var next = this.container.nextElementSibling
+            if (next && next.classList.contains('piko-graph-legend')) {
+              legend = next
+            }
+          }
+          if (legend) {
+            this._legendParent = legend.parentNode
+            this._legendNextSibling = legend.nextSibling
+            overlay.appendChild(legend)
+          }
+
+          document.body.appendChild(overlay)
+          this._fsOverlay = overlay
+
+          // Bind events on overlay
+          var that = this
+          overlay.addEventListener('wheel', this._bound.wheel, {passive: false})
+          body.addEventListener('mousedown', this._bound.mousedown)
+          body.addEventListener('click', this._bound.click, true)
+          body.addEventListener('touchstart', this._bound.touchstart, {passive: false})
+          body.addEventListener('touchmove', this._bound.touchmove, {passive: false})
+          body.addEventListener('touchend', this._bound.touchend)
+
+          closeDiv.addEventListener('click', function(e) {
+            var btn = e.target.closest('button')
+            if (!btn) return
+            e.stopPropagation()
+            var action = btn.getAttribute('data-action')
+            if (action === 'zoomIn') that.zoomIn()
+            else if (action === 'zoomOut') that.zoomOut()
+            else if (action === 'reset') that.reset()
+            else if (action === 'close') that._exitFullscreen()
+          })
+
+          this._bound.escKey = function(e) {
+            if (e.key === 'Escape') that._exitFullscreen()
+          }
+          document.addEventListener('keydown', this._bound.escKey)
+
+          // Hide container controls
+          this._controlsEl.style.display = 'none'
+          if (this.onFullscreenChange) this.onFullscreenChange(true)
+        },
+
+        _exitFullscreen: function() {
+          if (!this._fsOverlay) return
+
+          // Move SVG back
+          if (this._svgParent) {
+            if (this._svgNextSibling) {
+              this._svgParent.insertBefore(this.svg, this._svgNextSibling)
+            } else {
+              this._svgParent.appendChild(this.svg)
+            }
+          }
+          // Restore SVG sizing
+          if (this.baseViewBox) {
+            this.svg.style.maxWidth = 'none'
+            this.svg.style.maxHeight = 'none'
+            this.svg.style.width = '100%'
+            this.svg.style.height = '100%'
+          }
+
+          // Move legend back
+          if (this._legendParent) {
+            var legend = this._fsOverlay.querySelector('.piko-graph-legend')
+            if (legend) {
+              if (this._legendNextSibling) {
+                this._legendParent.insertBefore(legend, this._legendNextSibling)
+              } else {
+                this._legendParent.appendChild(legend)
+              }
+            }
+            this._legendParent = null
+            this._legendNextSibling = null
+          }
+
+          document.removeEventListener('keydown', this._bound.escKey)
+          this._fsOverlay.remove()
+          this._fsOverlay = null
+          this._controlsEl.style.display = 'flex'
+          if (this.onFullscreenChange) this.onFullscreenChange(false)
+        },
+
+        destroy: function() {
+          this._exitFullscreen()
+          this.container.removeEventListener('wheel', this._bound.wheel)
+          this.container.removeEventListener('mousedown', this._bound.mousedown)
+          window.removeEventListener('mousemove', this._bound.mousemove)
+          window.removeEventListener('mouseup', this._bound.mouseup)
+          this.container.removeEventListener('click', this._bound.click, true)
+          this.container.removeEventListener('touchstart', this._bound.touchstart)
+          this.container.removeEventListener('touchmove', this._bound.touchmove)
+          this.container.removeEventListener('touchend', this._bound.touchend)
+          if (this._controlsEl && this._controlsEl.parentNode) {
+            this._controlsEl.remove()
+          }
+        }
+      }
+
       app.PipelineGraphView = Backbone.View.extend({
         template: _.template($('#pipeline-graph-view').html()),
         initialize: function(options) {
           this.noLinks = options.noLinks||false
+          this.onSVGReady = options.onSVGReady||null
           this.listenTo(this.model, "change", this.render)
         },
         render: function() {
           if (this.model.get("image")) {
+            var that = this
             window.Viz.instance().then(viz =>{
-              let svg = viz.renderSVGElement(this.model.get("image"))
-              svg.setAttribute("width","100%")
+              let svg = viz.renderSVGElement(that.model.get("image"))
+              // Read natural dimensions and set viewBox for zoom/pan support
+              var naturalWidth = parseFloat(svg.getAttribute("width"))
+              var naturalHeight = parseFloat(svg.getAttribute("height"))
+              if (naturalWidth && naturalHeight) {
+                svg.setAttribute("viewBox", "0 0 " + naturalWidth + " " + naturalHeight)
+              }
+              svg.setAttribute("width", "100%")
               svg.removeAttribute("height")
+              svg.style.maxWidth = (naturalWidth || 800) + "px"
               svg.style.maxHeight = "400px"
               svg.style.background = "transparent"
               // Post-process SVG for cleaner look
@@ -1999,13 +2444,14 @@
               svg.querySelectorAll('g.node').forEach(function(g) {
                 g.style.cursor = 'pointer'
               })
-              this.$el.html(this.template());
-              this.$el.find("#pipeline-graph").html(svg);
-              if (this.noLinks) {
-                this.$el.find("a").each(function() {
+              that.$el.html(that.template());
+              that.$el.find("#pipeline-graph").html(svg);
+              if (that.noLinks) {
+                that.$el.find("a").each(function() {
                   $(this).attr("xlink:href",null)
                 })
               }
+              if (that.onSVGReady) that.onSVGReady(svg)
             })
           }
           return this
@@ -2187,10 +2633,25 @@
           }
           this.$el.html(this.template(data));
           this.image = new app.PipelineImage()
-          this.graphView = new app.PipelineGraphView({model: this.image, noLinks: true})
+          var that = this
+          this.graphView = new app.PipelineGraphView({model: this.image, noLinks: true, onSVGReady: function(svg) {
+            var container = that.$el.find("#graph")[0]
+            if (!container) return
+            if (!that.graphZoom) {
+              that.graphZoom = new app.PikoGraphZoom(container)
+            }
+            that.graphZoom.attachSVG(svg)
+          }})
           this.$el.find("#graph").html(this.graphView.render().el)
           // Second graph view for fullscreen bottom panel
-          this.graphViewFs = new app.PipelineGraphView({model: this.image, noLinks: true})
+          this.graphViewFs = new app.PipelineGraphView({model: this.image, noLinks: true, onSVGReady: function(svg) {
+            var container = that.$el.find("#graph-fullscreen")[0]
+            if (!container) return
+            if (!that.graphZoomFs) {
+              that.graphZoomFs = new app.PikoGraphZoom(container)
+            }
+            that.graphZoomFs.attachSVG(svg)
+          }})
           this.$el.find("#graph-fullscreen").html(this.graphViewFs.render().el)
           this.initEditor(data.raw || '')
           this.$el.find('#graph-strip-header').addClass('open')
@@ -2542,6 +3003,8 @@
           if (this.editor) { this.editor.destroy() }
           if (this._escHandler) { $(document).off('keydown', this._escHandler) }
           if (this._docClickHandler) { $(document).off('click', this._docClickHandler) }
+          if (this.graphZoom) { this.graphZoom.destroy() }
+          if (this.graphZoomFs) { this.graphZoomFs.destroy() }
           $('body').removeClass('piko-fullscreen')
           Backbone.View.prototype.remove.call(this)
         },


### PR DESCRIPTION
## Summary

- Add `PikoGraphZoom` JS utility with scroll-wheel zoom toward cursor, click-drag pan (works on nodes too), zoom in/out/reset buttons, and fullscreen overlay that preserves the navbar
- Integrate into pipeline show view (preserves zoom/pan state across 5s refresh), editor strip, and editor bottom panel
- Auto-size viewBox to prevent small pipelines from rendering with oversized nodes while filling the container for large pipelines
- Mobile support: pinch-zoom, touch-drag pan, and 36px touch-friendly control buttons

Closes #338