### PR TITLE
Fix triggered resource version appearing at bottom of list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Trigger Resource new version appears at bottom of versions list instead of at top ([#380](https://github.com/PikoCI/pikoci/issues/380))
 - SIGQUIT graceful shutdown hanging forever: cancel the main context after workers drain so blocked Receive() calls unblock and the process exits cleanly ([#384](https://github.com/PikoCI/pikoci/issues/384))
 - Worker stuck in loop after build cancellation: use parent server context for DB operations so writes survive job cancellation but respect server shutdown ([#382](https://github.com/PikoCI/pikoci/issues/382))
 - Follow button: fix race conditions between auto-scroll and scroll listeners, target running step in multi-step builds, and improve visual feedback with "Following"/"Follow" text and solid/outline styles ([#343](https://github.com/PikoCI/pikoci/issues/343))

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -3365,13 +3365,17 @@
         resetVersions: function() {
           this.$('#resource-versions').empty();
           this.collection.each(function(m) {
-            this.addVersion(m);
+            this.addVersion(m, true);
           }, this);
         },
-        addVersion: function(m) {
+        addVersion: function(m, isReset) {
           var isFirst = $('#resource-versions').children().length === 0
           var ver = new app.ResourceVersionView({model: m, isFirst: isFirst})
-          $('#resource-versions').append(ver.render().el);
+          if (isReset) {
+            $('#resource-versions').append(ver.render().el);
+          } else {
+            $('#resource-versions').prepend(ver.render().el);
+          }
         },
         remove: function() {
           clearInterval(this.intervalID)


### PR DESCRIPTION
## Summary

- Fix resource versions appearing at the bottom of the list when triggering a resource (#380)
- Newly polled versions are now prepended to the top; initial load still appends in API order (newest-first)
- Add changelog entry for the fix