### PR TITLE
Remove redundant Reverse after Filter now returns DESC order

### DIFF
--- a/pikoci/jobs.go
+++ b/pikoci/jobs.go
@@ -37,7 +37,7 @@ func (q *PikoCI) TriggerPipelineJob(ctx context.Context, tc, pc, jn string) erro
 		vers, err := q.Resources.FilterVersions(ctx, tc, pc, rCan, nil, nil, 0)
 		if err == nil && len(vers) > 0 {
 			bb.ResourceCanonical = rCan
-			bb.VersionID = vers[len(vers)-1].ID
+			bb.VersionID = vers[0].ID
 		}
 	}
 

--- a/pikoci/jobs_test.go
+++ b/pikoci/jobs_test.go
@@ -101,9 +101,9 @@ func TestTriggerPipelineJob_PinsLatestVersion(t *testing.T) {
 	}
 
 	versions := []*resource.Version{
-		{ID: 10},
-		{ID: 20},
 		{ID: 30},
+		{ID: 20},
+		{ID: 10},
 	}
 
 	rCan := j.GetSteps()[0].ResourceCanonical()

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -3,7 +3,6 @@ package pikoci
 import (
 	"context"
 	"fmt"
-	"slices"
 	"strings"
 	"time"
 
@@ -485,7 +484,6 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 		if err != nil {
 			return nil, fmt.Errorf("failed to filter builds from Job %q: %w", j.Name, err)
 		}
-		slices.Reverse(builds)
 		color := colorDefault
 		borderColor := colorDefaultBorder
 

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -1490,8 +1490,8 @@ func TestGetPipelineImage_JobStatusColors(t *testing.T) {
 		{
 			name: "latest main build succeeded",
 			builds: []*build.Build{
-				{ID: 1, BuildNumber: "1", Status: build.Failed},
 				{ID: 2, BuildNumber: "2", Status: build.Succeeded},
+				{ID: 1, BuildNumber: "1", Status: build.Failed},
 			},
 			wantFillColor:   colorSucceeded,
 			wantDashedStyle: false,
@@ -1499,8 +1499,8 @@ func TestGetPipelineImage_JobStatusColors(t *testing.T) {
 		{
 			name: "latest main build failed",
 			builds: []*build.Build{
-				{ID: 1, BuildNumber: "1", Status: build.Succeeded},
 				{ID: 2, BuildNumber: "2", Status: build.Failed},
+				{ID: 1, BuildNumber: "1", Status: build.Succeeded},
 			},
 			wantFillColor:   colorFailed,
 			wantDashedStyle: false,
@@ -1508,8 +1508,8 @@ func TestGetPipelineImage_JobStatusColors(t *testing.T) {
 		{
 			name: "latest main build running - shows previous color with dashed outline",
 			builds: []*build.Build{
-				{ID: 1, BuildNumber: "1", Status: build.Succeeded},
 				{ID: 2, BuildNumber: "2", Status: build.Started},
+				{ID: 1, BuildNumber: "1", Status: build.Succeeded},
 			},
 			wantFillColor:   colorSucceeded,
 			wantDashedStyle: true,
@@ -1518,8 +1518,8 @@ func TestGetPipelineImage_JobStatusColors(t *testing.T) {
 		{
 			name: "retry running - latest main build color with dashed outline",
 			builds: []*build.Build{
-				{ID: 1, BuildNumber: "1", Status: build.Failed},
 				{ID: 2, BuildNumber: "1.1", Status: build.Started},
+				{ID: 1, BuildNumber: "1", Status: build.Failed},
 			},
 			wantFillColor:   colorFailed,
 			wantDashedStyle: true,
@@ -1528,8 +1528,8 @@ func TestGetPipelineImage_JobStatusColors(t *testing.T) {
 		{
 			name: "retry succeeded - color reflects retry success",
 			builds: []*build.Build{
-				{ID: 1, BuildNumber: "1", Status: build.Failed},
 				{ID: 2, BuildNumber: "1.1", Status: build.Succeeded},
+				{ID: 1, BuildNumber: "1", Status: build.Failed},
 			},
 			wantFillColor:   colorSucceeded,
 			wantDashedStyle: false,
@@ -1546,10 +1546,10 @@ func TestGetPipelineImage_JobStatusColors(t *testing.T) {
 		{
 			name: "multiple main builds with retries - latest main build wins",
 			builds: []*build.Build{
-				{ID: 1, BuildNumber: "1", Status: build.Succeeded},
-				{ID: 2, BuildNumber: "1.1", Status: build.Succeeded},
-				{ID: 3, BuildNumber: "2", Status: build.Failed},
 				{ID: 4, BuildNumber: "2.1", Status: build.Started},
+				{ID: 3, BuildNumber: "2", Status: build.Failed},
+				{ID: 2, BuildNumber: "1.1", Status: build.Succeeded},
+				{ID: 1, BuildNumber: "1", Status: build.Succeeded},
 			},
 			wantFillColor:   colorFailed,
 			wantDashedStyle: true,
@@ -1558,8 +1558,8 @@ func TestGetPipelineImage_JobStatusColors(t *testing.T) {
 		{
 			name: "pending build with previous success - shows previous color with gray dashed outline",
 			builds: []*build.Build{
-				{ID: 1, BuildNumber: "1", Status: build.Succeeded},
 				{ID: 2, BuildNumber: "2", Status: build.Pending},
+				{ID: 1, BuildNumber: "1", Status: build.Succeeded},
 			},
 			wantFillColor:   colorSucceeded,
 			wantDashedStyle: true,
@@ -1568,9 +1568,9 @@ func TestGetPipelineImage_JobStatusColors(t *testing.T) {
 		{
 			name: "pending and running builds - running takes priority with orange outline",
 			builds: []*build.Build{
-				{ID: 1, BuildNumber: "1", Status: build.Succeeded},
-				{ID: 2, BuildNumber: "2", Status: build.Pending},
 				{ID: 3, BuildNumber: "1.1", Status: build.Started},
+				{ID: 2, BuildNumber: "2", Status: build.Pending},
+				{ID: 1, BuildNumber: "1", Status: build.Succeeded},
 			},
 			wantFillColor:   colorSucceeded,
 			wantDashedStyle: true,


### PR DESCRIPTION
## Summary

Follow-up to #393. The pagination changes made `Filter` and `FilterVersions` return results in DESC order (newest-first) by default. Two callers still assumed ASC order:

- `generateImage` called `slices.Reverse(builds)` — now redundant, removed
- `TriggerPipelineJob` used `vers[len(vers)-1]` for latest version — changed to `vers[0]`

Test mock data updated to match DESC ordering.
