### PR TITLE
Skip build triggers on first resource check

### DIFF
--- a/integration/backends/concurrent_builds_test.go
+++ b/integration/backends/concurrent_builds_test.go
@@ -137,7 +137,16 @@ job "job-c" {
 	require.NoError(t, err)
 	require.NotNil(t, pp)
 
-	// Trigger the resource — this creates a version which triggers all 3 jobs
+	// First trigger seeds the cursor (first check stores versions without triggering)
+	err = svc.TriggerPipelineResource(ctx, "main", "concurrent-test", "cron.trigger")
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		vers, err := svc.ListResourceVersions(ctx, "main", "concurrent-test", "cron.trigger")
+		return err == nil && len(vers) > 0
+	}, 10*time.Second, 200*time.Millisecond)
+
+	// Second trigger sees existing versions and triggers all 3 jobs
 	err = svc.TriggerPipelineResource(ctx, "main", "concurrent-test", "cron.trigger")
 	require.NoError(t, err)
 

--- a/integration/backends/concurrent_builds_test.go
+++ b/integration/backends/concurrent_builds_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/xescugc/pikoci/pikoci"
 	"github.com/xescugc/pikoci/pikoci/build"
+	"github.com/xescugc/pikoci/pikoci/resource"
 	"github.com/xescugc/pikoci/pikoci/mysql"
 	"github.com/xescugc/pikoci/pikoci/mysql/migrate"
 	"github.com/xescugc/pikoci/pikoci/unitwork"
@@ -137,16 +138,14 @@ job "job-c" {
 	require.NoError(t, err)
 	require.NotNil(t, pp)
 
-	// First trigger seeds the cursor (first check stores versions without triggering)
-	err = svc.TriggerPipelineResource(ctx, "main", "concurrent-test", "cron.trigger")
+	// Seed a version so the trigger is not a first check (first checks store
+	// versions without triggering builds).
+	_, err = svc.CreateResourceVersion(ctx, "main", "concurrent-test", "cron.trigger", resource.Version{
+		Version: map[string]interface{}{"date": "seed"},
+	})
 	require.NoError(t, err)
 
-	require.Eventually(t, func() bool {
-		vers, err := svc.ListResourceVersions(ctx, "main", "concurrent-test", "cron.trigger")
-		return err == nil && len(vers) > 0
-	}, 10*time.Second, 200*time.Millisecond)
-
-	// Second trigger sees existing versions and triggers all 3 jobs
+	// Trigger the resource — this creates a version which triggers all 3 jobs
 	err = svc.TriggerPipelineResource(ctx, "main", "concurrent-test", "cron.trigger")
 	require.NoError(t, err)
 

--- a/integration/backends/secrets_test.go
+++ b/integration/backends/secrets_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/xescugc/pikoci/pikoci"
 	"github.com/xescugc/pikoci/pikoci/build"
+	"github.com/xescugc/pikoci/pikoci/resource"
 	"github.com/xescugc/pikoci/pikoci/mysql"
 	"github.com/xescugc/pikoci/pikoci/mysql/migrate"
 	"github.com/xescugc/pikoci/pikoci/unitwork"
@@ -132,13 +133,19 @@ job "deploy" {
 		assert.Len(t, pp.SecretTypes, 1)
 		assert.Equal(t, "mock-vault", pp.SecretTypes[0].Name)
 
-		// First trigger seeds the cursor (first check stores versions without triggering)
+		// Seed a version so the trigger is not a first check
+		_, err = svc.CreateResourceVersion(ctx, "main", "secrets-e2e", "cron.timer", resource.Version{
+			Version: map[string]interface{}{"date": "seed"},
+		})
+		require.NoError(t, err)
+
+		// Trigger resource check to create a version and trigger builds
 		err = svc.TriggerPipelineResource(ctx, "main", "secrets-e2e", "cron.timer")
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
 			vers, err := svc.ListResourceVersions(ctx, "main", "secrets-e2e", "cron.timer")
-			return err == nil && len(vers) > 0
+			return err == nil && len(vers) > 1
 		}, 10*time.Second, 200*time.Millisecond)
 
 		// Second trigger sees existing versions and triggers builds
