### PR TITLE
Add lazy loading for builds and resource versions (#345)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Lazy loading (infinite scroll) for job builds and resource versions: only the newest 50 items load initially, with older items fetched on scroll and new items appearing via polling. CLI backward compatibility preserved with `limit=0`. Cursor-based pagination uses `before`/`after`/`limit` query params with `has_more` metadata ([#345](https://github.com/PikoCI/pikoci/issues/345))
+
 ## [0.2.0] - 2026-05-27
 
 ### Added

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -1003,7 +1003,7 @@ var buildsListCmd = &cobra.Command{
 			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
 		}
 
-		builds, err := c.ListJobBuilds(cmd.Context(), tc, pn, jn)
+		builds, _, err := c.ListJobBuilds(cmd.Context(), tc, pn, jn, nil, nil, 0)
 		if err != nil {
 			return fmt.Errorf("failed to list builds for job %q: %w", jn, err)
 		}
@@ -1237,7 +1237,7 @@ var resourcesVersionsCmd = &cobra.Command{
 			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
 		}
 
-		versions, err := c.ListResourceVersions(cmd.Context(), tc, pn, rCan)
+		versions, _, err := c.ListResourceVersions(cmd.Context(), tc, pn, rCan, nil, nil, 0)
 		if err != nil {
 			return fmt.Errorf("failed to list versions for resource %q: %w", rCan, err)
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -277,7 +277,7 @@ func runLocal(ctx context.Context, logger *slog.Logger, pipelineConfig, jobName 
 			// This can happen if context is cancelled
 			return 1, nil
 		case <-ticker.C:
-			builds, err := svc.ListJobBuilds(ctx, mainTeamCanonical, "local", jobName)
+			builds, _, err := svc.ListJobBuilds(ctx, mainTeamCanonical, "local", jobName, nil, nil, 0)
 			if err != nil {
 				continue
 			}

--- a/integration/backends/concurrent_builds_test.go
+++ b/integration/backends/concurrent_builds_test.go
@@ -161,7 +161,7 @@ job "job-c" {
 	for _, jn := range jobs {
 		jn := jn
 		require.Eventually(t, func() bool {
-			builds, err := svc.ListJobBuilds(ctx, "main", "concurrent-test", jn)
+			builds, _, err := svc.ListJobBuilds(ctx, "main", "concurrent-test", jn, nil, nil, 0)
 			if err != nil || len(builds) == 0 {
 				return false
 			}
@@ -171,7 +171,7 @@ job "job-c" {
 
 	// Verify all 3 builds succeeded
 	for _, jn := range jobs {
-		builds, err := svc.ListJobBuilds(ctx, "main", "concurrent-test", jn)
+		builds, _, err := svc.ListJobBuilds(ctx, "main", "concurrent-test", jn, nil, nil, 0)
 		require.NoError(t, err)
 		require.NotEmpty(t, builds, "job %q should have builds", jn)
 		assert.Equal(t, build.Succeeded, builds[0].Status, "job %q build should succeed, error: %s", jn, builds[0].Error)

--- a/integration/backends/db_test.go
+++ b/integration/backends/db_test.go
@@ -172,7 +172,7 @@ func TestDBBackends(t *testing.T) {
 				assert.NotZero(t, vID)
 
 				// Filter versions
-				versions, err := rr.FilterVersions(ctx, "main", "test-pipeline", "git-test-resource")
+				versions, err := rr.FilterVersions(ctx, "main", "test-pipeline", "git-test-resource", nil, nil, 0)
 				require.NoError(t, err)
 				assert.Len(t, versions, 1)
 			})
@@ -189,7 +189,7 @@ func TestDBBackends(t *testing.T) {
 				assert.Equal(t, "1", bn)
 
 				// Filter builds
-				builds, err := br.Filter(ctx, "main", "test-pipeline", "test-job")
+				builds, err := br.Filter(ctx, "main", "test-pipeline", "test-job", nil, nil, 0)
 				require.NoError(t, err)
 				assert.Len(t, builds, 1)
 				assert.Equal(t, build.Started, builds[0].Status)

--- a/integration/backends/export_test.go
+++ b/integration/backends/export_test.go
@@ -125,7 +125,7 @@ job "export-job" {
 
 	// Wait for build to complete
 	require.Eventually(t, func() bool {
-		builds, err := svc.ListJobBuilds(ctx, "main", "export-test", "export-job")
+		builds, _, err := svc.ListJobBuilds(ctx, "main", "export-test", "export-job", nil, nil, 0)
 		if err != nil || len(builds) == 0 {
 			return false
 		}

--- a/integration/backends/secrets_test.go
+++ b/integration/backends/secrets_test.go
@@ -152,7 +152,7 @@ job "deploy" {
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
-			vers, err := svc.ListResourceVersions(ctx, "main", "secrets-e2e", "cron.timer")
+			vers, _, err := svc.ListResourceVersions(ctx, "main", "secrets-e2e", "cron.timer", nil, nil, 0)
 			return err == nil && len(vers) > 1
 		}, 10*time.Second, 200*time.Millisecond)
 
@@ -163,7 +163,7 @@ job "deploy" {
 		// Wait for the build triggered by the resource to finish
 		var builds []*build.Build
 		require.Eventually(t, func() bool {
-			builds, err = svc.ListJobBuilds(ctx, "main", "secrets-e2e", "deploy")
+			builds, _, err = svc.ListJobBuilds(ctx, "main", "secrets-e2e", "deploy", nil, nil, 0)
 			if err != nil || len(builds) == 0 {
 				return false
 			}
@@ -249,7 +249,7 @@ job "deploy" {
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
-			vers, err := svc.ListResourceVersions(ctx, "main", "secrets-file-e2e", "cron.timer")
+			vers, _, err := svc.ListResourceVersions(ctx, "main", "secrets-file-e2e", "cron.timer", nil, nil, 0)
 			return err == nil && len(vers) > 1
 		}, 10*time.Second, 200*time.Millisecond)
 
@@ -260,7 +260,7 @@ job "deploy" {
 		// Wait for the build triggered by the resource to finish
 		var builds []*build.Build
 		require.Eventually(t, func() bool {
-			builds, err = svc.ListJobBuilds(ctx, "main", "secrets-file-e2e", "deploy")
+			builds, _, err = svc.ListJobBuilds(ctx, "main", "secrets-file-e2e", "deploy", nil, nil, 0)
 			if err != nil || len(builds) == 0 {
 				return false
 			}
@@ -363,7 +363,7 @@ job "deploy" {
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
-			vers, err := svc.ListResourceVersions(ctx, "main", "secrets-env-file-e2e", "cron.timer")
+			vers, _, err := svc.ListResourceVersions(ctx, "main", "secrets-env-file-e2e", "cron.timer", nil, nil, 0)
 			return err == nil && len(vers) > 1
 		}, 10*time.Second, 200*time.Millisecond)
 
@@ -374,7 +374,7 @@ job "deploy" {
 		// Wait for the build triggered by the resource to finish
 		var builds []*build.Build
 		require.Eventually(t, func() bool {
-			builds, err = svc.ListJobBuilds(ctx, "main", "secrets-env-file-e2e", "deploy")
+			builds, _, err = svc.ListJobBuilds(ctx, "main", "secrets-env-file-e2e", "deploy", nil, nil, 0)
 			if err != nil || len(builds) == 0 {
 				return false
 			}

--- a/integration/backends/services_test.go
+++ b/integration/backends/services_test.go
@@ -144,7 +144,7 @@ job "use-service" {
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
-			vers, err := svc.ListResourceVersions(ctx, "main", "svc-start-stop-e2e", "cron.timer")
+			vers, _, err := svc.ListResourceVersions(ctx, "main", "svc-start-stop-e2e", "cron.timer", nil, nil, 0)
 			return err == nil && len(vers) > 1
 		}, 10*time.Second, 200*time.Millisecond)
 
@@ -154,7 +154,7 @@ job "use-service" {
 
 		var builds []*build.Build
 		require.Eventually(t, func() bool {
-			builds, err = svc.ListJobBuilds(ctx, "main", "svc-start-stop-e2e", "use-service")
+			builds, _, err = svc.ListJobBuilds(ctx, "main", "svc-start-stop-e2e", "use-service", nil, nil, 0)
 			if err != nil || len(builds) == 0 {
 				return false
 			}
@@ -237,7 +237,7 @@ job "use-slow-service" {
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
-			vers, err := svc.ListResourceVersions(ctx, "main", "svc-timeout-e2e", "cron.timer")
+			vers, _, err := svc.ListResourceVersions(ctx, "main", "svc-timeout-e2e", "cron.timer", nil, nil, 0)
 			return err == nil && len(vers) > 1
 		}, 10*time.Second, 200*time.Millisecond)
 
@@ -249,7 +249,7 @@ job "use-slow-service" {
 		// (stop runs via defer after failBuild, so there's a brief window)
 		var builds []*build.Build
 		require.Eventually(t, func() bool {
-			builds, err = svc.ListJobBuilds(ctx, "main", "svc-timeout-e2e", "use-slow-service")
+			builds, _, err = svc.ListJobBuilds(ctx, "main", "svc-timeout-e2e", "use-slow-service", nil, nil, 0)
 			if err != nil || len(builds) == 0 {
 				return false
 			}
@@ -332,7 +332,7 @@ job "use-param-service" {
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
-			vers, err := svc.ListResourceVersions(ctx, "main", "svc-params-e2e", "cron.timer")
+			vers, _, err := svc.ListResourceVersions(ctx, "main", "svc-params-e2e", "cron.timer", nil, nil, 0)
 			return err == nil && len(vers) > 1
 		}, 10*time.Second, 200*time.Millisecond)
 
@@ -342,7 +342,7 @@ job "use-param-service" {
 
 		var builds []*build.Build
 		require.Eventually(t, func() bool {
-			builds, err = svc.ListJobBuilds(ctx, "main", "svc-params-e2e", "use-param-service")
+			builds, _, err = svc.ListJobBuilds(ctx, "main", "svc-params-e2e", "use-param-service", nil, nil, 0)
 			if err != nil || len(builds) == 0 {
 				return false
 			}
@@ -411,7 +411,7 @@ job "will-fail" {
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
-			vers, err := svc.ListResourceVersions(ctx, "main", "svc-stop-fail-e2e", "cron.timer")
+			vers, _, err := svc.ListResourceVersions(ctx, "main", "svc-stop-fail-e2e", "cron.timer", nil, nil, 0)
 			return err == nil && len(vers) > 1
 		}, 10*time.Second, 200*time.Millisecond)
 
@@ -422,7 +422,7 @@ job "will-fail" {
 		// Wait until the build completes AND the stop step is present
 		var builds []*build.Build
 		require.Eventually(t, func() bool {
-			builds, err = svc.ListJobBuilds(ctx, "main", "svc-stop-fail-e2e", "will-fail")
+			builds, _, err = svc.ListJobBuilds(ctx, "main", "svc-stop-fail-e2e", "will-fail", nil, nil, 0)
 			if err != nil || len(builds) == 0 {
 				return false
 			}

--- a/integration/backends/vault_test.go
+++ b/integration/backends/vault_test.go
@@ -224,14 +224,14 @@ job "deploy" {
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		vers, err := svc.ListResourceVersions(ctx, "main", "vault-e2e", "cron.timer")
+		vers, _, err := svc.ListResourceVersions(ctx, "main", "vault-e2e", "cron.timer", nil, nil, 0)
 		return err == nil && len(vers) > 0
 	}, 10*time.Second, 200*time.Millisecond)
 
 	// Wait for the build to finish
 	var builds []*build.Build
 	require.Eventually(t, func() bool {
-		builds, err = svc.ListJobBuilds(ctx, "main", "vault-e2e", "deploy")
+		builds, _, err = svc.ListJobBuilds(ctx, "main", "vault-e2e", "deploy", nil, nil, 0)
 		if err != nil || len(builds) == 0 {
 			return false
 		}

--- a/pikoci/build/repository.go
+++ b/pikoci/build/repository.go
@@ -11,7 +11,7 @@ type Repository interface {
 	Create(ctx context.Context, tc, pn, jn string, b Build) (uint32, string, error)
 	CreateRetry(ctx context.Context, tc, pn, jn, parentBuildNumber string, b Build) (uint32, string, error)
 	Find(ctx context.Context, tc, pn, jn string, buildNumber string) (*Build, error)
-	Filter(ctx context.Context, tc, pn, jn string) ([]*Build, error)
+	Filter(ctx context.Context, tc, pn, jn string, before *uint32, after *uint32, limit uint32) ([]*Build, error)
 	Update(ctx context.Context, tc, pn, jn string, buildNumber string, b Build) error
 	Delete(ctx context.Context, tc, pn, jn string, buildNumber string) error
 	InsertGetVersion(ctx context.Context, tc, pn, jn string, buildID uint32, stepName string, versionID uint32) error

--- a/pikoci/builds.go
+++ b/pikoci/builds.go
@@ -49,23 +49,37 @@ func (q *PikoCI) CreateJobBuild(ctx context.Context, tc, pc, jn string, b build.
 	return &b, nil
 }
 
-func (q *PikoCI) ListJobBuilds(ctx context.Context, tc, pc, jn string) ([]*build.Build, error) {
+func (q *PikoCI) ListJobBuilds(ctx context.Context, tc, pc, jn string, before *uint32, after *uint32, limit uint32) ([]*build.Build, bool, error) {
 	if !utils.ValidateCanonical(tc) {
-		return nil, fmt.Errorf("invalid Team Canonical format %q", tc)
+		return nil, false, fmt.Errorf("invalid Team Canonical format %q", tc)
 	} else if !utils.ValidateCanonical(pc) {
-		return nil, fmt.Errorf("invalid Pipeline Canonical format %q", pc)
+		return nil, false, fmt.Errorf("invalid Pipeline Canonical format %q", pc)
 	} else if !utils.ValidateCanonical(jn) {
-		return nil, fmt.Errorf("invalid Job Name format %q", jn)
+		return nil, false, fmt.Errorf("invalid Job Name format %q", jn)
 	}
 
-	builds, err := q.Builds.Filter(ctx, tc, pc, jn)
+	fetchLimit := limit
+	if limit > 0 {
+		fetchLimit = limit + 1
+	}
+
+	builds, err := q.Builds.Filter(ctx, tc, pc, jn, before, after, fetchLimit)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list Builds: %w", err)
+		return nil, false, fmt.Errorf("failed to list Builds: %w", err)
 	}
 
-	slices.Reverse(builds)
+	hasMore := false
+	if limit > 0 && uint32(len(builds)) > limit {
+		hasMore = true
+		builds = builds[:limit]
+	}
 
-	return builds, nil
+	// For "after" queries the DB returns ASC order; reverse to newest-first
+	if after != nil {
+		slices.Reverse(builds)
+	}
+
+	return builds, hasMore, nil
 }
 
 func (q *PikoCI) GetJobBuild(ctx context.Context, tc, pc, jn string, buildNumber string) (*build.Build, error) {

--- a/pikoci/builds_test.go
+++ b/pikoci/builds_test.go
@@ -47,18 +47,77 @@ func TestListJobBuilds(t *testing.T) {
 	s := newService(ctrl)
 	ctx := context.TODO()
 
-	// Builds returned in ascending order from DB, reversed by service
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job").Return([]*build.Build{
-		{ID: 1, BuildNumber: "1", Status: build.Succeeded},
+	// limit=0 fetches all, DB returns DESC order
+	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{
 		{ID: 2, BuildNumber: "2", Status: build.Started},
+		{ID: 1, BuildNumber: "1", Status: build.Succeeded},
 	}, nil)
 
-	builds, err := s.S.ListJobBuilds(ctx, "main", "my-pipeline", "my-job")
+	builds, hasMore, err := s.S.ListJobBuilds(ctx, "main", "my-pipeline", "my-job", nil, nil, 0)
 	require.NoError(t, err)
 	require.Len(t, builds, 2)
-	// Should be reversed (newest first)
+	assert.False(t, hasMore)
+	// Newest first
 	assert.Equal(t, uint32(2), builds[0].ID)
 	assert.Equal(t, uint32(1), builds[1].ID)
+}
+
+func TestListJobBuilds_WithLimit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	// DB returns limit+1 items (3) when we ask for limit=2 → hasMore=true
+	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", (*uint32)(nil), (*uint32)(nil), uint32(3)).Return([]*build.Build{
+		{ID: 5, BuildNumber: "5"},
+		{ID: 4, BuildNumber: "4"},
+		{ID: 3, BuildNumber: "3"},
+	}, nil)
+
+	builds, hasMore, err := s.S.ListJobBuilds(ctx, "main", "my-pipeline", "my-job", nil, nil, 2)
+	require.NoError(t, err)
+	require.Len(t, builds, 2)
+	assert.True(t, hasMore)
+	assert.Equal(t, uint32(5), builds[0].ID)
+	assert.Equal(t, uint32(4), builds[1].ID)
+}
+
+func TestListJobBuilds_Before(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	before := uint32(4)
+	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", &before, (*uint32)(nil), uint32(3)).Return([]*build.Build{
+		{ID: 3, BuildNumber: "3"},
+		{ID: 2, BuildNumber: "2"},
+	}, nil)
+
+	builds, hasMore, err := s.S.ListJobBuilds(ctx, "main", "my-pipeline", "my-job", &before, nil, 2)
+	require.NoError(t, err)
+	require.Len(t, builds, 2)
+	assert.False(t, hasMore)
+}
+
+func TestListJobBuilds_After(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	after := uint32(3)
+	// DB returns ASC order for after queries
+	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", (*uint32)(nil), &after, uint32(0)).Return([]*build.Build{
+		{ID: 4, BuildNumber: "4"},
+		{ID: 5, BuildNumber: "5"},
+	}, nil)
+
+	builds, hasMore, err := s.S.ListJobBuilds(ctx, "main", "my-pipeline", "my-job", nil, &after, 0)
+	require.NoError(t, err)
+	require.Len(t, builds, 2)
+	assert.False(t, hasMore)
+	// Should be reversed to newest-first
+	assert.Equal(t, uint32(5), builds[0].ID)
+	assert.Equal(t, uint32(4), builds[1].ID)
 }
 
 func TestUpdateJobBuild(t *testing.T) {

--- a/pikoci/jobs.go
+++ b/pikoci/jobs.go
@@ -34,7 +34,7 @@ func (q *PikoCI) TriggerPipelineJob(ctx context.Context, tc, pc, jn string) erro
 	if len(getSteps) > 0 {
 		g := getSteps[0]
 		rCan := g.ResourceCanonical()
-		vers, err := q.Resources.FilterVersions(ctx, tc, pc, rCan)
+		vers, err := q.Resources.FilterVersions(ctx, tc, pc, rCan, nil, nil, 0)
 		if err == nil && len(vers) > 0 {
 			bb.ResourceCanonical = rCan
 			bb.VersionID = vers[len(vers)-1].ID

--- a/pikoci/jobs_test.go
+++ b/pikoci/jobs_test.go
@@ -109,7 +109,7 @@ func TestTriggerPipelineJob_PinsLatestVersion(t *testing.T) {
 	rCan := j.GetSteps()[0].ResourceCanonical()
 
 	s.Jobs.EXPECT().Find(ctx, tc, ppc, jn).Return(j, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, tc, ppc, rCan).Return(versions, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, tc, ppc, rCan, (*uint32)(nil), (*uint32)(nil), uint32(0)).Return(versions, nil)
 	// TriggerPipelineJob now creates a pending build first
 	s.Builds.EXPECT().Create(ctx, tc, ppc, jn, gomock.Any()).Return(uint32(5), "1", nil)
 

--- a/pikoci/mock/build_repository.go
+++ b/pikoci/mock/build_repository.go
@@ -104,18 +104,18 @@ func (mr *BuildRepositoryMockRecorder) Delete(ctx, tc, pn, jn, buildNumber any) 
 }
 
 // Filter mocks base method.
-func (m *BuildRepository) Filter(ctx context.Context, tc, pn, jn string) ([]*build.Build, error) {
+func (m *BuildRepository) Filter(ctx context.Context, tc, pn, jn string, before, after *uint32, limit uint32) ([]*build.Build, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Filter", ctx, tc, pn, jn)
+	ret := m.ctrl.Call(m, "Filter", ctx, tc, pn, jn, before, after, limit)
 	ret0, _ := ret[0].([]*build.Build)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Filter indicates an expected call of Filter.
-func (mr *BuildRepositoryMockRecorder) Filter(ctx, tc, pn, jn any) *gomock.Call {
+func (mr *BuildRepositoryMockRecorder) Filter(ctx, tc, pn, jn, before, after, limit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Filter", reflect.TypeOf((*BuildRepository)(nil).Filter), ctx, tc, pn, jn)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Filter", reflect.TypeOf((*BuildRepository)(nil).Filter), ctx, tc, pn, jn, before, after, limit)
 }
 
 // Find mocks base method.

--- a/pikoci/mock/resource_repository.go
+++ b/pikoci/mock/resource_repository.go
@@ -116,18 +116,18 @@ func (mr *ResourceRepositoryMockRecorder) FilterDueResources(ctx any) *gomock.Ca
 }
 
 // FilterVersions mocks base method.
-func (m *ResourceRepository) FilterVersions(ctx context.Context, tc, pn, rCan string) ([]*resource.Version, error) {
+func (m *ResourceRepository) FilterVersions(ctx context.Context, tc, pn, rCan string, before, after *uint32, limit uint32) ([]*resource.Version, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FilterVersions", ctx, tc, pn, rCan)
+	ret := m.ctrl.Call(m, "FilterVersions", ctx, tc, pn, rCan, before, after, limit)
 	ret0, _ := ret[0].([]*resource.Version)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FilterVersions indicates an expected call of FilterVersions.
-func (mr *ResourceRepositoryMockRecorder) FilterVersions(ctx, tc, pn, rCan any) *gomock.Call {
+func (mr *ResourceRepositoryMockRecorder) FilterVersions(ctx, tc, pn, rCan, before, after, limit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilterVersions", reflect.TypeOf((*ResourceRepository)(nil).FilterVersions), ctx, tc, pn, rCan)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilterVersions", reflect.TypeOf((*ResourceRepository)(nil).FilterVersions), ctx, tc, pn, rCan, before, after, limit)
 }
 
 // Find mocks base method.

--- a/pikoci/mock/service.go
+++ b/pikoci/mock/service.go
@@ -490,18 +490,19 @@ func (mr *ServiceMockRecorder) InsertBuildGetVersion(ctx, tc, pn, jn, buildID, s
 }
 
 // ListJobBuilds mocks base method.
-func (m *Service) ListJobBuilds(ctx context.Context, tc, pn, jn string) ([]*build.Build, error) {
+func (m *Service) ListJobBuilds(ctx context.Context, tc, pn, jn string, before, after *uint32, limit uint32) ([]*build.Build, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListJobBuilds", ctx, tc, pn, jn)
+	ret := m.ctrl.Call(m, "ListJobBuilds", ctx, tc, pn, jn, before, after, limit)
 	ret0, _ := ret[0].([]*build.Build)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // ListJobBuilds indicates an expected call of ListJobBuilds.
-func (mr *ServiceMockRecorder) ListJobBuilds(ctx, tc, pn, jn any) *gomock.Call {
+func (mr *ServiceMockRecorder) ListJobBuilds(ctx, tc, pn, jn, before, after, limit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobBuilds", reflect.TypeOf((*Service)(nil).ListJobBuilds), ctx, tc, pn, jn)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobBuilds", reflect.TypeOf((*Service)(nil).ListJobBuilds), ctx, tc, pn, jn, before, after, limit)
 }
 
 // ListPipelines mocks base method.
@@ -520,48 +521,51 @@ func (mr *ServiceMockRecorder) ListPipelines(ctx, tc any) *gomock.Call {
 }
 
 // ListPublicJobBuilds mocks base method.
-func (m *Service) ListPublicJobBuilds(ctx context.Context, tc, pn, jn string) ([]*build.Build, error) {
+func (m *Service) ListPublicJobBuilds(ctx context.Context, tc, pn, jn string, before, after *uint32, limit uint32) ([]*build.Build, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListPublicJobBuilds", ctx, tc, pn, jn)
+	ret := m.ctrl.Call(m, "ListPublicJobBuilds", ctx, tc, pn, jn, before, after, limit)
 	ret0, _ := ret[0].([]*build.Build)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // ListPublicJobBuilds indicates an expected call of ListPublicJobBuilds.
-func (mr *ServiceMockRecorder) ListPublicJobBuilds(ctx, tc, pn, jn any) *gomock.Call {
+func (mr *ServiceMockRecorder) ListPublicJobBuilds(ctx, tc, pn, jn, before, after, limit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPublicJobBuilds", reflect.TypeOf((*Service)(nil).ListPublicJobBuilds), ctx, tc, pn, jn)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPublicJobBuilds", reflect.TypeOf((*Service)(nil).ListPublicJobBuilds), ctx, tc, pn, jn, before, after, limit)
 }
 
 // ListPublicResourceVersions mocks base method.
-func (m *Service) ListPublicResourceVersions(ctx context.Context, tc, pn, rCan string) ([]*resource.Version, error) {
+func (m *Service) ListPublicResourceVersions(ctx context.Context, tc, pn, rCan string, before, after *uint32, limit uint32) ([]*resource.Version, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListPublicResourceVersions", ctx, tc, pn, rCan)
+	ret := m.ctrl.Call(m, "ListPublicResourceVersions", ctx, tc, pn, rCan, before, after, limit)
 	ret0, _ := ret[0].([]*resource.Version)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // ListPublicResourceVersions indicates an expected call of ListPublicResourceVersions.
-func (mr *ServiceMockRecorder) ListPublicResourceVersions(ctx, tc, pn, rCan any) *gomock.Call {
+func (mr *ServiceMockRecorder) ListPublicResourceVersions(ctx, tc, pn, rCan, before, after, limit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPublicResourceVersions", reflect.TypeOf((*Service)(nil).ListPublicResourceVersions), ctx, tc, pn, rCan)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPublicResourceVersions", reflect.TypeOf((*Service)(nil).ListPublicResourceVersions), ctx, tc, pn, rCan, before, after, limit)
 }
 
 // ListResourceVersions mocks base method.
-func (m *Service) ListResourceVersions(ctx context.Context, tc, pn, rCan string) ([]*resource.Version, error) {
+func (m *Service) ListResourceVersions(ctx context.Context, tc, pn, rCan string, before, after *uint32, limit uint32) ([]*resource.Version, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListResourceVersions", ctx, tc, pn, rCan)
+	ret := m.ctrl.Call(m, "ListResourceVersions", ctx, tc, pn, rCan, before, after, limit)
 	ret0, _ := ret[0].([]*resource.Version)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // ListResourceVersions indicates an expected call of ListResourceVersions.
-func (mr *ServiceMockRecorder) ListResourceVersions(ctx, tc, pn, rCan any) *gomock.Call {
+func (mr *ServiceMockRecorder) ListResourceVersions(ctx, tc, pn, rCan, before, after, limit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourceVersions", reflect.TypeOf((*Service)(nil).ListResourceVersions), ctx, tc, pn, rCan)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourceVersions", reflect.TypeOf((*Service)(nil).ListResourceVersions), ctx, tc, pn, rCan, before, after, limit)
 }
 
 // ListTeams mocks base method.

--- a/pikoci/mysql/build.go
+++ b/pikoci/mysql/build.go
@@ -241,8 +241,8 @@ func (r *BuildRepository) Find(ctx context.Context, tc, pn, jn string, buildNumb
 	return j, nil
 }
 
-func (r *BuildRepository) Filter(ctx context.Context, tc, pn, jn string) ([]*build.Build, error) {
-	rows, err := r.querier.QueryContext(ctx, `
+func (r *BuildRepository) Filter(ctx context.Context, tc, pn, jn string, before *uint32, after *uint32, limit uint32) ([]*build.Build, error) {
+	query := `
 		SELECT b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical
 		FROM builds AS b
 		JOIN jobs AS j
@@ -251,9 +251,29 @@ func (r *BuildRepository) Filter(ctx context.Context, tc, pn, jn string) ([]*bui
 			ON j.pipeline_id = p.id
 		JOIN teams AS t
 			ON p.team_id = t.id
-		WHERE t.canonical = ? AND p.canonical = ? AND j.name = ?
-		ORDER BY b.id ASC
-	`, tc, pn, jn)
+		WHERE t.canonical = ? AND p.canonical = ? AND j.name = ?`
+	args := []interface{}{tc, pn, jn}
+
+	if after != nil {
+		query += ` AND b.id > ?`
+		args = append(args, *after)
+		query += ` ORDER BY b.id ASC`
+	} else if before != nil {
+		query += ` AND b.id < ?`
+		args = append(args, *before)
+		query += ` ORDER BY b.id DESC`
+		if limit > 0 {
+			query += fmt.Sprintf(` LIMIT %d`, limit)
+		}
+	} else {
+		// Initial load or limit=0 (all)
+		query += ` ORDER BY b.id DESC`
+		if limit > 0 {
+			query += fmt.Sprintf(` LIMIT %d`, limit)
+		}
+	}
+
+	rows, err := r.querier.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to filter builds: %w", err)
 	}

--- a/pikoci/mysql/resource.go
+++ b/pikoci/mysql/resource.go
@@ -306,8 +306,8 @@ func (r *ResourceRepository) CreateVersion(ctx context.Context, tc, pn, rCan str
 	return id, nil
 }
 
-func (r *ResourceRepository) FilterVersions(ctx context.Context, tc, pn, rCan string) ([]*resource.Version, error) {
-	rows, err := r.querier.QueryContext(ctx, `
+func (r *ResourceRepository) FilterVersions(ctx context.Context, tc, pn, rCan string, before *uint32, after *uint32, limit uint32) ([]*resource.Version, error) {
+	query := `
 		SELECT rv.id, rv.version
 		FROM resource_versions AS rv
 		JOIN resources AS r
@@ -316,9 +316,29 @@ func (r *ResourceRepository) FilterVersions(ctx context.Context, tc, pn, rCan st
 			ON r.pipeline_id = p.id
 		JOIN teams AS t
 			ON p.team_id = t.id
-		WHERE t.canonical = ? AND p.canonical = ? AND r.canonical = ?
-		ORDER BY rv.id ASC
-	`, tc, pn, rCan)
+		WHERE t.canonical = ? AND p.canonical = ? AND r.canonical = ?`
+	args := []interface{}{tc, pn, rCan}
+
+	if after != nil {
+		query += ` AND rv.id > ?`
+		args = append(args, *after)
+		query += ` ORDER BY rv.id ASC`
+	} else if before != nil {
+		query += ` AND rv.id < ?`
+		args = append(args, *before)
+		query += ` ORDER BY rv.id DESC`
+		if limit > 0 {
+			query += fmt.Sprintf(` LIMIT %d`, limit)
+		}
+	} else {
+		// Initial load or limit=0 (all)
+		query += ` ORDER BY rv.id DESC`
+		if limit > 0 {
+			query += fmt.Sprintf(` LIMIT %d`, limit)
+		}
+	}
+
+	rows, err := r.querier.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to filter Resources: %w", err)
 	}

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -481,7 +481,7 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 
 	// Print all the Jobs and the connection to resources
 	for i, j := range pp.Jobs {
-		builds, err := q.Builds.Filter(ctx, tc, pp.Canonical, j.Name)
+		builds, err := q.Builds.Filter(ctx, tc, pp.Canonical, j.Name, nil, nil, 0)
 		if err != nil {
 			return nil, fmt.Errorf("failed to filter builds from Job %q: %w", j.Name, err)
 		}
@@ -758,15 +758,15 @@ func (q *PikoCI) GetPublicPipelineJob(ctx context.Context, tc, pCan, jn string) 
 	return q.GetPipelineJob(ctx, tc, pCan, jn)
 }
 
-func (q *PikoCI) ListPublicJobBuilds(ctx context.Context, tc, pCan, jn string) ([]*build.Build, error) {
+func (q *PikoCI) ListPublicJobBuilds(ctx context.Context, tc, pCan, jn string, before *uint32, after *uint32, limit uint32) ([]*build.Build, bool, error) {
 	_, err := q.Pipelines.FindPublic(ctx, tc, pCan)
 	if err != nil {
-		return nil, fmt.Errorf("pipeline not found or not public: %w", err)
+		return nil, false, fmt.Errorf("pipeline not found or not public: %w", err)
 	}
 
-	builds, err := q.ListJobBuilds(ctx, tc, pCan, jn)
+	builds, hasMore, err := q.ListJobBuilds(ctx, tc, pCan, jn, before, after, limit)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	for _, b := range builds {
 		for i, s := range b.Steps {
@@ -775,7 +775,7 @@ func (q *PikoCI) ListPublicJobBuilds(ctx context.Context, tc, pCan, jn string) (
 			}
 		}
 	}
-	return builds, nil
+	return builds, hasMore, nil
 }
 
 func (q *PikoCI) GetPublicPipelineResource(ctx context.Context, tc, pCan, rCan string) (*resource.Resource, error) {
@@ -793,13 +793,13 @@ func (q *PikoCI) GetPublicPipelineResource(ctx context.Context, tc, pCan, rCan s
 	return &sr, nil
 }
 
-func (q *PikoCI) ListPublicResourceVersions(ctx context.Context, tc, pCan, rCan string) ([]*resource.Version, error) {
+func (q *PikoCI) ListPublicResourceVersions(ctx context.Context, tc, pCan, rCan string, before *uint32, after *uint32, limit uint32) ([]*resource.Version, bool, error) {
 	_, err := q.Pipelines.FindPublic(ctx, tc, pCan)
 	if err != nil {
-		return nil, fmt.Errorf("pipeline not found or not public: %w", err)
+		return nil, false, fmt.Errorf("pipeline not found or not public: %w", err)
 	}
 
-	return q.ListResourceVersions(ctx, tc, pCan, rCan)
+	return q.ListResourceVersions(ctx, tc, pCan, rCan, before, after, limit)
 }
 
 func (q *PikoCI) DeletePipeline(ctx context.Context, tc, pCan string) error {

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -1341,7 +1341,7 @@ func TestGetPipelineImage_HidesUnlinkedResources(t *testing.T) {
 	}
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "build").Return([]*build.Build{}, nil)
+	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "build", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot")
 	require.NoError(t, err)
@@ -1390,7 +1390,7 @@ func TestGetPipelineImage_QuotesHyphenatedName(t *testing.T) {
 	}
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "hello-world").Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "hello-world", "hello").Return([]*build.Build{}, nil)
+	s.Builds.EXPECT().Filter(ctx, "main", "hello-world", "hello", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "hello-world", "dot")
 	require.NoError(t, err)
@@ -1433,7 +1433,7 @@ func TestGetPipelineImage_ShowsLinkedResources(t *testing.T) {
 	}
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "test").Return([]*build.Build{}, nil)
+	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "test", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot")
 	require.NoError(t, err)
@@ -1595,7 +1595,7 @@ func TestGetPipelineImage_JobStatusColors(t *testing.T) {
 
 			pp := makePipeline()
 			s.Pipelines.EXPECT().Find(ctx, "main", "p").Return(pp, nil)
-			s.Builds.EXPECT().Filter(ctx, "main", "p", "j").Return(tt.builds, nil)
+			s.Builds.EXPECT().Filter(ctx, "main", "p", "j", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return(tt.builds, nil)
 
 			img, err := s.S.GetPipelineImage(ctx, "main", "p", "dot")
 			require.NoError(t, err)

--- a/pikoci/resource/repository.go
+++ b/pikoci/resource/repository.go
@@ -14,7 +14,7 @@ type Repository interface {
 	Delete(ctx context.Context, tc, pn, rCan string) error
 
 	CreateVersion(ctx context.Context, tc, pn, rCan string, v Version) (uint32, error)
-	FilterVersions(ctx context.Context, tc, pn, rCan string) ([]*Version, error)
+	FilterVersions(ctx context.Context, tc, pn, rCan string, before *uint32, after *uint32, limit uint32) ([]*Version, error)
 }
 
 type ResourceWithPipeline struct {

--- a/pikoci/resources.go
+++ b/pikoci/resources.go
@@ -34,23 +34,37 @@ func (q *PikoCI) CreateResourceVersion(ctx context.Context, tc, pc, rCan string,
 	return &v, nil
 }
 
-func (q *PikoCI) ListResourceVersions(ctx context.Context, tc, pc, rCan string) ([]*resource.Version, error) {
+func (q *PikoCI) ListResourceVersions(ctx context.Context, tc, pc, rCan string, before *uint32, after *uint32, limit uint32) ([]*resource.Version, bool, error) {
 	if !utils.ValidateCanonical(tc) {
-		return nil, fmt.Errorf("invalid Team Canonical format %q", tc)
+		return nil, false, fmt.Errorf("invalid Team Canonical format %q", tc)
 	} else if !utils.ValidateCanonical(pc) {
-		return nil, fmt.Errorf("invalid Pipeline Canonical format %q", pc)
+		return nil, false, fmt.Errorf("invalid Pipeline Canonical format %q", pc)
 	} else if !utils.ValidateResourceCanonical(rCan) {
-		return nil, fmt.Errorf("invalid Resource Canonical format %q", rCan)
+		return nil, false, fmt.Errorf("invalid Resource Canonical format %q", rCan)
 	}
 
-	rvers, err := q.Resources.FilterVersions(ctx, tc, pc, rCan)
+	fetchLimit := limit
+	if limit > 0 {
+		fetchLimit = limit + 1
+	}
+
+	rvers, err := q.Resources.FilterVersions(ctx, tc, pc, rCan, before, after, fetchLimit)
 	if err != nil {
-		return nil, fmt.Errorf("failed to List Resource Version: %w", err)
+		return nil, false, fmt.Errorf("failed to List Resource Version: %w", err)
 	}
 
-	slices.Reverse(rvers)
+	hasMore := false
+	if limit > 0 && uint32(len(rvers)) > limit {
+		hasMore = true
+		rvers = rvers[:limit]
+	}
 
-	return rvers, nil
+	// For "after" queries the DB returns ASC order; reverse to newest-first
+	if after != nil {
+		slices.Reverse(rvers)
+	}
+
+	return rvers, hasMore, nil
 }
 
 func (q *PikoCI) GetPipelineResource(ctx context.Context, tc, pc, rCan string) (*resource.Resource, error) {

--- a/pikoci/resources_test.go
+++ b/pikoci/resources_test.go
@@ -47,17 +47,56 @@ func TestListResourceVersions(t *testing.T) {
 	s := newService(ctrl)
 	ctx := context.TODO()
 
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "git.repo").Return([]*resource.Version{
-		{ID: 1},
+	// limit=0 fetches all, DB returns DESC order
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "git.repo", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*resource.Version{
 		{ID: 2},
+		{ID: 1},
 	}, nil)
 
-	vers, err := s.S.ListResourceVersions(ctx, "main", "my-pipeline", "git.repo")
+	vers, hasMore, err := s.S.ListResourceVersions(ctx, "main", "my-pipeline", "git.repo", nil, nil, 0)
 	require.NoError(t, err)
 	require.Len(t, vers, 2)
-	// Should be reversed
+	assert.False(t, hasMore)
+	// Newest first
 	assert.Equal(t, uint32(2), vers[0].ID)
 	assert.Equal(t, uint32(1), vers[1].ID)
+}
+
+func TestListResourceVersions_WithLimit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "git.repo", (*uint32)(nil), (*uint32)(nil), uint32(3)).Return([]*resource.Version{
+		{ID: 5},
+		{ID: 4},
+		{ID: 3},
+	}, nil)
+
+	vers, hasMore, err := s.S.ListResourceVersions(ctx, "main", "my-pipeline", "git.repo", nil, nil, 2)
+	require.NoError(t, err)
+	require.Len(t, vers, 2)
+	assert.True(t, hasMore)
+}
+
+func TestListResourceVersions_After(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	after := uint32(3)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "git.repo", (*uint32)(nil), &after, uint32(0)).Return([]*resource.Version{
+		{ID: 4},
+		{ID: 5},
+	}, nil)
+
+	vers, hasMore, err := s.S.ListResourceVersions(ctx, "main", "my-pipeline", "git.repo", nil, &after, 0)
+	require.NoError(t, err)
+	require.Len(t, vers, 2)
+	assert.False(t, hasMore)
+	// Reversed to newest-first
+	assert.Equal(t, uint32(5), vers[0].ID)
+	assert.Equal(t, uint32(4), vers[1].ID)
 }
 
 func TestGetPipelineResource(t *testing.T) {

--- a/pikoci/service.go
+++ b/pikoci/service.go
@@ -55,9 +55,9 @@ type Service interface {
 	GetPublicPipeline(ctx context.Context, tc, pn string) (*pipeline.Pipeline, error)
 	GetPublicPipelineImage(ctx context.Context, tc, pn, format string) ([]byte, error)
 	GetPublicPipelineJob(ctx context.Context, tc, pn, jn string) (*job.Job, error)
-	ListPublicJobBuilds(ctx context.Context, tc, pn, jn string) ([]*build.Build, error)
+	ListPublicJobBuilds(ctx context.Context, tc, pn, jn string, before *uint32, after *uint32, limit uint32) ([]*build.Build, bool, error)
 	GetPublicPipelineResource(ctx context.Context, tc, pn, rCan string) (*resource.Resource, error)
-	ListPublicResourceVersions(ctx context.Context, tc, pn, rCan string) ([]*resource.Version, error)
+	ListPublicResourceVersions(ctx context.Context, tc, pn, rCan string, before *uint32, after *uint32, limit uint32) ([]*resource.Version, bool, error)
 
 	GetPipelineImage(ctx context.Context, tc, pn, format string) ([]byte, error)
 	CreatePipelineImage(ctx context.Context, tc string, pp []byte, vars map[string]interface{}, format string) ([]byte, error)
@@ -69,7 +69,7 @@ type Service interface {
 	CreateRetryJobBuild(ctx context.Context, tc, pn, jn, parentBuildNumber string, b build.Build) (*build.Build, error)
 	UpdateJobBuild(ctx context.Context, tc, pn, jn string, buildNumber string, b build.Build) error
 	DeleteJobBuild(ctx context.Context, tc, pn, jn string, buildNumber string) error
-	ListJobBuilds(ctx context.Context, tc, pn, jn string) ([]*build.Build, error)
+	ListJobBuilds(ctx context.Context, tc, pn, jn string, before *uint32, after *uint32, limit uint32) ([]*build.Build, bool, error)
 	GetJobBuild(ctx context.Context, tc, pn, jn string, buildNumber string) (*build.Build, error)
 	CancelJobBuild(ctx context.Context, tc, pn, jn string, buildNumber string) error
 	RetryJobBuild(ctx context.Context, tc, pn, jn, buildNumber string) error
@@ -82,7 +82,7 @@ type Service interface {
 	UpdatePipelineResource(ctx context.Context, tc, pn, rCan string, r resource.Resource) error
 	TriggerPipelineResource(ctx context.Context, tc, pn, rCan string) error
 	CreateResourceVersion(ctx context.Context, tc, pn, rCan string, v resource.Version) (*resource.Version, error)
-	ListResourceVersions(ctx context.Context, tc, pn, rCan string) ([]*resource.Version, error)
+	ListResourceVersions(ctx context.Context, tc, pn, rCan string, before *uint32, after *uint32, limit uint32) ([]*resource.Version, bool, error)
 
 	InsertBuildGetVersion(ctx context.Context, tc, pn, jn string, buildID uint32, stepName string, versionID uint32) error
 

--- a/pikoci/transport/http/builds.go
+++ b/pikoci/transport/http/builds.go
@@ -329,12 +329,46 @@ type ListJobBuildsRequest struct {
 	PipelineCanonical string `json:"pipeline_canonical"`
 	JobName           string `json:"job_name"`
 }
+
+type PageMeta struct {
+	HasMore  bool   `json:"has_more"`
+	OldestID uint32 `json:"oldest_id"`
+	NewestID uint32 `json:"newest_id"`
+}
+
 type ListJobBuildsResponse struct {
 	Builds []*build.Build `json:"data,omitempty"`
+	Meta   *PageMeta      `json:"meta,omitempty"`
 	Err    string         `json:"error,omitempty"`
 }
 
 func (r ListJobBuildsResponse) Error() string { return r.Err }
+
+func parsePaginationParams(r *http.Request) (before *uint32, after *uint32, limit uint32) {
+	limit = 50
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.ParseUint(v, 10, 32); err == nil {
+			limit = uint32(n)
+		}
+	}
+	if v := r.URL.Query().Get("before"); v != "" {
+		if n, err := strconv.ParseUint(v, 10, 32); err == nil {
+			val := uint32(n)
+			before = &val
+		}
+	}
+	if v := r.URL.Query().Get("after"); v != "" {
+		if n, err := strconv.ParseUint(v, 10, 32); err == nil {
+			val := uint32(n)
+			after = &val
+		}
+	}
+	// before and after are mutually exclusive; before takes precedence
+	if before != nil && after != nil {
+		after = nil
+	}
+	return
+}
 
 func listJobBuilds(s pikoci.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -346,17 +380,29 @@ func listJobBuilds(s pikoci.Service) http.HandlerFunc {
 		req.TeamCanonical = vars["team_canonical"]
 		req.PipelineCanonical = vars["pipeline_canonical"]
 		req.JobName = vars["job_name"]
+
+		before, after, limit := parsePaginationParams(r)
+
 		var builds []*build.Build
+		var hasMore bool
 		var err error
 		if isPublic, _ := ctx.Value(IsPublicAccessKey).(bool); isPublic {
-			builds, err = s.ListPublicJobBuilds(ctx, req.TeamCanonical, req.PipelineCanonical, req.JobName)
+			builds, hasMore, err = s.ListPublicJobBuilds(ctx, req.TeamCanonical, req.PipelineCanonical, req.JobName, before, after, limit)
 		} else {
-			builds, err = s.ListJobBuilds(ctx, req.TeamCanonical, req.PipelineCanonical, req.JobName)
+			builds, hasMore, err = s.ListJobBuilds(ctx, req.TeamCanonical, req.PipelineCanonical, req.JobName, before, after, limit)
 		}
 		var errs string
 		if err != nil {
 			errs = err.Error()
 		}
-		encodeResponse(ListJobBuildsResponse{Builds: builds, Err: errs}, w)
+		var meta *PageMeta
+		if len(builds) > 0 {
+			meta = &PageMeta{
+				HasMore:  hasMore,
+				OldestID: builds[len(builds)-1].ID,
+				NewestID: builds[0].ID,
+			}
+		}
+		encodeResponse(ListJobBuildsResponse{Builds: builds, Meta: meta, Err: errs}, w)
 	}
 }

--- a/pikoci/transport/http/client/client.go
+++ b/pikoci/transport/http/client/client.go
@@ -382,16 +382,16 @@ func (cl *Client) GetPublicPipelineJob(ctx context.Context, tc, pn, jn string) (
 	return cl.GetPipelineJob(ctx, tc, pn, jn)
 }
 
-func (cl *Client) ListPublicJobBuilds(ctx context.Context, tc, pn, jn string) ([]*build.Build, error) {
-	return cl.ListJobBuilds(ctx, tc, pn, jn)
+func (cl *Client) ListPublicJobBuilds(ctx context.Context, tc, pn, jn string, before *uint32, after *uint32, limit uint32) ([]*build.Build, bool, error) {
+	return cl.ListJobBuilds(ctx, tc, pn, jn, before, after, limit)
 }
 
 func (cl *Client) GetPublicPipelineResource(ctx context.Context, tc, pn, rCan string) (*resource.Resource, error) {
 	return cl.GetPipelineResource(ctx, tc, pn, rCan)
 }
 
-func (cl *Client) ListPublicResourceVersions(ctx context.Context, tc, pn, rCan string) ([]*resource.Version, error) {
-	return cl.ListResourceVersions(ctx, tc, pn, rCan)
+func (cl *Client) ListPublicResourceVersions(ctx context.Context, tc, pn, rCan string, before *uint32, after *uint32, limit uint32) ([]*resource.Version, bool, error) {
+	return cl.ListResourceVersions(ctx, tc, pn, rCan, before, after, limit)
 }
 
 func (cl *Client) UpdatePipeline(ctx context.Context, tc, pn string, pp []byte, vars map[string]interface{}, newName ...string) (*pipeline.Pipeline, error) {
@@ -715,19 +715,26 @@ func (cl *Client) FindOldestPendingBuild(ctx context.Context, tc, pn, jn string)
 	return resp.Build, nil
 }
 
-func (cl *Client) ListJobBuilds(ctx context.Context, tc, pn, jn string) ([]*build.Build, error) {
+// ListJobBuilds always fetches all builds (limit=0) for CLI backward compat.
+// The before/after/limit params satisfy the Service interface but are not sent.
+func (cl *Client) ListJobBuilds(ctx context.Context, tc, pn, jn string, before *uint32, after *uint32, limit uint32) ([]*build.Build, bool, error) {
 	var resp thttp.ListJobBuildsResponse
 
-	err := cl.Request(ctx, http.MethodGet, fmt.Sprintf("%s/teams/%s/pipelines/%s/jobs/%s/builds", cl.url, tc, pn, jn), nil, &resp)
+	err := cl.Request(ctx, http.MethodGet, fmt.Sprintf("%s/teams/%s/pipelines/%s/jobs/%s/builds?limit=0", cl.url, tc, pn, jn), nil, &resp)
 	if err != nil {
-		return nil, fmt.Errorf("failed to make request: %w", err)
+		return nil, false, fmt.Errorf("failed to make request: %w", err)
 	}
 
 	if resp.Err != "" {
-		return nil, fmt.Errorf("error from request: %s", resp.Err)
+		return nil, false, fmt.Errorf("error from request: %s", resp.Err)
 	}
 
-	return resp.Builds, nil
+	hasMore := false
+	if resp.Meta != nil {
+		hasMore = resp.Meta.HasMore
+	}
+
+	return resp.Builds, hasMore, nil
 }
 
 func (cl *Client) CreateResourceVersion(ctx context.Context, tc, pn, rCan string, rv resource.Version) (*resource.Version, error) {
@@ -747,19 +754,26 @@ func (cl *Client) CreateResourceVersion(ctx context.Context, tc, pn, rCan string
 	return resp.Version, nil
 }
 
-func (cl *Client) ListResourceVersions(ctx context.Context, tc, pn, rCan string) ([]*resource.Version, error) {
+// ListResourceVersions always fetches all versions (limit=0) for CLI backward compat.
+// The before/after/limit params satisfy the Service interface but are not sent.
+func (cl *Client) ListResourceVersions(ctx context.Context, tc, pn, rCan string, before *uint32, after *uint32, limit uint32) ([]*resource.Version, bool, error) {
 	var resp thttp.ListResourceVersionsResponse
 
-	err := cl.Request(ctx, http.MethodGet, fmt.Sprintf("%s/teams/%s/pipelines/%s/resources/%s/versions", cl.url, tc, pn, rCan), nil, &resp)
+	err := cl.Request(ctx, http.MethodGet, fmt.Sprintf("%s/teams/%s/pipelines/%s/resources/%s/versions?limit=0", cl.url, tc, pn, rCan), nil, &resp)
 	if err != nil {
-		return nil, fmt.Errorf("failed to make request: %w", err)
+		return nil, false, fmt.Errorf("failed to make request: %w", err)
 	}
 
 	if resp.Err != "" {
-		return nil, fmt.Errorf("error from request: %s", resp.Err)
+		return nil, false, fmt.Errorf("error from request: %s", resp.Err)
 	}
 
-	return resp.Versions, nil
+	hasMore := false
+	if resp.Meta != nil {
+		hasMore = resp.Meta.HasMore
+	}
+
+	return resp.Versions, hasMore, nil
 }
 
 func (cl *Client) GetPipelineResource(ctx context.Context, tc, pn, rCan string) (*resource.Resource, error) {

--- a/pikoci/transport/http/client/client_test.go
+++ b/pikoci/transport/http/client/client_test.go
@@ -561,7 +561,7 @@ func TestListJobBuilds(t *testing.T) {
 	c, err := client.New(ts.URL, "jwt")
 	require.NoError(t, err)
 
-	builds, err := c.ListJobBuilds(context.Background(), "team", "pipe", "job1")
+	builds, _, err := c.ListJobBuilds(context.Background(), "team", "pipe", "job1", nil, nil, 0)
 	require.NoError(t, err)
 	assert.Len(t, builds, 2)
 }
@@ -674,7 +674,7 @@ func TestListResourceVersions(t *testing.T) {
 	c, err := client.New(ts.URL, "jwt")
 	require.NoError(t, err)
 
-	versions, err := c.ListResourceVersions(context.Background(), "team", "pipe", "res1")
+	versions, _, err := c.ListResourceVersions(context.Background(), "team", "pipe", "res1", nil, nil, 0)
 	require.NoError(t, err)
 	assert.Len(t, versions, 1)
 }

--- a/pikoci/transport/http/resources.go
+++ b/pikoci/transport/http/resources.go
@@ -53,6 +53,7 @@ type ListResourceVersionsRequest struct {
 }
 type ListResourceVersionsResponse struct {
 	Versions []*resource.Version `json:"data,omitempty"`
+	Meta     *PageMeta           `json:"meta,omitempty"`
 	Err      string              `json:"error,omitempty"`
 }
 
@@ -68,18 +69,30 @@ func listResourceVersions(s pikoci.Service) http.HandlerFunc {
 		req.TeamCanonical = vars["team_canonical"]
 		req.PipelineCanonical = vars["pipeline_canonical"]
 		req.ResourceCanonical = vars["resource_canonical"]
+
+		before, after, limit := parsePaginationParams(r)
+
 		var vers []*resource.Version
+		var hasMore bool
 		var err error
 		if isPublic, _ := ctx.Value(IsPublicAccessKey).(bool); isPublic {
-			vers, err = s.ListPublicResourceVersions(ctx, req.TeamCanonical, req.PipelineCanonical, req.ResourceCanonical)
+			vers, hasMore, err = s.ListPublicResourceVersions(ctx, req.TeamCanonical, req.PipelineCanonical, req.ResourceCanonical, before, after, limit)
 		} else {
-			vers, err = s.ListResourceVersions(ctx, req.TeamCanonical, req.PipelineCanonical, req.ResourceCanonical)
+			vers, hasMore, err = s.ListResourceVersions(ctx, req.TeamCanonical, req.PipelineCanonical, req.ResourceCanonical, before, after, limit)
 		}
 		var errs string
 		if err != nil {
 			errs = err.Error()
 		}
-		encodeResponse(ListResourceVersionsResponse{Versions: vers, Err: errs}, w)
+		var meta *PageMeta
+		if len(vers) > 0 {
+			meta = &PageMeta{
+				HasMore:  hasMore,
+				OldestID: vers[len(vers)-1].ID,
+				NewestID: vers[0].ID,
+			}
+		}
+		encodeResponse(ListResourceVersionsResponse{Versions: vers, Meta: meta, Err: errs}, w)
 	}
 }
 

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -1149,8 +1149,21 @@
         },
         initialize: function(attr, opts) {
           this.job = opts.job
+          this.newestID = 0
+          this.oldestID = 0
+          this.hasMore = false
+          this.loadingMore = false
         },
         parse: function(response) {
+          if (response.meta) {
+            this.hasMore = response.meta.has_more
+            if (!this.newestID || response.meta.newest_id > this.newestID) {
+              this.newestID = response.meta.newest_id
+            }
+            if (!this.oldestID || response.meta.oldest_id < this.oldestID) {
+              this.oldestID = response.meta.oldest_id
+            }
+          }
           var builds = response.data;
           _.each(builds, function(data) {
             if (data.duration  !== 0) {
@@ -1164,6 +1177,27 @@
             })
           })
           return builds
+        },
+        fetchMore: function() {
+          if (this.loadingMore || !this.hasMore) return
+          this.loadingMore = true
+          var that = this
+          this.fetch({
+            remove: false,
+            data: { before: this.oldestID, limit: 50 },
+            success: function() { that.loadingMore = false },
+            error: function() { that.loadingMore = false },
+          })
+        },
+        fetchNew: function() {
+          if (!this.newestID) {
+            this.fetch({ remove: false })
+            return
+          }
+          this.fetch({
+            remove: false,
+            data: { after: this.newestID },
+          })
         },
         setActive: function(id) {
           if (!id && this.first()) {
@@ -1180,12 +1214,49 @@
         url: function() {
           return this.resource.url() + "/versions"
         },
+        comparator: function(a, b) {
+          return (b.get("id") || 0) - (a.get("id") || 0)
+        },
         initialize: function(attr, opts) {
           this.resource = opts.resource
+          this.newestID = 0
+          this.oldestID = 0
+          this.hasMore = false
+          this.loadingMore = false
         },
         parse: function(response) {
+          if (response.meta) {
+            this.hasMore = response.meta.has_more
+            if (!this.newestID || response.meta.newest_id > this.newestID) {
+              this.newestID = response.meta.newest_id
+            }
+            if (!this.oldestID || response.meta.oldest_id < this.oldestID) {
+              this.oldestID = response.meta.oldest_id
+            }
+          }
           return response.data;
-        }
+        },
+        fetchMore: function() {
+          if (this.loadingMore || !this.hasMore) return
+          this.loadingMore = true
+          var that = this
+          this.fetch({
+            remove: false,
+            data: { before: this.oldestID, limit: 50 },
+            success: function() { that.loadingMore = false },
+            error: function() { that.loadingMore = false },
+          })
+        },
+        fetchNew: function() {
+          if (!this.newestID) {
+            this.fetch({ remove: false })
+            return
+          }
+          this.fetch({
+            remove: false,
+            data: { after: this.newestID },
+          })
+        },
       });
 
       app.teams = new app.Teams();
@@ -3055,17 +3126,14 @@
           this.collection.fetch({
             reset: true,
             success: function(){
-              var bid = that.collection.setActive(opts.currentBuildID)
-              that.currentBuildID = bid
-              var tc = that.collection.job.collection.pipeline.collection.team.get("canonical")
-              var url = new URL(location.origin+"/teams/"+tc+"/pipelines/"+that.pipeline.get("canonical")+"/jobs/"+that.job.get("name")+"/builds/"+bid)
-              app.router.navigate(url.pathname, { trigger: false, replace: true });
+              that.activateAndNavigate(opts.currentBuildID)
+              that.bindScrollListener()
             },
           })
 
           var that = this
           this.intervalID = window.setInterval(function() {
-            that.collection.fetch({isInterval: true})
+            that.collection.fetchNew()
           }, fetchInterval);
         },
         events: {
@@ -3086,8 +3154,47 @@
           })));
           return this; // enable chained calls
         },
+        activateAndNavigate: function(requestedBID) {
+          var that = this
+          var found = requestedBID && this.collection.get(requestedBID)
+          if (requestedBID && !found) {
+            // Requested build is outside the initial page — fetch it individually
+            var singleBuild = new app.Build({build_number: requestedBID})
+            singleBuild.url = this.collection.url() + "/" + requestedBID
+            singleBuild.fetch({
+              success: function(model) {
+                that.collection.add(model, {merge: true})
+                that.doActivate(requestedBID)
+              },
+              error: function() {
+                // Build not found, fall back to newest
+                that.doActivate(null)
+              },
+            })
+          } else {
+            this.doActivate(requestedBID)
+          }
+        },
+        doActivate: function(bid) {
+          bid = this.collection.setActive(bid)
+          this.currentBuildID = bid
+          var tc = this.collection.job.collection.pipeline.collection.team.get("canonical")
+          var url = new URL(location.origin+"/teams/"+tc+"/pipelines/"+this.pipeline.get("canonical")+"/jobs/"+this.job.get("name")+"/builds/"+bid)
+          app.router.navigate(url.pathname, { trigger: false, replace: true });
+        },
+        bindScrollListener: function() {
+          var that = this
+          this._scrollHandler = function() {
+            var el = that.$('#builds-tabs')[0]
+            if (el && el.scrollLeft + el.clientWidth >= el.scrollWidth - 50) {
+              that.collection.fetchMore()
+            }
+          }
+          this.$('#builds-tabs').on('scroll', this._scrollHandler)
+        },
         remove: function() {
           clearInterval(this.intervalID)
+          this.$('#builds-tabs').off('scroll', this._scrollHandler)
           Backbone.View.prototype.remove.call(this);
         },
         addBuild: function(m) {
@@ -3323,12 +3430,15 @@
           this.listenTo(this.collection, "reset", this.resetVersions)
           this.listenTo(this.model, "change", this.render)
 
-          this.collection.fetch({reset: true})
-
           var that = this
+          this.collection.fetch({
+            reset: true,
+            success: function() { that.bindScrollListener() },
+          })
+
           this.intervalID = window.setInterval(function() {
             that.model.fetch({isInterval: true})
-            that.collection.fetch({isInterval: true})
+            that.collection.fetchNew()
           }, fetchInterval);
         },
         render: function () {
@@ -3374,11 +3484,29 @@
           if (isReset) {
             $('#resource-versions').append(ver.render().el);
           } else {
-            $('#resource-versions').prepend(ver.render().el);
+            var idx = this.collection.indexOf(m);
+            var children = $('#resource-versions').children();
+            if (idx === 0 || children.length === 0) {
+              $('#resource-versions').prepend(ver.render().el);
+            } else if (idx < children.length) {
+              $(children[idx]).before(ver.render().el);
+            } else {
+              $('#resource-versions').append(ver.render().el);
+            }
           }
+        },
+        bindScrollListener: function() {
+          var that = this
+          this._scrollHandler = function() {
+            if ($(window).scrollTop() + $(window).height() >= $(document).height() - 200) {
+              that.collection.fetchMore()
+            }
+          }
+          $(window).on('scroll', this._scrollHandler)
         },
         remove: function() {
           clearInterval(this.intervalID)
+          $(window).off('scroll', this._scrollHandler)
           Backbone.View.prototype.remove.call(this);
         },
         clickTriggerResource: function(event) {

--- a/worker/service.go
+++ b/worker/service.go
@@ -424,7 +424,7 @@ func (w *Worker) checkPassedConstraints(ctx context.Context, m queue.Body, b *bu
 		var intersection map[uint32]bool
 		var hasSucceeded bool
 		for _, p := range g.Passed {
-			builds, err := w.pikoci.ListJobBuilds(ctx, m.TeamCanonical, m.PipelineCanonical, p)
+			builds, _, err := w.pikoci.ListJobBuilds(ctx, m.TeamCanonical, m.PipelineCanonical, p, nil, nil, 0)
 			if err != nil {
 				w.failBuild(ctx, m, *b, fmt.Errorf("failed to list builds for passed job %q: %w", p, err))
 				return false, nil
@@ -496,7 +496,7 @@ func (w *Worker) checkVersionAvailability(ctx context.Context, m queue.Body, b *
 			continue
 		}
 
-		dbvers, err := w.pikoci.ListResourceVersions(ctx, m.TeamCanonical, m.PipelineCanonical, r.Canonical)
+		dbvers, _, err := w.pikoci.ListResourceVersions(ctx, m.TeamCanonical, m.PipelineCanonical, r.Canonical, nil, nil, 0)
 		if err != nil {
 			// Transient errors (DB, network) should fail the build, not silently delete it.
 			w.failBuild(ctx, m, *b, fmt.Errorf("failed to list resource versions: %w", err))
@@ -1031,7 +1031,7 @@ func (w *Worker) buildPullParams(ctx context.Context, m queue.Body, b *build.Bui
 		params = make(map[string]string)
 	}
 
-	dbvers, err := w.pikoci.ListResourceVersions(ctx, m.TeamCanonical, m.PipelineCanonical, r.Canonical)
+	dbvers, _, err := w.pikoci.ListResourceVersions(ctx, m.TeamCanonical, m.PipelineCanonical, r.Canonical, nil, nil, 0)
 	if err != nil {
 		w.failBuild(ctx, m, *b, fmt.Errorf("failed to list resource versions: %w", err))
 		return nil, 0
@@ -1185,7 +1185,7 @@ func (w *Worker) processResourceCheck(ctx context.Context, m queue.Body, cwd str
 		params[k] = v
 	}
 
-	dbvers, err := w.pikoci.ListResourceVersions(ctx, m.TeamCanonical, m.PipelineCanonical, r.Canonical)
+	dbvers, _, err := w.pikoci.ListResourceVersions(ctx, m.TeamCanonical, m.PipelineCanonical, r.Canonical, nil, nil, 0)
 	if err != nil {
 		w.logger.Error("failed to list resource versions", "error", err)
 		return
@@ -1284,7 +1284,7 @@ func (w *Worker) processResourceCheckTrigger(ctx context.Context, m queue.Body, 
 
 	// Get latest resource version to find the last trigger_id
 	var afterID uint32
-	dbvers, err := w.pikoci.ListResourceVersions(ctx, m.TeamCanonical, m.PipelineCanonical, r.Canonical)
+	dbvers, _, err := w.pikoci.ListResourceVersions(ctx, m.TeamCanonical, m.PipelineCanonical, r.Canonical, nil, nil, 0)
 	if err != nil {
 		w.logger.Error("failed to list resource versions for trigger check", "error", err)
 		return

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -265,10 +265,10 @@ func TestProcessJob_Success_WithGetAndTask(t *testing.T) {
 		Return(&build.Build{ID: 10, BuildNumber: "10", StartedAt: time.Now()}, nil)
 	svc.EXPECT().GetPipelineJob(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName).
 		Return(&pp.Jobs[0], nil)
-	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron").
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron", (*uint32)(nil), (*uint32)(nil), uint32(0)).
 		Return([]*resource.Version{
 			{ID: 1, Version: map[string]interface{}{"date": "now"}},
-		}, nil).AnyTimes()
+		}, false, nil).AnyTimes()
 
 	// running steps + after get step + after task step + after marking succeeded
 	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "10", gomock.Any()).
@@ -350,10 +350,10 @@ func TestInsertBuildGetVersion_CalledWithCorrectArgs(t *testing.T) {
 		Return(&build.Build{ID: 10, BuildNumber: "10", StartedAt: time.Now()}, nil)
 	svc.EXPECT().GetPipelineJob(gomock.Any(), "main", "test-pipeline", "test-job").
 		Return(&pp.Jobs[0], nil)
-	svc.EXPECT().ListResourceVersions(gomock.Any(), "main", "test-pipeline", "cron.my-cron").
+	svc.EXPECT().ListResourceVersions(gomock.Any(), "main", "test-pipeline", "cron.my-cron", (*uint32)(nil), (*uint32)(nil), uint32(0)).
 		Return([]*resource.Version{
 			{ID: 1, Version: map[string]interface{}{"date": "now"}},
-		}, nil).AnyTimes()
+		}, false, nil).AnyTimes()
 	svc.EXPECT().UpdateJobBuild(gomock.Any(), "main", "test-pipeline", "test-job", "10", gomock.Any()).
 		Return(nil).AnyTimes()
 
@@ -407,8 +407,8 @@ func TestProcessJob_FailedPassedConstraint_NoBuilds(t *testing.T) {
 		Return(&pp.Jobs[0], nil)
 
 	// Passed check: upstream-job has no builds
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "upstream-job").
-		Return([]*build.Build{}, nil)
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "upstream-job", (*uint32)(nil), (*uint32)(nil), uint32(0)).
+		Return([]*build.Build{}, false, nil)
 
 	// Build should be deleted (not failed)
 	svc.EXPECT().DeleteJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "20").
@@ -461,8 +461,8 @@ func TestProcessJob_FailedPassedConstraint_NotSucceeded(t *testing.T) {
 		Return(&pp.Jobs[0], nil)
 
 	// Passed check: upstream-job has a failed build
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "upstream-job").
-		Return([]*build.Build{{ID: 5, Status: build.Failed}}, nil)
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "upstream-job", (*uint32)(nil), (*uint32)(nil), uint32(0)).
+		Return([]*build.Build{{ID: 5, Status: build.Failed}}, false, nil)
 
 	// Build should be deleted
 	svc.EXPECT().DeleteJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "21").
@@ -695,8 +695,8 @@ func TestProcessResourceCheck_NewVersions(t *testing.T) {
 	cwd := t.TempDir()
 
 	// ListResourceVersions - no existing versions
-	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron").
-		Return([]*resource.Version{}, nil).AnyTimes()
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron", (*uint32)(nil), (*uint32)(nil), uint32(0)).
+		Return([]*resource.Version{}, false, nil).AnyTimes()
 
 	// CreateResourceVersion for the new version found
 	svc.EXPECT().CreateResourceVersion(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron", gomock.Any()).
@@ -771,8 +771,8 @@ func TestProcessResourceCheck_DuplicateVersionSkipped_FirstCheck(t *testing.T) {
 	}
 	cwd := t.TempDir()
 
-	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "git.my-repo").
-		Return([]*resource.Version{}, nil).AnyTimes()
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "git.my-repo", (*uint32)(nil), (*uint32)(nil), uint32(0)).
+		Return([]*resource.Version{}, false, nil).AnyTimes()
 
 	// First version: duplicate error (already exists)
 	svc.EXPECT().CreateResourceVersion(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "git.my-repo", gomock.Any()).
@@ -842,10 +842,10 @@ func TestProcessResourceCheck_SecondCheckTriggers(t *testing.T) {
 	cwd := t.TempDir()
 
 	// Not a first check: existing versions present
-	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron").
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron", (*uint32)(nil), (*uint32)(nil), uint32(0)).
 		Return([]*resource.Version{
 			{ID: 1, Version: map[string]interface{}{"date": "now"}},
-		}, nil).AnyTimes()
+		}, false, nil).AnyTimes()
 
 	// CreateResourceVersion for the new version
 	svc.EXPECT().CreateResourceVersion(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron", gomock.Any()).
@@ -899,8 +899,8 @@ func TestProcessResourceCheckTrigger_FirstCheckTriggers(t *testing.T) {
 	}
 
 	// No existing versions — first check
-	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "trigger.my-trigger").
-		Return([]*resource.Version{}, nil).AnyTimes()
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "trigger.my-trigger", (*uint32)(nil), (*uint32)(nil), uint32(0)).
+		Return([]*resource.Version{}, false, nil).AnyTimes()
 
 	// Triggers exist
 	svc.EXPECT().ListTriggersAfter(gomock.Any(), m.TeamCanonical, "trigger.my-trigger", uint32(0)).
@@ -960,10 +960,10 @@ func TestProcessResourceCheckTrigger_SecondCheckTriggers(t *testing.T) {
 	}
 
 	// Existing versions present — not a first check
-	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "trigger.my-trigger").
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "trigger.my-trigger", (*uint32)(nil), (*uint32)(nil), uint32(0)).
 		Return([]*resource.Version{
 			{ID: 1, Version: map[string]interface{}{"key": "old", "trigger_id": float64(1)}},
-		}, nil)
+		}, false, nil)
 
 	// New trigger after the existing one
 	svc.EXPECT().ListTriggersAfter(gomock.Any(), m.TeamCanonical, "trigger.my-trigger", uint32(1)).
@@ -1015,14 +1015,14 @@ func TestCheckPassedConstraints_AllPassed(t *testing.T) {
 		},
 	}
 
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "job-a").
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "job-a", (*uint32)(nil), (*uint32)(nil), uint32(0)).
 		Return([]*build.Build{{ID: 1, Status: build.Succeeded, Steps: []build.Step{
 			{Type: "get", Name: "my-cron", VersionID: 5},
-		}}}, nil)
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "job-b").
+		}}}, false, nil)
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "job-b", (*uint32)(nil), (*uint32)(nil), uint32(0)).
 		Return([]*build.Build{{ID: 2, Status: build.Succeeded, Steps: []build.Step{
 			{Type: "get", Name: "my-cron", VersionID: 5},
-		}}}, nil)
+		}}}, false, nil)
 
 	ok, resolved := w.checkPassedConstraints(ctx, m, &b, j)
 	assert.True(t, ok)
@@ -1056,14 +1056,14 @@ func TestCheckPassedConstraints_NoCommonVersion(t *testing.T) {
 	}
 
 	// lint succeeded with version 5, test succeeded with version 6
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "lint").
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "lint", (*uint32)(nil), (*uint32)(nil), uint32(0)).
 		Return([]*build.Build{{ID: 10, Status: build.Succeeded, Steps: []build.Step{
 			{Type: "get", Name: "my-repo", VersionID: 5},
-		}}}, nil)
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "test").
+		}}}, false, nil)
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "test", (*uint32)(nil), (*uint32)(nil), uint32(0)).
 		Return([]*build.Build{{ID: 11, Status: build.Succeeded, Steps: []build.Step{
 			{Type: "get", Name: "my-repo", VersionID: 6},
-		}}}, nil)
+		}}}, false, nil)
 
 	// Build should be deleted
 	svc.EXPECT().DeleteJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "51").
@@ -1101,7 +1101,7 @@ func TestCheckPassedConstraints_PicksNewestCommon(t *testing.T) {
 	}
 
 	// lint has builds with versions {3, 5}
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "lint").
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "lint", (*uint32)(nil), (*uint32)(nil), uint32(0)).
 		Return([]*build.Build{
 			{ID: 10, Status: build.Succeeded, Steps: []build.Step{
 				{Type: "get", Name: "my-repo", VersionID: 5},
@@ -1109,9 +1109,9 @@ func TestCheckPassedConstraints_PicksNewestCommon(t *testing.T) {
 			{ID: 9, Status: build.Succeeded, Steps: []build.Step{
 				{Type: "get", Name: "my-repo", VersionID: 3},
 			}},
-		}, nil)
+		}, false, nil)
 	// test has builds with versions {5, 7}
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "test").
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "test", (*uint32)(nil), (*uint32)(nil), uint32(0)).
 		Return([]*build.Build{
 			{ID: 12, Status: build.Succeeded, Steps: []build.Step{
 				{Type: "get", Name: "my-repo", VersionID: 7},
@@ -1119,7 +1119,7 @@ func TestCheckPassedConstraints_PicksNewestCommon(t *testing.T) {
 			{ID: 11, Status: build.Succeeded, Steps: []build.Step{
 				{Type: "get", Name: "my-repo", VersionID: 5},
 			}},
-		}, nil)
+		}, false, nil)
 
 	ok, resolved := w.checkPassedConstraints(ctx, m, &b, j)
 	assert.True(t, ok)
@@ -1319,11 +1319,11 @@ func TestBuildPullParams_WithVersionID(t *testing.T) {
 	}
 	g := job.GetStep{}
 
-	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron").
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron", (*uint32)(nil), (*uint32)(nil), uint32(0)).
 		Return([]*resource.Version{
 			{ID: 3, Version: map[string]interface{}{"ref": "abc"}},
 			{ID: 5, Version: map[string]interface{}{"ref": "def"}},
-		}, nil).AnyTimes()
+		}, false, nil).AnyTimes()
 
 	params, vid := w.buildPullParams(ctx, m, &b, rt, r, g, 0)
 	require.NotNil(t, params)
@@ -1354,11 +1354,11 @@ func TestBuildPullParams_NoVersionID_UsesLatest(t *testing.T) {
 	g := job.GetStep{}
 
 	// Returns versions ordered by ID desc — after Reverse, last becomes first
-	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron").
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron", (*uint32)(nil), (*uint32)(nil), uint32(0)).
 		Return([]*resource.Version{
 			{ID: 1, Version: map[string]interface{}{"ref": "old"}},
 			{ID: 2, Version: map[string]interface{}{"ref": "latest"}},
-		}, nil).AnyTimes()
+		}, false, nil).AnyTimes()
 
 	params, vid := w.buildPullParams(ctx, m, &b, rt, r, g, 0)
 	require.NotNil(t, params)
@@ -1385,8 +1385,8 @@ func TestBuildPullParams_NoVersions_Fails(t *testing.T) {
 	r := resource.Resource{Canonical: "cron.my-cron"}
 	g := job.GetStep{}
 
-	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron").
-		Return([]*resource.Version{}, nil).AnyTimes()
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron", (*uint32)(nil), (*uint32)(nil), uint32(0)).
+		Return([]*resource.Version{}, false, nil).AnyTimes()
 
 	// Should call failBuild
 	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "72", gomock.Any()).
@@ -1416,11 +1416,11 @@ func TestBuildPullParams_ResolvedVersionTakesPriority(t *testing.T) {
 	r := resource.Resource{Canonical: "git.my-repo"}
 	g := job.GetStep{}
 
-	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "git.my-repo").
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "git.my-repo", (*uint32)(nil), (*uint32)(nil), uint32(0)).
 		Return([]*resource.Version{
 			{ID: 5, Version: map[string]interface{}{"ref": "queue-ver"}},
 			{ID: 10, Version: map[string]interface{}{"ref": "resolved-ver"}},
-		}, nil).AnyTimes()
+		}, false, nil).AnyTimes()
 
 	// resolvedVersionID=10 should take priority over m.VersionID=5
 	params, vid := w.buildPullParams(ctx, m, &b, rt, r, g, 10)
@@ -1464,8 +1464,8 @@ func TestCheckVersionAvailability_NoVersions_DeletesBuild(t *testing.T) {
 	}
 
 	// No versions available
-	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron").
-		Return([]*resource.Version{}, nil)
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron", (*uint32)(nil), (*uint32)(nil), uint32(0)).
+		Return([]*resource.Version{}, false, nil)
 
 	// Should delete build (not fail it)
 	svc.EXPECT().DeleteJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "99").
@@ -1505,10 +1505,10 @@ func TestCheckVersionAvailability_VersionExists_Passes(t *testing.T) {
 		},
 	}
 
-	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron").
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron", (*uint32)(nil), (*uint32)(nil), uint32(0)).
 		Return([]*resource.Version{
 			{ID: 1, Version: map[string]interface{}{"date": "now"}},
-		}, nil)
+		}, false, nil)
 
 	result := w.checkVersionAvailability(ctx, m, &b, j, pp)
 	assert.True(t, result, "should return true when version exists")
