### PR TITLE
Preserve version_id on build when worker starts it

### DIFF
--- a/worker/service.go
+++ b/worker/service.go
@@ -297,11 +297,13 @@ func (w *Worker) processJob(ctx context.Context, m queue.Body, cwd string, pp *p
 	}
 
 	b := build.Build{
-		ID:          nb.ID,
-		BuildNumber: nb.BuildNumber,
-		Status:      build.Started,
-		StartedAt:   nb.StartedAt,
-		Steps:       []build.Step{},
+		ID:                nb.ID,
+		BuildNumber:       nb.BuildNumber,
+		Status:            build.Started,
+		StartedAt:         nb.StartedAt,
+		Steps:             []build.Step{},
+		VersionID:         nb.VersionID,
+		ResourceCanonical: nb.ResourceCanonical,
 	}
 
 	// If the message doesn't carry version info, fall back to what was stored on the build


### PR DESCRIPTION
## Summary

- Worker was creating a new build struct without copying `VersionID` from the pending build, so `updateBuild` overwrote `version_id` to 0 in the DB
- This broke the `NOT EXISTS` check in `FindReadyDownstreamVersion` from #414, causing the scheduler to keep creating duplicate builds

Closes #413