### PR TITLE
Add database export feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - User management: Profile page, admin Users page, CLI commands, force password change on default `admin/admin123`, and `--users` flag preserves UI/CLI password changes ([#237](https://github.com/PikoCI/pikoci/issues/237))
 - Pipeline graph zoom, pan, and fullscreen controls: scroll-wheel zoom toward cursor, click-drag pan (including on nodes), zoom buttons, reset, fullscreen overlay with navbar visible, pinch-zoom on mobile, and auto-sizing that prevents small pipelines from appearing oversized ([#338](https://github.com/PikoCI/pikoci/issues/338))
+- Database export: admin-only `GET /admin/export` endpoint, CLI `pikoci client export -o file.db`, and web UI dropdown button to download the full database as a portable SQLite file ([#275](https://github.com/PikoCI/pikoci/issues/275))
 
 ### Changed
 

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -64,6 +64,7 @@ func init() {
 	clientCmd.AddCommand(buildsCmd)
 	clientCmd.AddCommand(resourcesCmd)
 	clientCmd.AddCommand(triggersCmd)
+	clientCmd.AddCommand(exportCmd)
 }
 
 // login
@@ -1362,4 +1363,33 @@ func init() {
 	triggersListCmd.Flags().String("name", "", "Name of the Trigger")
 	triggersListCmd.Flags().Uint32("after", 0, "List triggers after this ID")
 	triggersListCmd.MarkFlagRequired("name")
+}
+
+// export
+var exportCmd = &cobra.Command{
+	Use:   "export",
+	Short: "Export the database to a SQLite file",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		output, _ := cmd.Flags().GetString("output")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		err = c.ExportDatabase(cmd.Context(), output)
+		if err != nil {
+			return fmt.Errorf("failed to export database: %w", err)
+		}
+
+		fmt.Printf("Database exported to %s\n", output)
+		return nil
+	},
+}
+
+func init() {
+	exportCmd.Flags().StringP("output", "o", "", "Output file path for the SQLite export")
+	exportCmd.MarkFlagRequired("output")
 }

--- a/cmd/client_test.go
+++ b/cmd/client_test.go
@@ -23,7 +23,7 @@ func TestCommandTree(t *testing.T) {
 		parentName  string
 		subcommands []string
 	}{
-		{clientCmd, "client", []string{"login", "pipelines", "jobs", "users", "teams", "builds", "resources", "triggers"}},
+		{clientCmd, "client", []string{"login", "pipelines", "jobs", "users", "teams", "builds", "resources", "triggers", "export"}},
 		{usersCmd, "users", []string{"create", "list", "update", "delete", "change-password"}},
 		{teamsCmd, "teams", []string{"create", "list", "get", "update", "delete", "members"}},
 		{teamsMembersCmd, "members", []string{"create", "update", "delete"}},
@@ -69,6 +69,7 @@ func TestRequiredFlags(t *testing.T) {
 		{"resources webhook-regenerate", resourcesWebhookRegenerateCmd, []string{"resource-canonical"}},
 		{"triggers create", triggersCreateCmd, []string{"name", "version"}},
 		{"triggers list", triggersListCmd, []string{"name"}},
+		{"export", exportCmd, []string{"output"}},
 	}
 
 	for _, tt := range tests {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -132,7 +132,7 @@ var serverCmd = &cobra.Command{
 		logger.Info("initialized service")
 
 		logger.Info("initializing http handlers")
-		var handler = tshttp.Handler(svc, jwtSecret, logger.With("component", "HTTP"))
+		var handler = tshttp.Handler(svc, jwtSecret, logger.With("component", "HTTP"), db, cfg.DBSystem)
 		logger.Info("initialized http handlers")
 
 		reg := prometheus.NewRegistry()

--- a/integration/backends/export_test.go
+++ b/integration/backends/export_test.go
@@ -1,0 +1,178 @@
+//go:build integration
+
+package backends_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xescugc/pikoci/pikoci"
+	"github.com/xescugc/pikoci/pikoci/build"
+	"github.com/xescugc/pikoci/pikoci/mysql"
+	"github.com/xescugc/pikoci/pikoci/mysql/migrate"
+	"github.com/xescugc/pikoci/pikoci/resource"
+	"github.com/xescugc/pikoci/pikoci/unitwork"
+	"github.com/xescugc/pikoci/pikoci/user"
+	"github.com/xescugc/pikoci/worker"
+	"gocloud.dev/pubsub"
+	"gocloud.dev/pubsub/mempubsub"
+)
+
+func TestExportE2E(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})).With("service", "test-export")
+
+	dbFile := t.TempDir() + "/test.db"
+	db, err := mysql.New("", 0, "", "", mysql.Options{
+		MultiStatements: true,
+		ClientFoundRows: true,
+		System:          mysql.SQLite,
+		DBName:          dbFile,
+		DBFile:          dbFile,
+	})
+	require.NoError(t, err)
+
+	err = migrate.Migrate(db, mysql.SQLite)
+	require.NoError(t, err)
+
+	topic, err := pubsub.OpenTopic(ctx, fmt.Sprintf("%s://export-test", mempubsub.Scheme))
+	require.NoError(t, err)
+	defer topic.Shutdown(ctx)
+
+	ur := mysql.NewUserRepository(db)
+	tr := mysql.NewTeamRepository(db)
+	ppr := mysql.NewPipelineRepository(db)
+	jr := mysql.NewJobRepository(db)
+	rr := mysql.NewResourceRepository(db, mysql.SQLite)
+	rt := mysql.NewResourceTypeRepository(db)
+	br := mysql.NewBuildRepository(db, mysql.SQLite)
+	rur := mysql.NewRunnerRepository(db)
+	str := mysql.NewSecretTypeRepository(db)
+	tgr := mysql.NewTriggerRepository(db)
+	suow := unitwork.NewStartUnitOfWork(db, mysql.SQLite)
+
+	jwtSecret := []byte("test-secret")
+	svc := pikoci.New(ctx, topic, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, suow, jwtSecret, logger)
+	svc.StartScheduler(ctx)
+
+	_, _ = svc.CreateUser(ctx, user.User{
+		FullName: "admin",
+		Username: "admin",
+		Password: "$2a$14$rwQk8Qvc2rij7qhFO4P1W.OiSF6AkgVU1RCrLaY2wawJcpkPEKwbm",
+	}, true)
+
+	subscription, err := pubsub.OpenSubscription(ctx, fmt.Sprintf("%s://export-test", mempubsub.Scheme))
+	require.NoError(t, err)
+	defer subscription.Shutdown(ctx)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		w := worker.New(svc, topic, subscription, logger.With("worker", 1))
+		w.Run(ctx)
+	}()
+
+	hclConfig := []byte(`
+resource "cron" "trigger" {
+  check_interval = "@every 1h"
+}
+
+job "export-job" {
+  get "cron" "trigger" {
+    trigger = true
+  }
+  task "work" {
+    run "exec" {
+      path = "/bin/sh"
+      args = ["-ec", "echo export-job done"]
+    }
+  }
+}
+`)
+
+	pp, err := svc.CreatePipeline(ctx, "main", "export-test", hclConfig, nil)
+	require.NoError(t, err)
+	require.NotNil(t, pp)
+
+	// Seed a version so the trigger is not a first check
+	_, err = svc.CreateResourceVersion(ctx, "main", "export-test", "cron.trigger", resource.Version{
+		Version: map[string]interface{}{"date": "seed"},
+	})
+	require.NoError(t, err)
+
+	// Trigger the resource — creates a build
+	err = svc.TriggerPipelineResource(ctx, "main", "export-test", "cron.trigger")
+	require.NoError(t, err)
+
+	// Wait for build to complete
+	require.Eventually(t, func() bool {
+		builds, err := svc.ListJobBuilds(ctx, "main", "export-test", "export-job")
+		if err != nil || len(builds) == 0 {
+			return false
+		}
+		return builds[0].Status == build.Succeeded || builds[0].Status == build.Failed
+	}, 30*time.Second, 200*time.Millisecond, "build should complete")
+
+	// Export the database
+	migrateFn := func(db *sql.DB, system string) error {
+		return migrate.Migrate(db, system)
+	}
+	exportPath, err := mysql.Export(ctx, db, mysql.SQLite, migrateFn)
+	require.NoError(t, err)
+	defer os.Remove(exportPath)
+
+	// Open the exported SQLite file
+	exportDB, err := mysql.New("", 0, "", "", mysql.Options{
+		System: mysql.SQLite,
+		DBFile: exportPath,
+	})
+	require.NoError(t, err)
+	defer exportDB.Close()
+
+	// Verify key tables have data
+	tables := []struct {
+		name     string
+		minCount int
+	}{
+		{"teams", 1},
+		{"users", 1},
+		{"pipelines", 1},
+		{"jobs", 1},
+		{"resources", 1},
+		{"resource_versions", 2}, // seed + trigger
+		{"builds", 1},
+	}
+
+	for _, tc := range tables {
+		var count int
+		err := exportDB.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM `%s`", tc.name)).Scan(&count)
+		require.NoError(t, err, "table %s", tc.name)
+		assert.GreaterOrEqual(t, count, tc.minCount, "table %s should have at least %d rows, got %d", tc.name, tc.minCount, count)
+	}
+
+	// Verify specific data: pipeline name
+	var pipelineName string
+	err = exportDB.QueryRow("SELECT name FROM pipelines WHERE canonical = 'export-test'").Scan(&pipelineName)
+	require.NoError(t, err)
+	assert.Equal(t, "export-test", pipelineName)
+
+	// Verify the exported DB can be used by creating repositories from it
+	exportUR := mysql.NewUserRepository(exportDB)
+	u, err := exportUR.Find(ctx, "admin")
+	require.NoError(t, err)
+	assert.Equal(t, "admin", u.Username)
+
+	cancel()
+	wg.Wait()
+}

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -66,7 +66,7 @@ func runTests(m *testing.M) int {
 	suow := unitwork.NewStartUnitOfWork(db, mysql.Mem)
 	var svc = pikoci.New(ctx, topic, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, suow, jwtSecret, logger)
 	svc.StartScheduler(ctx)
-	var handler = tshttp.Handler(svc, jwtSecret, logger.With("component", "HTTP"))
+	var handler = tshttp.Handler(svc, jwtSecret, logger.With("component", "HTTP"), db, mysql.Mem)
 	server := httptest.NewServer(handler)
 	pikoURL = server.URL
 	defer server.Close()

--- a/integration/pikoci_test.go
+++ b/integration/pikoci_test.go
@@ -585,6 +585,30 @@ job "gen" {
 				require.Equal(t, 2, len(members))
 			})
 		})
+		t.Run("Export Database Visible", func(t *testing.T) {
+			navLink, err := wd.FindElement(selenium.ByCSSSelector, ".navbar .nav-link")
+			require.NoError(t, err)
+
+			err = navLink.Click()
+			require.NoError(t, err)
+
+			// Admin should see the export database link
+			exportLink, err := wd.FindElement(selenium.ByCSSSelector, "#nav-export-db")
+			require.NoError(t, err, "admin should see export database link")
+
+			txt, err := exportLink.Text()
+			require.NoError(t, err)
+			require.Contains(t, txt, "Export Database")
+
+			// Also verify admin-only Users link is visible
+			_, err = wd.FindElement(selenium.ByCSSSelector, "#nav-users")
+			require.NoError(t, err, "admin should see users link")
+
+			// Close the dropdown by clicking elsewhere
+			logo, err := wd.FindElement(selenium.ByCSSSelector, "#logo")
+			require.NoError(t, err)
+			logo.Click()
+		})
 		t.Run("Logout", func(t *testing.T) {
 			navLink, err := wd.FindElement(selenium.ByCSSSelector, ".navbar .nav-link")
 			require.NoError(t, err)
@@ -619,6 +643,26 @@ job "gen" {
 			require.NoError(t, err)
 
 			waitFor(t, wd, eqText(selenium.ByCSSSelector, "#breadcrumb", "Teams"), 5*time.Second)
+		})
+		t.Run("Export Database Not Visible", func(t *testing.T) {
+			navLink, err := wd.FindElement(selenium.ByCSSSelector, ".navbar .nav-link")
+			require.NoError(t, err)
+
+			err = navLink.Click()
+			require.NoError(t, err)
+
+			// Non-admin should NOT see the export database link
+			_, err = wd.FindElement(selenium.ByCSSSelector, "#nav-export-db")
+			require.Error(t, err, "non-admin should not see export database link")
+
+			// Non-admin should NOT see the users link either
+			_, err = wd.FindElement(selenium.ByCSSSelector, "#nav-users")
+			require.Error(t, err, "non-admin should not see users link")
+
+			// Close the dropdown by clicking elsewhere
+			logo, err := wd.FindElement(selenium.ByCSSSelector, "#logo")
+			require.NoError(t, err)
+			logo.Click()
 		})
 		t.Run("Teams", func(t *testing.T) {
 			teams, err := wd.FindElements(selenium.ByCSSSelector, ".piko-team-row")
@@ -903,6 +947,59 @@ job "gen" {
 			// Trigger job button should not be present for public viewers
 			_, err := wd.FindElement(selenium.ByCSSSelector, "#trigger-job")
 			require.Error(t, err, "trigger job button should not be visible on public pipeline view")
+		})
+
+		t.Run("ExportEndpoint_AdminAllowed", func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, pikoURL+"/admin/export", nil)
+			require.NoError(t, err)
+			req.Header.Set("Authorization", "Bearer "+adminJWT)
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			require.Equal(t, http.StatusOK, resp.StatusCode, "admin should be able to export")
+			require.Equal(t, "application/octet-stream", resp.Header.Get("Content-Type"))
+			require.Contains(t, resp.Header.Get("Content-Disposition"), "pikoci.db")
+		})
+
+		t.Run("ExportEndpoint_UnauthenticatedRejected", func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, pikoURL+"/admin/export", nil)
+			require.NoError(t, err)
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode, "unauthenticated should be rejected")
+		})
+
+		t.Run("ExportEndpoint_NonAdminRejected", func(t *testing.T) {
+			// Login as pepito (non-admin) via HTTP
+			pepitoBody, _ := json.Marshal(thttp.UserLoginRequest{
+				Username: "pepito",
+				Password: "pepito",
+			})
+			pepitoReq, err := http.NewRequest(http.MethodPost, pikoURL+"/login.json", bytes.NewReader(pepitoBody))
+			require.NoError(t, err)
+			pepitoResp, err := http.DefaultClient.Do(pepitoReq)
+			require.NoError(t, err)
+			defer pepitoResp.Body.Close()
+			require.Equal(t, http.StatusOK, pepitoResp.StatusCode)
+			var plr thttp.UserLoginResponse
+			json.NewDecoder(pepitoResp.Body).Decode(&plr)
+			require.Empty(t, plr.Err)
+			pepitoJWT := plr.Data.JWT
+
+			req, err := http.NewRequest(http.MethodGet, pikoURL+"/admin/export", nil)
+			require.NoError(t, err)
+			req.Header.Set("Authorization", "Bearer "+pepitoJWT)
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode, "non-admin should be rejected")
 		})
 
 		// Log back in as pepito for the RefreshToken test

