### PR TITLE
Remove first-check trigger skip

### DIFF
--- a/deploy/pipeline.hcl
+++ b/deploy/pipeline.hcl
@@ -5,6 +5,16 @@ job "lint" {
     trigger = true
   }
   put "github-check" "ci" { status = "in_progress" }
+  task "install-jq" {
+    run "docker" {
+      image = var.go_image
+      cmd   = "apt-get update -qq && apt-get install -qq -y jq"
+      args  = [
+        "-v", "pikoci-go-mod:/go/pkg/mod",
+        "-v", "pikoci-build:/root/.cache/go-build",
+      ]
+    }
+  }
   task "make" {
     run "docker" {
       image = var.go_image
@@ -28,6 +38,16 @@ job "test-mock" {
     trigger = true
   }
   put "github-check" "ci" { status = "in_progress" }
+  task "install-jq" {
+    run "docker" {
+      image = var.go_image
+      cmd   = "apt-get update -qq && apt-get install -qq -y jq"
+      args  = [
+        "-v", "pikoci-go-mod:/go/pkg/mod",
+        "-v", "pikoci-build:/root/.cache/go-build",
+      ]
+    }
+  }
   task "make" {
     run "docker" {
       image = var.go_image
@@ -51,6 +71,16 @@ job "test-integration" {
     trigger = true
   }
   put "github-check" "ci" { status = "in_progress" }
+  task "install-jq" {
+    run "docker" {
+      image = "ghcr.io/xescugc/pikoci-integration:latest"
+      cmd   = "apt-get update -qq && apt-get install -qq -y jq"
+      args  = [
+        "-v", "pikoci-go-mod:/go/pkg/mod",
+        "-v", "pikoci-build:/root/.cache/go-build",
+      ]
+    }
+  }
   task "make" {
     run "docker" {
       image = "ghcr.io/xescugc/pikoci-integration:latest"
@@ -110,6 +140,17 @@ job "test-backends" {
     root_token = "test-root-token"
   }
 
+  task "install-jq" {
+    run "docker" {
+      image = var.go_image
+      cmd   = "apt-get update -qq && apt-get install -qq -y jq"
+      args  = [
+        "--network=host",
+        "-v", "pikoci-go-mod:/go/pkg/mod",
+        "-v", "pikoci-build:/root/.cache/go-build",
+      ]
+    }
+  }
   task "make" {
     run "docker" {
       image = var.go_image

--- a/docs/Resource-Types.md
+++ b/docs/Resource-Types.md
@@ -44,6 +44,8 @@ All three operations are optional. A resource type that only defines `push` can 
 [{"ref": "abc123"}, {"ref": "def456"}]
 ```
 
+> **First check convention:** When no previous version exists, the `check` command should return only the **current/latest** version (a single-element array). PikoCI triggers builds for all versions returned, including the first check. Returning a large list of historical versions (e.g. all git tags) on the first check will create a build for each one. Resource types should be designed to return only what is new.
+
 **pull** fetches a specific version into the working directory. The version fields are available as `$version_<key>` environment variables.
 
 **push** publishes to the resource. Used when a job has a `put` step.

--- a/integration/backends/concurrent_builds_test.go
+++ b/integration/backends/concurrent_builds_test.go
@@ -138,8 +138,7 @@ job "job-c" {
 	require.NoError(t, err)
 	require.NotNil(t, pp)
 
-	// Seed a version so the trigger is not a first check (first checks store
-	// versions without triggering builds).
+	// Seed a version so the next check creates a second version.
 	_, err = svc.CreateResourceVersion(ctx, "main", "concurrent-test", "cron.trigger", resource.Version{
 		Version: map[string]interface{}{"date": "seed"},
 	})

--- a/integration/backends/export_test.go
+++ b/integration/backends/export_test.go
@@ -105,7 +105,7 @@ job "export-job" {
 	require.NoError(t, err)
 	require.NotNil(t, pp)
 
-	// Seed a version so the trigger is not a first check
+	// Seed a version so the next check creates a second version
 	_, err = svc.CreateResourceVersion(ctx, "main", "export-test", "cron.trigger", resource.Version{
 		Version: map[string]interface{}{"date": "seed"},
 	})

--- a/integration/backends/secrets_test.go
+++ b/integration/backends/secrets_test.go
@@ -133,7 +133,7 @@ job "deploy" {
 		assert.Len(t, pp.SecretTypes, 1)
 		assert.Equal(t, "mock-vault", pp.SecretTypes[0].Name)
 
-		// Seed a version so the trigger is not a first check
+		// Seed a version so the next check creates a second version
 		_, err = svc.CreateResourceVersion(ctx, "main", "secrets-e2e", "cron.timer", resource.Version{
 			Version: map[string]interface{}{"date": "seed"},
 		})
@@ -230,7 +230,7 @@ job "deploy" {
 		assert.Equal(t, "my-file", pp.SecretTypes[0].Name)
 		assert.Equal(t, "pikoci://file", pp.SecretTypes[0].Source)
 
-		// Seed a version so the trigger is not a first check
+		// Seed a version so the next check creates a second version
 		_, err = svc.CreateResourceVersion(ctx, "main", "secrets-file-e2e", "cron.timer", resource.Version{
 			Version: map[string]interface{}{"date": "seed"},
 		})
@@ -344,7 +344,7 @@ job "deploy" {
 		assert.Equal(t, "env-file", pp.SecretTypes[0].Name)
 		assert.Equal(t, "pikoci://file", pp.SecretTypes[0].Source)
 
-		// Seed a version so the trigger is not a first check
+		// Seed a version so the next check creates a second version
 		_, err = svc.CreateResourceVersion(ctx, "main", "secrets-env-file-e2e", "cron.timer", resource.Version{
 			Version: map[string]interface{}{"date": "seed"},
 		})

--- a/integration/backends/services_test.go
+++ b/integration/backends/services_test.go
@@ -126,7 +126,7 @@ job "use-service" {
 		require.NoError(t, err)
 		require.NotNil(t, pp)
 
-		// Seed a version so the trigger is not a first check
+		// Seed a version so the next check creates a second version
 		_, err = svc.CreateResourceVersion(ctx, "main", "svc-start-stop-e2e", "cron.timer", resource.Version{
 			Version: map[string]interface{}{"date": "seed"},
 		})
@@ -219,7 +219,7 @@ job "use-slow-service" {
 		_, err := svc.CreatePipeline(ctx, "main", "svc-timeout-e2e", hclConfig, nil)
 		require.NoError(t, err)
 
-		// Seed a version so the trigger is not a first check
+		// Seed a version so the next check creates a second version
 		_, err = svc.CreateResourceVersion(ctx, "main", "svc-timeout-e2e", "cron.timer", resource.Version{
 			Version: map[string]interface{}{"date": "seed"},
 		})
@@ -314,7 +314,7 @@ job "use-param-service" {
 		_, err := svc.CreatePipeline(ctx, "main", "svc-params-e2e", hclConfig, nil)
 		require.NoError(t, err)
 
-		// Seed a version so the trigger is not a first check
+		// Seed a version so the next check creates a second version
 		_, err = svc.CreateResourceVersion(ctx, "main", "svc-params-e2e", "cron.timer", resource.Version{
 			Version: map[string]interface{}{"date": "seed"},
 		})
@@ -393,7 +393,7 @@ job "will-fail" {
 		_, err := svc.CreatePipeline(ctx, "main", "svc-stop-fail-e2e", hclConfig, nil)
 		require.NoError(t, err)
 
-		// Seed a version so the trigger is not a first check
+		// Seed a version so the next check creates a second version
 		_, err = svc.CreateResourceVersion(ctx, "main", "svc-stop-fail-e2e", "cron.timer", resource.Version{
 			Version: map[string]interface{}{"date": "seed"},
 		})

--- a/integration/pikoci_test.go
+++ b/integration/pikoci_test.go
@@ -406,8 +406,19 @@ job "gen" {
 
 			waitFor(t, wd, eqText(selenium.ByCSSSelector, "#breadcrumb", "Teams\nMain\nPipelines\ncron\nJobs\ngen\nBuilds"), 5*time.Second)
 
-			// The first resource check stores versions without triggering
-			// builds, so trigger the job manually to get the first build.
+			// The first resource check triggers a build, so wait for it.
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				builds, err := wd.FindElements(selenium.ByCSSSelector, "#builds-tabs>.piko-build-tab")
+				require.NoError(t, err)
+
+				return len(builds) >= 1
+			}, 5*time.Second)
+
+			// Count current builds, then trigger one more manually.
+			builds, err := wd.FindElements(selenium.ByCSSSelector, "#builds-tabs>.piko-build-tab")
+			require.NoError(t, err)
+			countBefore := len(builds)
+
 			tjBtn, err := wd.FindElement(selenium.ByCSSSelector, "#trigger-job")
 			require.NoError(t, err)
 
@@ -418,18 +429,7 @@ job "gen" {
 				builds, err := wd.FindElements(selenium.ByCSSSelector, "#builds-tabs>.piko-build-tab")
 				require.NoError(t, err)
 
-				return len(builds) == 1
-			}, 5*time.Second)
-
-			// Trigger a second build
-			err = tjBtn.Click()
-			require.NoError(t, err)
-
-			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
-				builds, err := wd.FindElements(selenium.ByCSSSelector, "#builds-tabs>.piko-build-tab")
-				require.NoError(t, err)
-
-				return len(builds) == 2
+				return len(builds) >= countBefore+1
 			}, 5*time.Second)
 
 		})

--- a/pikoci/builtin/resource_check_test.go
+++ b/pikoci/builtin/resource_check_test.go
@@ -1,0 +1,729 @@
+package builtin_test
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2/hclsimple"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xescugc/pikoci/pikoci/builtin"
+	"github.com/xescugc/pikoci/pikoci/restype"
+	"github.com/xescugc/pikoci/pikoci/utils"
+)
+
+// runScript extracts a shell script from a RunnerCommand and executes it
+// with the given environment variables. It returns combined stdout+stderr.
+func runScript(t *testing.T, rc *utils.RunnerCommand, workDir string, env map[string]string) (string, error) {
+	t.Helper()
+	require.NotNil(t, rc)
+	require.GreaterOrEqual(t, len(rc.Args), 2, "expected at least 2 args (flag + script)")
+
+	script := rc.Args[1]
+
+	cmd := exec.Command("/bin/sh", "-ec", script)
+	cmd.Dir = workDir
+	cmd.Env = os.Environ()
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// fakeCurlDir creates a directory with a fake curl script that logs all
+// arguments to curl.log and prints the canned response to stdout.
+// Returns the directory (to prepend to PATH) and the log file path.
+func fakeCurlDir(t *testing.T, response string) (dir string, logFile string) {
+	t.Helper()
+	dir = t.TempDir()
+	logFile = filepath.Join(dir, "curl.log")
+
+	script := `#!/bin/sh
+# Log all arguments so the test can inspect them
+echo "$@" >> ` + logFile + `
+cat << 'RESP'
+` + response + `
+RESP
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "curl"), []byte(script), 0755))
+	return dir, logFile
+}
+
+// initBareRepo creates a bare git repo with one commit and returns the
+// bare dir, the work dir, and a helper to run git in the work dir.
+func initBareRepo(t *testing.T) (bareDir, workDir string, runWork func(args ...string)) {
+	t.Helper()
+	gitEnv := append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+	)
+
+	bareDir = t.TempDir()
+	cmd := exec.Command("git", "init", "--bare")
+	cmd.Dir = bareDir
+	cmd.Env = gitEnv
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git init --bare failed: %s", out)
+
+	workDir = t.TempDir()
+	cmd = exec.Command("git", "clone", bareDir, workDir)
+	cmd.Env = gitEnv
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, "git clone failed: %s", out)
+
+	runWork = func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = workDir
+		cmd.Env = gitEnv
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v failed: %s", args, out)
+	}
+
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "file.txt"), []byte("hello"), 0644))
+	runWork("add", ".")
+	runWork("commit", "-m", "first commit")
+	runWork("push", "origin", "HEAD")
+
+	return bareDir, workDir, runWork
+}
+
+// headSHA returns the HEAD sha of the given git directory.
+func headSHA(t *testing.T, dir string) string {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git rev-parse HEAD failed: %s", out)
+	return strings.TrimSpace(string(out))
+}
+
+// --- Cron resource type ---
+
+func TestCronCheck_ReturnsSingleVersion(t *testing.T) {
+	rts := builtin.ResourceTypes()
+	rt := rts["cron"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), nil)
+	require.NoError(t, err, "cron check failed: %s", out)
+
+	var versions []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &versions))
+	assert.Len(t, versions, 1, "cron check should return exactly 1 version")
+	assert.Contains(t, versions[0], "date")
+}
+
+// --- Git resource type: check ---
+
+func TestGitCheck_LsRemote_ReturnsSingleVersion(t *testing.T) {
+	bareDir, _, _ := initBareRepo(t)
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url": bareDir,
+	})
+	require.NoError(t, err, "git check (ls-remote) failed: %s", out)
+
+	var versions []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &versions))
+	assert.Len(t, versions, 1)
+	assert.Contains(t, versions[0], "ref")
+	assert.NotEmpty(t, versions[0]["ref"])
+}
+
+func TestGitCheck_LsRemote_WithBranch(t *testing.T) {
+	bareDir, workDir, runWork := initBareRepo(t)
+	runWork("checkout", "-b", "develop")
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "file2.txt"), []byte("world"), 0644))
+	runWork("add", ".")
+	runWork("commit", "-m", "second commit")
+	runWork("push", "origin", "develop")
+
+	expectedSHA := headSHA(t, workDir)
+
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":    bareDir,
+		"param_branch": "develop",
+	})
+	require.NoError(t, err, "git check (ls-remote branch) failed: %s", out)
+
+	var versions []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &versions))
+	assert.Len(t, versions, 1)
+	assert.Equal(t, expectedSHA, versions[0]["ref"])
+}
+
+func TestGitCheck_GitHubAPI_ReturnsSingleVersion(t *testing.T) {
+	cannedCommits := `[{"sha":"abc123"}]`
+	curlDir, logFile := fakeCurlDir(t, cannedCommits)
+
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":   "https://github.com/example/repo",
+		"param_token": "fake-token",
+		"PATH":        curlDir + ":" + os.Getenv("PATH"),
+	})
+	require.NoError(t, err, "git check (GitHub API) failed: %s", out)
+
+	curlLog, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(curlLog), "api.github.com/repos/example/repo/commits")
+	assert.Contains(t, string(curlLog), "per_page=1")
+
+	var versions []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &versions))
+	assert.Len(t, versions, 1)
+	assert.Equal(t, "abc123", versions[0]["ref"])
+}
+
+func TestGitCheck_GitLabAPI_ReturnsSingleVersion(t *testing.T) {
+	cannedCommits := `[{"id":"def456"}]`
+	curlDir, logFile := fakeCurlDir(t, cannedCommits)
+
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":   "https://gitlab.com/example/repo",
+		"param_token": "fake-token",
+		"PATH":        curlDir + ":" + os.Getenv("PATH"),
+	})
+	require.NoError(t, err, "git check (GitLab API) failed: %s", out)
+
+	curlLog, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(curlLog), "gitlab.com/api/v4/projects/example%2Frepo/repository/commits")
+	assert.Contains(t, string(curlLog), "per_page=1")
+
+	var versions []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &versions))
+	assert.Len(t, versions, 1)
+	assert.Equal(t, "def456", versions[0]["ref"])
+}
+
+func TestGitCheck_TagMode_GitHub_FirstCheck(t *testing.T) {
+	cannedTags := `[{"name":"v3","commit":{"sha":"aaa"}},{"name":"v2","commit":{"sha":"bbb"}},{"name":"v1","commit":{"sha":"ccc"}}]`
+	curlDir, logFile := fakeCurlDir(t, cannedTags)
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":   "https://github.com/example/repo",
+		"param_token": "fake-token",
+		"param_tag":   "true",
+		"PATH":        curlDir + ":" + os.Getenv("PATH"),
+	})
+	require.NoError(t, err, "git check (GitHub tag, first) failed: %s", out)
+
+	curlLog, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(curlLog), "per_page=1",
+		"first check should request per_page=1")
+}
+
+func TestGitCheck_TagMode_GitHub_SubsequentCheck(t *testing.T) {
+	cannedTags := `[{"name":"v3","commit":{"sha":"aaa"}},{"name":"v2","commit":{"sha":"bbb"}}]`
+	curlDir, logFile := fakeCurlDir(t, cannedTags)
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":   "https://github.com/example/repo",
+		"param_token": "fake-token",
+		"param_tag":   "true",
+		"version_tag": "v1",
+		"version_ref": "old-sha",
+		"PATH":        curlDir + ":" + os.Getenv("PATH"),
+	})
+	require.NoError(t, err, "git check (GitHub tag, subsequent) failed: %s", out)
+
+	curlLog, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(curlLog), "per_page=100",
+		"subsequent check should request per_page=100")
+
+	var versions []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &versions))
+	assert.Len(t, versions, 2)
+}
+
+func TestGitCheck_TagMode_GitLab_FirstCheck(t *testing.T) {
+	cannedTags := `[{"name":"v3","commit":{"id":"aaa"}},{"name":"v2","commit":{"id":"bbb"}}]`
+	curlDir, logFile := fakeCurlDir(t, cannedTags)
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":   "https://gitlab.com/example/repo",
+		"param_token": "fake-token",
+		"param_tag":   "true",
+		"PATH":        curlDir + ":" + os.Getenv("PATH"),
+	})
+	require.NoError(t, err, "git check (GitLab tag, first) failed: %s", out)
+
+	curlLog, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(curlLog), "gitlab.com/api/v4/projects/example%2Frepo/repository/tags")
+	assert.Contains(t, string(curlLog), "per_page=1")
+}
+
+func TestGitCheck_TagMode_GitLab_SubsequentCheck(t *testing.T) {
+	cannedTags := `[{"name":"v3","commit":{"id":"aaa"}},{"name":"v2","commit":{"id":"bbb"}}]`
+	curlDir, logFile := fakeCurlDir(t, cannedTags)
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":   "https://gitlab.com/example/repo",
+		"param_token": "fake-token",
+		"param_tag":   "true",
+		"version_tag": "v1",
+		"version_ref": "old-sha",
+		"PATH":        curlDir + ":" + os.Getenv("PATH"),
+	})
+	require.NoError(t, err, "git check (GitLab tag, subsequent) failed: %s", out)
+
+	curlLog, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(curlLog), "per_page=100")
+
+	var versions []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &versions))
+	assert.Len(t, versions, 2)
+}
+
+func TestGitCheck_PRMode_GitHub_FirstCheck(t *testing.T) {
+	cannedPRs := `[{"number":10,"head":{"sha":"aaa"}},{"number":9,"head":{"sha":"bbb"}}]`
+	curlDir, logFile := fakeCurlDir(t, cannedPRs)
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":   "https://github.com/example/repo",
+		"param_token": "fake-token",
+		"param_pr":    "true",
+		"PATH":        curlDir + ":" + os.Getenv("PATH"),
+	})
+	require.NoError(t, err, "git check (GitHub PR, first) failed: %s", out)
+
+	curlLog, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(curlLog), "per_page=1")
+}
+
+func TestGitCheck_PRMode_GitHub_SubsequentCheck(t *testing.T) {
+	cannedPRs := `[{"number":10,"head":{"sha":"aaa"}},{"number":9,"head":{"sha":"bbb"}}]`
+	curlDir, logFile := fakeCurlDir(t, cannedPRs)
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":   "https://github.com/example/repo",
+		"param_token": "fake-token",
+		"param_pr":    "true",
+		"version_pr":  "8",
+		"version_ref": "old-sha",
+		"PATH":        curlDir + ":" + os.Getenv("PATH"),
+	})
+	require.NoError(t, err, "git check (GitHub PR, subsequent) failed: %s", out)
+
+	curlLog, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(curlLog), "per_page=100")
+
+	var versions []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &versions))
+	assert.Len(t, versions, 2)
+}
+
+func TestGitCheck_PRMode_GitLab_FirstCheck(t *testing.T) {
+	cannedMRs := `[{"iid":10,"sha":"aaa"},{"iid":9,"sha":"bbb"}]`
+	curlDir, logFile := fakeCurlDir(t, cannedMRs)
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":   "https://gitlab.com/example/repo",
+		"param_token": "fake-token",
+		"param_pr":    "true",
+		"PATH":        curlDir + ":" + os.Getenv("PATH"),
+	})
+	require.NoError(t, err, "git check (GitLab MR, first) failed: %s", out)
+
+	curlLog, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(curlLog), "gitlab.com/api/v4/projects/example%2Frepo/merge_requests")
+	assert.Contains(t, string(curlLog), "per_page=1")
+}
+
+func TestGitCheck_PRMode_GitLab_SubsequentCheck(t *testing.T) {
+	cannedMRs := `[{"iid":10,"sha":"aaa"},{"iid":9,"sha":"bbb"}]`
+	curlDir, logFile := fakeCurlDir(t, cannedMRs)
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":   "https://gitlab.com/example/repo",
+		"param_token": "fake-token",
+		"param_pr":    "true",
+		"version_pr":  "8",
+		"version_ref": "old-sha",
+		"PATH":        curlDir + ":" + os.Getenv("PATH"),
+	})
+	require.NoError(t, err, "git check (GitLab MR, subsequent) failed: %s", out)
+
+	curlLog, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(curlLog), "per_page=100")
+
+	var versions []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &versions))
+	assert.Len(t, versions, 2)
+}
+
+func TestGitCheck_TagMode_RequiresToken(t *testing.T) {
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url": "https://github.com/example/repo",
+		"param_tag": "true",
+	})
+	assert.Error(t, err, "tag mode without token should fail")
+	assert.Contains(t, out, "tag=true requires a token")
+}
+
+func TestGitCheck_PRMode_RequiresToken(t *testing.T) {
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url": "https://github.com/example/repo",
+		"param_pr":  "true",
+	})
+	assert.Error(t, err, "PR mode without token should fail")
+	assert.Contains(t, out, "pr=true requires a token")
+}
+
+// --- Git resource type: pull ---
+
+func TestGitPull_DefaultBranch(t *testing.T) {
+	bareDir, workDir, _ := initBareRepo(t)
+	sha := headSHA(t, workDir)
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	pullDir := t.TempDir()
+	out, err := runScript(t, rt.Pull, pullDir, map[string]string{
+		"param_url":  bareDir,
+		"param_name": "myrepo",
+		"version_ref": sha,
+	})
+	require.NoError(t, err, "git pull (default) failed: %s", out)
+
+	// Verify the repo was cloned and checked out at the right ref
+	clonedSHA := headSHA(t, filepath.Join(pullDir, "myrepo"))
+	assert.Equal(t, sha, clonedSHA)
+}
+
+func TestGitPull_WithBranch(t *testing.T) {
+	bareDir, workDir, runWork := initBareRepo(t)
+	runWork("checkout", "-b", "feature")
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "feature.txt"), []byte("feature"), 0644))
+	runWork("add", ".")
+	runWork("commit", "-m", "feature commit")
+	runWork("push", "origin", "feature")
+	featureSHA := headSHA(t, workDir)
+
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	pullDir := t.TempDir()
+	out, err := runScript(t, rt.Pull, pullDir, map[string]string{
+		"param_url":    bareDir,
+		"param_name":   "myrepo",
+		"param_branch": "feature",
+		"version_ref":  featureSHA,
+	})
+	require.NoError(t, err, "git pull (branch) failed: %s", out)
+
+	clonedSHA := headSHA(t, filepath.Join(pullDir, "myrepo"))
+	assert.Equal(t, featureSHA, clonedSHA)
+
+	// Verify the feature file exists
+	_, err = os.Stat(filepath.Join(pullDir, "myrepo", "feature.txt"))
+	assert.NoError(t, err)
+}
+
+func TestGitPull_TagMode(t *testing.T) {
+	bareDir, workDir, runWork := initBareRepo(t)
+	runWork("tag", "v1.0.0")
+	runWork("push", "origin", "v1.0.0")
+	tagSHA := headSHA(t, workDir)
+
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	pullDir := t.TempDir()
+	out, err := runScript(t, rt.Pull, pullDir, map[string]string{
+		"param_url":   bareDir,
+		"param_name":  "myrepo",
+		"param_tag":   "true",
+		"version_tag": "v1.0.0",
+		"version_ref": tagSHA,
+	})
+	require.NoError(t, err, "git pull (tag) failed: %s", out)
+
+	clonedSHA := headSHA(t, filepath.Join(pullDir, "myrepo"))
+	assert.Equal(t, tagSHA, clonedSHA)
+}
+
+// --- Git resource type: push ---
+
+func TestGitPush(t *testing.T) {
+	bareDir, workDir, runWork := initBareRepo(t)
+	_ = workDir
+
+	// Clone into a fresh dir (simulating the pull step output)
+	pushDir := t.TempDir()
+	cmd := exec.Command("git", "clone", bareDir, filepath.Join(pushDir, "myrepo"))
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "clone failed: %s", out)
+
+	// Make a change and commit
+	repoDir := filepath.Join(pushDir, "myrepo")
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "pushed.txt"), []byte("pushed"), 0644))
+	gitRun := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoDir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v failed: %s", args, out)
+	}
+	gitRun("add", ".")
+	gitRun("commit", "-m", "push test")
+
+	pushSHA := headSHA(t, repoDir)
+
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	pushOut, err := runScript(t, rt.Push, pushDir, map[string]string{
+		"param_url":  bareDir,
+		"param_name": "myrepo",
+	})
+	require.NoError(t, err, "git push failed: %s", pushOut)
+
+	// Verify the bare repo received the push
+	_ = runWork // silence unused
+	remoteSHA := headSHA(t, bareDir)
+	assert.Equal(t, pushSHA, remoteSHA)
+}
+
+// --- GitHub Check resource type: push ---
+//
+// github-check.hcl is not included in the embed directive (builtin.go),
+// so we parse and test it directly from the HCL file.
+
+// parseGitHubCheckPush parses the github-check.hcl file and returns
+// the push script. Returns empty string if parsing fails.
+func parseGitHubCheckPush(t *testing.T) string {
+	t.Helper()
+
+	// github-check.hcl is not embedded; read it directly from disk.
+	data, err := os.ReadFile("resource_types/github-check.hcl")
+	require.NoError(t, err, "failed to read github-check.hcl")
+
+	var parsed struct {
+		ResourceTypes []restype.ResourceType `hcl:"resource_type,block"`
+	}
+	err = hclsimple.Decode("github-check.hcl", data, nil, &parsed)
+	require.NoError(t, err, "failed to parse github-check.hcl")
+	require.Len(t, parsed.ResourceTypes, 1)
+	require.NotNil(t, parsed.ResourceTypes[0].Push)
+	require.GreaterOrEqual(t, len(parsed.ResourceTypes[0].Push.Args), 2)
+	return parsed.ResourceTypes[0].Push.Args[1]
+}
+
+func runGitHubCheckPush(t *testing.T, workDir string, env map[string]string) (string, error) {
+	t.Helper()
+	script := parseGitHubCheckPush(t)
+
+	cmd := exec.Command("/bin/sh", "-ec", script)
+	cmd.Dir = workDir
+	cmd.Env = os.Environ()
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func TestGitHubCheckPush_CreateCheckRun(t *testing.T) {
+	// The github-check push script needs: openssl, jq, and curl.
+	// We fake curl; openssl and jq must be available on the system.
+	for _, tool := range []string{"openssl", "jq"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("%s not available, skipping github-check push test", tool)
+		}
+	}
+
+	// Generate a throwaway RSA key for JWT signing
+	workDir := t.TempDir()
+	keyFile := filepath.Join(workDir, "test-key.pem")
+	cmd := exec.Command("openssl", "genrsa", "-out", keyFile, "2048")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "openssl genrsa failed: %s", out)
+	keyData, err := os.ReadFile(keyFile)
+	require.NoError(t, err)
+
+	// Fake curl: first call returns installation token, second returns check run
+	curlDir := t.TempDir()
+	logFile := filepath.Join(curlDir, "curl.log")
+	curlScript := `#!/bin/sh
+echo "$@" >> ` + logFile + `
+COUNT=$(wc -l < ` + logFile + `)
+if [ "$COUNT" -le 1 ]; then
+  echo '{"token":"fake-install-token"}'
+else
+  echo '{"id":42}'
+fi
+`
+	require.NoError(t, os.WriteFile(filepath.Join(curlDir, "curl"), []byte(curlScript), 0755))
+
+	pushOut, err := runGitHubCheckPush(t, workDir, map[string]string{
+		"param_app_id":          "12345",
+		"param_installation_id": "67890",
+		"param_private_key":     string(keyData),
+		"param_repository":      "example/repo",
+		"put_status":            "in_progress",
+		"put_head_sha":          "abc123",
+		"put_name":              "ci-test",
+		"WORKDIR":               workDir,
+		"BUILD_PIPELINE_NAME":   "my-pipeline",
+		"BUILD_JOB_NAME":        "my-job",
+		"PATH":                  curlDir + ":" + os.Getenv("PATH"),
+	})
+	require.NoError(t, err, "github-check push (create) failed: %s", pushOut)
+
+	assert.Contains(t, pushOut, "Created check run 42")
+
+	// Verify curl was called with correct endpoints
+	curlLog, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	log := string(curlLog)
+	assert.Contains(t, log, "api.github.com/app/installations/67890/access_tokens")
+	assert.Contains(t, log, "api.github.com/repos/example/repo/check-runs")
+}
+
+func TestGitHubCheckPush_UpdateCheckRun(t *testing.T) {
+	for _, tool := range []string{"openssl", "jq"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("%s not available, skipping github-check push test", tool)
+		}
+	}
+
+	workDir := t.TempDir()
+	keyFile := filepath.Join(workDir, "test-key.pem")
+	cmd := exec.Command("openssl", "genrsa", "-out", keyFile, "2048")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "openssl genrsa failed: %s", out)
+	keyData, err := os.ReadFile(keyFile)
+	require.NoError(t, err)
+
+	// Pre-create the check run ID file (simulating a prior in_progress call)
+	idFile := filepath.Join(workDir, ".github-check-ci-test.id")
+	require.NoError(t, os.WriteFile(idFile, []byte("42"), 0644))
+
+	curlDir := t.TempDir()
+	logFile := filepath.Join(curlDir, "curl.log")
+	curlScript := `#!/bin/sh
+echo "$@" >> ` + logFile + `
+COUNT=$(wc -l < ` + logFile + `)
+if [ "$COUNT" -le 1 ]; then
+  echo '{"token":"fake-install-token"}'
+fi
+`
+	require.NoError(t, os.WriteFile(filepath.Join(curlDir, "curl"), []byte(curlScript), 0755))
+
+	pushOut, err := runGitHubCheckPush(t, workDir, map[string]string{
+		"param_app_id":          "12345",
+		"param_installation_id": "67890",
+		"param_private_key":     string(keyData),
+		"param_repository":      "example/repo",
+		"put_conclusion":        "success",
+		"put_name":              "ci-test",
+		"put_head_sha":          "abc123",
+		"WORKDIR":               workDir,
+		"BUILD_PIPELINE_NAME":   "my-pipeline",
+		"BUILD_JOB_NAME":        "my-job",
+		"PATH":                  curlDir + ":" + os.Getenv("PATH"),
+	})
+	require.NoError(t, err, "github-check push (update) failed: %s", pushOut)
+
+	assert.Contains(t, pushOut, "Updated check run 42 with conclusion=success")
+
+	curlLog, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	log := string(curlLog)
+	assert.Contains(t, log, "api.github.com/app/installations/67890/access_tokens")
+	assert.Contains(t, log, "api.github.com/repos/example/repo/check-runs/42")
+}
+
+func TestGitHubCheckPush_RequiresStatusOrConclusion(t *testing.T) {
+	for _, tool := range []string{"openssl", "jq"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("%s not available, skipping github-check push test", tool)
+		}
+	}
+
+	workDir := t.TempDir()
+	keyFile := filepath.Join(workDir, "test-key.pem")
+	cmd := exec.Command("openssl", "genrsa", "-out", keyFile, "2048")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "openssl genrsa failed: %s", out)
+	keyData, err := os.ReadFile(keyFile)
+	require.NoError(t, err)
+
+	curlDir, _ := fakeCurlDir(t, `{"token":"fake-install-token"}`)
+
+	pushOut, err := runGitHubCheckPush(t, workDir, map[string]string{
+		"param_app_id":          "12345",
+		"param_installation_id": "67890",
+		"param_private_key":     string(keyData),
+		"param_repository":      "example/repo",
+		"put_head_sha":          "abc123",
+		"WORKDIR":               workDir,
+		"PATH":                  curlDir + ":" + os.Getenv("PATH"),
+	})
+	assert.Error(t, err, "should fail without status or conclusion")
+	assert.Contains(t, pushOut, "either put_status or put_conclusion must be set")
+}
+
+// --- Trigger resource type ---
+
+func TestTrigger_NoScripts(t *testing.T) {
+	rts := builtin.ResourceTypes()
+	rt := rts["trigger"]
+
+	assert.Nil(t, rt.Check, "trigger should have no check script")
+	assert.Nil(t, rt.Pull, "trigger should have no pull script")
+	assert.Nil(t, rt.Push, "trigger should have no push script")
+	assert.Equal(t, "pikoci://trigger", rt.Source)
+}

