### PR TITLE
Fix tag mode returning all tags on every check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Git resource tag mode returns all tags on every check, triggering builds for every historical tag after pipeline recreation ([#419](https://github.com/PikoCI/pikoci/issues/419))
+
 ## [0.2.2] - 2026-05-29
 
 ### Added

--- a/pikoci/builtin/resource_check_test.go
+++ b/pikoci/builtin/resource_check_test.go
@@ -234,7 +234,8 @@ func TestGitCheck_TagMode_GitHub_FirstCheck(t *testing.T) {
 }
 
 func TestGitCheck_TagMode_GitHub_SubsequentCheck(t *testing.T) {
-	cannedTags := `[{"name":"v3","commit":{"sha":"aaa"}},{"name":"v2","commit":{"sha":"bbb"}}]`
+	// v3 and v4 are newer than the known tag v2; v1 is older.
+	cannedTags := `[{"name":"v4","commit":{"sha":"ddd"}},{"name":"v3","commit":{"sha":"aaa"}},{"name":"v2","commit":{"sha":"bbb"}},{"name":"v1","commit":{"sha":"ccc"}}]`
 	curlDir, logFile := fakeCurlDir(t, cannedTags)
 	rts := builtin.ResourceTypes()
 	rt := rts["git"]
@@ -243,8 +244,8 @@ func TestGitCheck_TagMode_GitHub_SubsequentCheck(t *testing.T) {
 		"param_url":   "https://github.com/example/repo",
 		"param_token": "fake-token",
 		"param_tag":   "true",
-		"version_tag": "v1",
-		"version_ref": "old-sha",
+		"version_tag": "v2",
+		"version_ref": "bbb",
 		"PATH":        curlDir + ":" + os.Getenv("PATH"),
 	})
 	require.NoError(t, err, "git check (GitHub tag, subsequent) failed: %s", out)
@@ -256,7 +257,31 @@ func TestGitCheck_TagMode_GitHub_SubsequentCheck(t *testing.T) {
 
 	var versions []map[string]interface{}
 	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &versions))
-	assert.Len(t, versions, 2)
+	assert.Len(t, versions, 2, "should only return tags newer than known tag v2")
+	assert.Equal(t, "v4", versions[0]["tag"])
+	assert.Equal(t, "v3", versions[1]["tag"])
+}
+
+func TestGitCheck_TagMode_GitHub_SubsequentCheck_NoNewTags(t *testing.T) {
+	// Known tag is the latest — no new tags to return.
+	cannedTags := `[{"name":"v2","commit":{"sha":"bbb"}},{"name":"v1","commit":{"sha":"ccc"}}]`
+	curlDir, _ := fakeCurlDir(t, cannedTags)
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":   "https://github.com/example/repo",
+		"param_token": "fake-token",
+		"param_tag":   "true",
+		"version_tag": "v2",
+		"version_ref": "bbb",
+		"PATH":        curlDir + ":" + os.Getenv("PATH"),
+	})
+	require.NoError(t, err, "git check (GitHub tag, no new) failed: %s", out)
+
+	var versions []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &versions))
+	assert.Len(t, versions, 0, "should return empty list when no new tags exist")
 }
 
 func TestGitCheck_TagMode_GitLab_FirstCheck(t *testing.T) {
@@ -280,7 +305,8 @@ func TestGitCheck_TagMode_GitLab_FirstCheck(t *testing.T) {
 }
 
 func TestGitCheck_TagMode_GitLab_SubsequentCheck(t *testing.T) {
-	cannedTags := `[{"name":"v3","commit":{"id":"aaa"}},{"name":"v2","commit":{"id":"bbb"}}]`
+	// v4 and v3 are newer than the known tag v2; v1 is older.
+	cannedTags := `[{"name":"v4","commit":{"id":"ddd"}},{"name":"v3","commit":{"id":"aaa"}},{"name":"v2","commit":{"id":"bbb"}},{"name":"v1","commit":{"id":"ccc"}}]`
 	curlDir, logFile := fakeCurlDir(t, cannedTags)
 	rts := builtin.ResourceTypes()
 	rt := rts["git"]
@@ -289,8 +315,8 @@ func TestGitCheck_TagMode_GitLab_SubsequentCheck(t *testing.T) {
 		"param_url":   "https://gitlab.com/example/repo",
 		"param_token": "fake-token",
 		"param_tag":   "true",
-		"version_tag": "v1",
-		"version_ref": "old-sha",
+		"version_tag": "v2",
+		"version_ref": "bbb",
 		"PATH":        curlDir + ":" + os.Getenv("PATH"),
 	})
 	require.NoError(t, err, "git check (GitLab tag, subsequent) failed: %s", out)
@@ -301,7 +327,30 @@ func TestGitCheck_TagMode_GitLab_SubsequentCheck(t *testing.T) {
 
 	var versions []map[string]interface{}
 	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &versions))
