### PR TITLE
Fix pending builds showing gray on pipeline graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Follow button: fix race conditions between auto-scroll and scroll listeners, target running step in multi-step builds, and improve visual feedback with "Following"/"Follow" text and solid/outline styles ([#343](https://github.com/PikoCI/pikoci/issues/343))
+- Pending builds showing gray on pipeline graph instead of previous build's color with dashed border
 - Concurrency re-queuing infinite loop: builds are now created as Pending at trigger time and transitioned to Started atomically by workers, eliminating duplicate build creation from re-queued messages ([#358](https://github.com/PikoCI/pikoci/issues/358), [#246](https://github.com/PikoCI/pikoci/issues/246))
 - Resource "Last checked" showing raw duration (e.g., "739760d ago") instead of "never" for resources that have never been checked ([#367](https://github.com/PikoCI/pikoci/issues/367))
 

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -500,7 +500,7 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 		// Find the latest main build number first
 		var latestMain string
 		for _, b := range builds {
-			if b.Status == build.Started && rb == nil {
+			if (b.Status == build.Started || b.Status == build.Pending) && rb == nil {
 				rb = b
 			}
 			if !strings.Contains(b.BuildNumber, ".") && latestMain == "" {
@@ -511,7 +511,7 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 		if latestMain != "" {
 			for _, b := range builds {
 				if b.BuildNumber == latestMain || strings.HasPrefix(b.BuildNumber, latestMain+".") {
-					if b.Status != build.Started {
+					if b.Status != build.Started && b.Status != build.Pending {
 						cb = b
 						break
 					}
@@ -520,7 +520,7 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 			// If all builds in the group are running, fall back to previous main build
 			if cb == nil {
 				for _, b := range builds {
-					if b.Status != build.Started && !strings.Contains(b.BuildNumber, ".") && b.BuildNumber != latestMain {
+					if b.Status != build.Started && b.Status != build.Pending && !strings.Contains(b.BuildNumber, ".") && b.BuildNumber != latestMain {
 						cb = b
 						break
 					}

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -1549,6 +1549,23 @@ func TestGetPipelineImage_JobStatusColors(t *testing.T) {
 			wantFillColor:   colorFailed,
 			wantDashedStyle: true,
 		},
+		{
+			name: "pending build with previous success - shows previous color with dashed outline",
+			builds: []*build.Build{
+				{ID: 1, BuildNumber: "1", Status: build.Succeeded},
+				{ID: 2, BuildNumber: "2", Status: build.Pending},
+			},
+			wantFillColor:   colorSucceeded,
+			wantDashedStyle: true,
+		},
+		{
+			name: "only build is pending - default color with dashed outline",
+			builds: []*build.Build{
+				{ID: 1, BuildNumber: "1", Status: build.Pending},
+			},
+			wantFillColor:   colorDefault,
+			wantDashedStyle: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Treat pending builds like running builds in graph color selection: skip them when picking the completed build (`cb`) and use them to trigger the dashed border (`rb`)
- Pending builds now show the previous build's color with a dashed outline instead of solid gray
- Added two test cases for pending build scenarios