### PR TITLE
Fix stale URLs, outdated info, and missing docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Documentation: update stale GitHub/Docker URLs to PikoCI org and GHCR, fix outdated claims, add missing docs for `run`, `export`, `pipelines rename`, `on_cancel` hook, and `/metrics` endpoint ([#388](https://github.com/PikoCI/pikoci/issues/388))
 - Trigger Resource new version appears at bottom of versions list instead of at top ([#380](https://github.com/PikoCI/pikoci/issues/380))
 - SIGQUIT graceful shutdown hanging forever: cancel the main context after workers drain so blocked Receive() calls unblock and the process exits cleanly ([#384](https://github.com/PikoCI/pikoci/issues/384))
 - Worker stuck in loop after build cancellation: use parent server context for DB operations so writes survive job cancellation but respect server shutdown ([#382](https://github.com/PikoCI/pikoci/issues/382))

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -52,7 +52,7 @@ var clientCmd = &cobra.Command{
 }
 
 func init() {
-	clientCmd.PersistentFlags().StringP("url", "u", "localhost:4000", "URL to the PikoCI server")
+	clientCmd.PersistentFlags().StringP("url", "u", "localhost:8080", "URL to the PikoCI server")
 	clientCmd.MarkPersistentFlagRequired("url")
 	clientCmd.PersistentFlags().String("jwt", "", "Provide the JWT to authenticate on the API, if not provided will read it from the FS")
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-PikoCI provides three top-level commands: `server`, `worker`, and `client`, plus utility commands `user-password` and `worker-token`.
+PikoCI provides three top-level commands: `server`, `worker`, and `client`, plus `run` for local execution and utility commands `user-password` and `worker-token`.
 
 ## Global structure
 
@@ -8,6 +8,7 @@ PikoCI provides three top-level commands: `server`, `worker`, and `client`, plus
 pikoci server       [flags]          # Start the server
 pikoci worker       [flags]          # Start a standalone worker
 pikoci client       [flags] <cmd>    # Interact with the API
+pikoci run          [flags]          # Run a pipeline job locally
 pikoci user-password [flags]         # Generate hashed passwords
 pikoci worker-token  [flags]         # Generate a worker authentication token
 ```
@@ -20,7 +21,7 @@ Manage pipelines and jobs via the PikoCI API.
 
 | Flag | Alias | Default | Required | Description |
 |------|-------|---------|----------|-------------|
-| `--url` | `-u` | `localhost:4000` | **yes** | PikoCI server URL |
+| `--url` | `-u` | `localhost:8080` | **yes** | PikoCI server URL |
 | `--jwt` | | | no | JWT token (if not provided, reads from `$XDG_CONFIG_HOME/pikoci/authentication`) |
 
 ### login
@@ -109,6 +110,17 @@ pikoci client -u localhost:8080 pipelines delete -n my-pipeline
 | Flag | Alias | Required | Description |
 |------|-------|----------|-------------|
 | `--name` | `-n`, `-pn` | **yes** | Pipeline name |
+
+#### pipelines rename
+
+```bash
+pikoci client -u localhost:8080 pipelines rename -n my-pipeline --new-name new-pipeline
+```
+
+| Flag | Alias | Required | Description |
+|------|-------|----------|-------------|
+| `--name` | `-n`, `-pn` | **yes** | Current pipeline name |
+| `--new-name` | | **yes** | New name for the pipeline |
 
 ### jobs
 
@@ -387,6 +399,47 @@ pikoci client triggers list --team-canonical main --name my-trigger --after 0
 |------|----------|-------------|
 | `--name` | **yes** | Name of the Trigger |
 | `--after` | no | List triggers after this ID (default: 0) |
+
+### export
+
+Export the full database as a portable SQLite file. Requires admin credentials.
+
+```bash
+pikoci client -u localhost:8080 export -o backup.db
+```
+
+| Flag | Alias | Required | Description |
+|------|-------|----------|-------------|
+| `--output` | `-o` | **yes** | Output file path for the SQLite export |
+
+This is also available via the web UI admin dropdown and as a `GET /admin/export` API endpoint.
+
+## run
+
+Run a pipeline job locally without needing a server. Creates an ephemeral in-memory environment, executes the specified job, streams output, and exits with the job's status code.
+
+```bash
+pikoci run -p pipeline.hcl -j my-job
+```
+
+| Flag | Alias | Default | Required | Description |
+|------|-------|---------|----------|-------------|
+| `--pipeline-config` | `-p` | | **yes** | Path to the pipeline HCL file |
+| `--job` | `-j` | | **yes** | Job name to execute |
+| `--var` | | | no | Variable overrides in `key=value` format (repeatable) |
+| `--vars` | `-v` | | no | Path to a JSON vars file |
+| `--resource` | | | no | Resource overrides in `type.name=path` format (repeatable, e.g. `git.my-repo=./local-dir`) |
+| `--log-level` | | `error` | no | Log level: `debug`, `info`, `warn`, `error` |
+
+### Resource overrides
+
+Use `--resource` to skip cloning and point a resource at a local directory instead:
+
+```bash
+pikoci run -p pipeline.hcl -j test --resource git.my-repo=./
+```
+
+This replaces the `pull` step for that resource with a symlink to the local path, so your task runs against local files.
 
 ## user-password
 

--- a/docs/Concourse.md
+++ b/docs/Concourse.md
@@ -18,7 +18,7 @@ PikoCI's resource model is directly inspired by [Concourse CI](https://concourse
 | Web UI | Built-in UI | Similar functionality. |
 | `passed` constraint | `passed` | Same. Gates a resource version through upstream jobs. |
 | `trigger: true` | `trigger = true` | Same. Auto-triggers the job on new versions. |
-| `on_success` / `on_failure` / `ensure` | Same names | Same semantics. Available on both steps and jobs. |
+| `on_success` / `on_failure` / `on_cancel` / `ensure` | Same names | Same semantics. Available on both steps and jobs. |
 | Webhook triggers | Webhook triggers | Same. `POST /webhooks/<token>` triggers a resource check. |
 | Teams | Teams | Similar. PikoCI has team-based scoping. |
 
@@ -121,7 +121,7 @@ Pipelines use HCL syntax, which supports variables, string interpolation, and is
 
 ## Known gaps vs Concourse
 
-- **No built-in resource registry**: Concourse ships with built-in resource types (git, s3, time, etc.). PikoCI ships only with the `cron` resource type. You define your own resource types in HCL.
+- **No built-in resource registry**: Concourse ships with built-in resource types (git, s3, time, etc.). PikoCI ships with `cron`, `git`, `trigger`, and `github-check` resource types, but does not have the breadth of Concourse's registry. You can define your own resource types in HCL.
 
 ## Migration tips
 
@@ -130,4 +130,4 @@ Pipelines use HCL syntax, which supports variables, string interpolation, and is
 3. Convert your pipeline YAML to HCL, mapping `get`/`task`/`put` steps
 4. Use `variable` blocks for values that were in your Concourse credential manager
 
-A [Concourse pipeline importer](https://github.com/xescugc/pikoci/issues/210) is planned.
+A [Concourse pipeline importer](https://github.com/PikoCI/pikoci/issues/210) is planned.

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -22,7 +22,7 @@ PikoCI is now running on port 8080. That's it for a minimal deploy.
 
 This setup runs PikoCI as a bare binary managed by systemd, with supporting services (Caddy, Prometheus, Grafana, Node Exporter) in Docker Compose. This avoids Docker-in-Docker while keeping infrastructure containerized.
 
-All config files are in the [`deploy/`](https://github.com/xescugc/pikoci/tree/master/deploy) directory.
+All config files are in the [`deploy/`](https://github.com/PikoCI/pikoci/tree/master/deploy) directory.
 
 ### 1. Install PikoCI
 
@@ -34,18 +34,18 @@ GOOS=linux GOARCH=amd64 go build -o pikoci .
 scp pikoci root@your-server:/usr/local/bin/pikoci
 
 # Or download a release
-curl -L https://github.com/xescugc/pikoci/releases/latest/download/linux-amd64 -o /usr/local/bin/pikoci
+curl -L https://github.com/PikoCI/pikoci/releases/latest/download/linux-amd64 -o /usr/local/bin/pikoci
 chmod +x /usr/local/bin/pikoci
 ```
 
 Alternatively, use the Docker image:
 
 ```bash
-docker pull xescugc/pikoci:latest
-docker run -p 8080:8080 xescugc/pikoci:latest server --db-system mem --pubsub-system mem --jwt-secret my-secret --run-worker
+docker pull ghcr.io/pikoci/pikoci:latest
+docker run -p 8080:8080 ghcr.io/pikoci/pikoci:latest server --db-system mem --pubsub-system mem --jwt-secret my-secret --run-worker
 ```
 
-The image is based on Alpine and includes git, jq, curl, openssl, and docker-cli. See the [Dockerfile](https://github.com/xescugc/pikoci/blob/master/Dockerfile) for details.
+The image is based on Alpine and includes git, jq, curl, openssl, and docker-cli. See the [Dockerfile](https://github.com/PikoCI/pikoci/blob/master/Dockerfile) for details.
 
 ### 2. Install prerequisites
 

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -6,24 +6,24 @@ Download the latest release for your platform:
 
 ```bash
 # Linux (amd64)
-curl -L https://github.com/xescugc/pikoci/releases/latest/download/linux-amd64 -o pikoci
+curl -L https://github.com/PikoCI/pikoci/releases/latest/download/linux-amd64 -o pikoci
 chmod +x pikoci
 
 # macOS (amd64)
-curl -L https://github.com/xescugc/pikoci/releases/latest/download/darwin-amd64 -o pikoci
+curl -L https://github.com/PikoCI/pikoci/releases/latest/download/darwin-amd64 -o pikoci
 chmod +x pikoci
 ```
 
 Or pull the Docker image:
 
 ```bash
-docker pull xescugc/pikoci:latest
+docker pull ghcr.io/pikoci/pikoci:latest
 ```
 
 Or build from source:
 
 ```bash
-git clone https://github.com/xescugc/pikoci.git
+git clone https://github.com/PikoCI/pikoci.git
 cd pikoci
 go build -o pikoci .
 ```
@@ -83,7 +83,7 @@ The default user is `admin` / `admin123` (created by the initial database migrat
 
 ## Try with Docker Compose
 
-The [`examples/`](https://github.com/xescugc/pikoci/tree/master/examples) folder contains ready-to-run pipelines. The fastest way to try PikoCI:
+The [`examples/`](https://github.com/PikoCI/pikoci/tree/master/examples) folder contains ready-to-run pipelines. The fastest way to try PikoCI:
 
 ```bash
 cd examples

--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -9,7 +9,7 @@ Declares a pipeline variable. Variables can be referenced as `var.<name>` or `${
 ```hcl
 variable "repo_url" {
   type    = string
-  default = "https://github.com/xescugc/pikoci.git"
+  default = "https://github.com/PikoCI/pikoci.git"
 }
 
 variable "repo_name" {
@@ -348,11 +348,12 @@ An empty body references a top-level `service` block by name. Attributes in the 
 
 ### Step hooks
 
-Each step (and the job itself) can have `on_success`, `on_failure`, and `ensure` blocks:
+Each step (and the job itself) can have `on_success`, `on_failure`, `on_cancel`, and `ensure` blocks:
 
 - `on_success` runs after the step succeeds
 - `on_failure` runs after the step fails
-- `ensure` always runs, regardless of success or failure
+- `on_cancel` runs when the build is cancelled (via UI, CLI, or API)
+- `ensure` always runs, regardless of success, failure, or cancellation
 
 Hooks can contain runner commands or `put` steps:
 
@@ -440,7 +441,7 @@ Using built-in `git` and `docker` (no inline resource_type or runner blocks need
 ```hcl
 variable "repo_url" {
   type    = string
-  default = "https://github.com/xescugc/pikoci.git"
+  default = "https://github.com/PikoCI/pikoci.git"
 }
 
 variable "repo_name" {
@@ -466,7 +467,7 @@ job "test" {
 
   task "run-tests" {
     run "docker" {
-      image = "golang:1.23"
+      image = "golang:1.25"
       cmd   = "cd ${var.repo_name} && make test"
     }
   }

--- a/docs/Queue.md
+++ b/docs/Queue.md
@@ -47,7 +47,7 @@ pikoci worker --pikoci-url http://localhost:8080 --pubsub-system kafka --worker-
 
 ## Planned
 
-AWS SQS and GCP Pub/Sub support is planned. See [#209](https://github.com/xescugc/pikoci/issues/209).
+AWS SQS and GCP Pub/Sub support is planned. See [#209](https://github.com/PikoCI/pikoci/issues/209).
 
 ## Choosing a backend
 

--- a/docs/Resource-Types.md
+++ b/docs/Resource-Types.md
@@ -79,7 +79,7 @@ resource_type "my-git" {
 
 Two URL formats are supported:
 
-- **`pikoci://<name>`** resolves to the PikoCI registry. For shipped built-ins (`git`, `cron`), the embedded definition is used directly (no network call). For other names, fetches from `https://raw.githubusercontent.com/xescugc/pikoci/master/pikoci/builtin/resource_types/<name>.hcl`.
+- **`pikoci://<name>`** resolves to the PikoCI registry. For shipped built-ins (`git`, `cron`), the embedded definition is used directly (no network call). For other names, fetches from `https://raw.githubusercontent.com/PikoCI/pikoci/master/pikoci/builtin/resource_types/<name>.hcl`.
 - **`https://...`** or **`http://...`** fetches HCL from any URL.
 
 When `source` is set, you must not define inline `check`, `pull`, or `push` blocks. PikoCI will error if both are present.
@@ -119,7 +119,7 @@ A resource is an instance of a resource type with concrete parameter values:
 ```hcl
 resource "git" "my_repo" {
   params {
-    url  = "https://github.com/xescugc/pikoci.git"
+    url  = "https://github.com/PikoCI/pikoci.git"
     name = "pikoci"
   }
 }
@@ -180,7 +180,7 @@ The `git` resource type is built in with API-aware check support for GitHub and 
 ```hcl
 resource "git" "my-repo" {
   params {
-    url  = "https://github.com/xescugc/pikoci.git"
+    url  = "https://github.com/PikoCI/pikoci.git"
     name = "pikoci"
   }
 }
@@ -270,7 +270,7 @@ Public repository:
 ```hcl
 resource "git" "my-repo" {
   params {
-    url  = "https://github.com/xescugc/pikoci.git"
+    url  = "https://github.com/PikoCI/pikoci.git"
     name = "pikoci"
   }
 }
@@ -308,7 +308,7 @@ job "ci" {
 
   task "test" {
     run "docker" {
-      image = "golang:1.23"
+      image = "golang:1.25"
       cmd   = "cd my-repo && make test"
     }
   }

--- a/docs/Runners.md
+++ b/docs/Runners.md
@@ -139,7 +139,7 @@ The `docker` runner is built in. It runs commands inside Docker containers:
 ```hcl
 task "test" {
   run "docker" {
-    image = "golang:1.23"
+    image = "golang:1.25"
     cmd   = "make test"
   }
 }
@@ -162,7 +162,7 @@ Use the `args` parameter to pass additional flags to `docker run`:
 ```hcl
 task "test" {
   run "docker" {
-    image = "golang:1.23"
+    image = "golang:1.25"
     cmd   = "make test"
     args  = ["-e", "CI=true", "-e", "FOO=bar"]
   }
@@ -174,7 +174,7 @@ With volumes:
 ```hcl
 task "test" {
   run "docker" {
-    image = "golang:1.23"
+    image = "golang:1.25"
     cmd   = "make test"
     args  = ["-v", "/data:/data"]
   }
@@ -198,7 +198,7 @@ Using HCL functions to build args dynamically:
 ```hcl
 task "test" {
   run "docker" {
-    image = "golang:1.23"
+    image = "golang:1.25"
     cmd   = "make test"
     args  = concat(
       ["-e", "CI=true"],

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -116,6 +116,16 @@ PikoCI supports running multiple server instances concurrently when using Postgr
 
 SQLite and in-memory backends are single-instance only (no locking support).
 
+## Metrics
+
+PikoCI exposes a `/metrics` endpoint in Prometheus format with Go runtime metrics (goroutines, memory, GC), HTTP request counts by status code and method, and HTTP request duration histograms.
+
+```bash
+curl http://localhost:8080/metrics
+```
+
+See [Deployment — Monitoring](Deployment.md#monitoring) for setting up Prometheus and Grafana.
+
 ## Signal handling
 
 PikoCI supports two shutdown modes:

--- a/docs/Variables.md
+++ b/docs/Variables.md
@@ -7,7 +7,7 @@ Pipeline variables let you parameterize your pipeline configuration.
 ```hcl
 variable "repo_url" {
   type    = string
-  default = "https://github.com/xescugc/pikoci.git"
+  default = "https://github.com/PikoCI/pikoci.git"
 }
 
 variable "repo_name" {
@@ -76,7 +76,7 @@ variable "git_token" {
 
 resource "git" "repo" {
   params {
-    url   = "https://github.com/xescugc/pikoci.git"
+    url   = "https://github.com/PikoCI/pikoci.git"
     token = var.git_token  # resolved lazily from vault at runtime
   }
 }
@@ -139,7 +139,7 @@ variable "git_token" {
 resource "git" "app" {
   check_interval = "@every 1m"
   params {
-    url   = "https://github.com/xescugc/pikoci.git"
+    url   = "https://github.com/PikoCI/pikoci.git"
     token = var.git_token
   }
 }

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   pikoci:
-    image: xescugc/pikoci:latest
+    image: ghcr.io/pikoci/pikoci:latest
     ports:
       - "8080:8080"
     volumes:

--- a/examples/go-project/pipeline.hcl
+++ b/examples/go-project/pipeline.hcl
@@ -44,7 +44,7 @@ job "build" {
 
 variable "repo_url" {
   type    = string
-  default = "https://github.com/xescugc/pikoci"
+  default = "https://github.com/PikoCI/pikoci"
 }
 
 variable "repo_name" {


### PR DESCRIPTION
## Summary

- Update all GitHub URLs from `xescugc/pikoci` to `PikoCI/pikoci` across docs and examples
- Update Docker image references from Docker Hub to GHCR (`ghcr.io/pikoci/pikoci`)
- Fix client `--url` default from `localhost:4000` to `localhost:8080`
- Update Concourse guide to list all 4 built-in resource types (was only mentioning `cron`)
- Update `golang:1.23` → `golang:1.25` in code examples
- Add `on_cancel` hook to Pipeline Reference
- Add `pikoci run`, `client export`, `pipelines rename` to CLI Reference
- Add `/metrics` endpoint to Server Configuration
- Add changelog entry

Closes #388