### PR TITLE
Add base_url param to github-check for automatic Details links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Local pipeline editor: `pikoci pipeline edit ./file.hcl` opens the browser-based editor for local HCL files with live graph preview and save-to-disk ([#353](https://github.com/PikoCI/pikoci/issues/353))
+- `base_url` param for `github-check` resource type to auto-construct a Details link on GitHub check runs from build metadata ([#257](https://github.com/PikoCI/pikoci/issues/257))
 - Display current deployed version and commit hash in the web UI header dropdown and via `/version.json` API endpoint ([#392](https://github.com/PikoCI/pikoci/issues/392))
 - `--version` CLI flag to print the application version and commit hash ([#392](https://github.com/PikoCI/pikoci/issues/392))
 - Docker pull and run instructions in README Quick Start ([#387](https://github.com/PikoCI/pikoci/issues/387))

--- a/deploy/pipeline.hcl
+++ b/deploy/pipeline.hcl
@@ -391,6 +391,7 @@ resource "github-check" "ci" {
     installation_id = var.github_app_installation_id
     private_key     = var.pikoci_github_app_pem
     repository      = "PikoCI/pikoci"
+    base_url        = "https://${var.pikoci_domain}"
   }
 }
 
@@ -432,6 +433,13 @@ secret_type "pikoci_github_pem" {
   source = "pikoci://file"
   format = "raw"
   path   = "/etc/pikoci/pikoci_github_app.pem"
+}
+
+variable "pikoci_domain" {
+  type = string
+  secret "env" {
+    key = "PIKOCI_DOMAIN"
+  }
 }
 
 variable "go_image" {

--- a/docs/Resource-Types.md
+++ b/docs/Resource-Types.md
@@ -411,6 +411,7 @@ job "test" {
 | `installation_id` | yes      | GitHub App installation ID                       |
 | `private_key`     | yes      | GitHub App private key content (PEM format). Use the `file` secret type with `format = "raw"` to read from a PEM file |
 | `repository`      | yes      | Repository in `owner/repo` format                |
+| `base_url`        | no       | PikoCI instance URL (e.g. `https://ci.pikoci.com`). When set, auto-constructs a `details_url` from `$BUILD_*` env vars if no explicit `put_details_url` is provided. The constructed URL follows the pattern: `{base_url}/teams/{team}/pipelines/{pipeline}/jobs/{job}/builds/{number}` |
 
 ### Put params
 

--- a/pikoci/builtin/resource_types/github-check.hcl
+++ b/pikoci/builtin/resource_types/github-check.hcl
@@ -4,6 +4,7 @@ resource_type "github-check" {
     "installation_id",
     "private_key",
     "repository",
+    "base_url",
   ]
   push "exec" {
     path = "/bin/sh"
@@ -20,6 +21,13 @@ resource_type "github-check" {
       HEAD_SHA="$put_head_sha"
       CHECK_NAME="$put_name"
       DETAILS_URL="$put_details_url"
+      BASE_URL="$param_base_url"
+      BASE_URL="$${BASE_URL%/}"
+
+      # Default details URL from base_url and build metadata
+      if [ -z "$DETAILS_URL" ] && [ -n "$BASE_URL" ]; then
+        DETAILS_URL="$${BASE_URL}/teams/$${BUILD_TEAM_NAME}/pipelines/$${BUILD_PIPELINE_NAME}/jobs/$${BUILD_JOB_NAME}/builds/$${BUILD_NUMBER}"
+      fi
 
       # Default check name from build metadata
       if [ -z "$CHECK_NAME" ]; then


### PR DESCRIPTION
## Summary

- Adds a `base_url` resource-level param to the `github-check` resource type that auto-constructs a Details URL from `$BUILD_*` env vars when no explicit `details_url` is set on the put step
- Updates the deploy pipeline to use the new param with `https://ci.pikoci.com`
- Documents the new param in Resource-Types.md

Closes #257