@@ -1652,10 +1652,10 @@ func TestProcessJob_OrderedPlan_GetTaskPut(t *testing.T) {
 		Return(&build.Build{ID: 90, BuildNumber: "90", StartedAt: time.Now()}, nil)
 	svc.EXPECT().GetPipelineJob(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName).
 		Return(&pp.Jobs[0], nil)
-	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron").
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron", (*uint32)(nil), (*uint32)(nil), uint32(0)).
 		Return([]*resource.Version{
 			{ID: 1, Version: map[string]interface{}{"date": "now"}},
-		}, nil).AnyTimes()
+		}, false, nil).AnyTimes()
 
 	// running steps + after get + after task + after put + after success
 	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "90", gomock.Any()).
@@ -1796,10 +1796,10 @@ func TestProcessJob_GetTimeout(t *testing.T) {
 		Return(&build.Build{ID: 101, BuildNumber: "101", StartedAt: time.Now()}, nil)
 	svc.EXPECT().GetPipelineJob(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName).
 		Return(&pp.Jobs[0], nil)
-	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron").
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron", (*uint32)(nil), (*uint32)(nil), uint32(0)).
 		Return([]*resource.Version{
 			{ID: 1, Version: map[string]interface{}{"date": "now"}},
-		}, nil).AnyTimes()
+		}, false, nil).AnyTimes()
 
 	// running step + partial logs + failBuild
 	var capturedBuild build.Build
