### PR TITLE
Move pending build re-enqueue to after workers start

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -138,9 +138,6 @@ var serverCmd = &cobra.Command{
 		logger.Info("initializing service")
 		var svc = pikoci.New(ctx, jobTopic, checkTopic, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, suow, jwtSecret, logger)
 		svc.StartScheduler(ctx)
-		if err := svc.ReEnqueuePendingBuilds(ctx); err != nil {
-			logger.Error("failed to re-enqueue pending builds", "error", err)
-		}
 		logger.Info("initialized service")
 
 		logger.Info("initializing http handlers")
@@ -201,6 +198,10 @@ var serverCmd = &cobra.Command{
 				return fmt.Errorf("worker failed to start: %w", werr)
 			}
 			defer workerCleanup()
+
+			if err := svc.ReEnqueuePendingBuilds(ctx); err != nil {
+				logger.Error("failed to re-enqueue pending builds", "error", err)
+			}
 		}
 
 		pipelineName := serverViper.GetString("pipeline-name")


### PR DESCRIPTION
## Summary

- `ReEnqueuePendingBuilds` was called during service init, before workers subscribed to the in-memory pubsub. Messages were dropped silently, leaving pending builds stranded after every restart.
- Moved the call to after `runWorker`, which opens subscriptions before returning.