--- a/pikoci/builtin/resource_types/git.hcl
+++ b/pikoci/builtin/resource_types/git.hcl
@@ -18,6 +18,9 @@ resource_type "git" {
       PR="$param_pr"
       TAG="$param_tag"
 
+      # First check: version vars are empty when no previous versions exist.
+      # Return only the latest item to avoid triggering a build per historical entry.
+
       # Tag mode: check for latest tags
       if [ "$TAG" = "true" ]; then
         if [ -z "$TOKEN" ]; then
@@ -25,11 +28,18 @@ resource_type "git" {
           exit 1
         fi
 
+        # On first check return only the latest tag
+        if [ -z "$version_tag" ]; then
+          PER_PAGE=1
+        else
+          PER_PAGE=100
+        fi
+
         # GitHub tags
         if echo "$URL" | grep -q "github.com"; then
           REPO=$(echo "$URL" | sed -E 's|https?://github\.com/||;s|\.git$||')
           curl -sf -H "Authorization: token $TOKEN" \
-            "https://api.github.com/repos/$REPO/tags?per_page=100" \
+            "https://api.github.com/repos/$REPO/tags?per_page=$PER_PAGE" \
             | jq -c '[.[] | {"ref": .commit.sha, "tag": .name}]'
           exit 0
         fi
@@ -38,7 +48,7 @@ resource_type "git" {
         if echo "$URL" | grep -q "gitlab.com"; then
           PROJECT=$(echo "$URL" | sed -E 's|https?://gitlab\.com/||;s|\.git$||' | sed 's|/|%2F|g')
           curl -sf -H "PRIVATE-TOKEN: $TOKEN" \
-            "https://gitlab.com/api/v4/projects/$PROJECT/repository/tags?order_by=updated&sort=desc&per_page=100" \
+            "https://gitlab.com/api/v4/projects/$PROJECT/repository/tags?order_by=updated&sort=desc&per_page=$PER_PAGE" \
             | jq -c '[.[] | {"ref": .commit.id, "tag": .name}]'
           exit 0
         fi
@@ -54,11 +64,18 @@ resource_type "git" {
           exit 1
         fi
 
+        # On first check return only the most recently updated PR
+        if [ -z "$version_pr" ]; then
+          PER_PAGE=1
+        else
+          PER_PAGE=100
+        fi
+
         # GitHub PRs
         if echo "$URL" | grep -q "github.com"; then
           REPO=$(echo "$URL" | sed -E 's|https?://github\.com/||;s|\.git$||')
           curl -sf -H "Authorization: token $TOKEN" \
-            "https://api.github.com/repos/$REPO/pulls?state=open&sort=updated&direction=desc&per_page=100" \
+            "https://api.github.com/repos/$REPO/pulls?state=open&sort=updated&direction=desc&per_page=$PER_PAGE" \
             | jq -c '[.[] | {"ref": .head.sha, "pr": (.number | tostring)}]'
           exit 0
         fi
@@ -67,7 +84,7 @@ resource_type "git" {
         if echo "$URL" | grep -q "gitlab.com"; then
           PROJECT=$(echo "$URL" | sed -E 's|https?://gitlab\.com/||;s|\.git$||' | sed 's|/|%2F|g')
           curl -sf -H "PRIVATE-TOKEN: $TOKEN" \
-            "https://gitlab.com/api/v4/projects/$PROJECT/merge_requests?state=opened&order_by=updated_at&sort=desc&per_page=100" \
+            "https://gitlab.com/api/v4/projects/$PROJECT/merge_requests?state=opened&order_by=updated_at&sort=desc&per_page=$PER_PAGE" \
             | jq -c '[.[] | {"ref": .sha, "pr": (.iid | tostring)}]'
           exit 0
         fi

--- a/worker/service.go
+++ b/worker/service.go
@@ -1099,7 +1099,6 @@ func (w *Worker) processResourceCheck(ctx context.Context, m queue.Body, cwd str
 		w.logger.Error("failed to list resource versions", "error", err)
 		return
 	}
-	isFirstCheck := len(dbvers) == 0
 	if len(dbvers) != 0 {
 		for k, v := range dbvers[0].Version {
 			params["version_"+k] = fmt.Sprintf("%s", v)
@@ -1183,14 +1182,9 @@ func (w *Worker) processResourceCheck(ctx context.Context, m queue.Body, cwd str
 			w.logger.Error("failed to create resource version", "error", err)
 			return
 		}
-		if isFirstCheck {
-			w.logger.Info("first check, setting cursor without triggering",
-				"pipeline", m.PipelineCanonical, "resource", r.Canonical, "version_id", cv.ID)
-		} else {
-			w.logger.Info("new version created, triggering jobs",
-				"pipeline", m.PipelineCanonical, "resource", r.Canonical, "version_id", cv.ID)
-			w.triggerResourceJobs(ctx, m, pp, r, cv)
-		}
+		w.logger.Info("new version created, triggering jobs",
+			"pipeline", m.PipelineCanonical, "resource", r.Canonical, "version_id", cv.ID)
+		w.triggerResourceJobs(ctx, m, pp, r, cv)
 	}
 }
 
@@ -1204,7 +1198,6 @@ func (w *Worker) processResourceCheckTrigger(ctx context.Context, m queue.Body, 
 		w.logger.Error("failed to list resource versions for trigger check", "error", err)
 		return
 	}
-	isFirstCheck := len(dbvers) == 0
 	if len(dbvers) > 0 {
 		if tid, ok := dbvers[0].Version["trigger_id"]; ok {
 			switch v := tid.(type) {
@@ -1242,14 +1235,9 @@ func (w *Worker) processResourceCheckTrigger(ctx context.Context, m queue.Body, 
 			w.logger.Error("failed to create resource version from trigger", "error", err)
 			return
 		}
-		if isFirstCheck {
-			w.logger.Info("first check, setting cursor without triggering",
-				"pipeline", m.PipelineCanonical, "resource", r.Canonical, "trigger_id", t.ID, "version_id", cv.ID)
-		} else {
-			w.logger.Info("trigger version created, triggering jobs",
-				"pipeline", m.PipelineCanonical, "resource", r.Canonical, "trigger_id", t.ID, "version_id", cv.ID)
-			w.triggerResourceJobs(ctx, m, pp, r, cv)
-		}
+		w.logger.Info("trigger version created, triggering jobs",
+			"pipeline", m.PipelineCanonical, "resource", r.Canonical, "trigger_id", t.ID, "version_id", cv.ID)
+		w.triggerResourceJobs(ctx, m, pp, r, cv)
 	}
 }
 

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -615,7 +615,7 @@ func TestProcessJob_NoDownstreamTrigger(t *testing.T) {
 
 func TestProcessResourceCheck_NewVersions(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	w, svc, _ := newTestWorker(ctrl)
+	w, svc, topic := newTestWorker(ctrl)
 
 	ctx := context.Background()
 	m := queue.Body{
@@ -668,15 +668,23 @@ func TestProcessResourceCheck_NewVersions(t *testing.T) {
 	svc.EXPECT().CreateResourceVersion(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron", gomock.Any()).
 		Return(&resource.Version{ID: 1, Version: map[string]interface{}{"date": "now"}}, nil)
 
-	// First check: versions are stored but NO jobs should be triggered
-	// (topic.Send is NOT expected)
+	// First check: jobs should be triggered
+	topic.EXPECT().Send(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, msg *pubsub.Message) error {
+		var body queue.Body
+		err := json.Unmarshal(msg.Body, &body)
+		require.NoError(t, err)
+		assert.Equal(t, "test-job", body.JobName)
+		assert.Equal(t, "cron.my-cron", body.ResourceCanonical)
+		assert.Equal(t, uint32(1), body.VersionID)
+		return nil
+	})
 
 	w.processResourceCheck(ctx, m, cwd, pp)
 }
 
-func TestProcessResourceCheck_DuplicateVersionSkipped_FirstCheckNoTrigger(t *testing.T) {
+func TestProcessResourceCheck_DuplicateVersionSkipped_FirstCheck(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	w, svc, _ := newTestWorker(ctrl)
+	w, svc, topic := newTestWorker(ctrl)
 
 	ctx := context.Background()
 	m := queue.Body{
@@ -740,8 +748,15 @@ func TestProcessResourceCheck_DuplicateVersionSkipped_FirstCheckNoTrigger(t *tes
 	svc.EXPECT().CreateResourceVersion(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "git.my-repo", gomock.Any()).
 		Return(&resource.Version{ID: 2, Version: map[string]interface{}{"ref": "new"}}, nil)
 
-	// First check: NO jobs should be triggered even for new versions
-	// (topic.Send is NOT expected)
+	// First check: jobs should be triggered for the non-duplicate version
+	topic.EXPECT().Send(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, msg *pubsub.Message) error {
+		var body queue.Body
+		err := json.Unmarshal(msg.Body, &body)
+		require.NoError(t, err)
+		assert.Equal(t, "git.my-repo", body.ResourceCanonical)
+		assert.Equal(t, uint32(2), body.VersionID)
+		return nil
+	}).Times(2) // Two jobs: lint and test
 
 	w.processResourceCheck(ctx, m, cwd, pp)
 }
@@ -816,9 +831,9 @@ func TestProcessResourceCheck_SecondCheckTriggers(t *testing.T) {
 	w.processResourceCheck(ctx, m, cwd, pp)
 }
 
-func TestProcessResourceCheckTrigger_FirstCheckNoTrigger(t *testing.T) {
+func TestProcessResourceCheckTrigger_FirstCheckTriggers(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	w, svc, _ := newTestWorker(ctrl)
+	w, svc, topic := newTestWorker(ctrl)
 
 	ctx := context.Background()
 	m := queue.Body{
@@ -863,7 +878,16 @@ func TestProcessResourceCheckTrigger_FirstCheckNoTrigger(t *testing.T) {
 	svc.EXPECT().CreateResourceVersion(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "trigger.my-trigger", gomock.Any()).
 		Return(&resource.Version{ID: 1, Version: map[string]interface{}{"key": "val", "trigger_id": float64(1)}}, nil)
 
-	// First check: NO jobs should be triggered (topic.Send is NOT expected)
+	// First check: jobs should be triggered
+	topic.EXPECT().Send(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, msg *pubsub.Message) error {
+		var body queue.Body
+		err := json.Unmarshal(msg.Body, &body)
+		require.NoError(t, err)
+		assert.Equal(t, "deploy", body.JobName)
+		assert.Equal(t, "trigger.my-trigger", body.ResourceCanonical)
+		assert.Equal(t, uint32(1), body.VersionID)
+		return nil
+	})
 
 	w.processResourceCheck(ctx, m, "", pp)
 }


### PR DESCRIPTION
## Summary

Remove the `isFirstCheck` guard that suppressed build triggers on the first resource check. Resource types are responsible for returning only the latest version on first check (Concourse convention). Document this convention in `docs/Resource-Types.md`.

## Changelog

- Remove `isFirstCheck` conditional in `processResourceCheck` and `processResourceCheckTrigger` — always trigger builds
- Add first-check convention note to `docs/Resource-Types.md`
- Update unit tests to expect triggering on first check
- Update stale comments in integration tests

Closes #369