@@ -223,13 +230,19 @@ job "deploy" {
 		assert.Equal(t, "my-file", pp.SecretTypes[0].Name)
 		assert.Equal(t, "pikoci://file", pp.SecretTypes[0].Source)
 
-		// First trigger seeds the cursor
+		// Seed a version so the trigger is not a first check
+		_, err = svc.CreateResourceVersion(ctx, "main", "secrets-file-e2e", "cron.timer", resource.Version{
+			Version: map[string]interface{}{"date": "seed"},
+		})
+		require.NoError(t, err)
+
+		// Trigger resource check to create a version and trigger builds
 		err = svc.TriggerPipelineResource(ctx, "main", "secrets-file-e2e", "cron.timer")
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
 			vers, err := svc.ListResourceVersions(ctx, "main", "secrets-file-e2e", "cron.timer")
-			return err == nil && len(vers) > 0
+			return err == nil && len(vers) > 1
 		}, 10*time.Second, 200*time.Millisecond)
 
 		// Second trigger sees existing versions and triggers builds
@@ -331,13 +344,19 @@ job "deploy" {
 		assert.Equal(t, "env-file", pp.SecretTypes[0].Name)
 		assert.Equal(t, "pikoci://file", pp.SecretTypes[0].Source)
 
-		// First trigger seeds the cursor
+		// Seed a version so the trigger is not a first check
+		_, err = svc.CreateResourceVersion(ctx, "main", "secrets-env-file-e2e", "cron.timer", resource.Version{
+			Version: map[string]interface{}{"date": "seed"},
+		})
+		require.NoError(t, err)
+
+		// Trigger resource check to create a version and trigger builds
 		err = svc.TriggerPipelineResource(ctx, "main", "secrets-env-file-e2e", "cron.timer")
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
 			vers, err := svc.ListResourceVersions(ctx, "main", "secrets-env-file-e2e", "cron.timer")
-			return err == nil && len(vers) > 0
+			return err == nil && len(vers) > 1
 		}, 10*time.Second, 200*time.Millisecond)
 
 		// Second trigger sees existing versions and triggers builds