-	assert.Len(t, versions, 2)
+	assert.Len(t, versions, 2, "should only return tags newer than known tag v2")
+	assert.Equal(t, "v4", versions[0]["tag"])
+	assert.Equal(t, "v3", versions[1]["tag"])
+}
+
+func TestGitCheck_TagMode_GitLab_SubsequentCheck_NoNewTags(t *testing.T) {
+	cannedTags := `[{"name":"v2","commit":{"id":"bbb"}},{"name":"v1","commit":{"id":"ccc"}}]`
+	curlDir, _ := fakeCurlDir(t, cannedTags)
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":   "https://gitlab.com/example/repo",
+		"param_token": "fake-token",
+		"param_tag":   "true",
+		"version_tag": "v2",
+		"version_ref": "bbb",
+		"PATH":        curlDir + ":" + os.Getenv("PATH"),
+	})
+	require.NoError(t, err, "git check (GitLab tag, no new) failed: %s", out)
+
+	var versions []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &versions))
+	assert.Len(t, versions, 0, "should return empty list when no new tags exist")
 }
 
 func TestGitCheck_PRMode_GitHub_FirstCheck(t *testing.T) {

--- a/pikoci/builtin/resource_types/git.hcl
+++ b/pikoci/builtin/resource_types/git.hcl
@@ -40,7 +40,13 @@ resource_type "git" {
           REPO=$(echo "$URL" | sed -E 's|https?://github\.com/||;s|\.git$||')
           curl -sf -H "Authorization: token $TOKEN" \
             "https://api.github.com/repos/$REPO/tags?per_page=$PER_PAGE" \
-            | jq -c '[.[] | {"ref": .commit.sha, "tag": .name}]'
+            | jq -c --arg known "$version_tag" \
+              'map({"ref": .commit.sha, "tag": .name})
+               | if $known == "" then .
+                 else reduce .[] as $t ({out:[], done:false};
+                   if .done then . else (if $t.tag == $known then .done=true else .out += [$t] end) end
+                 ) | .out
+                 end'
           exit 0
         fi
 
@@ -49,7 +55,13 @@ resource_type "git" {
           PROJECT=$(echo "$URL" | sed -E 's|https?://gitlab\.com/||;s|\.git$||' | sed 's|/|%2F|g')
           curl -sf -H "PRIVATE-TOKEN: $TOKEN" \
             "https://gitlab.com/api/v4/projects/$PROJECT/repository/tags?order_by=updated&sort=desc&per_page=$PER_PAGE" \
-            | jq -c '[.[] | {"ref": .commit.id, "tag": .name}]'
+            | jq -c --arg known "$version_tag" \
+              'map({"ref": .commit.id, "tag": .name})
+               | if $known == "" then .
+                 else reduce .[] as $t ({out:[], done:false};
+                   if .done then . else (if $t.tag == $known then .done=true else .out += [$t] end) end
+                 ) | .out
+                 end'
           exit 0
         fi
 


### PR DESCRIPTION
## Summary

Fixes #419. The git resource tag check now truncates results at the known `version_tag` using a `jq` `reduce` filter, so only newer tags are returned on subsequent checks. This prevents triggering builds for every historical tag after pipeline recreation.

- Added `jq` post-fetch filter for both GitHub and GitLab tag endpoints
- First check (empty `version_tag`) is unchanged — still uses `PER_PAGE=1`
- Updated existing tests to verify truncation; added no-new-tags edge case tests