### PR TITLE
Fix resource 'Last checked' showing raw duration for unchecked resources (#367)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Concurrency re-queuing infinite loop: builds are now created as Pending at trigger time and transitioned to Started atomically by workers, eliminating duplicate build creation from re-queued messages ([#358](https://github.com/PikoCI/pikoci/issues/358), [#246](https://github.com/PikoCI/pikoci/issues/246))
+- Resource "Last checked" showing raw duration (e.g., "739760d ago") instead of "never" for resources that have never been checked ([#367](https://github.com/PikoCI/pikoci/issues/367))
 
 ### Changed
 

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -599,7 +599,7 @@
         </div>
       </div>
       <div class="piko-resource-info">
-        <span class="piko-build-label">Last checked</span> (<%- resource.check_interval||"@every 1m" %>) at: <span class="piko-time-ago" data-time="<%= resource.last_check %>" title="<%= new Date(resource.last_check).toLocaleString() %>" style="color: var(--text-primary);"><%= pikoTimeAgo(resource.last_check) %></span>
+        <span class="piko-build-label">Last checked</span> (<%- resource.check_interval||"@every 1m" %>)<%= (!resource.last_check || resource.last_check.startsWith('0001-01-01')) ? ':' : ' at:' %> <span class="piko-time-ago" data-time="<%= resource.last_check %>" title="<%= new Date(resource.last_check).toLocaleString() %>" style="color: var(--text-primary);"><%= pikoTimeAgo(resource.last_check) %></span>
       </div>
       <div id="resource-versions">
       </div>
@@ -813,7 +813,7 @@
       var isLogin = true
 
       function pikoTimeAgo(dateStr) {
-        if (!dateStr) return ''
+        if (!dateStr || dateStr.startsWith('0001-01-01')) return 'never'
         var seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000)
         if (seconds < 60) return 'just now'
         if (seconds < 3600) return Math.floor(seconds / 60) + 'm ago'


### PR DESCRIPTION
## Summary

- Detect Go's zero-value timestamp (`0001-01-01T00:00:00Z`) in `pikoTimeAgo()` and return `"never"` instead of calculating `"739760d ago"`
- Update "Last checked" label to show `Last checked (every 10s): never` (no "at:") for unchecked resources, vs `Last checked (every 10s) at: 2m ago` for checked ones
- Add changelog entry

Fixes #367