### PR TITLE
Fix pipeline graph fallback ignoring retries from previous build group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Git resource tag mode returns all tags on every check, triggering builds for every historical tag after pipeline recreation ([#419](https://github.com/PikoCI/pikoci/issues/419))
+- Pipeline graph shows original build color instead of successful retry when a new build is running ([#421](https://github.com/PikoCI/pikoci/issues/421))
 
 ## [0.2.2] - 2026-05-29
 

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -534,12 +534,23 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 					}
 				}
 			}
-			// If all builds in the group are running, fall back to previous main build
+			// If all builds in the group are running, fall back to previous main build's group
 			if cb == nil {
+				var prevMain string
 				for _, b := range builds {
-					if b.Status != build.Started && b.Status != build.Pending && !strings.Contains(b.BuildNumber, ".") && b.BuildNumber != latestMain {
-						cb = b
+					if !strings.Contains(b.BuildNumber, ".") && b.BuildNumber != latestMain {
+						prevMain = b.BuildNumber
 						break
+					}
+				}
+				if prevMain != "" {
+					for _, b := range builds {
+						if b.BuildNumber == prevMain || strings.HasPrefix(b.BuildNumber, prevMain+".") {
+							if b.Status != build.Started && b.Status != build.Pending {
+								cb = b
+								break
+							}
+						}
 					}
 				}
 			}

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -1556,6 +1556,17 @@ func TestGetPipelineImage_JobStatusColors(t *testing.T) {
 			wantBorderColor: colorStartedBorder,
 		},
 		{
+			name: "new build running - fallback uses retry from previous group",
+			builds: []*build.Build{
+				{ID: 3, BuildNumber: "2", Status: build.Started},
+				{ID: 2, BuildNumber: "1.1", Status: build.Succeeded},
+				{ID: 1, BuildNumber: "1", Status: build.Cancelled},
+			},
+			wantFillColor:   colorSucceeded,
+			wantDashedStyle: true,
+			wantBorderColor: colorStartedBorder,
+		},
+		{
 			name: "pending build with previous success - shows previous color with gray dashed outline",
 			builds: []*build.Build{
 				{ID: 2, BuildNumber: "2", Status: build.Pending},


### PR DESCRIPTION
## Summary

Fixes #421. When a new build is running, the fallback logic to determine job fill color only looked at main (non-retry) builds. This caused it to pick the cancelled/failed original build instead of a successful retry.

Example: build `1` cancelled → retry `1.1` succeeded → build `2` starts running → graph showed cancelled (brown) instead of succeeded (green).

The fix makes the fallback search the previous main build's entire group (main + retries), matching the logic already used for the primary build group.