### PR TITLE
Simplify HCL escaping in built-in resource/service types

### DIFF
--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -56,7 +56,7 @@ resource_type "git" {
 | `source` | no       | URL to fetch definition (e.g. `pikoci://git`)       |
 | `params` | no       | List of parameter names                             |
 
-When `source` is set, inline commands are not needed.
+When `source` is set, inline commands are not needed. The source is resolved once when the pipeline is created or updated — if the remote definition changes, you must re-set the pipeline to pick up the new version. This applies to all block types that support `source` (`resource_type`, `runner_type`, `secret_type`, `service_type`).
 
 ## resource
 

--- a/docs/Resource-Types.md
+++ b/docs/Resource-Types.md
@@ -82,6 +82,8 @@ Two URL formats are supported:
 
 When `source` is set, you must not define inline `check`, `pull`, or `push` blocks. PikoCI will error if both are present.
 
+> **Note:** The source is resolved once when the pipeline is created or updated. If the remote HCL file changes, you must re-set the pipeline to pick up the new definition.
+
 ## Overriding built-ins
 
 All built-in resource types (`cron`, `git`) can be overridden by defining a `resource_type` block with the same name in your pipeline. Inline definitions always take precedence over built-ins.

--- a/docs/Runners.md
+++ b/docs/Runners.md
@@ -57,6 +57,8 @@ Two URL formats are supported:
 
 When `source` is set, you must not define an inline `run` block. PikoCI will error if both are present.
 
+> **Note:** The source is resolved once when the pipeline is created or updated. If the remote HCL file changes, you must re-set the pipeline to pick up the new definition.
+
 ## Overriding built-ins
 
 All built-in runners (`exec`, `docker`) can be overridden by defining a `runner_type` block with the same name in your pipeline. Inline definitions always take precedence over built-ins.

--- a/docs/Secret-Types.md
+++ b/docs/Secret-Types.md
@@ -63,6 +63,8 @@ Two URL formats are supported:
 
 When `source` is set, you must not define an inline `get` block. PikoCI will error if both are present. Config attributes (like `address`, `token`) are still set on the block and merged with the resolved definition.
 
+> **Note:** The source is resolved once when the pipeline is created or updated. If the remote HCL file changes, you must re-set the pipeline to pick up the new definition.
+
 ## Using secrets via variables
 
 Secrets are consumed through **secret-backed variables**. Declare a variable with a `secret` block referencing a secret type, then use `var.<name>` anywhere in your pipeline:

--- a/docs/Services.md
+++ b/docs/Services.md
@@ -73,6 +73,8 @@ Two URL formats are supported:
 
 When `source` is set, you must not define inline `start`, `stop`, or `ready_check` blocks. PikoCI will error if both are present.
 
+> **Note:** The source is resolved once when the pipeline is created or updated. If the remote HCL file changes, you must re-set the pipeline to pick up the new definition.
+
 ## Referencing service types in jobs
 
 Reference a top-level service type by name in a job:

--- a/pikoci/builtin/resource_types/git.hcl
+++ b/pikoci/builtin/resource_types/git.hcl
@@ -126,7 +126,7 @@ resource_type "git" {
 
       # Inject token into HTTPS URL if provided
       if [ -n "$TOKEN" ]; then
-        URL=$(echo "$URL" | sed -E "s|https://|https://oauth2:$${TOKEN}@|")
+        URL=$(echo "$URL" | sed -E "s|https://|https://oauth2:$TOKEN@|")
       fi
 
       if [ "$TAG" = "true" ] && [ -n "$version_tag" ]; then
@@ -160,7 +160,7 @@ resource_type "git" {
 
       cd "$param_name"
       if [ -n "$TOKEN" ]; then
-        REMOTE_URL=$(echo "$URL" | sed -E "s|https://|https://oauth2:$${TOKEN}@|")
+        REMOTE_URL=$(echo "$URL" | sed -E "s|https://|https://oauth2:$TOKEN@|")
         git remote set-url origin "$REMOTE_URL"
       fi
       git push

--- a/pikoci/builtin/services/kafka.hcl
+++ b/pikoci/builtin/services/kafka.hcl
@@ -4,26 +4,26 @@ service_type "kafka" {
   start "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-kafka"
+      NAME="pikoci-$BUILD_PIPELINE_NAME-$BUILD_JOB_NAME-kafka"
       docker rm -f $NAME 2>/dev/null || true
       docker run -d --name $NAME \
-        -p $${param_port}:9092 \
+        -p $param_port:9092 \
         -e KAFKA_NODE_ID=0 \
         -e KAFKA_PROCESS_ROLES=controller,broker \
         -e KAFKA_CONTROLLER_QUORUM_VOTERS=0@localhost:9093 \
         -e KAFKA_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093 \
-        -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:$${param_port} \
+        -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:$param_port \
         -e KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER \
         -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT \
         -e CLUSTER_ID=MkU3OEVBNTcwNTJENDM2Qk \
-        apache/kafka:$${param_version}
+        apache/kafka:$param_version
     EOT
     ]
   }
 
   ready_check "exec" {
     path     = "/bin/sh"
-    args     = ["-ec", "nc -z localhost $${param_port}"]
+    args     = ["-ec", "nc -z localhost $param_port"]
     interval = "3s"
     timeout  = "60s"
   }
@@ -31,7 +31,7 @@ service_type "kafka" {
   stop "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-kafka"
+      NAME="pikoci-$BUILD_PIPELINE_NAME-$BUILD_JOB_NAME-kafka"
       docker rm -f $NAME 2>/dev/null || true
     EOT
     ]

--- a/pikoci/builtin/services/mariadb.hcl
+++ b/pikoci/builtin/services/mariadb.hcl
@@ -4,12 +4,12 @@ service_type "mariadb" {
   start "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-mariadb"
+      NAME="pikoci-$BUILD_PIPELINE_NAME-$BUILD_JOB_NAME-mariadb"
       docker rm -f $NAME 2>/dev/null || true
       docker run -d --name $NAME \
-        -p $${param_port}:3306 \
-        -e MYSQL_ROOT_PASSWORD=$${param_root_password} \
-        mariadb:$${param_version}
+        -p $param_port:3306 \
+        -e MYSQL_ROOT_PASSWORD=$param_root_password \
+        mariadb:$param_version
     EOT
     ]
   }
@@ -17,7 +17,7 @@ service_type "mariadb" {
   ready_check "exec" {
     path     = "/bin/sh"
     args     = ["-ec", <<-EOT
-      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-mariadb"
+      NAME="pikoci-$BUILD_PIPELINE_NAME-$BUILD_JOB_NAME-mariadb"
       docker exec $NAME mariadb -uroot -p$${param_root_password} -e 'SELECT 1'
     EOT
     ]
@@ -28,7 +28,7 @@ service_type "mariadb" {
   stop "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-mariadb"
+      NAME="pikoci-$BUILD_PIPELINE_NAME-$BUILD_JOB_NAME-mariadb"
       docker rm -f $NAME 2>/dev/null || true
     EOT
     ]

--- a/pikoci/builtin/services/nats.hcl
+++ b/pikoci/builtin/services/nats.hcl
@@ -4,18 +4,18 @@ service_type "nats" {
   start "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-nats"
+      NAME="pikoci-$BUILD_PIPELINE_NAME-$BUILD_JOB_NAME-nats"
       docker rm -f $NAME 2>/dev/null || true
       docker run -d --name $NAME \
-        -p $${param_port}:4222 \
-        nats:$${param_version}
+        -p $param_port:4222 \
+        nats:$param_version
     EOT
     ]
   }
 
   ready_check "exec" {
     path     = "/bin/sh"
-    args     = ["-ec", "nc -z localhost $${param_port}"]
+    args     = ["-ec", "nc -z localhost $param_port"]
     interval = "1s"
     timeout  = "60s"
   }
@@ -23,7 +23,7 @@ service_type "nats" {
   stop "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-nats"
+      NAME="pikoci-$BUILD_PIPELINE_NAME-$BUILD_JOB_NAME-nats"
       docker rm -f $NAME 2>/dev/null || true
     EOT
     ]

--- a/pikoci/builtin/services/postgresql.hcl
+++ b/pikoci/builtin/services/postgresql.hcl
@@ -4,12 +4,12 @@ service_type "postgresql" {
   start "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-pg"
+      NAME="pikoci-$BUILD_PIPELINE_NAME-$BUILD_JOB_NAME-pg"
       docker rm -f $NAME 2>/dev/null || true
       docker run -d --name $NAME \
-        -p $${param_port}:5432 \
-        -e POSTGRES_PASSWORD=$${param_password} \
-        postgres:$${param_version}
+        -p $param_port:5432 \
+        -e POSTGRES_PASSWORD=$param_password \
+        postgres:$param_version
     EOT
     ]
   }
@@ -17,7 +17,7 @@ service_type "postgresql" {
   ready_check "exec" {
     path     = "/bin/sh"
     args     = ["-ec", <<-EOT
-      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-pg"
+      NAME="pikoci-$BUILD_PIPELINE_NAME-$BUILD_JOB_NAME-pg"
       docker exec $NAME pg_isready
     EOT
     ]
@@ -28,7 +28,7 @@ service_type "postgresql" {
   stop "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-pg"
+      NAME="pikoci-$BUILD_PIPELINE_NAME-$BUILD_JOB_NAME-pg"
       docker rm -f $NAME 2>/dev/null || true
     EOT
     ]

--- a/pikoci/builtin/services/rabbitmq.hcl
+++ b/pikoci/builtin/services/rabbitmq.hcl
@@ -4,19 +4,19 @@ service_type "rabbitmq" {
   start "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-rabbit"
+      NAME="pikoci-$BUILD_PIPELINE_NAME-$BUILD_JOB_NAME-rabbit"
       docker rm -f $NAME 2>/dev/null || true
       docker run -d --name $NAME \
-        -p $${param_port}:5672 \
+        -p $param_port:5672 \
         -e RABBITMQ_NODENAME=rabbit \
-        rabbitmq:$${param_version}
+        rabbitmq:$param_version
     EOT
     ]
   }
 
   ready_check "exec" {
     path     = "/bin/sh"
-    args     = ["-ec", "nc -z localhost $${param_port}"]
+    args     = ["-ec", "nc -z localhost $param_port"]
     interval = "3s"
     timeout  = "60s"
   }
@@ -24,7 +24,7 @@ service_type "rabbitmq" {
   stop "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-rabbit"
+      NAME="pikoci-$BUILD_PIPELINE_NAME-$BUILD_JOB_NAME-rabbit"
       docker rm -f $NAME 2>/dev/null || true
     EOT
     ]

--- a/pikoci/builtin/services/redis.hcl
+++ b/pikoci/builtin/services/redis.hcl
@@ -4,18 +4,18 @@ service_type "redis" {
   start "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-redis"
+      NAME="pikoci-$BUILD_PIPELINE_NAME-$BUILD_JOB_NAME-redis"
       docker rm -f $NAME 2>/dev/null || true
       docker run -d --name $NAME \
-        -p $${param_port}:6379 \
-        redis:$${param_version}
+        -p $param_port:6379 \
+        redis:$param_version
     EOT
     ]
   }
 
   ready_check "exec" {
     path     = "/bin/sh"
-    args     = ["-ec", "redis-cli -p $${param_port} ping"]
+    args     = ["-ec", "redis-cli -p $param_port ping"]
     interval = "1s"
     timeout  = "30s"
   }
@@ -23,7 +23,7 @@ service_type "redis" {
   stop "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-redis"
+      NAME="pikoci-$BUILD_PIPELINE_NAME-$BUILD_JOB_NAME-redis"
       docker rm -f $NAME 2>/dev/null || true
     EOT
     ]

--- a/pikoci/builtin/services/vault.hcl
+++ b/pikoci/builtin/services/vault.hcl
@@ -4,22 +4,22 @@ service_type "vault" {
   start "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-vault"
+      NAME="pikoci-$BUILD_PIPELINE_NAME-$BUILD_JOB_NAME-vault"
       docker rm -f $NAME 2>/dev/null || true
       docker run -d --name $NAME \
-        -p $${param_port}:8200 \
-        -e VAULT_DEV_ROOT_TOKEN_ID=$${param_root_token} \
+        -p $param_port:8200 \
+        -e VAULT_DEV_ROOT_TOKEN_ID=$param_root_token \
         -e VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200 \
         -e SKIP_SETCAP=1 \
         --cap-add IPC_LOCK \
-        hashicorp/vault:$${param_version}
+        hashicorp/vault:$param_version
     EOT
     ]
   }
 
   ready_check "exec" {
     path     = "/bin/sh"
-    args     = ["-ec", "curl -sf http://127.0.0.1:$${param_port}/v1/sys/health"]
+    args     = ["-ec", "curl -sf http://127.0.0.1:$param_port/v1/sys/health"]
     interval = "2s"
     timeout  = "60s"
   }
@@ -27,7 +27,7 @@ service_type "vault" {
   stop "exec" {
     path = "/bin/sh"
     args = ["-ec", <<-EOT
-      NAME="pikoci-$${BUILD_PIPELINE_NAME}-$${BUILD_JOB_NAME}-vault"
+      NAME="pikoci-$BUILD_PIPELINE_NAME-$BUILD_JOB_NAME-vault"
       docker rm -f $NAME 2>/dev/null || true
     EOT
     ]


### PR DESCRIPTION
## Summary

- Replace unnecessary `$${VAR}` with `$VAR` in all built-in HCL files where curly braces are not required by shell syntax
- Keep `$$` only in three cases where braces are semantically needed: `$${param_branch:-HEAD}` (shell default), `-p$${param_root_password}` (prefix disambiguation), and `$${RESOURCE_NAME}.id` (variable name disambiguation)
- Document that `source` URLs are resolved once at pipeline create/update time — if the remote definition changes, the pipeline must be re-set to pick up the new version

Closes #244