--- a/integration/backends/secrets_test.go
+++ b/integration/backends/secrets_test.go
@@ -132,15 +132,18 @@ job "deploy" {
 		assert.Len(t, pp.SecretTypes, 1)
 		assert.Equal(t, "mock-vault", pp.SecretTypes[0].Name)
 
-		// Trigger resource check to create a version (required by the get step)
+		// First trigger seeds the cursor (first check stores versions without triggering)
 		err = svc.TriggerPipelineResource(ctx, "main", "secrets-e2e", "cron.timer")
 		require.NoError(t, err)
 
-		// Wait for the resource version to be created
 		require.Eventually(t, func() bool {
 			vers, err := svc.ListResourceVersions(ctx, "main", "secrets-e2e", "cron.timer")
 			return err == nil && len(vers) > 0
 		}, 10*time.Second, 200*time.Millisecond)
+
+		// Second trigger sees existing versions and triggers builds
+		err = svc.TriggerPipelineResource(ctx, "main", "secrets-e2e", "cron.timer")
+		require.NoError(t, err)
 
 		// Wait for the build triggered by the resource to finish
 		var builds []*build.Build
@@ -220,7 +223,7 @@ job "deploy" {
 		assert.Equal(t, "my-file", pp.SecretTypes[0].Name)
 		assert.Equal(t, "pikoci://file", pp.SecretTypes[0].Source)
 
-		// Trigger resource check to create a version
+		// First trigger seeds the cursor
 		err = svc.TriggerPipelineResource(ctx, "main", "secrets-file-e2e", "cron.timer")
 		require.NoError(t, err)
 
@@ -228,6 +231,10 @@ job "deploy" {
 			vers, err := svc.ListResourceVersions(ctx, "main", "secrets-file-e2e", "cron.timer")
 			return err == nil && len(vers) > 0
 		}, 10*time.Second, 200*time.Millisecond)
+
+		// Second trigger sees existing versions and triggers builds
+		err = svc.TriggerPipelineResource(ctx, "main", "secrets-file-e2e", "cron.timer")
+		require.NoError(t, err)
 
 		// Wait for the build triggered by the resource to finish
 		var builds []*build.Build
@@ -324,7 +331,7 @@ job "deploy" {
 		assert.Equal(t, "env-file", pp.SecretTypes[0].Name)
 		assert.Equal(t, "pikoci://file", pp.SecretTypes[0].Source)
 
-		// Trigger resource check to create a version
+		// First trigger seeds the cursor
 		err = svc.TriggerPipelineResource(ctx, "main", "secrets-env-file-e2e", "cron.timer")
 		require.NoError(t, err)
 
@@ -332,6 +339,10 @@ job "deploy" {
 			vers, err := svc.ListResourceVersions(ctx, "main", "secrets-env-file-e2e", "cron.timer")
 			return err == nil && len(vers) > 0
 		}, 10*time.Second, 200*time.Millisecond)
+
+		// Second trigger sees existing versions and triggers builds
+		err = svc.TriggerPipelineResource(ctx, "main", "secrets-env-file-e2e", "cron.timer")
+		require.NoError(t, err)
 
 		// Wait for the build triggered by the resource to finish
 		var builds []*build.Build

--- a/integration/backends/services_test.go
+++ b/integration/backends/services_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/xescugc/pikoci/pikoci"
 	"github.com/xescugc/pikoci/pikoci/build"
+	"github.com/xescugc/pikoci/pikoci/resource"
 	"github.com/xescugc/pikoci/pikoci/mysql"
 	"github.com/xescugc/pikoci/pikoci/mysql/migrate"
 	"github.com/xescugc/pikoci/pikoci/unitwork"
@@ -125,12 +126,18 @@ job "use-service" {
 		require.NoError(t, err)
 		require.NotNil(t, pp)
 
+		// Seed a version so the trigger is not a first check
+		_, err = svc.CreateResourceVersion(ctx, "main", "svc-start-stop-e2e", "cron.timer", resource.Version{
+			Version: map[string]interface{}{"date": "seed"},
+		})
+		require.NoError(t, err)
+
 		err = svc.TriggerPipelineResource(ctx, "main", "svc-start-stop-e2e", "cron.timer")
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
 			vers, err := svc.ListResourceVersions(ctx, "main", "svc-start-stop-e2e", "cron.timer")
-			return err == nil && len(vers) > 0
+			return err == nil && len(vers) > 1
 		}, 10*time.Second, 200*time.Millisecond)
 
 		// Second trigger sees existing versions and triggers builds
@@ -212,12 +219,18 @@ job "use-slow-service" {
 		_, err := svc.CreatePipeline(ctx, "main", "svc-timeout-e2e", hclConfig, nil)
 		require.NoError(t, err)
 
+		// Seed a version so the trigger is not a first check
+		_, err = svc.CreateResourceVersion(ctx, "main", "svc-timeout-e2e", "cron.timer", resource.Version{
+			Version: map[string]interface{}{"date": "seed"},
+		})
+		require.NoError(t, err)
+
 		err = svc.TriggerPipelineResource(ctx, "main", "svc-timeout-e2e", "cron.timer")
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
 			vers, err := svc.ListResourceVersions(ctx, "main", "svc-timeout-e2e", "cron.timer")
-			return err == nil && len(vers) > 0
+			return err == nil && len(vers) > 1
 		}, 10*time.Second, 200*time.Millisecond)
 
 		// Second trigger sees existing versions and triggers builds