--- a/pikoci/mysql/export.go
+++ b/pikoci/mysql/export.go
@@ -1,0 +1,159 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// exportTables defines the order in which tables are copied during export.
+// The order respects FK constraints so that parent rows exist before children.
+var exportTables = []string{
+	"teams", "users", "teams_users", "pipelines", "jobs", "builds", "resources",
+	"resource_versions", "resource_types", "runners", "secret_types", "secrets",
+	"build_get_versions", "triggers", "schema_migrations",
+}
+
+// Export creates a SQLite file containing all data from srcDB.
+// migrateFn is called on the destination DB to create the schema before copying data.
+// It returns the path to the temporary file. The caller is responsible
+// for removing the file when done.
+func Export(ctx context.Context, srcDB *sql.DB, srcSystem string, migrateFn func(*sql.DB, string) error) (string, error) {
+	tmpFile, err := os.CreateTemp("", "pikoci-export-*.db")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+
+	dstDB, err := New("", 0, "", "", Options{
+		System:          SQLite,
+		DBFile:          tmpPath,
+		MultiStatements: true,
+	})
+	if err != nil {
+		os.Remove(tmpPath)
+		return "", fmt.Errorf("failed to open destination SQLite: %w", err)
+	}
+	defer dstDB.Close()
+
+	if err := migrateFn(dstDB, SQLite); err != nil {
+		os.Remove(tmpPath)
+		return "", fmt.Errorf("failed to run migrations on export db: %w", err)
+	}
+
+	for _, table := range exportTables {
+		exists, err := tableExists(ctx, srcDB, srcSystem, table)
+		if err != nil {
+			os.Remove(tmpPath)
+			return "", fmt.Errorf("failed to check table %q: %w", table, err)
+		}
+		if !exists {
+			continue
+		}
+		if err := copyTable(ctx, srcDB, dstDB, srcSystem, table); err != nil {
+			os.Remove(tmpPath)
+			return "", fmt.Errorf("failed to copy table %q: %w", table, err)
+		}
+	}
+
+	return tmpPath, nil
+}
+
+func copyTable(ctx context.Context, srcDB, dstDB *sql.DB, srcSystem, table string) error {
+	selectQuery := fmt.Sprintf("SELECT * FROM %s", quoteIdentifier(table, srcSystem))
+
+	rows, err := srcDB.QueryContext(ctx, selectQuery)
+	if err != nil {
+		return fmt.Errorf("failed to select: %w", err)
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return fmt.Errorf("failed to get columns: %w", err)
+	}
+	if len(cols) == 0 {
+		return nil
+	}
+
+	tx, err := dstDB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	quotedCols := make([]string, len(cols))
+	for i, c := range cols {
+		quotedCols[i] = "`" + c + "`"
+	}
+	placeholders := make([]string, len(cols))
+	for i := range cols {
+		placeholders[i] = "?"
+	}
+
+	// Clear any rows seeded by migrations to avoid unique constraint conflicts.
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM `%s`", table)); err != nil {
+		return fmt.Errorf("failed to clear table: %w", err)
+	}
+
+	insertSQL := fmt.Sprintf("INSERT INTO `%s` (%s) VALUES (%s)",
+		table,
+		strings.Join(quotedCols, ", "),
+		strings.Join(placeholders, ", "),
+	)
+
+	stmt, err := tx.PrepareContext(ctx, insertSQL)
+	if err != nil {
+		return fmt.Errorf("failed to prepare insert: %w", err)
+	}
+	defer stmt.Close()
+
+	for rows.Next() {
+		vals := make([]interface{}, len(cols))
+		ptrs := make([]interface{}, len(cols))
+		for i := range vals {
+			ptrs[i] = &vals[i]
+		}
+
+		if err := rows.Scan(ptrs...); err != nil {
+			return fmt.Errorf("failed to scan row: %w", err)
+		}
+
+		if _, err := stmt.ExecContext(ctx, vals...); err != nil {
+			return fmt.Errorf("failed to insert row: %w", err)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("row iteration error: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+// tableExists checks whether a table exists in the given database.
+func tableExists(ctx context.Context, db *sql.DB, system, table string) (bool, error) {
+	var query string
+	if IsPostgreSQL(system) {
+		query = "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = $1"
+	} else if system == SQLite || system == Mem {
+		query = "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?"
+	} else {
+		query = "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = ?"
+	}
+	var count int
+	if err := db.QueryRowContext(ctx, query, table).Scan(&count); err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+// quoteIdentifier quotes a table name appropriately for the given DB system.
+func quoteIdentifier(name, system string) string {
+	if IsPostgreSQL(system) {
+		return `"` + name + `"`
+	}
+	return "`" + name + "`"
+}

--- a/pikoci/mysql/export_internal_test.go
+++ b/pikoci/mysql/export_internal_test.go
@@ -1,0 +1,17 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+)
+
+// Exported wrappers for internal functions, used only by tests.
+var QuoteIdentifier = quoteIdentifier
+
+func TableExists(ctx context.Context, db *sql.DB, system, table string) (bool, error) {
+	return tableExists(ctx, db, system, table)
+}
+
+func CopyTable(ctx context.Context, srcDB, dstDB *sql.DB, srcSystem, table string) error {
+	return copyTable(ctx, srcDB, dstDB, srcSystem, table)
+}

--- a/pikoci/mysql/export_test.go
+++ b/pikoci/mysql/export_test.go
@@ -1,0 +1,204 @@
+package mysql_test
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xescugc/pikoci/pikoci/mysql"
+	"github.com/xescugc/pikoci/pikoci/mysql/migrate"
+)
+
+func newMemDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := mysql.New("", 0, "", "", mysql.Options{
+		System:          mysql.Mem,
+		MultiStatements: true,
+		ClientFoundRows: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func newSQLiteDB(t *testing.T, path string) *sql.DB {
+	t.Helper()
+	db, err := mysql.New("", 0, "", "", mysql.Options{
+		System:          mysql.SQLite,
+		DBFile:          path,
+		MultiStatements: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func runMigrations(t *testing.T, db *sql.DB, system string) {
+	t.Helper()
+	err := migrate.Migrate(db, system)
+	require.NoError(t, err)
+}
+
+func TestQuoteIdentifier(t *testing.T) {
+	tests := []struct {
+		name     string
+		table    string
+		system   string
+		expected string
+	}{
+		{"mysql", "users", mysql.MySQL, "`users`"},
+		{"sqlite", "users", mysql.SQLite, "`users`"},
+		{"mem", "users", mysql.Mem, "`users`"},
+		{"postgresql", "users", mysql.PostgreSQL, `"users"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, mysql.QuoteIdentifier(tt.table, tt.system))
+		})
+	}
+}
+
+func TestTableExists(t *testing.T) {
+	ctx := context.Background()
+
+	db := newMemDB(t)
+	runMigrations(t, db, mysql.Mem)
+
+	exists, err := mysql.TableExists(ctx, db, mysql.Mem, "users")
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	exists, err = mysql.TableExists(ctx, db, mysql.Mem, "nonexistent_table")
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestTableExists_SQLite(t *testing.T) {
+	ctx := context.Background()
+
+	dbFile := t.TempDir() + "/test.db"
+	db := newSQLiteDB(t, dbFile)
+	runMigrations(t, db, mysql.SQLite)
+
+	exists, err := mysql.TableExists(ctx, db, mysql.SQLite, "users")
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	exists, err = mysql.TableExists(ctx, db, mysql.SQLite, "nonexistent_table")
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestCopyTable(t *testing.T) {
+	ctx := context.Background()
+
+	srcDB := newMemDB(t)
+	runMigrations(t, srcDB, mysql.Mem)
+
+	// Insert test data
+	_, err := srcDB.ExecContext(ctx, "INSERT INTO `teams` (`id`, `name`, `canonical`) VALUES (99, 'test-team', 'test-team')")
+	require.NoError(t, err)
+
+	dstFile := t.TempDir() + "/dst.db"
+	dstDB := newSQLiteDB(t, dstFile)
+	runMigrations(t, dstDB, mysql.SQLite)
+
+	err = mysql.CopyTable(ctx, srcDB, dstDB, mysql.Mem, "teams")
+	require.NoError(t, err)
+
+	var name string
+	err = dstDB.QueryRow("SELECT `name` FROM `teams` WHERE `id` = 99").Scan(&name)
+	require.NoError(t, err)
+	assert.Equal(t, "test-team", name)
+}
+
+func TestCopyTable_ClearsMigrationSeededData(t *testing.T) {
+	ctx := context.Background()
+
+	srcDB := newMemDB(t)
+	runMigrations(t, srcDB, mysql.Mem)
+
+	dstFile := t.TempDir() + "/dst.db"
+	dstDB := newSQLiteDB(t, dstFile)
+	runMigrations(t, dstDB, mysql.SQLite)
+
+	// Both have the seeded "main" team from migrations.
+	// copyTable should clear the destination before copying.
+	err := mysql.CopyTable(ctx, srcDB, dstDB, mysql.Mem, "teams")
+	require.NoError(t, err)
+
+	var count int
+	err = dstDB.QueryRow("SELECT COUNT(*) FROM `teams`").Scan(&count)
+	require.NoError(t, err)
+
+	var srcCount int
+	err = srcDB.QueryRow("SELECT COUNT(*) FROM `teams`").Scan(&srcCount)
+	require.NoError(t, err)
+	assert.Equal(t, srcCount, count)
+}
+
+func TestExport(t *testing.T) {
+	ctx := context.Background()
+
+	srcDB := newMemDB(t)
+	runMigrations(t, srcDB, mysql.Mem)
+
+	exportPath, err := mysql.Export(ctx, srcDB, mysql.Mem, func(db *sql.DB, system string) error {
+		return migrate.Migrate(db, system)
+	})
+	require.NoError(t, err)
+	defer os.Remove(exportPath)
+
+	info, err := os.Stat(exportPath)
+	require.NoError(t, err)
+	assert.Greater(t, info.Size(), int64(0))
+
+	exportDB := newSQLiteDB(t, exportPath)
+
+	var count int
+	err = exportDB.QueryRow("SELECT COUNT(*) FROM `teams`").Scan(&count)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, count, 1)
+}
+
+func TestExport_SkipsMissingTables(t *testing.T) {
+	ctx := context.Background()
+
+	// Use a file-based SQLite to avoid shared in-memory state with other tests
+	srcFile := t.TempDir() + "/src.db"
+	srcDB := newSQLiteDB(t, srcFile)
+	// Only create a minimal schema — not all tables from exportTables
+	_, err := srcDB.Exec("CREATE TABLE teams (id INTEGER PRIMARY KEY, name TEXT, canonical TEXT)")
+	require.NoError(t, err)
+	_, err = srcDB.Exec("INSERT INTO teams (id, name, canonical) VALUES (1, 'main', 'main')")
+	require.NoError(t, err)
+
+	exportPath, err := mysql.Export(ctx, srcDB, mysql.SQLite, func(db *sql.DB, system string) error {
+		return migrate.Migrate(db, system)
+	})
+	require.NoError(t, err)
+	defer os.Remove(exportPath)
+
+	exportDB := newSQLiteDB(t, exportPath)
+
+	var name string
+	err = exportDB.QueryRow("SELECT `name` FROM `teams` WHERE `canonical` = 'main'").Scan(&name)
+	require.NoError(t, err)
+	assert.Equal(t, "main", name)
+}
+
+func TestExport_MigrationError(t *testing.T) {
+	ctx := context.Background()
+
+	srcDB := newMemDB(t)
+
+	_, err := mysql.Export(ctx, srcDB, mysql.Mem, func(db *sql.DB, system string) error {
+		return assert.AnError
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to run migrations")
+}

--- a/pikoci/transport/http/authorization.go
+++ b/pikoci/transport/http/authorization.go
@@ -65,6 +65,8 @@ var (
 
 		CreateTrigger:     admin,
 		ListTriggersAfter: member,
+
+		ExportDatabase: admin,
 	}
 )
 

--- a/pikoci/transport/http/client/client_test.go
+++ b/pikoci/transport/http/client/client_test.go
@@ -690,6 +690,47 @@ func TestListTriggersAfter(t *testing.T) {
 	assert.Equal(t, uint32(6), triggers[0].ID)
 }
 
+func TestExportDatabase(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/admin/export", func(w http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "Bearer jwt", req.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Disposition", `attachment; filename="pikoci.db"`)
+		w.Write([]byte("fake-sqlite-data"))
+	}).Methods("GET")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	outputPath := filepath.Join(t.TempDir(), "export.db")
+	err = c.ExportDatabase(context.Background(), outputPath)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	assert.Equal(t, "fake-sqlite-data", string(data))
+}
+
+func TestExportDatabase_Error(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/admin/export", func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte("needs to be admin"))
+	}).Methods("GET")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	outputPath := filepath.Join(t.TempDir(), "export.db")
+	err = c.ExportDatabase(context.Background(), outputPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+}
+
 func TestRequestError(t *testing.T) {
 	r := mux.NewRouter()
 	r.HandleFunc("/teams", func(w http.ResponseWriter, req *http.Request) {

--- a/pikoci/transport/http/client/export.go
+++ b/pikoci/transport/http/client/export.go
@@ -1,0 +1,41 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+// ExportDatabase downloads the database export from the server and writes it to outputPath.
+func (c *Client) ExportDatabase(ctx context.Context, outputPath string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/admin/export", c.url), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.jwt))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to make request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("export failed (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	f, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("failed to create output file: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		return fmt.Errorf("failed to write export file: %w", err)
+	}
+
+	return nil
+}

--- a/pikoci/transport/http/export.go
+++ b/pikoci/transport/http/export.go
@@ -1,0 +1,35 @@
+package http
+
+import (
+	"database/sql"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/xescugc/pikoci/pikoci/mysql"
+	"github.com/xescugc/pikoci/pikoci/mysql/migrate"
+)
+
+func exportDatabase(db *sql.DB, dbSystem string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		tmpPath, err := mysql.Export(r.Context(), db, dbSystem, func(db *sql.DB, system string) error {
+			return migrate.Migrate(db, system)
+		})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer os.Remove(tmpPath)
+
+		f, err := os.Open(tmpPath)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer f.Close()
+
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Disposition", `attachment; filename="pikoci.db"`)
+		http.ServeContent(w, r, "pikoci.db", time.Now(), f)
+	}
+}

--- a/pikoci/transport/http/handler.go
+++ b/pikoci/transport/http/handler.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -32,7 +33,7 @@ var publicFallbackRoutes = map[RouteName]bool{
 	ListResourceVersions: true,
 }
 
-func Handler(s pikoci.Service, ts []byte, l *slog.Logger) http.Handler {
+func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem string) http.Handler {
 	r := mux.NewRouter()
 
 	auth := func(h http.Handler) http.Handler {
@@ -245,6 +246,11 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger) http.Handler {
 			fmt.Fprintf(w, `{"error": "Path not found"}`)
 		},
 	)
+
+	// Binary API routes (authenticated, no JSON content-type requirement)
+	binApi := r.PathPrefix("/").Subrouter()
+	binApi.Use(auth)
+	binApi.Methods(http.MethodGet).Path("/admin/export").Name(ExportDatabase.String()).Handler(exportDatabase(db, dbSystem))
 
 	r.PathPrefix("/css/").Handler(http.FileServer(http.FS(assets.Assets)))
 	r.PathPrefix("/js/").Handler(http.FileServer(http.FS(assets.Assets)))

--- a/pikoci/transport/http/handler_test.go
+++ b/pikoci/transport/http/handler_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"database/sql"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 	"github.com/xescugc/pikoci/pikoci/pipeline"
 	"github.com/xescugc/pikoci/pikoci/user"
 	"go.uber.org/mock/gomock"
+	_ "modernc.org/sqlite"
 )
 
 func TestEncodeResponse_WithError(t *testing.T) {
@@ -154,7 +156,7 @@ func TestUpdatePipeline_TeamCanonicalFromURL(t *testing.T) {
 	secret := []byte("test-secret")
 	logger := slog.Default()
 
-	handler := Handler(s, secret, logger)
+	handler := Handler(s, secret, logger, nil, "")
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
@@ -194,7 +196,7 @@ func TestRefreshTokenEndpoint(t *testing.T) {
 	secret := []byte("test-secret")
 	logger := slog.Default()
 
-	handler := Handler(s, secret, logger)
+	handler := Handler(s, secret, logger, nil, "")
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
@@ -231,6 +233,130 @@ func TestRefreshTokenEndpoint(t *testing.T) {
 	assert.Len(t, refreshResp.Data.User.Memberships, 1)
 }
 
+func TestExportDatabase_AdminAllowed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	// Create an in-memory SQLite DB for the export handler
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	handler := Handler(s, secret, logger, db, "mem")
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	um := &user.WithMemberships{
+		User:        user.User{Username: "admin", Admin: true},
+		Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+	}
+	jwtToken := signJWT(t, secret, um)
+
+	s.EXPECT().GetUser(gomock.Any(), "admin").Return(um, nil).AnyTimes()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/admin/export", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+jwtToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// The export may fail (minimal DB without migrations), but it should
+	// not be a 400 auth error — it should reach the handler.
+	assert.NotEqual(t, http.StatusBadRequest, resp.StatusCode, "admin should pass authorization")
+}
+
+func TestExportDatabase_NonAdminForbidden(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	handler := Handler(s, secret, logger, nil, "")
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	um := &user.WithMemberships{
+		User:        user.User{Username: "pepito", Admin: false},
+		Memberships: []user.Member{{TeamCanonical: "main", Admin: false}},
+	}
+	jwtToken := signJWT(t, secret, um)
+
+	s.EXPECT().GetUser(gomock.Any(), "pepito").Return(um, nil).AnyTimes()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/admin/export", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+jwtToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "non-admin should be rejected")
+}
+
+func TestExportDatabase_UnauthenticatedForbidden(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	handler := Handler(s, secret, logger, nil, "")
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/admin/export", nil)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "unauthenticated should be rejected")
+}
+
+func TestExportDatabase_ResponseHeaders(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	// Use a real mem DB with migrations for a successful export
+	memDB, err := sql.Open("sqlite", "file::memory:?cache=shared&_pragma=foreign_keys(1)&_busy_timeout=5000&_txlock=immediate")
+	require.NoError(t, err)
+	defer memDB.Close()
+
+	handler := Handler(s, secret, logger, memDB, "mem")
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	um := &user.WithMemberships{
+		User:        user.User{Username: "admin", Admin: true},
+		Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+	}
+	jwtToken := signJWT(t, secret, um)
+
+	s.EXPECT().GetUser(gomock.Any(), "admin").Return(um, nil).AnyTimes()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/admin/export", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+jwtToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// With a fresh mem DB (no tables), the export runs migrations on dest
+	// and copies data. It should succeed with proper headers.
+	if resp.StatusCode == http.StatusOK {
+		assert.Equal(t, "application/octet-stream", resp.Header.Get("Content-Type"))
+		assert.Contains(t, resp.Header.Get("Content-Disposition"), "pikoci.db")
+	}
+}
+
 func TestXRefreshTokenHeader(t *testing.T) {
 	secret := []byte("test-secret")
 	logger := slog.Default()
@@ -238,7 +364,7 @@ func TestXRefreshTokenHeader(t *testing.T) {
 	t.Run("header set when memberships differ", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		s := mock.NewService(ctrl)
-		handler := Handler(s, secret, logger)
+		handler := Handler(s, secret, logger, nil, "")
 		server := httptest.NewServer(handler)
 		defer server.Close()
 
@@ -271,7 +397,7 @@ func TestXRefreshTokenHeader(t *testing.T) {
 	t.Run("header not set when memberships match", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		s := mock.NewService(ctrl)
-		handler := Handler(s, secret, logger)
+		handler := Handler(s, secret, logger, nil, "")
 		server := httptest.NewServer(handler)
 		defer server.Close()
 
@@ -298,7 +424,7 @@ func TestXRefreshTokenHeader(t *testing.T) {
 	t.Run("header not set for worker tokens", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		s := mock.NewService(ctrl)
-		handler := Handler(s, secret, logger)
+		handler := Handler(s, secret, logger, nil, "")
 		server := httptest.NewServer(handler)
 		defer server.Close()
 

--- a/pikoci/transport/http/route_names.go
+++ b/pikoci/transport/http/route_names.go
@@ -60,4 +60,6 @@ const (
 
 	CreateTrigger
 	ListTriggersAfter
+
+	ExportDatabase
 )

--- a/pikoci/transport/http/route_names_string.go
+++ b/pikoci/transport/http/route_names_string.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _RouteNameName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionswebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_after"
+const _RouteNameName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionswebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_database"
 
-var _RouteNameIndex = [...]uint16{0, 10, 23, 34, 44, 52, 63, 74, 89, 103, 114, 124, 132, 143, 154, 172, 190, 208, 223, 238, 250, 265, 279, 297, 318, 338, 354, 370, 392, 408, 424, 439, 463, 486, 499, 515, 530, 551, 575, 600, 623, 645, 660, 684, 698, 717}
+var _RouteNameIndex = [...]uint16{0, 10, 23, 34, 44, 52, 63, 74, 89, 103, 114, 124, 132, 143, 154, 172, 190, 208, 223, 238, 250, 265, 279, 297, 318, 338, 354, 370, 392, 408, 424, 439, 463, 486, 499, 515, 530, 551, 575, 600, 623, 645, 660, 684, 698, 717, 732}
 
-const _RouteNameLowerName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionswebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_after"
+const _RouteNameLowerName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionswebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_database"
 
 func (i RouteName) String() string {
 	if i < 0 || i >= RouteName(len(_RouteNameIndex)-1) {
@@ -69,9 +69,10 @@ func _RouteNameNoOp() {
 	_ = x[RegenerateWebhookToken-(42)]
 	_ = x[CreateTrigger-(43)]
 	_ = x[ListTriggersAfter-(44)]
+	_ = x[ExportDatabase-(45)]
 }
 
-var _RouteNameValues = []RouteName{UserLogin, RefreshToken, CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser, ChangePassword, UpdateProfile, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, GetPipelineJob, CreateJobBuild, CreateRetryJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, InsertBuildGetVersion, FindBuildGetVersions, GetJobBuild, CancelJobBuild, RetryJobBuild, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions, WebhookTrigger, RegenerateWebhookToken, CreateTrigger, ListTriggersAfter}
+var _RouteNameValues = []RouteName{UserLogin, RefreshToken, CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser, ChangePassword, UpdateProfile, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, GetPipelineJob, CreateJobBuild, CreateRetryJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, InsertBuildGetVersion, FindBuildGetVersions, GetJobBuild, CancelJobBuild, RetryJobBuild, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions, WebhookTrigger, RegenerateWebhookToken, CreateTrigger, ListTriggersAfter, ExportDatabase}
 
 var _RouteNameNameToValueMap = map[string]RouteName{
 	_RouteNameName[0:10]:         UserLogin,
@@ -164,6 +165,8 @@ var _RouteNameNameToValueMap = map[string]RouteName{
 	_RouteNameLowerName[684:698]: CreateTrigger,
 	_RouteNameName[698:717]:      ListTriggersAfter,
 	_RouteNameLowerName[698:717]: ListTriggersAfter,
+	_RouteNameName[717:732]:      ExportDatabase,
+	_RouteNameLowerName[717:732]: ExportDatabase,
 }
 
 var _RouteNameNames = []string{
@@ -212,6 +215,7 @@ var _RouteNameNames = []string{
 	_RouteNameName[660:684],
 	_RouteNameName[684:698],
 	_RouteNameName[698:717],
+	_RouteNameName[717:732],
 }
 
 // RouteNameString retrieves an enum value from the enum constants string name.

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -64,6 +64,7 @@
                   <li><a class="dropdown-item" id="nav-profile" href="/profile"><i class="bi bi-person"></i> Profile</a></li>
                   <% if (session.user.admin) { %>
                     <li><a class="dropdown-item" id="nav-users" href="/users"><i class="bi bi-people"></i> Users <span class="badge bg-secondary ms-1">Admin</span></a></li>
+                    <li><a class="dropdown-item" id="nav-export-db" href="#" onclick="event.preventDefault(); exportDatabase();"><i class="bi bi-download"></i> Export Database <span class="badge bg-secondary ms-1">Admin</span></a></li>
                   <% } %>
                   <li><hr class="dropdown-divider"></li>
                   <li><a class="dropdown-item" id="logout" href="/logout"><i class="bi bi-box-arrow-right"></i> Logout</a></li>
@@ -773,6 +774,32 @@
             t.classList.remove('on');
           }
         }
+      }
+
+      function exportDatabase() {
+        var jwt = app.session ? app.session.get('jwt') : '';
+        if (!jwt) { app.apiNotice.set({error: 'Not authenticated'}); return; }
+        fetch('/admin/export', {
+          headers: { 'Authorization': 'Bearer ' + jwt }
+        }).then(function(resp) {
+          if (!resp.ok) {
+            return resp.text().then(function(body) {
+              throw new Error(body || resp.statusText);
+            });
+          }
+          return resp.blob();
+        }).then(function(blob) {
+          var url = URL.createObjectURL(blob);
+          var a = document.createElement('a');
+          a.href = url;
+          a.download = 'pikoci.db';
+          document.body.appendChild(a);
+          a.click();
+          document.body.removeChild(a);
+          URL.revokeObjectURL(url);
+        }).catch(function(err) {
+          app.apiNotice.set({error: err.message});
+        });
       }
 
       var app = {};


### PR DESCRIPTION
## Summary

- Add admin-only `GET /admin/export` HTTP endpoint that exports the full database as a portable SQLite file
- Add `pikoci client export -o <path>` CLI command
- Add "Export Database" button in the web UI admin dropdown menu

Closes #275