@@ -2186,10 +2186,10 @@ func TestProcessResourceCheck_WithSecretVars(t *testing.T) {
 	cwd := t.TempDir()
 
 	// Existing versions present — not a first check
-	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "git.repo").
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "git.repo", (*uint32)(nil), (*uint32)(nil), uint32(0)).
 		Return([]*resource.Version{
 			{ID: 1, Version: map[string]interface{}{"ref": "old"}},
-		}, nil).AnyTimes()
+		}, false, nil).AnyTimes()
 
 	// CreateResourceVersion for the new version found
 	svc.EXPECT().CreateResourceVersion(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "git.repo", gomock.Any()).
@@ -2327,8 +2327,8 @@ func TestProcessResourceCheck_SecretResolutionError_UpdatesResourceLogs(t *testi
 	}
 	cwd := t.TempDir()
 
-	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "git.repo").
-		Return([]*resource.Version{}, nil)
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "git.repo", (*uint32)(nil), (*uint32)(nil), uint32(0)).
+		Return([]*resource.Version{}, false, nil)
 
 	// Expect the resource to be updated with error logs
 	svc.EXPECT().UpdatePipelineResource(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "git.repo", gomock.Any()).
@@ -2492,10 +2492,10 @@ func TestProcessResourceCheck_RawSecretFormat(t *testing.T) {
 	cwd := t.TempDir()
 
 	// Existing versions present — not a first check
-	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.timer").
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(0)).
 		Return([]*resource.Version{
 			{ID: 1, Version: map[string]interface{}{"date": "old"}},
-		}, nil)
+		}, false, nil)
 	svc.EXPECT().CreateResourceVersion(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.timer", gomock.Any()).
 		Return(&resource.Version{ID: 2, Version: map[string]interface{}{"date": "now"}}, nil)
 	topic.EXPECT().Send(gomock.Any(), gomock.Any()).Return(nil)
@@ -3089,10 +3089,10 @@ func TestProcessJob_Retry_UsesCreateRetryAndResolvedVersions(t *testing.T) {
 	// ListResourceVersions should NOT be called (retries skip version availability check)
 	// The get step still runs with the resolved version
 
-	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron").
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron", (*uint32)(nil), (*uint32)(nil), uint32(0)).
 		Return([]*resource.Version{
 			{ID: 42, Version: map[string]interface{}{"date": "now"}},
-		}, nil).AnyTimes()
+		}, false, nil).AnyTimes()
 
 	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "3.1", gomock.Any()).
 		Return(nil).AnyTimes()


### PR DESCRIPTION
## Summary

- Replace unbounded list endpoints with cursor-based pagination (`before`/`after`/`limit` query params, default limit 50)
- Response includes `meta` with `has_more`, `oldest_id`, `newest_id` for infinite scroll
- CLI sends `limit=0` to preserve backward compatibility (returns all records)
- Frontend: horizontal scroll on build tabs loads older builds, window scroll on resource versions loads older versions
- Polling uses `fetchNew()` with `after` cursor instead of full re-fetch
- Direct URL to an older build (outside initial page) fetches it individually

Closes #345