@@ -301,12 +314,18 @@ job "use-param-service" {
 		_, err := svc.CreatePipeline(ctx, "main", "svc-params-e2e", hclConfig, nil)
 		require.NoError(t, err)
 
+		// Seed a version so the trigger is not a first check
+		_, err = svc.CreateResourceVersion(ctx, "main", "svc-params-e2e", "cron.timer", resource.Version{
+			Version: map[string]interface{}{"date": "seed"},
+		})
+		require.NoError(t, err)
+
 		err = svc.TriggerPipelineResource(ctx, "main", "svc-params-e2e", "cron.timer")
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
 			vers, err := svc.ListResourceVersions(ctx, "main", "svc-params-e2e", "cron.timer")
-			return err == nil && len(vers) > 0
+			return err == nil && len(vers) > 1
 		}, 10*time.Second, 200*time.Millisecond)
 
 		// Second trigger sees existing versions and triggers builds
@@ -374,12 +393,18 @@ job "will-fail" {
 		_, err := svc.CreatePipeline(ctx, "main", "svc-stop-fail-e2e", hclConfig, nil)
 		require.NoError(t, err)
 
+		// Seed a version so the trigger is not a first check
+		_, err = svc.CreateResourceVersion(ctx, "main", "svc-stop-fail-e2e", "cron.timer", resource.Version{
+			Version: map[string]interface{}{"date": "seed"},
+		})
+		require.NoError(t, err)
+
 		err = svc.TriggerPipelineResource(ctx, "main", "svc-stop-fail-e2e", "cron.timer")
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
 			vers, err := svc.ListResourceVersions(ctx, "main", "svc-stop-fail-e2e", "cron.timer")
-			return err == nil && len(vers) > 0
+			return err == nil && len(vers) > 1
 		}, 10*time.Second, 200*time.Millisecond)
 
 		// Second trigger sees existing versions and triggers builds

--- a/integration/backends/services_test.go
+++ b/integration/backends/services_test.go
@@ -133,6 +133,10 @@ job "use-service" {
 			return err == nil && len(vers) > 0
 		}, 10*time.Second, 200*time.Millisecond)
 
+		// Second trigger sees existing versions and triggers builds
+		err = svc.TriggerPipelineResource(ctx, "main", "svc-start-stop-e2e", "cron.timer")
+		require.NoError(t, err)
+
 		var builds []*build.Build
 		require.Eventually(t, func() bool {
 			builds, err = svc.ListJobBuilds(ctx, "main", "svc-start-stop-e2e", "use-service")
@@ -215,6 +219,10 @@ job "use-slow-service" {
 			vers, err := svc.ListResourceVersions(ctx, "main", "svc-timeout-e2e", "cron.timer")
 			return err == nil && len(vers) > 0
 		}, 10*time.Second, 200*time.Millisecond)
+
+		// Second trigger sees existing versions and triggers builds
+		err = svc.TriggerPipelineResource(ctx, "main", "svc-timeout-e2e", "cron.timer")
+		require.NoError(t, err)
 
 		// Wait until the build completes AND the stop step is present
 		// (stop runs via defer after failBuild, so there's a brief window)
@@ -301,6 +309,10 @@ job "use-param-service" {
 			return err == nil && len(vers) > 0
 		}, 10*time.Second, 200*time.Millisecond)
 
