### PR TITLE
Fix webhook tokens lost on pipeline update (#408)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Webhook tokens lost on every pipeline update, causing GitHub webhooks to return 400 ([#408](https://github.com/PikoCI/pikoci/issues/408))
 - Re-enqueue pending builds on server startup so they are not stranded forever ([#399](https://github.com/PikoCI/pikoci/issues/399))
 - Error banner persists after backend reconnects: polling successes now clear errors, connection failures show "Connection lost. Retrying...", and polling errors are debounced ([#400](https://github.com/PikoCI/pikoci/issues/400))
 

--- a/pikoci/mysql/migrate/migrate.go
+++ b/pikoci/mysql/migrate/migrate.go
@@ -45,6 +45,13 @@ func Migrate(db *sql.DB, system string, opts ...migrator.Option) error {
 	return nil
 }
 
+// sqliteUUIDExpr is the SQLite expression used to generate UUID v4 values.
+const sqliteUUIDExpr = `lower(hex(randomblob(4))) || '-' || lower(hex(randomblob(2))) || '-4' || substr(lower(hex(randomblob(2))),2) || '-' || substr('89ab',abs(random()) % 4 + 1, 1) || substr(lower(hex(randomblob(2))),2) || '-' || lower(hex(randomblob(6)))`
+
+func replaceSQLiteUUID(sql, replacement string) string {
+	return strings.ReplaceAll(sql, sqliteUUIDExpr, replacement)
+}
+
 func adaptSQL(sql, system string) string {
 	switch system {
 	case mysql.Mem, mysql.SQLite:
@@ -62,11 +69,15 @@ func adaptSQL(sql, system string) string {
 		sql = strings.ReplaceAll(sql, "`check`", `"check"`)
 		// PostgreSQL doesn't support RENAME COLUMN with the same syntax in older versions,
 		// but ALTER TABLE ... RENAME COLUMN is standard and works in PG 9.6+
+		// Replace SQLite UUID expression with PostgreSQL's gen_random_uuid()
+		sql = replaceSQLiteUUID(sql, "gen_random_uuid()")
 	case mysql.MySQL:
 		// MySQL/MariaDB doesn't support CASCADE on DROP TABLE,
 		// but SET FOREIGN_KEY_CHECKS=0 achieves the same effect
 		sql = strings.ReplaceAll(sql, "DROP TABLE IF EXISTS pipelines CASCADE;",
 			"SET FOREIGN_KEY_CHECKS = 0; DROP TABLE IF EXISTS pipelines; SET FOREIGN_KEY_CHECKS = 1;")
+		// Replace SQLite UUID expression with MySQL's UUID()
+		sql = replaceSQLiteUUID(sql, "UUID()")
 	}
 	return sql
 }

--- a/pikoci/mysql/migrate/migrations/V23BackfillWebhookTokens.go
+++ b/pikoci/mysql/migrate/migrations/V23BackfillWebhookTokens.go
@@ -1,0 +1,9 @@
+package migrations
+
+// V23BackfillWebhookTokens generates webhook tokens for resources that were
+// created before V10 added the column. The hex(randomblob()) expression works
+// on SQLite; adaptSQL in migrate.go replaces it for MySQL and PostgreSQL.
+var V23BackfillWebhookTokens = Migration{
+	Name: "BackfillWebhookTokens",
+	SQL: `UPDATE resources SET webhook_token = lower(hex(randomblob(4))) || '-' || lower(hex(randomblob(2))) || '-4' || substr(lower(hex(randomblob(2))),2) || '-' || substr('89ab',abs(random()) % 4 + 1, 1) || substr(lower(hex(randomblob(2))),2) || '-' || lower(hex(randomblob(6))) WHERE webhook_token = '' OR webhook_token IS NULL;`,
+}

--- a/pikoci/mysql/migrate/migrations/migrations.go
+++ b/pikoci/mysql/migrate/migrations/migrations.go
@@ -16,7 +16,7 @@ type Migration struct {
 // Migrations is the ordered list of all schema migrations. It is defined as
 // a fixed-size array so that the compiler catches ordering conflicts when
 // multiple developers add migrations concurrently.
-var Migrations = [23]Migration{
+var Migrations = [24]Migration{
 	V0Initial,
 	V1ResourceCheckInterval,
 	V2JobsAndBuilds,
@@ -40,4 +40,5 @@ var Migrations = [23]Migration{
 	V20Triggers,
 	V21PipelineCanonical,
 	V22PendingBuilds,
+	V23BackfillWebhookTokens,
 }

--- a/pikoci/mysql/pipeline.go
+++ b/pikoci/mysql/pipeline.go
@@ -330,7 +330,7 @@ const pipelineQuery = `
 	SELECT
 		p.id, p.name, p.canonical, p.raw, p.public,
 		j.id, j.name, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure,
-		r.id, r.name, r.type, r.canonical, r.params, r.check_interval, r.logs, r.last_check, r.next_check,
+		r.id, r.name, r.type, r.canonical, r.params, r.check_interval, r.logs, r.last_check, r.next_check, r.webhook_token,
 		rt.id, rt.name, rt.` + "`check`" + `, rt.pull, rt.push, rt.params,
 		ru.id, ru.name, ru.run,
 		st.id, st.name, st.source, st.get, st.params, st.config
@@ -368,7 +368,7 @@ func scanPipelines(rows *sql.Rows) ([]*pipeline.Pipeline, error) {
 		err := rows.Scan(
 			&pp.ID, &pp.Name, &pp.Canonical, &pp.Raw, &pp.Public,
 			&j.ID, &j.Name, &j.Plan, &j.OnSuccess, &j.OnFailure, &j.OnCancel, &j.Ensure,
-			&r.ID, &r.Name, &r.Type, &r.Canonical, &r.Params, &r.CheckInterval, &r.Logs, &r.LastCheck, &r.NextCheck,
+			&r.ID, &r.Name, &r.Type, &r.Canonical, &r.Params, &r.CheckInterval, &r.Logs, &r.LastCheck, &r.NextCheck, &r.WebhookToken,
 			&rt.ID, &rt.Name, &rt.Check, &rt.Pull, &rt.Push, &rt.Params,
 			&ru.ID, &ru.Name, &ru.Run,
 			&st.ID, &st.Name, &st.Source, &st.Get, &st.Params, &st.Config,


### PR DESCRIPTION
## Summary

- The `pipelineQuery` SELECT was missing `r.webhook_token`, so `GetPipeline` always returned resources with empty `WebhookToken`
- `UpdatePipeline` copied that empty value back to the DB, wiping any real token on every pipeline update
- Adds a V23 migration to backfill UUIDs for resources with empty webhook tokens

Closes #408