### PR TITLE
Add Docker pull and run to README Quick Start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Docker pull and run instructions in README Quick Start ([#387](https://github.com/PikoCI/pikoci/issues/387))
+- GitHub Release and Docker Image badges in README
+
 ### Fixed
 
 - Error banner persists after backend reconnects: polling successes now clear errors, connection failures show "Connection lost. Retrying...", and polling errors are debounced ([#400](https://github.com/PikoCI/pikoci/issues/400))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Docker pull and run instructions in README Quick Start ([#387](https://github.com/PikoCI/pikoci/issues/387))
-- GitHub Release and Docker Image badges in README
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
   [![License](https://img.shields.io/badge/license-Apache%202.0-yellow)](LICENSE)
   [![Go Report Card](https://goreportcard.com/badge/github.com/pikoci/pikoci)](https://goreportcard.com/report/github.com/pikoci/pikoci)
   [![Go Reference](https://pkg.go.dev/badge/github.com/pikoci/pikoci.svg)](https://pkg.go.dev/github.com/pikoci/pikoci)
+  [![GitHub Release](https://img.shields.io/github/v/release/PikoCI/pikoci)](https://github.com/PikoCI/pikoci/releases/latest)
+  [![Docker Image](https://img.shields.io/badge/docker-ghcr.io%2Fpikoci%2Fpikoci-blue?logo=docker)](https://github.com/PikoCI/pikoci/pkgs/container/pikoci)
 
   [Documentation](https://docs.pikoci.com) · [Quick Start](#quick-start) · [Contributing](#contributing)
 </div>
@@ -64,12 +66,30 @@ cd pikoci
 go build -o pikoci .
 ```
 
+Or pull the Docker image:
+
+```bash
+docker pull ghcr.io/pikoci/pikoci:latest
+```
+
 ### Run with a pipeline
 
 The fastest way to get started. Pass a pipeline config directly at launch. When the server starts, your pipeline is already loaded and ready:
 
 ```bash
 ./pikoci server \
+  --db-system mem \
+  --pubsub-system mem \
+  --jwt-secret my-secret \
+  --run-worker \
+  --pipeline-name my-pipeline \
+  --pipeline-config pipeline.hcl
+```
+
+Or with Docker:
+
+```bash
+docker run -p 8080:8080 ghcr.io/pikoci/pikoci:latest server \
   --db-system mem \
   --pubsub-system mem \
   --jwt-secret my-secret \


### PR DESCRIPTION
## Summary

- Add GitHub Release and Docker Image badges to the README header
- Add `docker pull` as a download option in Quick Start
- Add `docker run` example alongside the binary server launch

Closes #387