+		// Second trigger sees existing versions and triggers builds
+		err = svc.TriggerPipelineResource(ctx, "main", "svc-params-e2e", "cron.timer")
+		require.NoError(t, err)
+
 		var builds []*build.Build
 		require.Eventually(t, func() bool {
 			builds, err = svc.ListJobBuilds(ctx, "main", "svc-params-e2e", "use-param-service")
@@ -369,6 +381,10 @@ job "will-fail" {
 			vers, err := svc.ListResourceVersions(ctx, "main", "svc-stop-fail-e2e", "cron.timer")
 			return err == nil && len(vers) > 0
 		}, 10*time.Second, 200*time.Millisecond)
+
+		// Second trigger sees existing versions and triggers builds
+		err = svc.TriggerPipelineResource(ctx, "main", "svc-stop-fail-e2e", "cron.timer")
+		require.NoError(t, err)
 
 		// Wait until the build completes AND the stop step is present
 		var builds []*build.Build

--- a/integration/pikoci_test.go
+++ b/integration/pikoci_test.go
@@ -406,13 +406,22 @@ job "gen" {
 
 			waitFor(t, wd, eqText(selenium.ByCSSSelector, "#breadcrumb", "Teams\nMain\nPipelines\ncron\nJobs\ngen\nBuilds"), 5*time.Second)
 
-			builds, err := wd.FindElements(selenium.ByCSSSelector, "#builds-tabs>.piko-build-tab")
-			require.NoError(t, err)
-			require.Equal(t, 1, len(builds))
-
+			// The first resource check stores versions without triggering
+			// builds, so trigger the job manually to get the first build.
 			tjBtn, err := wd.FindElement(selenium.ByCSSSelector, "#trigger-job")
 			require.NoError(t, err)
 
+			err = tjBtn.Click()
+			require.NoError(t, err)
+
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				builds, err := wd.FindElements(selenium.ByCSSSelector, "#builds-tabs>.piko-build-tab")
+				require.NoError(t, err)
+
+				return len(builds) == 1
+			}, 5*time.Second)
+
+			// Trigger a second build
 			err = tjBtn.Click()
 			require.NoError(t, err)
 

--- a/worker/service.go
+++ b/worker/service.go
@@ -1060,6 +1060,7 @@ func (w *Worker) processResourceCheck(ctx context.Context, m queue.Body, cwd str
 		w.logger.Error("failed to list resource versions", "error", err)
 		return
 	}
+	isFirstCheck := len(dbvers) == 0
 	if len(dbvers) != 0 {
 		for k, v := range dbvers[0].Version {
 			params["version_"+k] = fmt.Sprintf("%s", v)
@@ -1143,9 +1144,14 @@ func (w *Worker) processResourceCheck(ctx context.Context, m queue.Body, cwd str
 			w.logger.Error("failed to create resource version", "error", err)
 			return
 		}
-		w.logger.Info("new version created, triggering jobs",
-			"pipeline", m.PipelineCanonical, "resource", r.Canonical, "version_id", cv.ID)
-		w.triggerResourceJobs(ctx, m, pp, r, cv)
+		if isFirstCheck {
+			w.logger.Info("first check, setting cursor without triggering",
+				"pipeline", m.PipelineCanonical, "resource", r.Canonical, "version_id", cv.ID)
+		} else {
+			w.logger.Info("new version created, triggering jobs",
+				"pipeline", m.PipelineCanonical, "resource", r.Canonical, "version_id", cv.ID)
+			w.triggerResourceJobs(ctx, m, pp, r, cv)
+		}
 	}
 }
 
@@ -1159,6 +1165,7 @@ func (w *Worker) processResourceCheckTrigger(ctx context.Context, m queue.Body, 
 		w.logger.Error("failed to list resource versions for trigger check", "error", err)
 		return
 	}
