### PR TITLE
Separate queues for jobs and checks (#368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Separate queues for jobs and resource checks: long-running jobs no longer block resource version detection. New `--queues` flag lets operators run dedicated check-only or job-only workers ([#368](https://github.com/PikoCI/pikoci/issues/368))
 - User management: Profile page, admin Users page, CLI commands, force password change on default `admin/admin123`, and `--users` flag preserves UI/CLI password changes ([#237](https://github.com/PikoCI/pikoci/issues/237))
 - Pipeline graph zoom, pan, and fullscreen controls: scroll-wheel zoom toward cursor, click-drag pan (including on nodes), zoom buttons, reset, fullscreen overlay with navbar visible, pinch-zoom on mobile, and auto-sizing that prevents small pipelines from appearing oversized ([#338](https://github.com/PikoCI/pikoci/issues/338))
 - Database export: admin-only `GET /admin/export` endpoint, CLI `pikoci client export -o file.db`, and web UI dropdown button to download the full database as a portable SQLite file ([#275](https://github.com/PikoCI/pikoci/issues/275))

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -171,15 +171,24 @@ func runLocal(ctx context.Context, logger *slog.Logger, pipelineConfig, jobName 
 
 	suow := unitwork.NewStartUnitOfWork(db, mysql.Mem)
 
-	// Create pubsub with a unique topic name to avoid conflicts
-	topicName := fmt.Sprintf("mem://pikoci-run-%s", uuid.New().String())
-	topic, err := pubsub.OpenTopic(ctx, topicName)
-	if err != nil {
-		return 0, fmt.Errorf("failed to open topic: %w", err)
-	}
-	defer topic.Shutdown(ctx)
+	// Create pubsub with unique topic names to avoid conflicts
+	runID := uuid.New().String()
+	jobTopicName := fmt.Sprintf("mem://pikoci-run-jobs-%s", runID)
+	checkTopicName := fmt.Sprintf("mem://pikoci-run-checks-%s", runID)
 
-	subscription, err := pubsub.OpenSubscription(ctx, topicName)
+	jobTopic, err := pubsub.OpenTopic(ctx, jobTopicName)
+	if err != nil {
+		return 0, fmt.Errorf("failed to open job topic: %w", err)
+	}
+	defer jobTopic.Shutdown(ctx)
+
+	checkTopic, err := pubsub.OpenTopic(ctx, checkTopicName)
+	if err != nil {
+		return 0, fmt.Errorf("failed to open check topic: %w", err)
+	}
+	defer checkTopic.Shutdown(ctx)
+
+	subscription, err := pubsub.OpenSubscription(ctx, jobTopicName)
 	if err != nil {
 		return 0, fmt.Errorf("failed to open subscription: %w", err)
 	}
@@ -187,7 +196,7 @@ func runLocal(ctx context.Context, logger *slog.Logger, pipelineConfig, jobName 
 
 	// Create service (do NOT start scheduler)
 	jwtSecret := []byte("local-run-secret")
-	svc := pikoci.New(ctx, topic, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, suow, jwtSecret, logger)
+	svc := pikoci.New(ctx, jobTopic, checkTopic, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, suow, jwtSecret, logger)
 
 	// Create pipeline
 	pp, err := svc.CreatePipeline(ctx, mainTeamCanonical, "local", hclBytes, vars)
@@ -232,7 +241,7 @@ func runLocal(ctx context.Context, logger *slog.Logger, pipelineConfig, jobName 
 
 	// Create worker with overrides
 	workerLogger := logger.With("service", "worker")
-	w := worker.New(svc, topic, subscription, workerLogger)
+	w := worker.New(svc, jobTopic, subscription, nil, workerLogger)
 	w.ResourceOverrides = workerResourceOverrides
 	w.LocalMode = true
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -77,11 +77,17 @@ var serverCmd = &cobra.Command{
 			return fmt.Errorf("invalid DBSystem %q, should be one of: %s, %s, %s or %s", cfg.DBSystem, mysql.Mem, mysql.MySQL, mysql.SQLite, mysql.PostgreSQL)
 		}
 
-		topic, err := pubsub.OpenTopic(ctx, getTopicURL(cfg.PubSubSystem))
+		jobTopic, err := pubsub.OpenTopic(ctx, getTopicURL(cfg.PubSubSystem, "pikoci-jobs"))
 		if err != nil {
-			return fmt.Errorf("failed to open: %v", err)
+			return fmt.Errorf("failed to open job topic: %v", err)
 		}
-		defer topic.Shutdown(ctx)
+		defer jobTopic.Shutdown(ctx)
+
+		checkTopic, err := pubsub.OpenTopic(ctx, getTopicURL(cfg.PubSubSystem, "pikoci-checks"))
+		if err != nil {
+			return fmt.Errorf("failed to open check topic: %v", err)
+		}
+		defer checkTopic.Shutdown(ctx)
 		dbFile, err := xdg.DataFile(filepath.Join(AppName, AppName+".db"))
 		if err != nil {
 			return fmt.Errorf("failed to create dbFile: %v", err)
@@ -127,7 +133,7 @@ var serverCmd = &cobra.Command{
 		suow := unitwork.NewStartUnitOfWork(db, cfg.DBSystem)
 
 		logger.Info("initializing service")
-		var svc = pikoci.New(ctx, topic, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, suow, jwtSecret, logger)
+		var svc = pikoci.New(ctx, jobTopic, checkTopic, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, suow, jwtSecret, logger)
 		svc.StartScheduler(ctx)
 		logger.Info("initialized service")
 
@@ -180,7 +186,11 @@ var serverCmd = &cobra.Command{
 			logger.Info("Starting Worker ...")
 			var werr error
 			var workerCleanup func()
-			workers, wg, workerCleanup, werr = runWorker(ctx, cfg.PubSubSystem, topic, svc, cfg.Concurrency, cfg.LogLevel)
+			queues := cfg.Queues
+			if queues == "" {
+				queues = "jobs,checks"
+			}
+			workers, wg, workerCleanup, werr = runWorker(ctx, cfg.PubSubSystem, jobTopic, svc, cfg.Concurrency, cfg.LogLevel, queues)
 			if werr != nil {
 				return fmt.Errorf("worker failed to start: %w", werr)
 			}
@@ -278,6 +288,7 @@ func init() {
 	serverCmd.Flags().Int("concurrency", 1, "Number of workers to start in one instance")
 	serverCmd.Flags().String("drain-timeout", "10m", "Maximum time to wait for in-flight jobs to finish during graceful shutdown (SIGQUIT)")
 	serverCmd.Flags().String("pubsub-system", mempubsub.Scheme, "Which PubSub system to use (mem, nats, rabbit, kafka). Env vars: NATS_SERVER_URL, RABBIT_SERVER_URL, KAFKA_BROKERS")
+	serverCmd.Flags().String("queues", "jobs,checks", "Which queues the embedded worker listens on: jobs, checks, or jobs,checks")
 	serverCmd.Flags().String("log-level", "info", "Sets the log level ('debug', 'info', 'warn', 'error')")
 	serverCmd.Flags().String("team-canonical", mainTeamCanonical, "Team Canonical to scope the action")
 	serverCmd.Flags().String("pipeline-config", "", "Path to the Pipeline config file")
@@ -292,28 +303,28 @@ func init() {
 	serverViper.AutomaticEnv()
 }
 
-func getSubscriptionURL(s string) string {
-	u := fmt.Sprintf("%s://pikoci", s)
+func getSubscriptionURL(s, name string) string {
+	u := fmt.Sprintf("%s://%s", s, name)
 	switch s {
 	case natspubsub.Scheme:
-		u += "?queue=pikoci&natsv2"
+		u += fmt.Sprintf("?queue=%s&natsv2", name)
 	case "rabbit":
-		// rabbit://pikoci — uses RABBIT_SERVER_URL env var
+		// rabbit://<name> — uses RABBIT_SERVER_URL env var
 	case "kafka":
-		u = "kafka://pikoci-group?topic=pikoci"
+		u = fmt.Sprintf("kafka://%s-group?topic=%s", name, name)
 	}
 	return u
 }
 
-func getTopicURL(s string) string {
-	u := fmt.Sprintf("%s://pikoci", s)
+func getTopicURL(s, name string) string {
+	u := fmt.Sprintf("%s://%s", s, name)
 	switch s {
 	case natspubsub.Scheme:
 		u += "?natsv2"
 	case "rabbit":
-		// rabbit://pikoci — uses RABBIT_SERVER_URL env var
+		// rabbit://<name> — uses RABBIT_SERVER_URL env var
 	case "kafka":
-		// kafka://pikoci — uses KAFKA_BROKERS env var
+		// kafka://<name> — uses KAFKA_BROKERS env var
 	}
 	return u
 }

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -60,18 +60,23 @@ var workerCmd = &cobra.Command{
 			return fmt.Errorf("failed to initialize client with url %q: %w", cfg.PikoCIURL, err)
 		}
 
-		topic, err := pubsub.OpenTopic(ctx, getTopicURL(cfg.PubSubSystem))
+		jobTopic, err := pubsub.OpenTopic(ctx, getTopicURL(cfg.PubSubSystem, "pikoci-jobs"))
 		if err != nil {
-			return fmt.Errorf("failed to open: %v", err)
+			return fmt.Errorf("failed to open job topic: %v", err)
 		}
-		defer topic.Shutdown(ctx)
+		defer jobTopic.Shutdown(ctx)
 
 		drainTimeout, err := time.ParseDuration(cfg.DrainTimeout)
 		if err != nil {
 			return fmt.Errorf("invalid drain-timeout %q: %w", cfg.DrainTimeout, err)
 		}
 
-		workers, wg, cleanup, err := runWorker(ctx, cfg.PubSubSystem, topic, c, cfg.Concurrency, cfg.LogLevel)
+		queues := cfg.Queues
+		if queues == "" {
+			queues = "jobs,checks"
+		}
+
+		workers, wg, cleanup, err := runWorker(ctx, cfg.PubSubSystem, jobTopic, c, cfg.Concurrency, cfg.LogLevel, queues)
 		if err != nil {
 			return fmt.Errorf("failed to start worker: %w", err)
 		}
@@ -129,6 +134,7 @@ func init() {
 	workerCmd.Flags().String("drain-timeout", "10m", "Maximum time to wait for in-flight jobs to finish during graceful shutdown (SIGQUIT)")
 	workerCmd.Flags().String("log-level", "info", "Sets the log level ('debug', 'info', 'warn', 'error')")
 	workerCmd.Flags().String("worker-token", "", "Worker authentication token (from 'pikoci worker-token' or server startup logs)")
+	workerCmd.Flags().String("queues", "jobs,checks", "Which queues to listen on: jobs, checks, or jobs,checks")
 
 	workerViper.BindPFlags(workerCmd.Flags())
 
@@ -136,24 +142,59 @@ func init() {
 	workerViper.AutomaticEnv()
 }
 
-func runWorker(ctx context.Context, sy string, t queue.Topic, s pikoci.Service, c int, llvl string) ([]*worker.Worker, *sync.WaitGroup, func(), error) {
+func runWorker(ctx context.Context, sy string, jobTopic queue.Topic, s pikoci.Service, c int, llvl string, queues string) ([]*worker.Worker, *sync.WaitGroup, func(), error) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: parseSlogLevel(llvl)}))
 	logger = logger.With("service", "worker")
-	// Create a subscription connected to that topic.
-	subscription, err := pubsub.OpenSubscription(ctx, getSubscriptionURL(sy))
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to OpenSubscription: %w", err)
+
+	queueSet := make(map[string]bool)
+	for _, p := range strings.Split(queues, ",") {
+		queueSet[strings.TrimSpace(p)] = true
+	}
+	listenJobs := queueSet["jobs"]
+	listenChecks := queueSet["checks"]
+
+	if !listenJobs && !listenChecks {
+		return nil, nil, nil, fmt.Errorf("--queues must contain at least one of: jobs, checks (got %q)", queues)
 	}
 
-	cleanup := func() { subscription.Shutdown(context.Background()) }
+	var jobSub queue.Subscription
+	var checkSub queue.Subscription
+	var cleanups []func()
+
+	if listenJobs {
+		sub, err := pubsub.OpenSubscription(ctx, getSubscriptionURL(sy, "pikoci-jobs"))
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to open job subscription: %w", err)
+		}
+		jobSub = sub
+		cleanups = append(cleanups, func() { sub.Shutdown(context.Background()) })
+	}
+
+	if listenChecks {
+		sub, err := pubsub.OpenSubscription(ctx, getSubscriptionURL(sy, "pikoci-checks"))
+		if err != nil {
+			for _, fn := range cleanups {
+				fn()
+			}
+			return nil, nil, nil, fmt.Errorf("failed to open check subscription: %w", err)
+		}
+		checkSub = sub
+		cleanups = append(cleanups, func() { sub.Shutdown(context.Background()) })
+	}
+
+	cleanup := func() {
+		for _, fn := range cleanups {
+			fn()
+		}
+	}
 
 	var workers []*worker.Worker
 	var wg sync.WaitGroup
 	for i := range c {
 		wg.Add(1)
 		nlogger := logger.With("num", i+1)
-		nlogger.Info(fmt.Sprintf("Starting Worker %d", i+1))
-		w := worker.New(s, t, subscription, nlogger)
+		nlogger.Info(fmt.Sprintf("Starting Worker %d", i+1), "queues", queues)
+		w := worker.New(s, jobTopic, jobSub, checkSub, nlogger)
 		workers = append(workers, w)
 
 		go func() {

--- a/deploy/pipeline.hcl
+++ b/deploy/pipeline.hcl
@@ -5,20 +5,10 @@ job "lint" {
     trigger = true
   }
   put "github-check" "ci" { status = "in_progress" }
-  task "install-jq" {
-    run "docker" {
-      image = var.go_image
-      cmd   = "apt-get update -qq && apt-get install -qq -y jq"
-      args  = [
-        "-v", "pikoci-go-mod:/go/pkg/mod",
-        "-v", "pikoci-build:/root/.cache/go-build",
-      ]
-    }
-  }
   task "make" {
     run "docker" {
       image = var.go_image
-      cmd   = "cd ${var.git_name} && make lint"
+      cmd   = "apt-get update -qq && apt-get install -qq -y jq && cd ${var.git_name} && make lint"
       args  = [
         "-v", "pikoci-go-mod:/go/pkg/mod",
         "-v", "pikoci-build:/root/.cache/go-build",
@@ -38,20 +28,10 @@ job "test-mock" {
     trigger = true
   }
   put "github-check" "ci" { status = "in_progress" }
-  task "install-jq" {
-    run "docker" {
-      image = var.go_image
-      cmd   = "apt-get update -qq && apt-get install -qq -y jq"
-      args  = [
-        "-v", "pikoci-go-mod:/go/pkg/mod",
-        "-v", "pikoci-build:/root/.cache/go-build",
-      ]
-    }
-  }
   task "make" {
     run "docker" {
       image = var.go_image
-      cmd   = "cd ${var.git_name} && make test-mock"
+      cmd   = "apt-get update -qq && apt-get install -qq -y jq && cd ${var.git_name} && make test-mock"
       args  = [
         "-v", "pikoci-go-mod:/go/pkg/mod",
         "-v", "pikoci-build:/root/.cache/go-build",
@@ -71,20 +51,11 @@ job "test-integration" {
     trigger = true
   }
   put "github-check" "ci" { status = "in_progress" }
-  task "install-jq" {
-    run "docker" {
-      image = "ghcr.io/xescugc/pikoci-integration:latest"
-      cmd   = "apt-get update -qq && apt-get install -qq -y jq"
-      args  = [
-        "-v", "pikoci-go-mod:/go/pkg/mod",
-        "-v", "pikoci-build:/root/.cache/go-build",
-      ]
-    }
-  }
   task "make" {
     run "docker" {
       image = "ghcr.io/xescugc/pikoci-integration:latest"
       cmd   = <<-EOT
+        apt-get update -qq && apt-get install -qq -y jq
         cd ${var.git_name}
         cp /usr/local/bin/geckodriver integration/vendor/geckodriver
         make test-integration
@@ -140,21 +111,10 @@ job "test-backends" {
     root_token = "test-root-token"
   }
 
-  task "install-jq" {
-    run "docker" {
-      image = var.go_image
-      cmd   = "apt-get update -qq && apt-get install -qq -y jq"
-      args  = [
-        "--network=host",
-        "-v", "pikoci-go-mod:/go/pkg/mod",
-        "-v", "pikoci-build:/root/.cache/go-build",
-      ]
-    }
-  }
   task "make" {
     run "docker" {
       image = var.go_image
-      cmd   = "cd ${var.git_name} && make test-backends"
+      cmd   = "apt-get update -qq && apt-get install -qq -y jq && cd ${var.git_name} && make test-backends"
       args  = [
         "--network=host",
         "-v", "pikoci-go-mod:/go/pkg/mod",

--- a/deploy/pipeline.hcl
+++ b/deploy/pipeline.hcl
@@ -5,10 +5,20 @@ job "lint" {
     trigger = true
   }
   put "github-check" "ci" { status = "in_progress" }
+  task "install-jq" {
+    run "docker" {
+      image = var.go_image
+      cmd   = "apt-get update -qq && apt-get install -qq -y jq"
+      args  = [
+        "-v", "pikoci-go-mod:/go/pkg/mod",
+        "-v", "pikoci-build:/root/.cache/go-build",
+      ]
+    }
+  }
   task "make" {
     run "docker" {
       image = var.go_image
-      cmd   = "apt-get update -qq && apt-get install -qq -y jq && cd ${var.git_name} && make lint"
+      cmd   = "cd ${var.git_name} && make lint"
       args  = [
         "-v", "pikoci-go-mod:/go/pkg/mod",
         "-v", "pikoci-build:/root/.cache/go-build",
@@ -28,10 +38,20 @@ job "test-mock" {
     trigger = true
   }
   put "github-check" "ci" { status = "in_progress" }
+  task "install-jq" {
+    run "docker" {
+      image = var.go_image
+      cmd   = "apt-get update -qq && apt-get install -qq -y jq"
+      args  = [
+        "-v", "pikoci-go-mod:/go/pkg/mod",
+        "-v", "pikoci-build:/root/.cache/go-build",
+      ]
+    }
+  }
   task "make" {
     run "docker" {
       image = var.go_image
-      cmd   = "apt-get update -qq && apt-get install -qq -y jq && cd ${var.git_name} && make test-mock"
+      cmd   = "cd ${var.git_name} && make test-mock"
       args  = [
         "-v", "pikoci-go-mod:/go/pkg/mod",
         "-v", "pikoci-build:/root/.cache/go-build",
@@ -51,11 +71,20 @@ job "test-integration" {
     trigger = true
   }
   put "github-check" "ci" { status = "in_progress" }
+  task "install-jq" {
+    run "docker" {
+      image = "ghcr.io/xescugc/pikoci-integration:latest"
+      cmd   = "apt-get update -qq && apt-get install -qq -y jq"
+      args  = [
+        "-v", "pikoci-go-mod:/go/pkg/mod",
+        "-v", "pikoci-build:/root/.cache/go-build",
+      ]
+    }
+  }
   task "make" {
     run "docker" {
       image = "ghcr.io/xescugc/pikoci-integration:latest"
       cmd   = <<-EOT
-        apt-get update -qq && apt-get install -qq -y jq
         cd ${var.git_name}
         cp /usr/local/bin/geckodriver integration/vendor/geckodriver
         make test-integration
@@ -111,10 +140,21 @@ job "test-backends" {
     root_token = "test-root-token"
   }
 
+  task "install-jq" {
+    run "docker" {
+      image = var.go_image
+      cmd   = "apt-get update -qq && apt-get install -qq -y jq"
+      args  = [
+        "--network=host",
+        "-v", "pikoci-go-mod:/go/pkg/mod",
+        "-v", "pikoci-build:/root/.cache/go-build",
+      ]
+    }
+  }
   task "make" {
     run "docker" {
       image = var.go_image
-      cmd   = "apt-get update -qq && apt-get install -qq -y jq && cd ${var.git_name} && make test-backends"
+      cmd   = "cd ${var.git_name} && make test-backends"
       args  = [
         "--network=host",
         "-v", "pikoci-go-mod:/go/pkg/mod",

--- a/deploy/pipeline.hcl
+++ b/deploy/pipeline.hcl
@@ -8,20 +8,20 @@ job "lint" {
   task "install-jq" {
     run "docker" {
       image = var.go_image
-      cmd   = "apt-get update -qq && apt-get install -qq -y jq"
+      cmd   = "apt-get update -qq && apt-get install -qq -y jq && cp /usr/bin/jq /pikoci-tools/ && cp /usr/lib/*/libjq.so* /usr/lib/*/libonig.so* /pikoci-tools/ 2>/dev/null; true"
       args  = [
-        "-v", "pikoci-go-mod:/go/pkg/mod",
-        "-v", "pikoci-build:/root/.cache/go-build",
+        "-v", "pikoci-tools:/pikoci-tools",
       ]
     }
   }
   task "make" {
     run "docker" {
       image = var.go_image
-      cmd   = "cd ${var.git_name} && make lint"
+      cmd   = "export PATH=/pikoci-tools:$PATH LD_LIBRARY_PATH=/pikoci-tools:$LD_LIBRARY_PATH && cd ${var.git_name} && make lint"
       args  = [
         "-v", "pikoci-go-mod:/go/pkg/mod",
         "-v", "pikoci-build:/root/.cache/go-build",
+        "-v", "pikoci-tools:/pikoci-tools",
       ]
     }
   }
@@ -41,20 +41,20 @@ job "test-mock" {
   task "install-jq" {
     run "docker" {
       image = var.go_image
-      cmd   = "apt-get update -qq && apt-get install -qq -y jq"
+      cmd   = "apt-get update -qq && apt-get install -qq -y jq && cp /usr/bin/jq /pikoci-tools/ && cp /usr/lib/*/libjq.so* /usr/lib/*/libonig.so* /pikoci-tools/ 2>/dev/null; true"
       args  = [
-        "-v", "pikoci-go-mod:/go/pkg/mod",
-        "-v", "pikoci-build:/root/.cache/go-build",
+        "-v", "pikoci-tools:/pikoci-tools",
       ]
     }
   }
   task "make" {
     run "docker" {
       image = var.go_image
-      cmd   = "cd ${var.git_name} && make test-mock"
+      cmd   = "export PATH=/pikoci-tools:$PATH LD_LIBRARY_PATH=/pikoci-tools:$LD_LIBRARY_PATH && cd ${var.git_name} && make test-mock"
       args  = [
         "-v", "pikoci-go-mod:/go/pkg/mod",
         "-v", "pikoci-build:/root/.cache/go-build",
+        "-v", "pikoci-tools:/pikoci-tools",
       ]
     }
   }
@@ -74,10 +74,9 @@ job "test-integration" {
   task "install-jq" {
     run "docker" {
       image = "ghcr.io/xescugc/pikoci-integration:latest"
-      cmd   = "apt-get update -qq && apt-get install -qq -y jq"
+      cmd   = "apt-get update -qq && apt-get install -qq -y jq && cp /usr/bin/jq /pikoci-tools/ && cp /usr/lib/*/libjq.so* /usr/lib/*/libonig.so* /pikoci-tools/ 2>/dev/null; true"
       args  = [
-        "-v", "pikoci-go-mod:/go/pkg/mod",
-        "-v", "pikoci-build:/root/.cache/go-build",
+        "-v", "pikoci-tools:/pikoci-tools",
       ]
     }
   }
@@ -85,6 +84,7 @@ job "test-integration" {
     run "docker" {
       image = "ghcr.io/xescugc/pikoci-integration:latest"
       cmd   = <<-EOT
+        export PATH=/pikoci-tools:$PATH LD_LIBRARY_PATH=/pikoci-tools:$LD_LIBRARY_PATH
         cd ${var.git_name}
         cp /usr/local/bin/geckodriver integration/vendor/geckodriver
         make test-integration
@@ -92,6 +92,7 @@ job "test-integration" {
       args  = [
         "-v", "pikoci-go-mod:/go/pkg/mod",
         "-v", "pikoci-build:/root/.cache/go-build",
+        "-v", "pikoci-tools:/pikoci-tools",
       ]
     }
   }
@@ -143,22 +144,22 @@ job "test-backends" {
   task "install-jq" {
     run "docker" {
       image = var.go_image
-      cmd   = "apt-get update -qq && apt-get install -qq -y jq"
+      cmd   = "apt-get update -qq && apt-get install -qq -y jq && cp /usr/bin/jq /pikoci-tools/ && cp /usr/lib/*/libjq.so* /usr/lib/*/libonig.so* /pikoci-tools/ 2>/dev/null; true"
       args  = [
         "--network=host",
-        "-v", "pikoci-go-mod:/go/pkg/mod",
-        "-v", "pikoci-build:/root/.cache/go-build",
+        "-v", "pikoci-tools:/pikoci-tools",
       ]
     }
   }
   task "make" {
     run "docker" {
       image = var.go_image
-      cmd   = "cd ${var.git_name} && make test-backends"
+      cmd   = "export PATH=/pikoci-tools:$PATH LD_LIBRARY_PATH=/pikoci-tools:$LD_LIBRARY_PATH && cd ${var.git_name} && make test-backends"
       args  = [
         "--network=host",
         "-v", "pikoci-go-mod:/go/pkg/mod",
         "-v", "pikoci-build:/root/.cache/go-build",
+        "-v", "pikoci-tools:/pikoci-tools",
       ]
     }
   }

--- a/docs/Queue.md
+++ b/docs/Queue.md
@@ -2,6 +2,8 @@
 
 PikoCI uses a pub/sub queue to dispatch work from the server to workers. Configure with `--pubsub-system`.
 
+PikoCI uses two separate queues: `pikoci-jobs` for job execution and `pikoci-checks` for resource checks. This ensures long-running jobs never block resource version detection.
+
 ## mem (default)
 
 In-memory queue. Only works when the worker runs embedded in the server process (`--run-worker=true`). Suitable for development and single-process deployments.

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -22,6 +22,7 @@ pikoci server [flags]
 | `--run-migrations` | | `true` | no | Run database migrations on startup |
 | `--run-worker` | | `true` | no | Run an embedded worker |
 | `--concurrency` | | `1` | no | Number of worker goroutines |
+| `--queues` | | `jobs,checks` | no | Which queues the embedded worker listens on: `jobs`, `checks`, or `jobs,checks` |
 | `--drain-timeout` | | `10m` | no | Max time to wait for in-flight jobs during graceful shutdown (`SIGQUIT`) |
 | `--pubsub-system` | | `mem` | no | Queue backend: `mem`, `nats`, `rabbit`, `kafka` |
 | `--log-level` | | `info` | no | Log level: `debug`, `info`, `warn`, `error` |

--- a/docs/Workers.md
+++ b/docs/Workers.md
@@ -4,19 +4,24 @@ By default, PikoCI runs an embedded worker inside the server process. For produc
 
 ## Architecture
 
+PikoCI uses two separate queues: one for **jobs** and one for **resource checks**. This prevents long-running jobs (e.g. Docker builds) from blocking resource check processing.
+
 ```
                     ┌─────────┐
                     │  Server  │  --run-worker=false
                     └────┬────┘
-                         │ pub/sub queue
-              ┌──────────┼──────────┐
-              │          │          │
-         ┌────┴───┐ ┌───┴────┐ ┌──┴─────┐
-         │Worker 1│ │Worker 2│ │Worker 3│
-         └────────┘ └────────┘ └────────┘
+                    ┌────┴────┐
+              ┌─────┤  Queues ├─────┐
+              │     └─────────┘     │
+         jobs │                     │ checks
+              │                     │
+         ┌────┴───┐           ┌────┴───┐
+         │Worker 1│           │Worker 2│
+         │(all)   │           │(checks)│
+         └────────┘           └────────┘
 ```
 
-The server publishes jobs to a queue. Workers subscribe, execute the jobs, and report results back via the PikoCI API.
+The server publishes jobs and resource checks to separate queues. Workers subscribe, execute the work, and report results back via the PikoCI API.
 
 ## Requirements
 
@@ -65,6 +70,7 @@ pikoci worker \
 |------|-------|---------|----------|-------------|
 | `--pikoci-url` | `-u` | `localhost:8080` | no | PikoCI server URL |
 | `--pubsub-system` | | `mem` | no | Queue backend (must match server) |
+| `--queues` | | `jobs,checks` | no | Which queues to listen on: `jobs`, `checks`, or `jobs,checks` |
 | `--concurrency` | | `1` | no | Number of parallel job goroutines |
 | `--drain-timeout` | | `10m` | no | Max time to wait for in-flight jobs during graceful shutdown (`SIGQUIT`) |
 | `--log-level` | | `info` | no | Log level: `debug`, `info`, `warn`, `error` |
@@ -84,15 +90,22 @@ export CONCURRENCY=4
 
 ## Scaling
 
-Run multiple worker instances to increase throughput. Each worker independently subscribes to the queue:
+Run multiple worker instances to increase throughput. Each worker independently subscribes to the queues:
 
 ```bash
-# Machine A
+# Machine A — handles both jobs and checks (default)
 pikoci worker --pikoci-url http://server:8080 --pubsub-system nats --worker-token eyJhbG... --concurrency 2
 
-# Machine B
-pikoci worker --pikoci-url http://server:8080 --pubsub-system nats --worker-token eyJhbG... --concurrency 4
+# Machine B — dedicated job runner
+pikoci worker --pikoci-url http://server:8080 --pubsub-system nats --worker-token eyJhbG... --concurrency 4 --queues jobs
+
+# Machine C — dedicated check worker (never blocked by long jobs)
+pikoci worker --pikoci-url http://server:8080 --pubsub-system nats --worker-token eyJhbG... --queues checks
 ```
+
+## Dedicated check workers
+
+When jobs take minutes (e.g. Docker builds), a single worker processing both queues will block resource checks until the job finishes. Use `--queues checks` to run a dedicated check worker that detects new versions promptly, regardless of job load.
 
 ## Signal handling
 

--- a/integration/backends/concurrent_builds_test.go
+++ b/integration/backends/concurrent_builds_test.go
@@ -50,9 +50,13 @@ func TestConcurrentBuildCreation(t *testing.T) {
 	err = migrate.Migrate(db, mysql.SQLite)
 	require.NoError(t, err)
 
-	topic, err := pubsub.OpenTopic(ctx, fmt.Sprintf("%s://concurrent-test", mempubsub.Scheme))
+	jobTopic, err := pubsub.OpenTopic(ctx, fmt.Sprintf("%s://concurrent-test-jobs", mempubsub.Scheme))
 	require.NoError(t, err)
-	defer topic.Shutdown(ctx)
+	defer jobTopic.Shutdown(ctx)
+
+	checkTopic, err := pubsub.OpenTopic(ctx, fmt.Sprintf("%s://concurrent-test-checks", mempubsub.Scheme))
+	require.NoError(t, err)
+	defer checkTopic.Shutdown(ctx)
 
 	ur := mysql.NewUserRepository(db)
 	tr := mysql.NewTeamRepository(db)
@@ -67,7 +71,7 @@ func TestConcurrentBuildCreation(t *testing.T) {
 	suow := unitwork.NewStartUnitOfWork(db, mysql.SQLite)
 
 	jwtSecret := []byte("test-secret")
-	svc := pikoci.New(ctx, topic, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, suow, jwtSecret, logger)
+	svc := pikoci.New(ctx, jobTopic, checkTopic, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, suow, jwtSecret, logger)
 	svc.StartScheduler(ctx)
 
 	_, _ = svc.CreateUser(ctx, user.User{
@@ -76,9 +80,13 @@ func TestConcurrentBuildCreation(t *testing.T) {
 		Password: "$2a$14$rwQk8Qvc2rij7qhFO4P1W.OiSF6AkgVU1RCrLaY2wawJcpkPEKwbm",
 	}, true)
 
-	subscription, err := pubsub.OpenSubscription(ctx, fmt.Sprintf("%s://concurrent-test", mempubsub.Scheme))
+	jobSub, err := pubsub.OpenSubscription(ctx, fmt.Sprintf("%s://concurrent-test-jobs", mempubsub.Scheme))
 	require.NoError(t, err)
-	defer subscription.Shutdown(ctx)
+	defer jobSub.Shutdown(ctx)
+
+	checkSub, err := pubsub.OpenSubscription(ctx, fmt.Sprintf("%s://concurrent-test-checks", mempubsub.Scheme))
+	require.NoError(t, err)
+	defer checkSub.Shutdown(ctx)
 
 	// Start 3 concurrent workers (same as production CONCURRENCY=3)
 	var wg sync.WaitGroup
@@ -86,7 +94,7 @@ func TestConcurrentBuildCreation(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			w := worker.New(svc, topic, subscription, logger.With("worker", i+1))
+			w := worker.New(svc, jobTopic, jobSub, checkSub, logger.With("worker", i+1))
 			w.Run(ctx)
 		}()
 	}

--- a/integration/backends/export_test.go
+++ b/integration/backends/export_test.go
@@ -45,9 +45,13 @@ func TestExportE2E(t *testing.T) {
 	err = migrate.Migrate(db, mysql.SQLite)
 	require.NoError(t, err)
 
-	topic, err := pubsub.OpenTopic(ctx, fmt.Sprintf("%s://export-test", mempubsub.Scheme))
+	jobTopic, err := pubsub.OpenTopic(ctx, fmt.Sprintf("%s://export-test-jobs", mempubsub.Scheme))
 	require.NoError(t, err)
-	defer topic.Shutdown(ctx)
+	defer jobTopic.Shutdown(ctx)
+
+	checkTopic, err := pubsub.OpenTopic(ctx, fmt.Sprintf("%s://export-test-checks", mempubsub.Scheme))
+	require.NoError(t, err)
+	defer checkTopic.Shutdown(ctx)
 
 	ur := mysql.NewUserRepository(db)
 	tr := mysql.NewTeamRepository(db)
@@ -62,7 +66,7 @@ func TestExportE2E(t *testing.T) {
 	suow := unitwork.NewStartUnitOfWork(db, mysql.SQLite)
 
 	jwtSecret := []byte("test-secret")
-	svc := pikoci.New(ctx, topic, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, suow, jwtSecret, logger)
+	svc := pikoci.New(ctx, jobTopic, checkTopic, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, suow, jwtSecret, logger)
 	svc.StartScheduler(ctx)
 
 	_, _ = svc.CreateUser(ctx, user.User{
@@ -71,15 +75,19 @@ func TestExportE2E(t *testing.T) {
 		Password: "$2a$14$rwQk8Qvc2rij7qhFO4P1W.OiSF6AkgVU1RCrLaY2wawJcpkPEKwbm",
 	}, true)
 
-	subscription, err := pubsub.OpenSubscription(ctx, fmt.Sprintf("%s://export-test", mempubsub.Scheme))
+	jobSub, err := pubsub.OpenSubscription(ctx, fmt.Sprintf("%s://export-test-jobs", mempubsub.Scheme))
 	require.NoError(t, err)
-	defer subscription.Shutdown(ctx)
+	defer jobSub.Shutdown(ctx)
+
+	checkSub, err := pubsub.OpenSubscription(ctx, fmt.Sprintf("%s://export-test-checks", mempubsub.Scheme))
+	require.NoError(t, err)
+	defer checkSub.Shutdown(ctx)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		w := worker.New(svc, topic, subscription, logger.With("worker", 1))
+		w := worker.New(svc, jobTopic, jobSub, checkSub, logger.With("worker", 1))
 		w.Run(ctx)
 	}()
 

--- a/integration/backends/secrets_test.go
+++ b/integration/backends/secrets_test.go
@@ -42,9 +42,13 @@ func TestSecretsE2E(t *testing.T) {
 	err = migrate.Migrate(db, mysql.Mem)
 	require.NoError(t, err)
 
-	topic, err := pubsub.OpenTopic(ctx, fmt.Sprintf("%s://secrets-test", mempubsub.Scheme))
+	jobTopic, err := pubsub.OpenTopic(ctx, fmt.Sprintf("%s://secrets-test-jobs", mempubsub.Scheme))
 	require.NoError(t, err)
-	defer topic.Shutdown(ctx)
+	defer jobTopic.Shutdown(ctx)
+
+	checkTopic, err := pubsub.OpenTopic(ctx, fmt.Sprintf("%s://secrets-test-checks", mempubsub.Scheme))
+	require.NoError(t, err)
+	defer checkTopic.Shutdown(ctx)
 
 	ur := mysql.NewUserRepository(db)
 	tr := mysql.NewTeamRepository(db)
@@ -59,7 +63,7 @@ func TestSecretsE2E(t *testing.T) {
 	suow := unitwork.NewStartUnitOfWork(db, mysql.Mem)
 
 	jwtSecret := []byte("test-secret")
-	svc := pikoci.New(ctx, topic, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, suow, jwtSecret, logger)
+	svc := pikoci.New(ctx, jobTopic, checkTopic, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, suow, jwtSecret, logger)
 	svc.StartScheduler(ctx)
 
 	// Migration already creates admin user and "main" team.
@@ -71,15 +75,19 @@ func TestSecretsE2E(t *testing.T) {
 	}, true)
 
 	// Start worker
-	subscription, err := pubsub.OpenSubscription(ctx, fmt.Sprintf("%s://secrets-test", mempubsub.Scheme))
+	jobSub, err := pubsub.OpenSubscription(ctx, fmt.Sprintf("%s://secrets-test-jobs", mempubsub.Scheme))
 	require.NoError(t, err)
-	defer subscription.Shutdown(ctx)
+	defer jobSub.Shutdown(ctx)
+
+	checkSub, err := pubsub.OpenSubscription(ctx, fmt.Sprintf("%s://secrets-test-checks", mempubsub.Scheme))
+	require.NoError(t, err)
+	defer checkSub.Shutdown(ctx)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		w := worker.New(svc, topic, subscription, logger.With("component", "worker"))
+		w := worker.New(svc, jobTopic, jobSub, checkSub, logger.With("component", "worker"))
 		w.Run(ctx)
 	}()
 

--- a/integration/backends/services_test.go
+++ b/integration/backends/services_test.go
@@ -41,9 +41,13 @@ func TestServicesE2E(t *testing.T) {
 	err = migrate.Migrate(db, mysql.Mem)
 	require.NoError(t, err)
 
-	topic, err := pubsub.OpenTopic(ctx, fmt.Sprintf("%s://services-test", mempubsub.Scheme))
+	jobTopic, err := pubsub.OpenTopic(ctx, fmt.Sprintf("%s://services-test-jobs", mempubsub.Scheme))
 	require.NoError(t, err)
-	defer topic.Shutdown(ctx)
+	defer jobTopic.Shutdown(ctx)
+
+	checkTopic, err := pubsub.OpenTopic(ctx, fmt.Sprintf("%s://services-test-checks", mempubsub.Scheme))
+	require.NoError(t, err)
+	defer checkTopic.Shutdown(ctx)
 
 	ur := mysql.NewUserRepository(db)
 	tr := mysql.NewTeamRepository(db)
@@ -58,7 +62,7 @@ func TestServicesE2E(t *testing.T) {
 	suow := unitwork.NewStartUnitOfWork(db, mysql.Mem)
 
 	jwtSecret := []byte("test-secret")
-	svc := pikoci.New(ctx, topic, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, suow, jwtSecret, logger)
+	svc := pikoci.New(ctx, jobTopic, checkTopic, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, suow, jwtSecret, logger)
 	svc.StartScheduler(ctx)
 
 	_, _ = svc.CreateUser(ctx, user.User{
@@ -67,15 +71,19 @@ func TestServicesE2E(t *testing.T) {
 		Password: "$2a$14$rwQk8Qvc2rij7qhFO4P1W.OiSF6AkgVU1RCrLaY2wawJcpkPEKwbm",
 	}, true)
 
-	subscription, err := pubsub.OpenSubscription(ctx, fmt.Sprintf("%s://services-test", mempubsub.Scheme))
+	jobSub, err := pubsub.OpenSubscription(ctx, fmt.Sprintf("%s://services-test-jobs", mempubsub.Scheme))
 	require.NoError(t, err)
-	defer subscription.Shutdown(ctx)
+	defer jobSub.Shutdown(ctx)
+
+	checkSub, err := pubsub.OpenSubscription(ctx, fmt.Sprintf("%s://services-test-checks", mempubsub.Scheme))
+	require.NoError(t, err)
+	defer checkSub.Shutdown(ctx)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		w := worker.New(svc, topic, subscription, logger.With("component", "worker"))
+		w := worker.New(svc, jobTopic, jobSub, checkSub, logger.With("component", "worker"))
 		w.Run(ctx)
 	}()
 

--- a/integration/backends/vault_test.go
+++ b/integration/backends/vault_test.go
@@ -127,9 +127,13 @@ func TestSecretsVaultE2E(t *testing.T) {
 	err = migrate.Migrate(db, mysql.Mem)
 	require.NoError(t, err)
 
-	topic, err := pubsub.OpenTopic(ctx, fmt.Sprintf("%s://vault-test", mempubsub.Scheme))
+	jobTopic, err := pubsub.OpenTopic(ctx, fmt.Sprintf("%s://vault-test-jobs", mempubsub.Scheme))
 	require.NoError(t, err)
-	defer topic.Shutdown(ctx)
+	defer jobTopic.Shutdown(ctx)
+
+	checkTopic, err := pubsub.OpenTopic(ctx, fmt.Sprintf("%s://vault-test-checks", mempubsub.Scheme))
+	require.NoError(t, err)
+	defer checkTopic.Shutdown(ctx)
 
 	ur := mysql.NewUserRepository(db)
 	tr := mysql.NewTeamRepository(db)
@@ -143,7 +147,7 @@ func TestSecretsVaultE2E(t *testing.T) {
 	tgr := mysql.NewTriggerRepository(db)
 	suow := unitwork.NewStartUnitOfWork(db, mysql.Mem)
 
-	svc := pikoci.New(ctx, topic, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, suow, []byte("jwt"), logger)
+	svc := pikoci.New(ctx, jobTopic, checkTopic, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, suow, []byte("jwt"), logger)
 	svc.StartScheduler(ctx)
 
 	_, _ = svc.CreateUser(ctx, user.User{
@@ -152,15 +156,19 @@ func TestSecretsVaultE2E(t *testing.T) {
 	}, true)
 
 	// Start worker
-	subscription, err := pubsub.OpenSubscription(ctx, fmt.Sprintf("%s://vault-test", mempubsub.Scheme))
+	jobSub, err := pubsub.OpenSubscription(ctx, fmt.Sprintf("%s://vault-test-jobs", mempubsub.Scheme))
 	require.NoError(t, err)
-	defer subscription.Shutdown(ctx)
+	defer jobSub.Shutdown(ctx)
+
+	checkSub, err := pubsub.OpenSubscription(ctx, fmt.Sprintf("%s://vault-test-checks", mempubsub.Scheme))
+	require.NoError(t, err)
+	defer checkSub.Shutdown(ctx)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		w := worker.New(svc, topic, subscription, logger.With("component", "worker"))
+		w := worker.New(svc, jobTopic, jobSub, checkSub, logger.With("component", "worker"))
 		w.Run(ctx)
 	}()
 

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -47,11 +47,17 @@ func runTests(m *testing.M) int {
 		panic(err)
 	}
 
-	topic, err := pubsub.OpenTopic(ctx, getTopicURL(mempubsub.Scheme))
+	jobTopic, err := pubsub.OpenTopic(ctx, getTopicURL(mempubsub.Scheme, "pikoci-jobs"))
 	if err != nil {
-		panic(fmt.Errorf("failed to open: %v", err).Error())
+		panic(fmt.Errorf("failed to open job topic: %v", err).Error())
 	}
-	defer topic.Shutdown(ctx)
+	defer jobTopic.Shutdown(ctx)
+
+	checkTopic, err := pubsub.OpenTopic(ctx, getTopicURL(mempubsub.Scheme, "pikoci-checks"))
+	if err != nil {
+		panic(fmt.Errorf("failed to open check topic: %v", err).Error())
+	}
+	defer checkTopic.Shutdown(ctx)
 
 	ur := mysql.NewUserRepository(db)
 	tr := mysql.NewTeamRepository(db)
@@ -64,7 +70,7 @@ func runTests(m *testing.M) int {
 	str := mysql.NewSecretTypeRepository(db)
 	tgr := mysql.NewTriggerRepository(db)
 	suow := unitwork.NewStartUnitOfWork(db, mysql.Mem)
-	var svc = pikoci.New(ctx, topic, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, suow, jwtSecret, logger)
+	var svc = pikoci.New(ctx, jobTopic, checkTopic, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, suow, jwtSecret, logger)
 	svc.StartScheduler(ctx)
 	var handler = tshttp.Handler(svc, jwtSecret, logger.With("component", "HTTP"), db, mysql.Mem)
 	server := httptest.NewServer(handler)
@@ -75,14 +81,14 @@ func runTests(m *testing.M) int {
 	_, _ = svc.CreateUser(ctx, user.User{FullName: "pepito", Username: "pepito", Password: "$2a$14$rwQk8Qvc2rij7qhFO4P1W.OiSF6AkgVU1RCrLaY2wawJcpkPEKwbm"}, isHash)
 	_, _ = svc.CreateUser(ctx, user.User{FullName: "grillo", Username: "grillo", Password: "$2a$14$SvWir17.jlXxiZfe0pJuDedznetc/HWKv43YPsQQNo6MJiuypS2q6"}, isHash)
 	go func() {
-		runWorker(ctx, mempubsub.Scheme, topic, svc, 1, "DEBUG")
+		runWorker(ctx, mempubsub.Scheme, jobTopic, svc, 1, "DEBUG")
 	}()
 
 	return m.Run()
 }
 
-func getTopicURL(s string) string {
-	u := fmt.Sprintf("%s://pikoci", s)
+func getTopicURL(s, name string) string {
+	u := fmt.Sprintf("%s://%s", s, name)
 	switch s {
 	case natspubsub.Scheme:
 		u += "?natsv2"
@@ -90,16 +96,16 @@ func getTopicURL(s string) string {
 	return u
 }
 
-func getSubscriptionURL(s string) string {
-	u := fmt.Sprintf("%s://pikoci", s)
+func getSubscriptionURL(s, name string) string {
+	u := fmt.Sprintf("%s://%s", s, name)
 	switch s {
 	case natspubsub.Scheme:
-		u += "?queue=pikoci&natsv2"
+		u += fmt.Sprintf("?queue=%s&natsv2", name)
 	}
 	return u
 }
 
-func runWorker(ctx context.Context, sy string, t queue.Topic, s pikoci.Service, c int, llvl string) error {
+func runWorker(ctx context.Context, sy string, jobTopic queue.Topic, s pikoci.Service, c int, llvl string) error {
 	var lvl slog.Level
 	switch llvl {
 	case "DEBUG":
@@ -112,19 +118,25 @@ func runWorker(ctx context.Context, sy string, t queue.Topic, s pikoci.Service, 
 		lvl = slog.LevelInfo
 	}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: lvl})).With("service", "worker")
-	// Create a subscription connected to that topic.
-	subscription, err := pubsub.OpenSubscription(ctx, getSubscriptionURL(sy))
+
+	jobSub, err := pubsub.OpenSubscription(ctx, getSubscriptionURL(sy, "pikoci-jobs"))
 	if err != nil {
-		return fmt.Errorf("failed to OpenSubscription: %w", err)
+		return fmt.Errorf("failed to open job subscription: %w", err)
 	}
-	defer subscription.Shutdown(ctx)
+	defer jobSub.Shutdown(ctx)
+
+	checkSub, err := pubsub.OpenSubscription(ctx, getSubscriptionURL(sy, "pikoci-checks"))
+	if err != nil {
+		return fmt.Errorf("failed to open check subscription: %w", err)
+	}
+	defer checkSub.Shutdown(ctx)
 
 	var wg sync.WaitGroup
 	for i := range c {
 		wg.Add(1)
 		nlogger := logger.With("num", i+1)
 		nlogger.Info(fmt.Sprintf("Starting Worker %d", i+1))
-		w := worker.New(s, t, subscription, nlogger)
+		w := worker.New(s, jobTopic, jobSub, checkSub, nlogger)
 
 		go func() {
 			err = w.Run(ctx)

--- a/pikoci/builds.go
+++ b/pikoci/builds.go
@@ -217,7 +217,7 @@ func (q *PikoCI) RetryJobBuild(ctx context.Context, tc, pc, jn, buildNumber stri
 		return fmt.Errorf("failed to marshal Message Body: %w", err)
 	}
 
-	err = q.Topic.Send(ctx, &pubsub.Message{
+	err = q.JobTopic.Send(ctx, &pubsub.Message{
 		Body: mb,
 	})
 	if err != nil {
@@ -327,5 +327,5 @@ func (q *PikoCI) notifyNextPendingBuild(ctx context.Context, tc, pc, jn string) 
 	if err != nil {
 		return
 	}
-	q.Topic.Send(ctx, &pubsub.Message{Body: mb})
+	q.JobTopic.Send(ctx, &pubsub.Message{Body: mb})
 }

--- a/pikoci/config/config.go
+++ b/pikoci/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	RunWorker    bool   `mapstructure:"run-worker"`
 	Concurrency  int    `mapstructure:"concurrency"`
 	DrainTimeout string `mapstructure:"drain-timeout"`
+	Queues       string `mapstructure:"queues"`
 
 	PubSubSystem string `mapstructure:"pubsub-system"`
 

--- a/pikoci/helper_test.go
+++ b/pikoci/helper_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 type MockService struct {
-	Topic         *mock.Topic
+	Topic         *mock.Topic // used as JobTopic in tests
+	CheckTopic    *mock.Topic
 	Users         *mock.UserRepository
 	Teams         *mock.TeamRepository
 	Pipelines     *mock.PipelineRepository
@@ -38,6 +39,7 @@ func newService(ctrl *gomock.Controller) MockService {
 	str := mock.NewSecretTypeRepository(ctrl)
 	tgr := mock.NewTriggerRepository(ctrl)
 	t := mock.NewTopic(ctrl)
+	ct := mock.NewTopic(ctrl)
 
 	suow := unitwork.NewNoopStartUnitOfWork(unitwork.Repositories{
 		UsersRepo:         ur,
@@ -51,9 +53,10 @@ func newService(ctrl *gomock.Controller) MockService {
 		SecretTypesRepo:   str,
 	})
 
-	p := pikoci.New(context.TODO(), t, ur, tr, pr, jr, rr, rtr, br, rur, str, tgr, suow, []byte("test-secret"), nil)
+	p := pikoci.New(context.TODO(), t, ct, ur, tr, pr, jr, rr, rtr, br, rur, str, tgr, suow, []byte("test-secret"), nil)
 	return MockService{
 		Topic:         t,
+		CheckTopic:    ct,
 		Users:         ur,
 		Teams:         tr,
 		Pipelines:     pr,

--- a/pikoci/jobs.go
+++ b/pikoci/jobs.go
@@ -60,7 +60,7 @@ func (q *PikoCI) TriggerPipelineJob(ctx context.Context, tc, pc, jn string) erro
 		return fmt.Errorf("failed to marshal Message Body: %w", err)
 	}
 
-	err = q.Topic.Send(ctx, &pubsub.Message{
+	err = q.JobTopic.Send(ctx, &pubsub.Message{
 		Body: mb,
 	})
 	if err != nil {

--- a/pikoci/resources.go
+++ b/pikoci/resources.go
@@ -110,7 +110,7 @@ func (q *PikoCI) TriggerPipelineResource(ctx context.Context, tc, pc, rCan strin
 	if err != nil {
 		return fmt.Errorf("failed to marshal Message Body: %w", err)
 	}
-	err = q.Topic.Send(ctx, &pubsub.Message{
+	err = q.CheckTopic.Send(ctx, &pubsub.Message{
 		Body: mb,
 	})
 	if err != nil {

--- a/pikoci/resources_test.go
+++ b/pikoci/resources_test.go
@@ -99,7 +99,7 @@ func TestTriggerPipelineResource(t *testing.T) {
 		ResourceCanonical: "git.repo",
 	}
 	mb, _ := json.Marshal(expectedBody)
-	s.Topic.EXPECT().Send(ctx, &pubsub.Message{Body: mb}).Return(nil)
+	s.CheckTopic.EXPECT().Send(ctx, &pubsub.Message{Body: mb}).Return(nil)
 
 	// UpdatePipelineResource is called to set LastCheck
 	s.Resources.EXPECT().Update(ctx, "main", "my-pipeline", "git.repo", gomock.Any()).Return(nil)

--- a/pikoci/scheduler/scheduler.go
+++ b/pikoci/scheduler/scheduler.go
@@ -17,23 +17,25 @@ import (
 
 // Scheduler polls the database for resources due for a check and sends messages to the topic.
 type Scheduler struct {
-	resources resource.Repository
-	pipelines pipeline.Repository
-	builds    build.Repository
-	topic     queue.Topic
-	logger    *slog.Logger
-	interval  time.Duration
+	resources  resource.Repository
+	pipelines  pipeline.Repository
+	builds     build.Repository
+	jobTopic   queue.Topic
+	checkTopic queue.Topic
+	logger     *slog.Logger
+	interval   time.Duration
 }
 
 // New creates a new Scheduler.
-func New(resources resource.Repository, pipelines pipeline.Repository, builds build.Repository, topic queue.Topic, logger *slog.Logger) *Scheduler {
+func New(resources resource.Repository, pipelines pipeline.Repository, builds build.Repository, jobTopic, checkTopic queue.Topic, logger *slog.Logger) *Scheduler {
 	return &Scheduler{
-		resources: resources,
-		pipelines: pipelines,
-		builds:    builds,
-		topic:     topic,
-		logger:    logger,
-		interval:  10 * time.Second,
+		resources:  resources,
+		pipelines:  pipelines,
+		builds:     builds,
+		jobTopic:   jobTopic,
+		checkTopic: checkTopic,
+		logger:     logger,
+		interval:   10 * time.Second,
 	}
 }
 
@@ -78,7 +80,7 @@ func (s *Scheduler) tickResources(ctx context.Context) {
 			s.logger.Error("failed to marshal Message Body", "error", err)
 			continue
 		}
-		err = s.topic.Send(ctx, &pubsub.Message{
+		err = s.checkTopic.Send(ctx, &pubsub.Message{
 			Body: mb,
 		})
 		if err != nil {
@@ -209,7 +211,7 @@ func (s *Scheduler) evaluateJob(ctx context.Context, pwt *pipeline.WithTeam, j *
 		s.logger.Error("failed to marshal downstream trigger body", "error", err)
 		return
 	}
-	if err := s.topic.Send(ctx, &pubsub.Message{Body: mb}); err != nil {
+	if err := s.jobTopic.Send(ctx, &pubsub.Message{Body: mb}); err != nil {
 		s.logger.Error("failed to send downstream trigger message",
 			"job", j.Name, "error", err)
 	}

--- a/pikoci/scheduler/scheduler_test.go
+++ b/pikoci/scheduler/scheduler_test.go
@@ -20,14 +20,15 @@ import (
 	"gocloud.dev/pubsub"
 )
 
-func newTestScheduler(ctrl *gomock.Controller) (*Scheduler, *mock.ResourceRepository, *mock.PipelineRepository, *mock.BuildRepository, *mock.Topic) {
+func newTestScheduler(ctrl *gomock.Controller) (*Scheduler, *mock.ResourceRepository, *mock.PipelineRepository, *mock.BuildRepository, *mock.Topic, *mock.Topic) {
 	rr := mock.NewResourceRepository(ctrl)
 	pr := mock.NewPipelineRepository(ctrl)
 	br := mock.NewBuildRepository(ctrl)
-	topic := mock.NewTopic(ctrl)
+	jobTopic := mock.NewTopic(ctrl)
+	checkTopic := mock.NewTopic(ctrl)
 	logger := slog.Default()
-	s := New(rr, pr, br, topic, logger)
-	return s, rr, pr, br, topic
+	s := New(rr, pr, br, jobTopic, checkTopic, logger)
+	return s, rr, pr, br, jobTopic, checkTopic
 }
 
 // expectEmptyTickJobs sets up expectations for tickJobs when no pipelines exist.
@@ -37,7 +38,7 @@ func expectEmptyTickJobs(pr *mock.PipelineRepository) {
 
 func TestTickResources_NoDueResources(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	s, rr, pr, _, _ := newTestScheduler(ctrl)
+	s, rr, pr, _, _, _ := newTestScheduler(ctrl)
 
 	rr.EXPECT().FilterDueResources(gomock.Any()).Return(nil, nil)
 	expectEmptyTickJobs(pr)
@@ -47,7 +48,7 @@ func TestTickResources_NoDueResources(t *testing.T) {
 
 func TestTickResources_ProcessesDueResources(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	s, rr, pr, _, topic := newTestScheduler(ctrl)
+	s, rr, pr, _, _, topic := newTestScheduler(ctrl)
 
 	due := []*resource.ResourceWithPipeline{
 		{
@@ -89,7 +90,7 @@ func TestTickResources_ProcessesDueResources(t *testing.T) {
 
 func TestTickResources_MultipleDueResources(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	s, rr, pr, _, topic := newTestScheduler(ctrl)
+	s, rr, pr, _, _, topic := newTestScheduler(ctrl)
 
 	due := []*resource.ResourceWithPipeline{
 		{
@@ -116,7 +117,7 @@ func TestTickResources_MultipleDueResources(t *testing.T) {
 
 func TestTickResources_DefaultCheckInterval(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	s, rr, pr, _, topic := newTestScheduler(ctrl)
+	s, rr, pr, _, _, topic := newTestScheduler(ctrl)
 
 	due := []*resource.ResourceWithPipeline{
 		{
@@ -143,7 +144,7 @@ func TestTickResources_DefaultCheckInterval(t *testing.T) {
 
 func TestStart_StopsOnContextCancel(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	s, rr, pr, _, _ := newTestScheduler(ctrl)
+	s, rr, pr, _, _, _ := newTestScheduler(ctrl)
 	s.interval = 50 * time.Millisecond
 
 	rr.EXPECT().FilterDueResources(gomock.Any()).Return(nil, nil).AnyTimes()
@@ -159,7 +160,7 @@ func TestStart_StopsOnContextCancel(t *testing.T) {
 
 func TestTickResources_SendErrorSkipsResource(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	s, rr, pr, _, topic := newTestScheduler(ctrl)
+	s, rr, pr, _, _, topic := newTestScheduler(ctrl)
 
 	due := []*resource.ResourceWithPipeline{
 		{
@@ -181,7 +182,7 @@ func TestTickResources_SendErrorSkipsResource(t *testing.T) {
 
 func TestTickJobs_TriggersWhenCommonVersionExists(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	s, rr, pr, br, topic := newTestScheduler(ctrl)
+	s, rr, pr, br, topic, _ := newTestScheduler(ctrl)
 
 	rr.EXPECT().FilterDueResources(gomock.Any()).Return(nil, nil)
 
@@ -243,7 +244,7 @@ func TestTickJobs_TriggersWhenCommonVersionExists(t *testing.T) {
 
 func TestTickJobs_SkipsWhenNoCommonVersion(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	s, rr, pr, br, _ := newTestScheduler(ctrl)
+	s, rr, pr, br, _, _ := newTestScheduler(ctrl)
 
 	rr.EXPECT().FilterDueResources(gomock.Any()).Return(nil, nil)
 
@@ -284,7 +285,7 @@ func TestTickJobs_SkipsWhenNoCommonVersion(t *testing.T) {
 
 func TestTickJobs_SkipsWhenPendingBuildExists(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	s, rr, pr, br, _ := newTestScheduler(ctrl)
+	s, rr, pr, br, _, _ := newTestScheduler(ctrl)
 
 	rr.EXPECT().FilterDueResources(gomock.Any()).Return(nil, nil)
 
@@ -329,7 +330,7 @@ func TestTickJobs_SkipsWhenPendingBuildExists(t *testing.T) {
 
 func TestTickJobs_SkipsWhenTriggerFalse(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	s, rr, pr, _, _ := newTestScheduler(ctrl)
+	s, rr, pr, _, _, _ := newTestScheduler(ctrl)
 
 	rr.EXPECT().FilterDueResources(gomock.Any()).Return(nil, nil)
 
@@ -366,7 +367,7 @@ func TestTickJobs_SkipsWhenTriggerFalse(t *testing.T) {
 
 func TestTickJobs_SkipsJobsWithoutPassedConstraints(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	s, rr, pr, _, _ := newTestScheduler(ctrl)
+	s, rr, pr, _, _, _ := newTestScheduler(ctrl)
 
 	rr.EXPECT().FilterDueResources(gomock.Any()).Return(nil, nil)
 
@@ -401,7 +402,7 @@ func TestTickJobs_SkipsJobsWithoutPassedConstraints(t *testing.T) {
 
 func TestTickJobs_MultipleGetSteps_AllMustBeReady(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	s, rr, pr, br, _ := newTestScheduler(ctrl)
+	s, rr, pr, br, _, _ := newTestScheduler(ctrl)
 
 	rr.EXPECT().FilterDueResources(gomock.Any()).Return(nil, nil)
 
@@ -459,7 +460,7 @@ func TestTickJobs_MultipleGetSteps_AllMustBeReady(t *testing.T) {
 
 func TestTickJobs_MultipleGetSteps_BothReady_TriggersOnce(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	s, rr, pr, br, topic := newTestScheduler(ctrl)
+	s, rr, pr, br, topic, _ := newTestScheduler(ctrl)
 
 	rr.EXPECT().FilterDueResources(gomock.Any()).Return(nil, nil)
 
@@ -532,7 +533,7 @@ func TestTickJobs_MultipleGetSteps_BothReady_TriggersOnce(t *testing.T) {
 
 func TestTickJobs_FindReadyError_SkipsJob(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	s, rr, pr, br, _ := newTestScheduler(ctrl)
+	s, rr, pr, br, _, _ := newTestScheduler(ctrl)
 
 	rr.EXPECT().FilterDueResources(gomock.Any()).Return(nil, nil)
 

--- a/pikoci/service.go
+++ b/pikoci/service.go
@@ -94,8 +94,9 @@ type Service interface {
 }
 
 type PikoCI struct {
-	Topic         queue.Topic
-	Users         user.Repository
+	JobTopic   queue.Topic
+	CheckTopic queue.Topic
+	Users      user.Repository
 	Teams         team.Repository
 	Pipelines     pipeline.Repository
 	Jobs          job.Repository
@@ -114,10 +115,11 @@ type PikoCI struct {
 	logger    *slog.Logger
 }
 
-func New(ctx context.Context, t queue.Topic, ur user.Repository, tr team.Repository, pr pipeline.Repository, jr job.Repository, rr resource.Repository, rt restype.Repository, br build.Repository, rur runner.Repository, str sectype.Repository, tgr trigger.Repository, suow unitwork.StartUnitOfWork, js []byte, l *slog.Logger) *PikoCI {
+func New(ctx context.Context, jobTopic, checkTopic queue.Topic, ur user.Repository, tr team.Repository, pr pipeline.Repository, jr job.Repository, rr resource.Repository, rt restype.Repository, br build.Repository, rur runner.Repository, str sectype.Repository, tgr trigger.Repository, suow unitwork.StartUnitOfWork, js []byte, l *slog.Logger) *PikoCI {
 	return &PikoCI{
 		Ctx:           ctx,
-		Topic:         t,
+		JobTopic:      jobTopic,
+		CheckTopic:    checkTopic,
 		Users:         ur,
 		Teams:         tr,
 		Pipelines:     pr,
@@ -131,7 +133,7 @@ func New(ctx context.Context, t queue.Topic, ur user.Repository, tr team.Reposit
 		StartUoW:      suow,
 		JWTSecret:     js,
 		logger:        l,
-		scheduler:     scheduler.New(rr, pr, br, t, l),
+		scheduler:     scheduler.New(rr, pr, br, jobTopic, checkTopic, l),
 	}
 }
 

--- a/worker/config/config.go
+++ b/worker/config/config.go
@@ -7,6 +7,7 @@ type Config struct {
 	Concurrency  int    `mapstructure:"concurrency"`
 	DrainTimeout string `mapstructure:"drain-timeout"`
 	PubSubSystem string `mapstructure:"pubsub-system"`
+	Queues       string `mapstructure:"queues"`
 
 	LogLevel string `mapstructure:"log-level"`
 }

--- a/worker/service.go
+++ b/worker/service.go
@@ -196,6 +196,36 @@ func (w *Worker) processMessage(ctx context.Context, m queue.Body, cwd string) {
 // runs the plan steps, and runs hooks. Downstream job triggering is handled
 // by the scheduler.
 func (w *Worker) processJob(ctx context.Context, m queue.Body, cwd string, pp *pipeline.Pipeline) {
+	// Resolve the oldest pending build from the DB rather than trusting the
+	// message's BuildID. Queue messages are treated as wake-up signals — the
+	// DB is the source of truth for ordering. This ensures strict FIFO even
+	// when pub/sub backends deliver messages out of order.
+	if !w.LocalMode {
+		oldest, err := w.pikoci.FindOldestPendingBuild(ctx, m.TeamCanonical, m.PipelineCanonical, m.JobName)
+		if err != nil {
+			w.logger.Error("failed to find oldest pending build",
+				"pipeline", m.PipelineCanonical, "job", m.JobName, "error", err)
+			return
+		}
+		if oldest == nil {
+			w.logger.Info("no pending builds, skipping",
+				"pipeline", m.PipelineCanonical, "job", m.JobName, "msg_build_id", m.BuildID)
+			return
+		}
+		if oldest.ID != m.BuildID {
+			w.logger.Info("reordering: oldest pending build differs from message",
+				"pipeline", m.PipelineCanonical, "job", m.JobName,
+				"msg_build_id", m.BuildID, "oldest_build_id", oldest.ID)
+		}
+		m.BuildID = oldest.ID
+		if oldest.VersionID != 0 {
+			m.VersionID = oldest.VersionID
+		}
+		if oldest.ResourceCanonical != "" {
+			m.ResourceCanonical = oldest.ResourceCanonical
+		}
+	}
+
 	if m.BuildID == 0 {
 		w.logger.Error("missing build_id in message",
 			"pipeline", m.PipelineCanonical, "job", m.JobName)

--- a/worker/service.go
+++ b/worker/service.go
@@ -36,9 +36,10 @@ type Service interface {
 }
 
 type Worker struct {
-	topic        queue.Topic
-	pikoci       pikoci.Service
-	subscription queue.Subscription
+	jobTopic          queue.Topic
+	pikoci            pikoci.Service
+	jobSubscription   queue.Subscription
+	checkSubscription queue.Subscription
 
 	draining atomic.Bool
 	logger   *slog.Logger
@@ -52,12 +53,13 @@ type Worker struct {
 	LocalMode bool
 }
 
-func New(s pikoci.Service, t queue.Topic, ss queue.Subscription, l *slog.Logger) *Worker {
+func New(s pikoci.Service, jobTopic queue.Topic, jobSub, checkSub queue.Subscription, l *slog.Logger) *Worker {
 	return &Worker{
-		pikoci:       s,
-		topic:        t,
-		subscription: ss,
-		logger:       l,
+		pikoci:            s,
+		jobTopic:          jobTopic,
+		jobSubscription:   jobSub,
+		checkSubscription: checkSub,
+		logger:            l,
 	}
 }
 
@@ -67,21 +69,60 @@ func (w *Worker) Drain() {
 
 func (w *Worker) Run(ctx context.Context) error {
 	w.logger.Info("Worker waiting for messages...")
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+
+	if w.jobSubscription != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := w.receiveLoop(ctx, w.jobSubscription, "job"); err != nil {
+				errs <- err
+			}
+		}()
+	}
+
+	if w.checkSubscription != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := w.receiveLoop(ctx, w.checkSubscription, "check"); err != nil {
+				errs <- err
+			}
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+
+	select {
+	case err := <-errs:
+		return err
+	case <-done:
+		return nil
+	}
+}
+
+func (w *Worker) receiveLoop(ctx context.Context, sub queue.Subscription, kind string) error {
 	for {
 		if w.draining.Load() {
-			w.logger.Info("Worker draining, stopping message receive")
+			w.logger.Info("Worker draining, stopping message receive", "queue", kind)
 			return nil
 		}
-		msg, err := w.subscription.Receive(ctx)
+		msg, err := sub.Receive(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to receive message: %w", err)
+			return fmt.Errorf("failed to receive %s message: %w", kind, err)
 		}
 
-		w.logger.Info("received message", "body", string(msg.Body))
+		w.logger.Info("received message", "queue", kind, "body", string(msg.Body))
 
 		var m queue.Body
 		if err := json.Unmarshal(msg.Body, &m); err != nil {
-			w.logger.Error("failed unmarshal message body", "error", err)
+			w.logger.Error("failed unmarshal message body", "queue", kind, "error", err)
 			msg.Ack()
 			continue
 		}
@@ -171,7 +212,7 @@ func (w *Worker) processJob(ctx context.Context, m queue.Body, cwd string, pp *p
 			w.logger.Info("concurrency limit, re-queuing",
 				"pipeline", m.PipelineCanonical, "job", m.JobName, "build_id", m.BuildID)
 			mb, _ := json.Marshal(m)
-			if err := w.topic.Send(ctx, &pubsub.Message{Body: mb}); err != nil {
+			if err := w.jobTopic.Send(ctx, &pubsub.Message{Body: mb}); err != nil {
 				w.logger.Error("failed to re-queue", "error", err)
 			}
 			time.Sleep(2 * time.Second)
@@ -309,7 +350,7 @@ func (w *Worker) notifyNextPendingBuild(ctx context.Context, m queue.Body) {
 		BuildID:           pending.ID,
 	}
 	mb, _ := json.Marshal(msg)
-	if err := w.topic.Send(ctx, &pubsub.Message{Body: mb}); err != nil {
+	if err := w.jobTopic.Send(ctx, &pubsub.Message{Body: mb}); err != nil {
 		w.logger.Warn("failed to notify next pending build", "build_id", pending.ID, "error", err)
 	}
 }
@@ -1316,7 +1357,7 @@ func (w *Worker) triggerResourceJobs(ctx context.Context, m queue.Body, pp *pipe
 				w.logger.Info("sending trigger message",
 					"pipeline", pp.Canonical, "job", j.Name, "resource", r.Canonical,
 					"version_id", cv.ID, "step", g.Name, "build_id", nb.ID)
-				if err := w.topic.Send(ctx, &pubsub.Message{Body: mb}); err != nil {
+				if err := w.jobTopic.Send(ctx, &pubsub.Message{Body: mb}); err != nil {
 					w.logger.Error("failed to send trigger message", "job", j.Name, "error", err)
 				}
 			}

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -41,8 +41,10 @@ func newTestWorker(ctrl *gomock.Controller) (*Worker, *mock.Service, *mock.Topic
 		Return(&build.Build{Status: build.Started}, nil).AnyTimes()
 
 	// FindOldestPendingBuild is called by notifyNextPendingBuild at end of processJob.
-	svc.EXPECT().FindOldestPendingBuild(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(nil, nil).AnyTimes()
+	// Tests that call processJob must also call expectPendingBuild() to set up
+	// the ordering lookup that happens at the start of processJob.
+	// (No global fallback here — each test calls expectPendingBuild which
+	// registers a DoAndReturn that returns the build once, then nil.)
 
 	// CreateJobBuild is called by triggerResourceJobs to create pending builds.
 	var createBuildCounter uint32
@@ -58,6 +60,24 @@ func newTestWorker(ctrl *gomock.Controller) (*Worker, *mock.Service, *mock.Topic
 		logger:   logger,
 	}
 	return w, svc, jobTopic
+}
+
+// expectPendingBuild sets up a FindOldestPendingBuild expectation using
+// DoAndReturn: the first call returns a pending build with the given ID,
+// and subsequent calls return nil (for notifyNextPendingBuild at the end
+// of processJob). This must be called by any test that invokes processJob,
+// since processJob queries the DB for the oldest pending build before
+// starting it.
+func expectPendingBuild(svc *mock.Service, buildID uint32) {
+	var pendingCallCount int32
+	svc.EXPECT().FindOldestPendingBuild(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _ string) (*build.Build, error) {
+			pendingCallCount++
+			if pendingCallCount == 1 {
+				return &build.Build{ID: buildID, BuildNumber: "1", Status: build.Pending}, nil
+			}
+			return nil, nil
+		}).AnyTimes()
 }
 
 func runnerHook(rc utils.RunnerCommand) job.HookStep {
@@ -183,6 +203,7 @@ func TestProcessJob_Success_TaskOnly(t *testing.T) {
 	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "10", gomock.Any()).
 		Return(nil).AnyTimes()
 
+	expectPendingBuild(svc, 10)
 	w.processJob(ctx, m, cwd, pp)
 }
 
@@ -252,6 +273,7 @@ func TestProcessJob_Success_WithGetAndTask(t *testing.T) {
 	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "10", gomock.Any()).
 		Return(nil).AnyTimes()
 
+	expectPendingBuild(svc, 10)
 	w.processJob(ctx, m, cwd, pp)
 }
 
@@ -263,8 +285,15 @@ func TestInsertBuildGetVersion_CalledWithCorrectArgs(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	svc.EXPECT().GetJobBuild(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&build.Build{Status: build.Started}, nil).AnyTimes()
+	var pendingCallCount int32
 	svc.EXPECT().FindOldestPendingBuild(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(nil, nil).AnyTimes()
+		DoAndReturn(func(_ context.Context, _, _, _ string) (*build.Build, error) {
+			pendingCallCount++
+			if pendingCallCount == 1 {
+				return &build.Build{ID: 10, BuildNumber: "1", Status: build.Pending}, nil
+			}
+			return nil, nil
+		}).AnyTimes()
 	w := &Worker{pikoci: svc, jobTopic: topic, logger: logger}
 
 	ctx := context.Background()
@@ -384,6 +413,7 @@ func TestProcessJob_FailedPassedConstraint_NoBuilds(t *testing.T) {
 	svc.EXPECT().DeleteJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "20").
 		Return(nil)
 
+	expectPendingBuild(svc, 10)
 	w.processJob(ctx, m, cwd, pp)
 }
 
@@ -437,6 +467,7 @@ func TestProcessJob_FailedPassedConstraint_NotSucceeded(t *testing.T) {
 	svc.EXPECT().DeleteJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "21").
 		Return(nil)
 
+	expectPendingBuild(svc, 10)
 	w.processJob(ctx, m, cwd, pp)
 }
 
@@ -527,6 +558,7 @@ func TestProcessJob_TaskFailure_RunsHooks(t *testing.T) {
 	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "30", gomock.Any()).
 		Return(nil).AnyTimes()
 
+	expectPendingBuild(svc, 10)
 	w.processJob(ctx, m, cwd, pp)
 }
 
@@ -610,6 +642,7 @@ func TestProcessJob_NoDownstreamTrigger(t *testing.T) {
 
 	// No topic.Send expected — downstream is now scheduler-driven
 
+	expectPendingBuild(svc, 10)
 	w.processJob(ctx, m, cwd, pp)
 }
 
@@ -1252,6 +1285,7 @@ func TestProcessMessage_JobDispatch(t *testing.T) {
 			return nil
 		})
 
+	expectPendingBuild(svc, 10)
 	w.processMessage(ctx, m, cwd)
 }
 
@@ -1550,6 +1584,7 @@ func TestProcessJob_PutStep_Success(t *testing.T) {
 	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "80", gomock.Any()).
 		Return(nil).AnyTimes()
 
+	expectPendingBuild(svc, 10)
 	w.processJob(ctx, m, cwd, pp)
 }
 
@@ -1625,6 +1660,7 @@ func TestProcessJob_OrderedPlan_GetTaskPut(t *testing.T) {
 	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "90", gomock.Any()).
 		Return(nil).AnyTimes()
 
+	expectPendingBuild(svc, 10)
 	w.processJob(ctx, m, cwd, pp)
 }
 
@@ -1698,6 +1734,7 @@ func TestProcessJob_TaskTimeout(t *testing.T) {
 			return nil
 		}).AnyTimes()
 
+	expectPendingBuild(svc, 10)
 	w.processJob(ctx, m, cwd, pp)
 
 	assert.Equal(t, build.Failed, capturedBuild.Status)
@@ -1771,6 +1808,7 @@ func TestProcessJob_GetTimeout(t *testing.T) {
 			return nil
 		}).AnyTimes()
 
+	expectPendingBuild(svc, 10)
 	w.processJob(ctx, m, cwd, pp)
 
 	assert.Equal(t, build.Failed, capturedBuild.Status)
@@ -1831,6 +1869,7 @@ func TestProcessJob_NoTimeout_Succeeds(t *testing.T) {
 			return nil
 		}).AnyTimes()
 
+	expectPendingBuild(svc, 10)
 	w.processJob(ctx, m, cwd, pp)
 
 	assert.Equal(t, build.Succeeded, lastBuild.Status)
@@ -1903,6 +1942,7 @@ fi
 			return nil
 		}).AnyTimes()
 
+	expectPendingBuild(svc, 10)
 	w.processJob(ctx, m, cwd, pp)
 
 	assert.Equal(t, build.Succeeded, capturedBuild.Status)
@@ -1971,6 +2011,7 @@ func TestProcessJob_TaskRetry_ExhaustsAttempts(t *testing.T) {
 			return nil
 		}).AnyTimes()
 
+	expectPendingBuild(svc, 10)
 	w.processJob(ctx, m, cwd, pp)
 
 	assert.Equal(t, build.Failed, capturedBuild.Status)
@@ -2033,6 +2074,7 @@ func TestProcessJob_TaskRetry_WithTimeout(t *testing.T) {
 			return nil
 		}).AnyTimes()
 
+	expectPendingBuild(svc, 10)
 	w.processJob(ctx, m, cwd, pp)
 
 	assert.Equal(t, build.Failed, capturedBuild.Status)
@@ -2602,6 +2644,7 @@ func TestProcessJob_TaskInputMissing(t *testing.T) {
 			return nil
 		}).AnyTimes()
 
+	expectPendingBuild(svc, 10)
 	w.processJob(ctx, m, cwd, pp)
 
 	assert.Equal(t, build.Failed, capturedBuild.Status)
@@ -2664,6 +2707,7 @@ func TestProcessJob_TaskOutputMissing(t *testing.T) {
 			return nil
 		}).AnyTimes()
 
+	expectPendingBuild(svc, 10)
 	w.processJob(ctx, m, cwd, pp)
 
 	assert.Equal(t, build.Failed, capturedBuild.Status)
@@ -2732,6 +2776,7 @@ func TestProcessJob_TaskInputsOutputs_Success(t *testing.T) {
 			return nil
 		}).AnyTimes()
 
+	expectPendingBuild(svc, 10)
 	w.processJob(ctx, m, cwd, pp)
 
 	assert.Equal(t, build.Succeeded, capturedBuild.Status)
@@ -2798,6 +2843,7 @@ func TestProcessJob_TaskMultipleInputs_FailsOnFirst(t *testing.T) {
 			return nil
 		}).AnyTimes()
 
+	expectPendingBuild(svc, 10)
 	w.processJob(ctx, m, cwd, pp)
 
 	assert.Equal(t, build.Failed, capturedBuild.Status)
@@ -2863,6 +2909,7 @@ func TestProcessJob_TaskMultipleOutputs_FailsOnFirst(t *testing.T) {
 			return nil
 		}).AnyTimes()
 
+	expectPendingBuild(svc, 10)
 	w.processJob(ctx, m, cwd, pp)
 
 	assert.Equal(t, build.Failed, capturedBuild.Status)
@@ -2879,8 +2926,15 @@ func TestProcessJob_Cancellation(t *testing.T) {
 	topic := mock.NewTopic(ctrl)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	svc.EXPECT().InsertBuildGetVersion(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	var pendingCallCount int32
 	svc.EXPECT().FindOldestPendingBuild(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(nil, nil).AnyTimes()
+		DoAndReturn(func(_ context.Context, _, _, _ string) (*build.Build, error) {
+			pendingCallCount++
+			if pendingCallCount == 1 {
+				return &build.Build{ID: 10, BuildNumber: "1", Status: build.Pending}, nil
+			}
+			return nil, nil
+		}).AnyTimes()
 
 	w := &Worker{
 		pikoci: svc,
@@ -3042,6 +3096,7 @@ func TestProcessJob_Retry_UsesCreateRetryAndResolvedVersions(t *testing.T) {
 	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "3.1", gomock.Any()).
 		Return(nil).AnyTimes()
 
+	expectPendingBuild(svc, 20)
 	w.processJob(ctx, m, cwd, pp)
 }
 
@@ -3093,6 +3148,7 @@ func TestProcessJob_Retry_FailsOnVersionLookupError(t *testing.T) {
 			return nil
 		}).AnyTimes()
 
+	expectPendingBuild(svc, 20)
 	w.processJob(ctx, m, cwd, pp)
 }
 
@@ -3102,8 +3158,15 @@ func TestProcessJob_Cancellation_RunsOnCancelNotOnFailure(t *testing.T) {
 	topic := mock.NewTopic(ctrl)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	svc.EXPECT().InsertBuildGetVersion(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	var pendingCallCount int32
 	svc.EXPECT().FindOldestPendingBuild(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(nil, nil).AnyTimes()
+		DoAndReturn(func(_ context.Context, _, _, _ string) (*build.Build, error) {
+			pendingCallCount++
+			if pendingCallCount == 1 {
+				return &build.Build{ID: 10, BuildNumber: "1", Status: build.Pending}, nil
+			}
+			return nil, nil
+		}).AnyTimes()
 
 	w := &Worker{
 		pikoci: svc,
@@ -3219,7 +3282,7 @@ func TestProcessJob_Cancellation_RunsOnCancelNotOnFailure(t *testing.T) {
 
 func TestProcessJob_MissingBuildID(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	w, _, _ := newTestWorker(ctrl)
+	w, svc, _ := newTestWorker(ctrl)
 
 	ctx := context.Background()
 	m := queue.Body{
@@ -3231,6 +3294,9 @@ func TestProcessJob_MissingBuildID(t *testing.T) {
 	pp := testPipeline()
 	cwd := t.TempDir()
 
+	// FindOldestPendingBuild returns nil → no pending builds, processJob returns early.
+	svc.EXPECT().FindOldestPendingBuild(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, nil).AnyTimes()
 	// Should return immediately without calling any service methods
 	w.processJob(ctx, m, cwd, pp)
 }
@@ -3253,6 +3319,7 @@ func TestProcessJob_BuildNotPending(t *testing.T) {
 		Return(nil, pikoci.ErrBuildNotPending)
 
 	// Should return immediately — build already started by another worker
+	expectPendingBuild(svc, 10)
 	w.processJob(ctx, m, cwd, pp)
 }
 
@@ -3283,6 +3350,7 @@ func TestProcessJob_ConcurrencyLimit_Requeues(t *testing.T) {
 		return nil
 	})
 
+	expectPendingBuild(svc, 10)
 	w.processJob(ctx, m, cwd, pp)
 }
 

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -30,7 +30,7 @@ import (
 
 func newTestWorker(ctrl *gomock.Controller) (*Worker, *mock.Service, *mock.Topic) {
 	svc := mock.NewService(ctrl)
-	topic := mock.NewTopic(ctrl)
+	jobTopic := mock.NewTopic(ctrl)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
 	// InsertBuildGetVersion is called after every successful get step; allow it globally.
@@ -53,11 +53,11 @@ func newTestWorker(ctrl *gomock.Controller) (*Worker, *mock.Service, *mock.Topic
 		}).AnyTimes()
 
 	w := &Worker{
-		pikoci: svc,
-		topic:  topic,
-		logger: logger,
+		pikoci:   svc,
+		jobTopic: jobTopic,
+		logger:   logger,
 	}
-	return w, svc, topic
+	return w, svc, jobTopic
 }
 
 func runnerHook(rc utils.RunnerCommand) job.HookStep {
@@ -265,7 +265,7 @@ func TestInsertBuildGetVersion_CalledWithCorrectArgs(t *testing.T) {
 		Return(&build.Build{Status: build.Started}, nil).AnyTimes()
 	svc.EXPECT().FindOldestPendingBuild(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, nil).AnyTimes()
-	w := &Worker{pikoci: svc, topic: topic, logger: logger}
+	w := &Worker{pikoci: svc, jobTopic: topic, logger: logger}
 
 	ctx := context.Background()
 	m := queue.Body{
@@ -2884,7 +2884,7 @@ func TestProcessJob_Cancellation(t *testing.T) {
 
 	w := &Worker{
 		pikoci: svc,
-		topic:  topic,
+		jobTopic: topic,
 		logger: logger,
 	}
 
@@ -3107,7 +3107,7 @@ func TestProcessJob_Cancellation_RunsOnCancelNotOnFailure(t *testing.T) {
 
 	w := &Worker{
 		pikoci: svc,
-		topic:  topic,
+		jobTopic: topic,
 		logger: logger,
 	}
 


### PR DESCRIPTION
## Summary

- Split single pub/sub queue into two dedicated queues (`pikoci-jobs` and `pikoci-checks`) so long-running jobs never block resource check processing
- Workers run two concurrent receive loops — one per queue
- New `--queues` flag (`jobs`, `checks`, or `jobs,checks`) lets operators run dedicated check-only or job-only workers
- Updated all backends (mem, nats, rabbit, kafka) to use queue-specific topic/subscription URLs

Closes #368