### PR TITLE
Fix drain hanging on SIGQUIT by cancelling receive context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Drain hanging on SIGQUIT: `Drain()` now cancels the receive context immediately so blocked `Receive()` calls unblock without waiting for the drain timeout ([#390](https://github.com/PikoCI/pikoci/issues/390))
 - Documentation: update stale GitHub/Docker URLs to PikoCI org and GHCR, fix outdated claims, add missing docs for `run`, `export`, `pipelines rename`, `on_cancel` hook, and `/metrics` endpoint ([#388](https://github.com/PikoCI/pikoci/issues/388))
 - Trigger Resource new version appears at bottom of versions list instead of at top ([#380](https://github.com/PikoCI/pikoci/issues/380))
 - SIGQUIT graceful shutdown hanging forever: cancel the main context after workers drain so blocked Receive() calls unblock and the process exits cleanly ([#384](https://github.com/PikoCI/pikoci/issues/384))

--- a/worker/service.go
+++ b/worker/service.go
@@ -41,8 +41,9 @@ type Worker struct {
 	jobSubscription   queue.Subscription
 	checkSubscription queue.Subscription
 
-	draining atomic.Bool
-	logger   *slog.Logger
+	draining    atomic.Bool
+	drainCancel context.CancelFunc
+	logger      *slog.Logger
 
 	// apiCtx is the parent server context used for DB operations.
 	// It outlives individual job contexts (which get cancelled on
@@ -70,6 +71,9 @@ func New(s pikoci.Service, jobTopic queue.Topic, jobSub, checkSub queue.Subscrip
 
 func (w *Worker) Drain() {
 	w.draining.Store(true)
+	if w.drainCancel != nil {
+		w.drainCancel()
+	}
 }
 
 func (w *Worker) Run(ctx context.Context) error {
@@ -79,8 +83,11 @@ func (w *Worker) Run(ctx context.Context) error {
 	// job-level cancellation but respect server shutdown.
 	w.apiCtx = ctx
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	// receiveCtx is cancelled on Drain() to unblock Receive() calls
+	// immediately while still allowing in-flight jobs to finish.
+	receiveCtx, receiveCancel := context.WithCancel(ctx)
+	w.drainCancel = receiveCancel
+	defer receiveCancel()
 
 	var wg sync.WaitGroup
 	errs := make(chan error, 2)
@@ -89,7 +96,7 @@ func (w *Worker) Run(ctx context.Context) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if err := w.receiveLoop(ctx, w.jobSubscription, "job"); err != nil {
+			if err := w.receiveLoop(receiveCtx, ctx, w.jobSubscription, "job"); err != nil {
 				errs <- err
 			}
 		}()
@@ -99,7 +106,7 @@ func (w *Worker) Run(ctx context.Context) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if err := w.receiveLoop(ctx, w.checkSubscription, "check"); err != nil {
+			if err := w.receiveLoop(receiveCtx, ctx, w.checkSubscription, "check"); err != nil {
 				errs <- err
 			}
 		}()
@@ -116,15 +123,15 @@ func (w *Worker) Run(ctx context.Context) error {
 	}
 }
 
-func (w *Worker) receiveLoop(ctx context.Context, sub queue.Subscription, kind string) error {
+func (w *Worker) receiveLoop(receiveCtx, processCtx context.Context, sub queue.Subscription, kind string) error {
 	for {
 		if w.draining.Load() {
 			w.logger.Info("Worker draining, stopping message receive", "queue", kind)
 			return nil
 		}
-		msg, err := sub.Receive(ctx)
+		msg, err := sub.Receive(receiveCtx)
 		if err != nil {
-			if ctx.Err() != nil && w.draining.Load() {
+			if w.draining.Load() {
 				w.logger.Info("Worker draining, stopping message receive", "queue", kind)
 				return nil
 			}
@@ -150,7 +157,7 @@ func (w *Worker) receiveLoop(ctx context.Context, sub queue.Subscription, kind s
 			return err
 		}
 
-		w.processMessage(ctx, m, cwd)
+		w.processMessage(processCtx, m, cwd)
 		os.RemoveAll(cwd)
 	}
 }

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -3532,5 +3532,48 @@ func TestRunGetStepLocal_MissingPath(t *testing.T) {
 	assert.Contains(t, b.Steps[0].Logs, "does not exist")
 }
 
+func TestDrain_UnblocksReceiveImmediately(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	svc := mock.NewService(ctrl)
+	jobSub := mock.NewSubscription(ctrl)
+	checkSub := mock.NewSubscription(ctrl)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	w := &Worker{
+		pikoci:            svc,
+		jobSubscription:   jobSub,
+		checkSubscription: checkSub,
+		logger:            logger,
+	}
+
+	// Receive blocks until the context is cancelled (simulating waiting for messages)
+	jobSub.EXPECT().Receive(gomock.Any()).DoAndReturn(func(ctx context.Context) (*pubsub.Message, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}).AnyTimes()
+	checkSub.EXPECT().Receive(gomock.Any()).DoAndReturn(func(ctx context.Context) (*pubsub.Message, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}).AnyTimes()
+
+	ctx := context.Background()
+	done := make(chan error, 1)
+	go func() {
+		done <- w.Run(ctx)
+	}()
+
+	// Give Run() time to start the receive loops
+	time.Sleep(50 * time.Millisecond)
+
+	w.Drain()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Drain() did not unblock Run() within 2 seconds")
+	}
+}
+
 // Silence the unused import warnings
 var _ = time.Now


### PR DESCRIPTION
## Summary

- `Drain()` now cancels the receive context immediately, unblocking `Receive()` calls
- In-flight jobs continue on the parent context until they finish
- Adds regression test verifying `Drain()` unblocks `Run()` within 2 seconds

**Root cause:** `Drain()` only set a boolean flag, but `receiveLoop` was blocked on `sub.Receive(ctx)`. The context wasn't cancelled until the 10m drain timeout, but systemd killed the process at 90s — so every SIGQUIT graceful shutdown was actually a force-kill.

Closes #390