+	isFirstCheck := len(dbvers) == 0
 	if len(dbvers) > 0 {
 		if tid, ok := dbvers[0].Version["trigger_id"]; ok {
 			switch v := tid.(type) {
@@ -1196,9 +1203,14 @@ func (w *Worker) processResourceCheckTrigger(ctx context.Context, m queue.Body, 
 			w.logger.Error("failed to create resource version from trigger", "error", err)
 			return
 		}
-		w.logger.Info("trigger version created, triggering jobs",
-			"pipeline", m.PipelineCanonical, "resource", r.Canonical, "trigger_id", t.ID, "version_id", cv.ID)
-		w.triggerResourceJobs(ctx, m, pp, r, cv)
+		if isFirstCheck {
+			w.logger.Info("first check, setting cursor without triggering",
+				"pipeline", m.PipelineCanonical, "resource", r.Canonical, "trigger_id", t.ID, "version_id", cv.ID)
+		} else {
+			w.logger.Info("trigger version created, triggering jobs",
+				"pipeline", m.PipelineCanonical, "resource", r.Canonical, "trigger_id", t.ID, "version_id", cv.ID)
+			w.triggerResourceJobs(ctx, m, pp, r, cv)
+		}
 	}
 }
 

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/xescugc/pikoci/pikoci/restype"
 	"github.com/xescugc/pikoci/pikoci/runner"
 	"github.com/xescugc/pikoci/pikoci/sectype"
+	"github.com/xescugc/pikoci/pikoci/trigger"
 	"github.com/xescugc/pikoci/pikoci/utils"
 	"go.uber.org/mock/gomock"
 	"gocloud.dev/pubsub"
@@ -590,7 +591,7 @@ func TestProcessJob_NoDownstreamTrigger(t *testing.T) {
 
 func TestProcessResourceCheck_NewVersions(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	w, svc, topic := newTestWorker(ctrl)
+	w, svc, _ := newTestWorker(ctrl)
 
 	ctx := context.Background()
 	m := queue.Body{
@@ -643,23 +644,15 @@ func TestProcessResourceCheck_NewVersions(t *testing.T) {
 	svc.EXPECT().CreateResourceVersion(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron", gomock.Any()).
 		Return(&resource.Version{ID: 1, Version: map[string]interface{}{"date": "now"}}, nil)
 
-	// Should trigger the job that depends on this resource
-	topic.EXPECT().Send(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, msg *pubsub.Message) error {
-		var body queue.Body
-		err := json.Unmarshal(msg.Body, &body)
-		require.NoError(t, err)
-		assert.Equal(t, "test-job", body.JobName)
-		assert.Equal(t, "cron.my-cron", body.ResourceCanonical)
-		assert.Equal(t, uint32(1), body.VersionID)
-		return nil
-	})
+	// First check: versions are stored but NO jobs should be triggered
+	// (topic.Send is NOT expected)
 
 	w.processResourceCheck(ctx, m, cwd, pp)
 }
 
-func TestProcessResourceCheck_DuplicateVersionSkipped_NewVersionTriggered(t *testing.T) {
+func TestProcessResourceCheck_DuplicateVersionSkipped_FirstCheckNoTrigger(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	w, svc, topic := newTestWorker(ctrl)
+	w, svc, _ := newTestWorker(ctrl)
 
 	ctx := context.Background()
 	m := queue.Body{
@@ -723,25 +716,195 @@ func TestProcessResourceCheck_DuplicateVersionSkipped_NewVersionTriggered(t *tes
 	svc.EXPECT().CreateResourceVersion(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "git.my-repo", gomock.Any()).
 		Return(&resource.Version{ID: 2, Version: map[string]interface{}{"ref": "new"}}, nil)
 
-	// Should trigger both jobs for the new version only
+	// First check: NO jobs should be triggered even for new versions
+	// (topic.Send is NOT expected)
+
+	w.processResourceCheck(ctx, m, cwd, pp)
+}
+
+func TestProcessResourceCheck_SecondCheckTriggers(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, topic := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		ResourceCanonical: "cron.my-cron",
+	}
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "test-job",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeGet,
+						Get:  &job.GetStep{Type: "cron", Name: "my-cron", Trigger: true},
+					},
+				},
+			},
+		},
+		Resources: []resource.Resource{
+			{ID: 1, Name: "my-cron", Type: "cron", Canonical: "cron.my-cron"},
+		},
+		ResourceTypes: []restype.ResourceType{
+			{
+				ID: 1, Name: "cron",
+				Check: &utils.RunnerCommand{
+					Runner: "exec",
+					Args:   []string{"-ec", `printf "[{\"date\":\"now2\"}]\n"`},
+					Params: map[string]string{
+						"path": "/bin/sh",
+					},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	// Not a first check: existing versions present
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron").
+		Return([]*resource.Version{
+			{ID: 1, Version: map[string]interface{}{"date": "now"}},
+		}, nil).AnyTimes()
+
+	// CreateResourceVersion for the new version
+	svc.EXPECT().CreateResourceVersion(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron", gomock.Any()).
+		Return(&resource.Version{ID: 2, Version: map[string]interface{}{"date": "now2"}}, nil)
+
+	// Second check: jobs SHOULD be triggered
 	topic.EXPECT().Send(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, msg *pubsub.Message) error {
 		var body queue.Body
 		err := json.Unmarshal(msg.Body, &body)
 		require.NoError(t, err)
-		assert.Equal(t, "lint", body.JobName)
-		assert.Equal(t, uint32(2), body.VersionID)
-		return nil
-	})
-	topic.EXPECT().Send(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, msg *pubsub.Message) error {
-		var body queue.Body
-		err := json.Unmarshal(msg.Body, &body)
-		require.NoError(t, err)
-		assert.Equal(t, "test", body.JobName)
+		assert.Equal(t, "test-job", body.JobName)
+		assert.Equal(t, "cron.my-cron", body.ResourceCanonical)
 		assert.Equal(t, uint32(2), body.VersionID)
 		return nil
 	})
 
 	w.processResourceCheck(ctx, m, cwd, pp)
+}
+
+func TestProcessResourceCheckTrigger_FirstCheckNoTrigger(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		ResourceCanonical: "trigger.my-trigger",
+	}
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "deploy",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeGet,
+						Get:  &job.GetStep{Type: "trigger", Name: "my-trigger", Trigger: true},
+					},
+				},
+			},
+		},
+		Resources: []resource.Resource{
+			{ID: 1, Name: "my-trigger", Type: "trigger", Canonical: "trigger.my-trigger"},
+		},
+		ResourceTypes: []restype.ResourceType{
+			{ID: 1, Name: "trigger", Source: "pikoci://trigger"},
+		},
+	}
+
+	// No existing versions — first check
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "trigger.my-trigger").
+		Return([]*resource.Version{}, nil).AnyTimes()
+
+	// Triggers exist
+	svc.EXPECT().ListTriggersAfter(gomock.Any(), m.TeamCanonical, "trigger.my-trigger", uint32(0)).
+		Return([]*trigger.Trigger{
+			{ID: 1, Version: map[string]interface{}{"key": "val"}},
+		}, nil)
+
+	// CreateResourceVersion succeeds
+	svc.EXPECT().CreateResourceVersion(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "trigger.my-trigger", gomock.Any()).
+		Return(&resource.Version{ID: 1, Version: map[string]interface{}{"key": "val", "trigger_id": float64(1)}}, nil)
+
+	// First check: NO jobs should be triggered (topic.Send is NOT expected)
+
+	w.processResourceCheck(ctx, m, "", pp)
+}
+
+func TestProcessResourceCheckTrigger_SecondCheckTriggers(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, topic := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		ResourceCanonical: "trigger.my-trigger",
+	}
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "deploy",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeGet,
+						Get:  &job.GetStep{Type: "trigger", Name: "my-trigger", Trigger: true},
+					},
+				},
+			},
+		},
+		Resources: []resource.Resource{
+			{ID: 1, Name: "my-trigger", Type: "trigger", Canonical: "trigger.my-trigger"},
+		},
+		ResourceTypes: []restype.ResourceType{
+			{ID: 1, Name: "trigger", Source: "pikoci://trigger"},
+		},
+	}
+
+	// Existing versions present — not a first check
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "trigger.my-trigger").
+		Return([]*resource.Version{
+			{ID: 1, Version: map[string]interface{}{"key": "old", "trigger_id": float64(1)}},
+		}, nil)
+
+	// New trigger after the existing one
+	svc.EXPECT().ListTriggersAfter(gomock.Any(), m.TeamCanonical, "trigger.my-trigger", uint32(1)).
+		Return([]*trigger.Trigger{
+			{ID: 2, Version: map[string]interface{}{"key": "new"}},
+		}, nil)
+
+	// CreateResourceVersion succeeds
+	svc.EXPECT().CreateResourceVersion(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "trigger.my-trigger", gomock.Any()).
+		Return(&resource.Version{ID: 2, Version: map[string]interface{}{"key": "new", "trigger_id": float64(2)}}, nil)
+
+	// Second check: jobs SHOULD be triggered
+	topic.EXPECT().Send(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, msg *pubsub.Message) error {
+		var body queue.Body
+		err := json.Unmarshal(msg.Body, &body)
+		require.NoError(t, err)
+		assert.Equal(t, "deploy", body.JobName)
+		assert.Equal(t, "trigger.my-trigger", body.ResourceCanonical)
+		assert.Equal(t, uint32(2), body.VersionID)
+		return nil
+	})
+
+	w.processResourceCheck(ctx, m, "", pp)
 }
 
 func TestCheckPassedConstraints_AllPassed(t *testing.T) {
@@ -1909,13 +2072,15 @@ func TestProcessResourceCheck_WithSecretVars(t *testing.T) {
 	}
 	cwd := t.TempDir()
 
-	// No existing versions
+	// Existing versions present — not a first check
 	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "git.repo").
