### PR TITLE
Re-enqueue pending builds on server startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Re-enqueue pending builds on server startup so they are not stranded forever ([#399](https://github.com/PikoCI/pikoci/issues/399))
 - Error banner persists after backend reconnects: polling successes now clear errors, connection failures show "Connection lost. Retrying...", and polling errors are debounced ([#400](https://github.com/PikoCI/pikoci/issues/400))
 
 ## [0.2.1] - 2026-05-27

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -138,6 +138,9 @@ var serverCmd = &cobra.Command{
 		logger.Info("initializing service")
 		var svc = pikoci.New(ctx, jobTopic, checkTopic, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, suow, jwtSecret, logger)
 		svc.StartScheduler(ctx)
+		if err := svc.ReEnqueuePendingBuilds(ctx); err != nil {
+			logger.Error("failed to re-enqueue pending builds", "error", err)
+		}
 		logger.Info("initialized service")
 
 		logger.Info("initializing http handlers")

--- a/pikoci/builds.go
+++ b/pikoci/builds.go
@@ -378,3 +378,52 @@ func (q *PikoCI) notifyNextPendingBuild(ctx context.Context, tc, pc, jn string) 
 	}
 	q.JobTopic.Send(ctx, &pubsub.Message{Body: mb})
 }
+
+// ReEnqueuePendingBuilds scans all jobs for pending builds and re-publishes
+// queue messages so workers can pick them up. This is called on server startup
+// to recover builds that were stranded when the previous server instance stopped.
+//
+// This is safe to call even if some messages are still in the queue: the worker
+// does not trust the BuildID in the message — it always calls FindOldestPending
+// on the DB to determine which build to run (worker/service.go:238-266).
+// Duplicate messages simply result in redundant DB lookups with no side effects.
+func (q *PikoCI) ReEnqueuePendingBuilds(ctx context.Context) error {
+	pps, err := q.Pipelines.FilterAll(ctx)
+	if err != nil {
+		return fmt.Errorf("filtering all pipelines: %w", err)
+	}
+
+	var count int
+	for _, pwt := range pps {
+		tc := pwt.Team.Canonical
+		pc := pwt.Canonical
+		for _, j := range pwt.Jobs {
+			pending, err := q.Builds.FindOldestPending(ctx, tc, pc, j.Name)
+			if err != nil {
+				return fmt.Errorf("finding oldest pending build for %s/%s/%s: %w", tc, pc, j.Name, err)
+			}
+			if pending == nil {
+				continue
+			}
+			msg := queue.Body{
+				TeamCanonical:     tc,
+				PipelineCanonical: pc,
+				JobName:           j.Name,
+				BuildID:           pending.ID,
+			}
+			mb, err := json.Marshal(msg)
+			if err != nil {
+				return fmt.Errorf("marshalling queue body: %w", err)
+			}
+			if err := q.JobTopic.Send(ctx, &pubsub.Message{Body: mb}); err != nil {
+				return fmt.Errorf("sending queue message for %s/%s/%s: %w", tc, pc, j.Name, err)
+			}
+			count++
+		}
+	}
+
+	if q.logger != nil && count > 0 {
+		q.logger.Info("re-enqueued pending builds on startup", "count", count)
+	}
+	return nil
+}

--- a/pikoci/builds_test.go
+++ b/pikoci/builds_test.go
@@ -2,6 +2,7 @@ package pikoci_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,6 +10,9 @@ import (
 	"github.com/pikoci/pikoci/pikoci"
 	"github.com/pikoci/pikoci/pikoci/build"
 	"github.com/pikoci/pikoci/pikoci/job"
+	"github.com/pikoci/pikoci/pikoci/pipeline"
+	"github.com/pikoci/pikoci/pikoci/queue"
+	"github.com/pikoci/pikoci/pikoci/team"
 	"go.uber.org/mock/gomock"
 	"gocloud.dev/pubsub"
 )
@@ -312,5 +316,75 @@ func TestCancelJobBuild_Running_NotifiesNextPending(t *testing.T) {
 		Return(nil, nil)
 
 	err := s.S.CancelJobBuild(ctx, "main", "my-pipeline", "my-job", "1")
+	require.NoError(t, err)
+}
+
+func TestReEnqueuePendingBuilds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	pps := []*pipeline.WithTeam{
+		{
+			Pipeline: pipeline.Pipeline{
+				Canonical: "my-pipeline",
+				Jobs: []job.Job{
+					{Name: "job1"},
+					{Name: "job2"},
+				},
+			},
+			Team: team.Team{Canonical: "main"},
+		},
+	}
+	s.Pipelines.EXPECT().FilterAll(ctx).Return(pps, nil)
+	s.Builds.EXPECT().FindOldestPending(ctx, "main", "my-pipeline", "job1").
+		Return(&build.Build{ID: 42, Status: build.Pending}, nil)
+	s.Builds.EXPECT().FindOldestPending(ctx, "main", "my-pipeline", "job2").
+		Return(nil, nil)
+	s.Topic.EXPECT().Send(ctx, gomock.Any()).DoAndReturn(func(_ context.Context, msg *pubsub.Message) error {
+		var body queue.Body
+		err := json.Unmarshal(msg.Body, &body)
+		require.NoError(t, err)
+		assert.Equal(t, "main", body.TeamCanonical)
+		assert.Equal(t, "my-pipeline", body.PipelineCanonical)
+		assert.Equal(t, "job1", body.JobName)
+		assert.Equal(t, uint32(42), body.BuildID)
+		return nil
+	})
+
+	err := s.P.ReEnqueuePendingBuilds(ctx)
+	require.NoError(t, err)
+}
+
+func TestReEnqueuePendingBuilds_NoPending(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	pps := []*pipeline.WithTeam{
+		{
+			Pipeline: pipeline.Pipeline{
+				Canonical: "my-pipeline",
+				Jobs:      []job.Job{{Name: "job1"}},
+			},
+			Team: team.Team{Canonical: "main"},
+		},
+	}
+	s.Pipelines.EXPECT().FilterAll(ctx).Return(pps, nil)
+	s.Builds.EXPECT().FindOldestPending(ctx, "main", "my-pipeline", "job1").
+		Return(nil, nil)
+
+	err := s.P.ReEnqueuePendingBuilds(ctx)
+	require.NoError(t, err)
+}
+
+func TestReEnqueuePendingBuilds_NoPipelines(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Pipelines.EXPECT().FilterAll(ctx).Return(nil, nil)
+
+	err := s.P.ReEnqueuePendingBuilds(ctx)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary

- Add `ReEnqueuePendingBuilds` method that scans all jobs for pending builds and re-publishes queue messages so workers can pick them up
- Called once on server startup, right after `StartScheduler`
- Idempotent: the worker always calls `FindOldestPending` on the DB, so duplicate messages are harmless
- Only re-enqueues the oldest pending build per job; the worker chains to the next via `notifyNextPendingBuild`

Fixes #399