### PR TITLE
Add local pipeline editor: pikoci pipeline edit (#353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Local pipeline editor: `pikoci pipeline edit ./file.hcl` opens the browser-based editor for local HCL files with live graph preview and save-to-disk ([#353](https://github.com/PikoCI/pikoci/issues/353))
 - Display current deployed version and commit hash in the web UI header dropdown and via `/version.json` API endpoint ([#392](https://github.com/PikoCI/pikoci/issues/392))
 - `--version` CLI flag to print the application version and commit hash ([#392](https://github.com/PikoCI/pikoci/issues/392))
 - Docker pull and run instructions in README Quick Start ([#387](https://github.com/PikoCI/pikoci/issues/387))

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"syscall"
+
+	"github.com/cycloidio/sqlr"
+	"github.com/lopezator/migrator"
+	"github.com/pikoci/pikoci/pikoci"
+	"github.com/pikoci/pikoci/pikoci/mysql"
+	"github.com/pikoci/pikoci/pikoci/mysql/migrate"
+	tshttp "github.com/pikoci/pikoci/pikoci/transport/http"
+	"github.com/pikoci/pikoci/pikoci/unitwork"
+	"github.com/spf13/cobra"
+)
+
+var pipelineCmd = &cobra.Command{
+	Use:   "pipeline",
+	Short: "Pipeline management commands",
+}
+
+var editCmd = &cobra.Command{
+	Use:   "edit <file.hcl>",
+	Short: "Open the pipeline editor in a browser for a local HCL file",
+	Long:  "Start a local HTTP server and open the browser-based pipeline editor pre-loaded with the given HCL file. Changes saved in the editor are written back to disk.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		filePath, err := filepath.Abs(args[0])
+		if err != nil {
+			return fmt.Errorf("failed to resolve path: %w", err)
+		}
+		port, _ := cmd.Flags().GetInt("port")
+
+		// Verify the file exists
+		if _, err := os.Stat(filePath); os.IsNotExist(err) {
+			return fmt.Errorf("file not found: %s", filePath)
+		}
+
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+		// Create in-memory DB (same pattern as cmd/run.go)
+		db, err := mysql.New("", 0, "", "", mysql.Options{
+			System:          mysql.Mem,
+			MultiStatements: true,
+			ClientFoundRows: true,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create in-memory database: %w", err)
+		}
+		defer db.Close()
+
+		nopLogger := migrator.WithLogger(migrator.LoggerFunc(func(string, ...interface{}) {}))
+		if err := migrate.Migrate(db, mysql.Mem, nopLogger); err != nil {
+			return fmt.Errorf("failed to run migrations: %w", err)
+		}
+
+		var querier sqlr.Querier = db
+		ur := mysql.NewUserRepository(querier)
+		tr := mysql.NewTeamRepository(querier)
+		ppr := mysql.NewPipelineRepository(querier)
+		jr := mysql.NewJobRepository(querier)
+		rr := mysql.NewResourceRepository(querier, mysql.Mem)
+		rt := mysql.NewResourceTypeRepository(querier)
+		br := mysql.NewBuildRepository(querier, mysql.Mem)
+		rur := mysql.NewRunnerRepository(querier)
+		str := mysql.NewSecretTypeRepository(querier)
+		tgr := mysql.NewTriggerRepository(querier)
+		suow := unitwork.NewStartUnitOfWork(db, mysql.Mem)
+
+		ctx := cmd.Context()
+		jwtSecret := []byte("local-edit-secret")
+		svc := pikoci.New(ctx, nil, nil, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, suow, jwtSecret, logger)
+
+		handler := tshttp.LocalEditorHandler(svc, filePath, logger)
+
+		listenAddr := fmt.Sprintf("127.0.0.1:%d", port)
+		listener, err := net.Listen("tcp", listenAddr)
+		if err != nil {
+			return fmt.Errorf("failed to listen on %s: %w", listenAddr, err)
+		}
+
+		actualAddr := listener.Addr().String()
+		url := "http://" + actualAddr
+		fmt.Fprintf(os.Stderr, "Local editor running at %s\n", url)
+		fmt.Fprintf(os.Stderr, "Press Ctrl+C to stop\n")
+
+		// Open browser
+		go openBrowser(url)
+
+		server := &http.Server{Handler: handler}
+
+		// Graceful shutdown
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+		go func() {
+			<-sigCh
+			fmt.Fprintf(os.Stderr, "\nShutting down...\n")
+			server.Shutdown(context.Background())
+		}()
+
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			return fmt.Errorf("server error: %w", err)
+		}
+		return nil
+	},
+}
+
+func init() {
+	editCmd.Flags().Int("port", 0, "Port to listen on (0 for random available port)")
+	pipelineCmd.AddCommand(editCmd)
+}
+
+func openBrowser(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("cmd", "/c", "start", url)
+	default:
+		fmt.Fprintf(os.Stderr, "Open %s in your browser\n", url)
+		return
+	}
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Could not open browser: %v\nOpen %s manually\n", err, url)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,4 +33,5 @@ func init() {
 	rootCmd.AddCommand(workerTokenCmd)
 	rootCmd.AddCommand(userPasswordCmd)
 	rootCmd.AddCommand(runCmd)
+	rootCmd.AddCommand(pipelineCmd)
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,16 +1,17 @@
 # CLI Reference
 
-PikoCI provides three top-level commands: `server`, `worker`, and `client`, plus `run` for local execution and utility commands `user-password` and `worker-token`.
+PikoCI provides three top-level commands: `server`, `worker`, and `client`, plus `run` for local execution, `pipeline edit` for local pipeline editing, and utility commands `user-password` and `worker-token`.
 
 ## Global structure
 
 ```
-pikoci server       [flags]          # Start the server
-pikoci worker       [flags]          # Start a standalone worker
-pikoci client       [flags] <cmd>    # Interact with the API
-pikoci run          [flags]          # Run a pipeline job locally
-pikoci user-password [flags]         # Generate hashed passwords
-pikoci worker-token  [flags]         # Generate a worker authentication token
+pikoci server              [flags]          # Start the server
+pikoci worker              [flags]          # Start a standalone worker
+pikoci client              [flags] <cmd>    # Interact with the API
+pikoci run                 [flags]          # Run a pipeline job locally
+pikoci pipeline edit       <file> [flags]   # Edit a pipeline HCL file in the browser
+pikoci user-password       [flags]          # Generate hashed passwords
+pikoci worker-token        [flags]          # Generate a worker authentication token
 ```
 
 ## client
@@ -440,6 +441,26 @@ pikoci run -p pipeline.hcl -j test --resource git.my-repo=./
 ```
 
 This replaces the `pull` step for that resource with a symlink to the local path, so your task runs against local files.
+
+## pipeline edit
+
+Open the browser-based pipeline editor for a local HCL file. Starts a minimal local HTTP server with the full editor UI (CodeMirror syntax highlighting, live graph preview, block navigation), pre-loaded with the file contents. Changes saved in the editor are written back to disk. No PikoCI server or authentication required.
+
+```bash
+pikoci pipeline edit ./pipeline.hcl
+```
+
+With a specific port:
+
+```bash
+pikoci pipeline edit ./pipeline.hcl --port 8181
+```
+
+| Flag | Default | Required | Description |
+|------|---------|----------|-------------|
+| `--port` | `0` (random) | no | Port to listen on (`0` picks a random available port) |
+
+The server binds to `127.0.0.1` only. Press `Ctrl+C` to stop.
 
 ## user-password
 

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -92,6 +92,16 @@ docker compose up
 
 Open [http://localhost:8080](http://localhost:8080) and log in with `admin` / `admin123`. The hello-world pipeline runs automatically every 10 seconds.
 
+## Edit pipelines locally
+
+You can use the browser-based editor to develop pipelines without running a server:
+
+```bash
+pikoci pipeline edit ./pipeline.hcl
+```
+
+This opens the full editor UI with syntax highlighting, live graph preview, and block navigation. Changes are saved back to disk. See [CLI Reference](CLI.md#pipeline-edit) for details.
+
 ## Next steps
 
 - [Pipeline Reference](Pipeline.md) - Full HCL syntax

--- a/pikoci/transport/http/assets/js/app/local-init.js
+++ b/pikoci/transport/http/assets/js/app/local-init.js
@@ -1,0 +1,96 @@
+'use strict';
+
+import './namespace.js';
+import { ApiNotice, Pipeline } from './models.js';
+import { PipelinesNewView } from './views/editor.js';
+
+// Set up minimal app globals
+var apiNotice = new ApiNotice();
+window.app.apiNotice = apiNotice;
+window.app.session = new (Backbone.Model.extend({
+  isEmpty: function() { return true; },
+  isAdmin: function() { return true; },
+  isMember: function() { return true; },
+  data: function() {
+    return {
+      isAdmin: function() { return true; },
+      isMember: function() { return true; },
+    };
+  },
+}))();
+
+// Override Backbone.sync to skip auth headers
+var backboneSync = Backbone.sync;
+Backbone.sync = function(method, model, options) {
+  options.headers = {
+    'Content-Type': 'application/json',
+  };
+  var optError = options.error;
+  options.error = function(response) {
+    var msg = (response.responseJSON && response.responseJSON.error) || response.statusText || 'Unknown error';
+    apiNotice.set({error: msg});
+    if (optError) optError(response);
+  };
+  var optSuccess = options.success;
+  options.success = function(response) {
+    apiNotice.clear();
+    if (optSuccess) optSuccess(response);
+  };
+  return backboneSync(method, model, options);
+};
+
+// Notice view
+var NoticeView = Backbone.View.extend({
+  template: _.template($('#notice-view').html()),
+  initialize: function() {
+    this.listenTo(this.model, 'change', this.render);
+  },
+  render: function() {
+    this.$el.html(this.template(this.model.toJSON()));
+    return this;
+  },
+});
+
+// Fetch initial config and boot the editor
+$.getJSON('/local/config', function(config) {
+  var model = new Pipeline({
+    raw: config.raw,
+    name: config.name,
+    canonical: null,
+    id: null,
+  });
+
+  var collection = {
+    url: function() { return '/teams/local/pipelines'; },
+    create: function(attrs, options) {
+      options = options || {};
+      $.ajax({
+        url: '/local/save',
+        type: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify({config: btoa(String.fromCharCode.apply(null, attrs.config))}),
+        success: function() {
+          apiNotice.setSuccess('File saved successfully');
+          // Do not call options.success — it tries to navigate via router which doesn't exist locally
+        },
+        error: function(xhr) {
+          var msg = 'Failed to save file';
+          try {
+            var resp = JSON.parse(xhr.responseText);
+            if (resp && resp.error) msg = resp.error;
+          } catch(e) {}
+          apiNotice.set({error: msg});
+          if (options.error) options.error(xhr);
+        },
+      });
+    },
+  };
+
+  // Render main layout
+  $('#app').html($('#main-view').html());
+  var noticeView = new NoticeView({model: apiNotice});
+  $('#notice').html(noticeView.render().el);
+
+  var view = new PipelinesNewView({model: model, collection: collection});
+  $('#main').html(view.render().el);
+});

--- a/pikoci/transport/http/local.go
+++ b/pikoci/transport/http/local.go
@@ -1,0 +1,232 @@
+package http
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/gorilla/mux"
+	"github.com/pikoci/pikoci/pikoci"
+	"github.com/pikoci/pikoci/pikoci/transport/http/assets"
+)
+
+// LocalEditorHandler creates an HTTP handler for the local pipeline editor.
+// It serves the editor UI pre-loaded with the HCL file at filePath,
+// provides graph preview via the existing createPipelineImage handler,
+// and writes changes back to disk on save.
+func LocalEditorHandler(s pikoci.Service, filePath string, l *slog.Logger) http.Handler {
+	r := mux.NewRouter()
+
+	// API: load initial config
+	r.Methods(http.MethodGet).Path("/local/config").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		json.NewEncoder(w).Encode(map[string]string{
+			"raw":  base64.StdEncoding.EncodeToString(data),
+			"name": filepath.Base(filePath),
+		})
+	})
+
+	// API: save file
+	r.Methods(http.MethodPost).Path("/local/save").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		req.Body = http.MaxBytesReader(w, req.Body, 10<<20) // 10MB limit
+		var body struct {
+			Config []byte `json:"config"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			return
+		}
+		if err := os.WriteFile(filePath, body.Config, 0644); err != nil {
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	})
+
+	// Graph preview: reuse existing handler
+	r.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/image{ext}").Handler(createPipelineImage(s))
+
+	// Static assets
+	r.PathPrefix("/css/").Handler(http.FileServer(http.FS(assets.Assets)))
+	r.PathPrefix("/js/").Handler(http.FileServer(http.FS(assets.Assets)))
+	r.PathPrefix("/images/").Handler(http.FileServer(http.FS(assets.Assets)))
+	r.PathPrefix("/fonts/").Handler(http.FileServer(http.FS(assets.Assets)))
+
+	// Root: serve local editor HTML
+	r.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Write([]byte(localEditorHTML))
+	})
+
+	// JSON content-type wrapper (same as main handler)
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if len(req.URL.Path) > 5 && req.URL.Path[len(req.URL.Path)-5:] == ".json" {
+			req.URL.Path = req.URL.Path[:len(req.URL.Path)-5]
+			req.Header.Set("Content-Type", "application/json")
+		}
+		r.ServeHTTP(w, req)
+	})
+}
+
+const localEditorHTML = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>PikoCI - Local Editor</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link href="/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="/css/pikoci.css" rel="stylesheet" />
+    <link href="/css/bootstrap-icons.min.css" rel="stylesheet" />
+    <link href="/images/favicon.svg" rel="icon" type="image/svg+xml"/>
+  </head>
+
+  <body>
+    <div id="app">
+    </div>
+
+    <script type="text/javascript" src="/js/jquery.min.js"></script>
+    <script type="text/javascript" src="/js/underscorejs.min.js"></script>
+    <script type="text/javascript" src="/js/backbonejs.min.js"></script>
+    <script type="text/javascript" src="/js/bootstrap.bundle.min.js"></script>
+    <script type="text/javascript" src="/js/viz-global.js"></script>
+    <script type="text/javascript" src="/js/codemirror-hcl.min.js"></script>
+
+    <script type="text/template" id="main-view">
+      <main class="container">
+        <div id="notice"></div>
+        <div id="main"></div>
+      </main>
+    </script>
+
+    <script type="text/template" id="notice-view">
+      <div>
+        <% if (error) { %>
+          <div class="alert alert-danger" role="alert">
+            <%- error %>
+          </div>
+        <% } %>
+        <% if (success) { %>
+          <div class="alert alert-success" role="alert">
+            <%- success %>
+          </div>
+        <% } %>
+      </div>
+    </script>
+
+    <script type="text/template" id="pipeline-graph-view">
+      <div id="pipeline-graph"></div>
+    </script>
+
+    <script type="text/template" id="pipelines-new-view">
+      <div class="piko-page-header mb-3">
+        <h1 class="h4 fw-bold mb-0">Local Editor</h1>
+      </div>
+      <form>
+        <div class="piko-settings-row mb-3" style="display:none;">
+          <div class="piko-field">
+            <label class="form-label">Name</label>
+            <input type="text" class="form-control" id="name" value="<%- name %>" style="width:280px">
+          </div>
+          <div class="piko-checkbox-inline">
+            <input type="checkbox" class="form-check-input" id="public">
+            <label class="form-check-label" for="public">Public</label>
+          </div>
+        </div>
+        <div class="piko-editor-card" id="editor-card">
+          <div class="piko-editor-toolbar">
+            <div class="piko-tab active" id="tab-hcl">pipeline.hcl</div>
+            <div class="piko-tab" id="tab-vars">vars.json</div>
+            <div class="piko-toolbar-spacer"></div>
+            <div class="piko-docs-dropdown" id="docs-dropdown">
+              <button type="button" class="piko-tbtn" id="docs-btn" title="Pipeline documentation">
+                <i class="bi bi-book"></i> <span class="piko-tbtn-label">Docs</span> <i class="bi bi-chevron-down" style="font-size:0.6rem;margin-left:2px"></i>
+              </button>
+              <div class="piko-docs-menu" id="docs-menu">
+                <a href="https://docs.pikoci.com/Pipeline" target="_blank" rel="noopener"><i class="bi bi-file-text"></i> Pipeline overview</a>
+                <div class="piko-docs-divider"></div>
+                <div class="piko-docs-label">Blocks</div>
+                <a href="https://docs.pikoci.com/Pipeline#job" target="_blank" rel="noopener"><span class="piko-block-icon jb">J</span> job</a>
+                <a href="https://docs.pikoci.com/Pipeline#resource" target="_blank" rel="noopener"><span class="piko-block-icon rs">R</span> resource</a>
+                <a href="https://docs.pikoci.com/Pipeline#resource_type" target="_blank" rel="noopener"><span class="piko-block-icon rt">R</span> resource_type</a>
+                <a href="https://docs.pikoci.com/Pipeline#runner_type" target="_blank" rel="noopener"><span class="piko-block-icon rn">R</span> runner_type</a>
+                <a href="https://docs.pikoci.com/Pipeline#secret_type" target="_blank" rel="noopener"><span class="piko-block-icon st">S</span> secret_type</a>
+                <a href="https://docs.pikoci.com/Pipeline#service_type" target="_blank" rel="noopener"><span class="piko-block-icon sv">S</span> service_type</a>
+                <a href="https://docs.pikoci.com/Pipeline#variable" target="_blank" rel="noopener"><span class="piko-block-icon vr">V</span> variable</a>
+              </div>
+            </div>
+            <div class="piko-toolbar-sep"></div>
+            <button type="button" class="piko-tbtn active" id="blocks-btn" title="Toggle blocks panel">
+              <i class="bi bi-list-nested"></i> <span class="piko-tbtn-label">Blocks</span>
+              <span class="piko-error-badge"></span>
+            </button>
+            <div class="piko-toolbar-sep"></div>
+            <button type="button" class="piko-tbtn" id="graph-btn" title="Toggle graph preview">
+              <i class="bi bi-diagram-3"></i>
+            </button>
+            <div class="piko-toolbar-sep"></div>
+            <button type="button" class="piko-tbtn" id="fullscreen-btn" title="Fullscreen (Esc to exit)">
+              <i class="bi bi-arrows-fullscreen"></i>
+            </button>
+          </div>
+          <div class="piko-editor-body">
+            <div class="piko-blocks-panel" id="blocks-panel"></div>
+            <div class="piko-code-area" id="code-area">
+              <div id="pipeline-editor"></div>
+              <textarea id="pipeline" style="display:none"><%- raw %></textarea>
+            </div>
+            <div class="piko-vars-area" id="vars-area">
+              <textarea type="text" rows="10" class="form-control" id="vars" placeholder='{"key": "value"}'></textarea>
+              <div class="piko-vars-hint">JSON object passed as variables to the pipeline definition.</div>
+            </div>
+          </div>
+          <div class="piko-graph-bottom" id="graph-bottom-panel">
+            <div class="piko-graph-bottom-header">
+              <span><i class="bi bi-diagram-3"></i> Graph Preview</span>
+              <button type="button" id="graph-bottom-close" title="Close"><i class="bi bi-x-lg"></i></button>
+            </div>
+            <div class="piko-graph-bottom-body" id="graph-fullscreen"></div>
+          </div>
+        </div>
+        <div class="piko-graph-strip" id="graph-strip">
+          <div class="piko-graph-strip-header" id="graph-strip-header">
+            <span><i class="bi bi-diagram-3"></i> Graph Preview</span>
+            <i class="bi bi-chevron-right piko-graph-chev"></i>
+          </div>
+          <div class="piko-graph-strip-body" id="graph">
+          </div>
+        </div>
+        <button type="submit" class="btn btn-primary mt-2" id="create">Save</button>
+      </form>
+    </script>
+
+    <script type="text/javascript">
+      'use strict';
+      (function() {
+        var saved = localStorage.getItem('piko-theme');
+        if (saved === 'dark') {
+          document.documentElement.setAttribute('data-theme', 'dark');
+        }
+      })();
+    </script>
+
+    <script type="module" src="/js/app/local-init.js"></script>
+
+  </body>
+</html>`


### PR DESCRIPTION
## Summary

- Add `pikoci pipeline edit <file.hcl>` CLI command that opens the browser-based pipeline editor for local HCL files
- Starts a minimal local HTTP server (127.0.0.1 only) with the full editor UI: CodeMirror syntax highlighting, live graph preview via Viz.js, block navigation panel, docs dropdown
- Reuses existing `createPipelineImage` handler for graph preview and all embedded frontend assets
- Changes saved in the editor are written back to disk; no server or authentication required
- Updated CLI reference and Getting Started documentation

Closes #353