-		Return([]*resource.Version{}, nil).AnyTimes()
+		Return([]*resource.Version{
+			{ID: 1, Version: map[string]interface{}{"ref": "old"}},
+		}, nil).AnyTimes()
 
 	// CreateResourceVersion for the new version found
 	svc.EXPECT().CreateResourceVersion(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "git.repo", gomock.Any()).
-		Return(&resource.Version{ID: 1, Version: map[string]interface{}{"ref": "abc123"}}, nil)
+		Return(&resource.Version{ID: 2, Version: map[string]interface{}{"ref": "abc123"}}, nil)
 
 	// Trigger the job
 	topic.EXPECT().Send(gomock.Any(), gomock.Any()).Return(nil)
@@ -2213,10 +2378,13 @@ func TestProcessResourceCheck_RawSecretFormat(t *testing.T) {
 	}
 	cwd := t.TempDir()
 
+	// Existing versions present — not a first check
 	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.timer").
-		Return([]*resource.Version{}, nil)
+		Return([]*resource.Version{
+			{ID: 1, Version: map[string]interface{}{"date": "old"}},
+		}, nil)
 	svc.EXPECT().CreateResourceVersion(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.timer", gomock.Any()).
-		Return(&resource.Version{ID: 1, Version: map[string]interface{}{"date": "now"}}, nil)
+		Return(&resource.Version{ID: 2, Version: map[string]interface{}{"date": "now"}}, nil)
 	topic.EXPECT().Send(gomock.Any(), gomock.Any()).Return(nil)
 
 	w.processResourceCheck(ctx, m, cwd, pp)


### PR DESCRIPTION
## Summary

On the first resource check (no existing versions in DB), store all discovered versions as "already seen" without triggering builds. This prevents flooding the system with builds when a pipeline is first created with resources that return many versions (e.g. 100 git tags or all open PRs). Subsequent checks trigger builds normally via the existing deduplication logic.

## Changelog

- Added `isFirstCheck` guard in `processResourceCheck` and `processResourceCheckTrigger` to skip `triggerResourceJobs` when no prior versions exist
- Updated existing tests to reflect first-check-no-trigger behavior
- Added tests for second-check-triggers and trigger-resource-type paths

Closes #363