### PR TITLE
Fix error banner persisting after backend reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Error banner persists after backend reconnects: polling successes now clear errors, connection failures show "Connection lost. Retrying...", and polling errors are debounced ([#400](https://github.com/PikoCI/pikoci/issues/400))
+
 ## [0.2.1] - 2026-05-27
 
 ### Added

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -3937,7 +3937,18 @@
         }
         var optError = options.error
         options.error = function(response){
-          var msg = (response.responseJSON && response.responseJSON.error) || response.statusText || "Unknown error";
+          var msg;
+          if (response.status === 0) {
+            msg = "Connection lost. Retrying...";
+          } else {
+            msg = (response.responseJSON && response.responseJSON.error) || response.statusText || "Unknown error";
+          }
+          if (options.isInterval && app.apiNotice.get("error") !== "") {
+            if (optError) {
+              optError(response)
+            }
+            return;
+          }
           app.apiNotice.set({error: msg})
           if (optError) {
             optError(response)
@@ -3945,7 +3956,9 @@
         }
         var optSuccess = options.success
         options.success = function(response, textStatus, jqXHR){
-          if (!options.isInterval) {
+          if (options.isInterval) {
+            app.apiNotice.set({error: ""})
+          } else {
             app.apiNotice.clear()
           }
           if (jqXHR && jqXHR.getResponseHeader('X-Refresh-Token') === 'true') {


### PR DESCRIPTION
## Summary

Fixes the error banner that stays visible after the backend recovers from a restart. Polling successes now clear errors, network failures show a descriptive "Connection lost. Retrying..." message, and polling errors are debounced to avoid spamming the banner.

Closes #400