### PR TITLE
Refresh active build view during polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Webhook tokens lost on every pipeline update, causing GitHub webhooks to return 400 ([#408](https://github.com/PikoCI/pikoci/issues/408))
+- Active build view not refreshing steps and logs during execution ([#411](https://github.com/PikoCI/pikoci/issues/411))
 - Re-enqueue pending builds on server startup so they are not stranded forever ([#399](https://github.com/PikoCI/pikoci/issues/399))
 - Error banner persists after backend reconnects: polling successes now clear errors, connection failures show "Connection lost. Retrying...", and polling errors are debounced ([#400](https://github.com/PikoCI/pikoci/issues/400))
 

--- a/pikoci/transport/http/assets/js/app/collections.js
+++ b/pikoci/transport/http/assets/js/app/collections.js
@@ -1,7 +1,6 @@
 'use strict';
 
 import { Session, ApiNotice, User, Team, Pipeline, PipelineImage, Job, Build, Resource, ResourceVersion, TeamMembers } from './models.js';
-import { durationToString } from './namespace.js';
 
 export var Users = Backbone.Collection.extend({
   model: User,
@@ -90,19 +89,7 @@ export var Builds = Backbone.Collection.extend({
         this.oldestID = response.meta.oldest_id;
       }
     }
-    var builds = response.data;
-    _.each(builds, function(data) {
-      if (data.duration  !== 0) {
-        data.duration = durationToString(data.duration);
-      }
-      _.each(data.steps, function(s, i) {
-        data.steps[i].duration = durationToString(s.duration);
-      });
-      _.each(data.job, function(j, i) {
-        data.job[i].duration = durationToString(j.duration);
-      });
-    });
-    return builds;
+    return response.data;
   },
   fetchMore: function() {
     if (this.loadingMore || !this.hasMore) return;
@@ -115,15 +102,16 @@ export var Builds = Backbone.Collection.extend({
       error: function() { that.loadingMore = false; },
     });
   },
-  fetchNew: function() {
+  fetchNew: function(opts) {
+    opts = opts || {};
     if (!this.newestID) {
-      this.fetch({ remove: false });
+      this.fetch(_.extend({ remove: false }, opts));
       return;
     }
-    this.fetch({
+    this.fetch(_.extend({
       remove: false,
       data: { after: this.newestID },
-    });
+    }, opts));
   },
   setActive: function(id) {
     if (!id && this.first()) {

--- a/pikoci/transport/http/assets/js/app/models.js
+++ b/pikoci/transport/http/assets/js/app/models.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import { durationToString } from './namespace.js';
+
 export var Session = Backbone.Model.extend({
   url: "login",
   parse: function(response) {
@@ -151,10 +153,17 @@ export var Job = Backbone.Model.extend({
 export var Build = Backbone.Model.extend({
   idAttribute: "build_number",
   parse: function(response) {
-    if (response.data){
-      return response.data;
+    var data = response.data ? response.data : response;
+    if (data.duration !== 0) {
+      data.duration = durationToString(data.duration);
     }
-    return response;
+    _.each(data.steps, function(s, i) {
+      data.steps[i].duration = durationToString(s.duration);
+    });
+    _.each(data.job, function(j, i) {
+      data.job[i].duration = durationToString(j.duration);
+    });
+    return data;
   }
 });
 

--- a/pikoci/transport/http/assets/js/app/views/jobs.js
+++ b/pikoci/transport/http/assets/js/app/views/jobs.js
@@ -23,7 +23,9 @@ export var JobBuildsView = Backbone.View.extend({
     });
 
     this.intervalID = window.setInterval(function() {
-      that.collection.fetchNew();
+      that.collection.fetchNew({
+        success: function() { that.fetchActiveBuild(); }
+      });
     }, fetchInterval);
   },
   events: {
@@ -104,6 +106,13 @@ export var JobBuildsView = Backbone.View.extend({
         contEl.append(cont.render().el);
       }
     }
+  },
+  fetchActiveBuild: function() {
+    var active = this.collection.find(function(m) { return m.get("active"); });
+    if (!active) return;
+    var status = active.get("status");
+    if (status === "succeeded" || status === "failed" || status === "cancelled") return;
+    active.fetch();
   },
   clickTriggerJob: function(event) {
     event.preventDefault();


### PR DESCRIPTION
## Summary

- Re-fetch the active build model every poll interval so new steps, logs, and status changes appear without a page refresh
- Only polls running builds (skips succeeded/failed/cancelled)
- Moved duration formatting from `Builds` collection parse to `Build` model parse so it works for both list and individual fetches

Closes #411