### PR TITLE
Display current deployed version in the web UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Display current deployed version and commit hash in the web UI header dropdown and via `/version.json` API endpoint ([#392](https://github.com/PikoCI/pikoci/issues/392))
+- `--version` CLI flag to print the application version and commit hash ([#392](https://github.com/PikoCI/pikoci/issues/392))
 - Docker pull and run instructions in README Quick Start ([#387](https://github.com/PikoCI/pikoci/issues/387))
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /pikoci .
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -ldflags "-X github.com/pikoci/pikoci/cmd.Version=$(git describe --tags --abbrev=0 2>/dev/null || echo dev) -X github.com/pikoci/pikoci/cmd.Commit=$(git rev-parse --short HEAD 2>/dev/null || echo unknown)" \
+    -o /pikoci .
 
 FROM alpine:3.21
 RUN apk add --no-cache ca-certificates git jq curl openssl docker-cli

--- a/Makefile
+++ b/Makefile
@@ -119,5 +119,9 @@ arch = $(word 2, $(temp))
 .PHONY: release $(PLATFORMS)
 release: $(PLATFORMS) ## Creates the bin on the ./builds/
 
+VERSION := $(shell git describe --tags --abbrev=0 2>/dev/null || echo dev)
+COMMIT := $(shell git rev-parse --short HEAD)
+LDFLAGS := -X github.com/pikoci/pikoci/cmd.Version=$(VERSION) -X github.com/pikoci/pikoci/cmd.Commit=$(COMMIT)
+
 $(PLATFORMS):
-	GOOS=$(os) GOARCH=$(arch) go build -o ./builds/'$(os)-$(arch)' .
+	GOOS=$(os) GOARCH=$(arch) go build -ldflags "$(LDFLAGS)" -o ./builds/'$(os)-$(arch)' .

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,8 @@ import (
 // AppName is the application name used for CLI identification and XDG paths.
 var (
 	AppName = "pikoci"
+	Version = "dev"
+	Commit  = "unknown"
 )
 
 // rootCmd is the top-level cobra command for the PikoCI CLI.
@@ -24,6 +26,7 @@ func Execute() error {
 }
 
 func init() {
+	rootCmd.Version = Version + " (" + Commit + ")"
 	rootCmd.AddCommand(serverCmd)
 	rootCmd.AddCommand(clientCmd)
 	rootCmd.AddCommand(workerCmd)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -144,7 +144,7 @@ var serverCmd = &cobra.Command{
 		logger.Info("initialized service")
 
 		logger.Info("initializing http handlers")
-		var handler = tshttp.Handler(svc, jwtSecret, logger.With("component", "HTTP"), db, cfg.DBSystem)
+		var handler = tshttp.Handler(svc, jwtSecret, logger.With("component", "HTTP"), db, cfg.DBSystem, Version, Commit)
 		logger.Info("initialized http handlers")
 
 		reg := prometheus.NewRegistry()

--- a/deploy/pipeline.hcl
+++ b/deploy/pipeline.hcl
@@ -215,7 +215,7 @@ job "deploy" {
       image = var.go_image
       cmd   = <<-EOT
         cd ${var.git_name}
-        GOOS=linux GOARCH=arm64 go build -buildvcs=false -o /tmp/pikoci-new .
+        GOOS=linux GOARCH=arm64 go build -buildvcs=false -ldflags "-X github.com/pikoci/pikoci/cmd.Version=$(git describe --tags --abbrev=0 2>/dev/null || echo dev) -X github.com/pikoci/pikoci/cmd.Commit=$(git rev-parse --short HEAD)" -o /tmp/pikoci-new .
         mv /tmp/pikoci-new /hostbin/pikoci
       EOT
       args = [

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -72,7 +72,7 @@ func runTests(m *testing.M) int {
 	suow := unitwork.NewStartUnitOfWork(db, mysql.Mem)
 	var svc = pikoci.New(ctx, jobTopic, checkTopic, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, suow, jwtSecret, logger)
 	svc.StartScheduler(ctx)
-	var handler = tshttp.Handler(svc, jwtSecret, logger.With("component", "HTTP"), db, mysql.Mem)
+	var handler = tshttp.Handler(svc, jwtSecret, logger.With("component", "HTTP"), db, mysql.Mem, "test", "abc1234")
 	server := httptest.NewServer(handler)
 	pikoURL = server.URL
 	defer server.Close()

--- a/pikoci/transport/http/assets/js/app/views/layout.js
+++ b/pikoci/transport/http/assets/js/app/views/layout.js
@@ -20,6 +20,12 @@ export var HeaderView = Backbone.View.extend({
   template: _.template($('#header-view').html()),
   initialize: function() {
     this.listenTo(session, "change", this.render);
+    this.versionText = '';
+    var self = this;
+    $.getJSON('/version.json').done(function(data) {
+      self.versionText = data.version + ' (' + data.commit + ')';
+      self.render();
+    });
     this.render();
   },
   events: {
@@ -53,6 +59,9 @@ export var HeaderView = Backbone.View.extend({
       sjson = session.toJSON();
     }
     this.$el.html(this.template({session: sjson}));
+    if (this.versionText) {
+      this.$('#app-version').text(this.versionText);
+    }
     syncThemeSwitch();
     return this;
   }

--- a/pikoci/transport/http/handler.go
+++ b/pikoci/transport/http/handler.go
@@ -44,7 +44,7 @@ var publicFallbackRoutes = map[RouteName]bool{
 // It configures all API routes, authentication middleware, static asset serving,
 // and HTML template rendering. The ts parameter is the JWT signing secret,
 // and dbSystem identifies the database backend for the export endpoint.
-func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem string) http.Handler {
+func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, version, commit string) http.Handler {
 	r := mux.NewRouter()
 
 	auth := func(h http.Handler) http.Handler {
@@ -195,6 +195,13 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem s
 	jsonr := r.Headers("Content-Type", "application/json").Subrouter()
 
 	jsonr.Methods(http.MethodPost).Path("/login").Handler(userLogin(s))
+	jsonr.Methods(http.MethodGet).Path("/version").Name(GetVersion.String()).HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		json.NewEncoder(w).Encode(map[string]string{
+			"version": version,
+			"commit":  commit,
+		})
+	})
 
 	api := jsonr.PathPrefix("/").Subrouter()
 

--- a/pikoci/transport/http/handler_test.go
+++ b/pikoci/transport/http/handler_test.go
@@ -156,7 +156,7 @@ func TestUpdatePipeline_TeamCanonicalFromURL(t *testing.T) {
 	secret := []byte("test-secret")
 	logger := slog.Default()
 
-	handler := Handler(s, secret, logger, nil, "")
+	handler := Handler(s, secret, logger, nil, "", "test", "abc1234")
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
@@ -196,7 +196,7 @@ func TestRefreshTokenEndpoint(t *testing.T) {
 	secret := []byte("test-secret")
 	logger := slog.Default()
 
-	handler := Handler(s, secret, logger, nil, "")
+	handler := Handler(s, secret, logger, nil, "", "test", "abc1234")
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
@@ -233,6 +233,33 @@ func TestRefreshTokenEndpoint(t *testing.T) {
 	assert.Len(t, refreshResp.Data.User.Memberships, 1)
 }
 
+func TestGetVersion(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	handler := Handler(s, secret, logger, nil, "", "v0.2.1", "b17daa3")
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/version.json", nil)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/json")
+
+	var got map[string]string
+	err = json.NewDecoder(resp.Body).Decode(&got)
+	require.NoError(t, err)
+	assert.Equal(t, "v0.2.1", got["version"])
+	assert.Equal(t, "b17daa3", got["commit"])
+}
+
 func TestExportDatabase_AdminAllowed(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := mock.NewService(ctrl)
@@ -244,7 +271,7 @@ func TestExportDatabase_AdminAllowed(t *testing.T) {
 	require.NoError(t, err)
 	defer db.Close()
 
-	handler := Handler(s, secret, logger, db, "mem")
+	handler := Handler(s, secret, logger, db, "mem", "test", "abc1234")
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
@@ -275,7 +302,7 @@ func TestExportDatabase_NonAdminForbidden(t *testing.T) {
 	secret := []byte("test-secret")
 	logger := slog.Default()
 
-	handler := Handler(s, secret, logger, nil, "")
+	handler := Handler(s, secret, logger, nil, "", "test", "abc1234")
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
@@ -304,7 +331,7 @@ func TestExportDatabase_UnauthenticatedForbidden(t *testing.T) {
 	secret := []byte("test-secret")
 	logger := slog.Default()
 
-	handler := Handler(s, secret, logger, nil, "")
+	handler := Handler(s, secret, logger, nil, "", "test", "abc1234")
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
@@ -329,7 +356,7 @@ func TestExportDatabase_ResponseHeaders(t *testing.T) {
 	require.NoError(t, err)
 	defer memDB.Close()
 
-	handler := Handler(s, secret, logger, memDB, "mem")
+	handler := Handler(s, secret, logger, memDB, "mem", "test", "abc1234")
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
@@ -364,7 +391,7 @@ func TestXRefreshTokenHeader(t *testing.T) {
 	t.Run("header set when memberships differ", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		s := mock.NewService(ctrl)
-		handler := Handler(s, secret, logger, nil, "")
+		handler := Handler(s, secret, logger, nil, "", "test", "abc1234")
 		server := httptest.NewServer(handler)
 		defer server.Close()
 
@@ -397,7 +424,7 @@ func TestXRefreshTokenHeader(t *testing.T) {
 	t.Run("header not set when memberships match", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		s := mock.NewService(ctrl)
-		handler := Handler(s, secret, logger, nil, "")
+		handler := Handler(s, secret, logger, nil, "", "test", "abc1234")
 		server := httptest.NewServer(handler)
 		defer server.Close()
 
@@ -424,7 +451,7 @@ func TestXRefreshTokenHeader(t *testing.T) {
 	t.Run("header not set for worker tokens", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		s := mock.NewService(ctrl)
-		handler := Handler(s, secret, logger, nil, "")
+		handler := Handler(s, secret, logger, nil, "", "test", "abc1234")
 		server := httptest.NewServer(handler)
 		defer server.Close()
 

--- a/pikoci/transport/http/route_names.go
+++ b/pikoci/transport/http/route_names.go
@@ -114,4 +114,7 @@ const (
 
 	// ExportDatabase is the route for exporting the database as a binary dump.
 	ExportDatabase
+
+	// GetVersion is the route for retrieving the application version.
+	GetVersion
 )

--- a/pikoci/transport/http/route_names_string.go
+++ b/pikoci/transport/http/route_names_string.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _RouteNameName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionswebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_database"
+const _RouteNameName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionswebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databaseget_version"
 
-var _RouteNameIndex = [...]uint16{0, 10, 23, 34, 44, 52, 63, 74, 89, 103, 114, 124, 132, 143, 154, 172, 190, 208, 223, 238, 250, 265, 279, 297, 318, 338, 354, 370, 392, 408, 424, 439, 463, 486, 499, 515, 530, 549, 574, 595, 619, 644, 667, 689, 704, 728, 742, 761, 776}
+var _RouteNameIndex = [...]uint16{0, 10, 23, 34, 44, 52, 63, 74, 89, 103, 114, 124, 132, 143, 154, 172, 190, 208, 223, 238, 250, 265, 279, 297, 318, 338, 354, 370, 392, 408, 424, 439, 463, 486, 499, 515, 530, 549, 574, 595, 619, 644, 667, 689, 704, 728, 742, 761, 776, 787}
 
-const _RouteNameLowerName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionswebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_database"
+const _RouteNameLowerName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionswebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databaseget_version"
 
 func (i RouteName) String() string {
 	if i < 0 || i >= RouteName(len(_RouteNameIndex)-1) {
@@ -72,9 +72,10 @@ func _RouteNameNoOp() {
 	_ = x[CreateTrigger-(45)]
 	_ = x[ListTriggersAfter-(46)]
 	_ = x[ExportDatabase-(47)]
+	_ = x[GetVersion-(48)]
 }
 
-var _RouteNameValues = []RouteName{UserLogin, RefreshToken, CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser, ChangePassword, UpdateProfile, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, GetPipelineJob, CreateJobBuild, CreateRetryJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, InsertBuildGetVersion, FindBuildGetVersions, GetJobBuild, CancelJobBuild, RetryJobBuild, StartPendingBuild, FindOldestPendingBuild, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions, WebhookTrigger, RegenerateWebhookToken, CreateTrigger, ListTriggersAfter, ExportDatabase}
+var _RouteNameValues = []RouteName{UserLogin, RefreshToken, CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser, ChangePassword, UpdateProfile, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, GetPipelineJob, CreateJobBuild, CreateRetryJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, InsertBuildGetVersion, FindBuildGetVersions, GetJobBuild, CancelJobBuild, RetryJobBuild, StartPendingBuild, FindOldestPendingBuild, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions, WebhookTrigger, RegenerateWebhookToken, CreateTrigger, ListTriggersAfter, ExportDatabase, GetVersion}
 
 var _RouteNameNameToValueMap = map[string]RouteName{
 	_RouteNameName[0:10]:         UserLogin,
@@ -173,6 +174,8 @@ var _RouteNameNameToValueMap = map[string]RouteName{
 	_RouteNameLowerName[742:761]: ListTriggersAfter,
 	_RouteNameName[761:776]:      ExportDatabase,
 	_RouteNameLowerName[761:776]: ExportDatabase,
+	_RouteNameName[776:787]:      GetVersion,
+	_RouteNameLowerName[776:787]: GetVersion,
 }
 
 var _RouteNameNames = []string{
@@ -224,6 +227,7 @@ var _RouteNameNames = []string{
 	_RouteNameName[728:742],
 	_RouteNameName[742:761],
 	_RouteNameName[761:776],
+	_RouteNameName[776:787],
 }
 
 // RouteNameString retrieves an enum value from the enum constants string name.

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -67,6 +67,7 @@
                     <li><a class="dropdown-item" id="nav-export-db" href="#" onclick="event.preventDefault(); exportDatabase();"><i class="bi bi-download"></i> Export Database <span class="badge bg-secondary ms-1">Admin</span></a></li>
                   <% } %>
                   <li><hr class="dropdown-divider"></li>
+                  <li><span class="dropdown-item-text text-muted small" id="app-version"></span></li>
                   <li><a class="dropdown-item" id="logout" href="/logout"><i class="bi bi-box-arrow-right"></i> Logout</a></li>
                 </ul>
               </div>


### PR DESCRIPTION
## Summary

- Add `Version` and `Commit` build-time variables (`-ldflags`) with a public `/version.json` endpoint and `--version` CLI flag
- Show the version string (e.g. `v0.2.1 (b17daa3)`) in the user dropdown menu in the header
- Inject ldflags in all build targets: Dockerfile, deploy pipeline, and Makefile release

Closes #392