### PR TITLE
Fix SIGQUIT graceful shutdown hanging forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- SIGQUIT graceful shutdown hanging forever: cancel the main context after workers drain so blocked Receive() calls unblock and the process exits cleanly ([#384](https://github.com/PikoCI/pikoci/issues/384))
+- Worker stuck in loop after build cancellation: use parent server context for DB operations so writes survive job cancellation but respect server shutdown ([#382](https://github.com/PikoCI/pikoci/issues/382))
 - Follow button: fix race conditions between auto-scroll and scroll listeners, target running step in multi-step builds, and improve visual feedback with "Following"/"Follow" text and solid/outline styles ([#343](https://github.com/PikoCI/pikoci/issues/343))
 - Pending builds showing gray on pipeline graph instead of previous build's color with dashed border
 - Concurrency re-queuing infinite loop: builds are now created as Pending at trigger time and transitioned to Started atomically by workers, eliminating duplicate build creation from re-queued messages ([#358](https://github.com/PikoCI/pikoci/issues/358), [#246](https://github.com/PikoCI/pikoci/issues/246))

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -252,6 +252,10 @@ var serverCmd = &cobra.Command{
 				}
 			}
 
+			// Cancel the main context so any blocked Receive() calls
+			// unblock and worker goroutines can exit.
+			cancel()
+
 			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer shutdownCancel()
 			svr.Shutdown(shutdownCtx)

--- a/worker/service.go
+++ b/worker/service.go
@@ -44,6 +44,11 @@ type Worker struct {
 	draining atomic.Bool
 	logger   *slog.Logger
 
+	// apiCtx is the parent server context used for DB operations.
+	// It outlives individual job contexts (which get cancelled on
+	// build cancellation) but is cancelled on server shutdown.
+	apiCtx context.Context
+
 	// ResourceOverrides maps resource canonical names to local directory paths.
 	// When set, get steps for these resources will copy the local directory
 	// instead of running the resource type's pull command.
@@ -69,6 +74,10 @@ func (w *Worker) Drain() {
 
 func (w *Worker) Run(ctx context.Context) error {
 	w.logger.Info("Worker waiting for messages...")
+
+	// Store the parent context for DB operations that must survive
+	// job-level cancellation but respect server shutdown.
+	w.apiCtx = ctx
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -348,7 +357,7 @@ func (w *Worker) processJob(ctx context.Context, m queue.Body, cwd string, pp *p
 
 	if !failed {
 		b.Status = build.Succeeded
-		if err := w.updateBuild(jobCtx, m, b); err != nil {
+		if err := w.updateBuild(ctx, m, b); err != nil {
 			return
 		}
 		w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.OnSuccess, "on_success", resolved, "succeeded")
@@ -1422,23 +1431,37 @@ func (w *Worker) pollForCancellation(apiCtx, jobCtx context.Context, cancel cont
 }
 
 // updateBuild persists the current build state to the DB.
-func (w *Worker) updateBuild(ctx context.Context, m queue.Body, b build.Build) error {
-	err := w.pikoci.UpdateJobBuild(ctx, m.TeamCanonical, m.PipelineCanonical, m.JobName, b.BuildNumber, b)
+// It uses apiCtx (the parent server context) so that DB writes survive
+// job-level cancellation but are still cancelled on server shutdown.
+func (w *Worker) updateBuild(_ context.Context, m queue.Body, b build.Build) error {
+	dbCtx := w.dbContext()
+	err := w.pikoci.UpdateJobBuild(dbCtx, m.TeamCanonical, m.PipelineCanonical, m.JobName, b.BuildNumber, b)
 	if err != nil {
 		w.logger.Error("failed update build", "pipeline", m.PipelineCanonical, "job", m.JobName, "error", err)
 	}
 	return err
 }
 
-func (w *Worker) failBuild(ctx context.Context, m queue.Body, b build.Build, err error) {
+func (w *Worker) failBuild(_ context.Context, m queue.Body, b build.Build, err error) {
 	b.Status = build.Failed
 	if err != nil {
 		b.Error = err.Error()
 		w.logger.Error(err.Error())
 	}
-	if uerr := w.pikoci.UpdateJobBuild(ctx, m.TeamCanonical, m.PipelineCanonical, m.JobName, b.BuildNumber, b); uerr != nil {
+	dbCtx := w.dbContext()
+	if uerr := w.pikoci.UpdateJobBuild(dbCtx, m.TeamCanonical, m.PipelineCanonical, m.JobName, b.BuildNumber, b); uerr != nil {
 		w.logger.Error("failed update build", "pipeline", m.PipelineCanonical, "job", m.JobName, "error", uerr)
 	}
+}
+
+// dbContext returns the appropriate context for DB operations.
+// Uses apiCtx if set (normal server mode), falls back to background
+// context for tests and local mode.
+func (w *Worker) dbContext() context.Context {
+	if w.apiCtx != nil {
+		return w.apiCtx
+	}
+	return context.Background()
 }
 
 func (w *Worker) deleteBuild(ctx context.Context, m queue.Body, b build.Build) {
@@ -1537,7 +1560,12 @@ func (w *Worker) runRunner(ctx context.Context, ru runner.Runner, cwd string, rc
 			for {
 				select {
 				case <-ticker.C:
+					if ctx.Err() != nil {
+						return
+					}
 					partialCb(sw.String())
+				case <-ctx.Done():
+					return
 				case <-done:
 					return
 				}

--- a/worker/service.go
+++ b/worker/service.go
@@ -115,6 +115,10 @@ func (w *Worker) receiveLoop(ctx context.Context, sub queue.Subscription, kind s
 		}
 		msg, err := sub.Receive(ctx)
 		if err != nil {
+			if ctx.Err() != nil && w.draining.Load() {
+				w.logger.Info("Worker draining, stopping message receive", "queue", kind)
+				return nil
+			}
 			return fmt.Errorf("failed to receive %s message: %w", kind, err)
 		}
 

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -3278,6 +3279,103 @@ func TestProcessJob_Cancellation_RunsOnCancelNotOnFailure(t *testing.T) {
 	// on_failure hook should NOT have run
 	_, err = os.Stat(failureMarker)
 	assert.True(t, os.IsNotExist(err), "on_failure hook should NOT run on cancellation (marker file should not exist)")
+}
+
+func TestProcessJob_Cancellation_NoUpdateLoopAfterCancel(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	svc := mock.NewService(ctrl)
+	topic := mock.NewTopic(ctrl)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc.EXPECT().InsertBuildGetVersion(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	var pendingCallCount int32
+	svc.EXPECT().FindOldestPendingBuild(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _ string) (*build.Build, error) {
+			atomic.AddInt32(&pendingCallCount, 1)
+			if atomic.LoadInt32(&pendingCallCount) == 1 {
+				return &build.Build{ID: 10, BuildNumber: "1", Status: build.Pending}, nil
+			}
+			return nil, nil
+		}).AnyTimes()
+
+	w := &Worker{
+		pikoci:   svc,
+		jobTopic: topic,
+		logger:   logger,
+	}
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "cancel-loop-job",
+		BuildID:           10,
+	}
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "cancel-loop-job",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "long-task",
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Args:   []string{"60"},
+								Params: map[string]string{"path": "sleep"},
+							},
+						},
+					},
+				},
+				OnCancel: []job.HookStep{},
+				Ensure:   []job.HookStep{},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().StartPendingBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, m.BuildID).
+		Return(&build.Build{ID: 900, BuildNumber: "900", StartedAt: time.Now()}, nil)
+	svc.EXPECT().GetPipelineJob(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName).
+		Return(&pp.Jobs[0], nil)
+
+	// Return Cancelled immediately so the poll triggers cancellation fast
+	svc.EXPECT().GetJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "900").
+		Return(&build.Build{ID: 900, BuildNumber: "900", Status: build.Cancelled}, nil).AnyTimes()
+
+	// Track UpdateJobBuild calls that happen with a cancelled context
+	var cancelledCtxCalls int32
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "900", gomock.Any()).
+		DoAndReturn(func(ctx context.Context, tc, pn, jn string, bID string, b build.Build) error {
+			if ctx.Err() != nil {
+				atomic.AddInt32(&cancelledCtxCalls, 1)
+				return ctx.Err()
+			}
+			return nil
+		}).AnyTimes()
+
+	done := make(chan struct{})
+	go func() {
+		w.processJob(ctx, m, cwd, pp)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("processJob did not finish in time; likely stuck in update loop after cancellation")
+	}
+
+	// No UpdateJobBuild calls should have been made with a cancelled context
+	assert.Equal(t, int32(0), atomic.LoadInt32(&cancelledCtxCalls),
+		"UpdateJobBuild should not be called with a cancelled context")
 }
 
 func TestProcessJob_MissingBuildID(t *testing.T) {


### PR DESCRIPTION
## Summary

- Cancel the main context after workers drain so blocked `sub.Receive()` calls unblock and the process exits cleanly
- Handle context cancellation in `receiveLoop` gracefully when draining (return nil instead of error)
- Store parent server context as `apiCtx` on Worker struct, use it in `updateBuild`/`failBuild` for DB operations that must survive job cancellation but respect server shutdown
- Stop log-streaming ticker goroutine on context cancellation
- Regression test verifying no DB calls happen with a cancelled context after build cancellation

Closes #384
Closes #382