### PR TITLE
Add SVG and PNG pipeline graph formats for embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- SVG and PNG pipeline graph formats for embedding in READMEs and dashboards ([#332](https://github.com/PikoCI/pikoci/issues/332))
+
 ### Fixed
 
 - Git resource tag mode returns all tags on every check, triggering builds for every historical tag after pipeline recreation ([#419](https://github.com/PikoCI/pikoci/issues/419))

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
     -o /pikoci .
 
 FROM alpine:3.21
-RUN apk add --no-cache ca-certificates git jq curl openssl docker-cli
+RUN apk add --no-cache ca-certificates git jq curl openssl docker-cli graphviz
 COPY --from=builder /pikoci /usr/local/bin/pikoci
 ENTRYPOINT ["pikoci"]

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@
   [Documentation](https://docs.pikoci.com) · [Quick Start](#quick-start) · [Contributing](#contributing)
 </div>
 
-<!-- GIF goes here -->
-<!-- ![PikoCI demo](docs/images/pikoci.gif) -->
+![PikoCI pipeline](https://ci.pikoci.com/api/teams/main/pipelines/pikoci/image.svg)
 
 ## What is PikoCI?
 
@@ -41,7 +40,7 @@ Pipelines are defined in [HCL](https://github.com/hashicorp/hcl). The runner abs
 - **Public pipelines**: mark a pipeline as public so anyone can view its status without an account. Perfect for open source projects.
 - **Built-in UI**: visualize pipeline state, stream build logs, manage pipelines from a web interface.
 - **Teams and users**: multi-user support with team-based access control. [Granular role management planned (#207)](https://github.com/PikoCI/pikoci/issues/207).
-- **DOT graph output**: export pipeline state as a DOT graph and pipe it to Graphviz for terminal-native visualization.
+- **DOT graph output**: export pipeline state as a DOT graph, or as embeddable SVG/PNG images for READMEs and dashboards.
 
 
 ## Quick Start

--- a/docs/Public-Pipelines.md
+++ b/docs/Public-Pipelines.md
@@ -37,7 +37,27 @@ The following data is **removed** for security:
 | Endpoint | Description |
 |----------|-------------|
 | `GET /teams/{team}/pipelines/{pipeline}/public` | Sanitized pipeline data |
-| `GET /teams/{team}/pipelines/{pipeline}/public/image?format=dot` | Pipeline graph in DOT format |
+| `GET /teams/{team}/pipelines/{pipeline}/image.dot` | Pipeline graph in DOT format (JSON response) |
+| `GET /teams/{team}/pipelines/{pipeline}/image.svg` | Pipeline graph as SVG image |
+| `GET /teams/{team}/pipelines/{pipeline}/image.png` | Pipeline graph as PNG image |
+
+SVG and PNG endpoints return raw image data with the appropriate `Content-Type` header and `Access-Control-Allow-Origin: *` for cross-origin embedding. The pipeline must be public for unauthenticated access.
+
+## Embedding pipeline graphs
+
+Public pipelines can be embedded directly in READMEs, dashboards, or any HTML page. **The pipeline must be marked as public** (see above) for unauthenticated embedding to work — non-public pipelines require authentication and will return an error for anonymous requests.
+
+**Markdown:**
+
+```markdown
+![Pipeline](https://ci.example.com/api/teams/main/pipelines/my-pipeline/image.svg)
+```
+
+**HTML:**
+
+```html
+<img src="https://ci.example.com/api/teams/main/pipelines/my-pipeline/image.svg" alt="Pipeline status" />
+```
 
 ## Example
 
@@ -46,5 +66,11 @@ The following data is **removed** for security:
 curl http://localhost:8080/teams/main/pipelines/my-pipeline/public
 
 # Get the pipeline graph as SVG
-curl http://localhost:8080/teams/main/pipelines/my-pipeline/public/image?format=dot | dot -Tsvg > status.svg
+curl http://localhost:8080/api/teams/main/pipelines/my-pipeline/image.svg > status.svg
+
+# Get as PNG
+curl http://localhost:8080/api/teams/main/pipelines/my-pipeline/image.png > status.png
+
+# Get as DOT (JSON response, for piping to graphviz locally)
+curl http://localhost:8080/api/teams/main/pipelines/my-pipeline/image.dot
 ```

--- a/pikoci/pipeline_image_test.go
+++ b/pikoci/pipeline_image_test.go
@@ -1,0 +1,152 @@
+package pikoci
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderDOT(t *testing.T) {
+	if _, err := exec.LookPath("dot"); err != nil {
+		t.Skip("graphviz dot binary not available")
+	}
+
+	ctx := context.Background()
+	dot := []byte(`digraph G { A -> B; }`)
+
+	t.Run("svg", func(t *testing.T) {
+		out, err := renderDOT(ctx, dot, "svg")
+		require.NoError(t, err)
+		assert.Contains(t, string(out), "<svg")
+		assert.Contains(t, string(out), "</svg>")
+	})
+
+	t.Run("png", func(t *testing.T) {
+		out, err := renderDOT(ctx, dot, "png")
+		require.NoError(t, err)
+		// PNG files start with the magic bytes
+		assert.True(t, len(out) > 8)
+		assert.Equal(t, byte(0x89), out[0])
+		assert.Equal(t, byte('P'), out[1])
+		assert.Equal(t, byte('N'), out[2])
+		assert.Equal(t, byte('G'), out[3])
+	})
+
+	t.Run("invalid_dot", func(t *testing.T) {
+		_, err := renderDOT(ctx, []byte("not valid dot"), "svg")
+		require.Error(t, err)
+	})
+}
+
+func TestConvertDOTImage(t *testing.T) {
+	if _, err := exec.LookPath("dot"); err != nil {
+		t.Skip("graphviz dot binary not available")
+	}
+
+	ctx := context.Background()
+	dot := []byte(`digraph G { A -> B; }`)
+
+	t.Run("dot_passthrough", func(t *testing.T) {
+		out, err := convertDOTImage(ctx, dot, "dot")
+		require.NoError(t, err)
+		assert.Equal(t, dot, out)
+	})
+
+	t.Run("svg_with_postprocessing", func(t *testing.T) {
+		out, err := convertDOTImage(ctx, dot, "svg")
+		require.NoError(t, err)
+		result := string(out)
+		assert.Contains(t, result, "<svg")
+		assert.Contains(t, result, "background: transparent")
+		assert.Contains(t, result, "Plus Jakarta Sans")
+	})
+
+	t.Run("png", func(t *testing.T) {
+		out, err := convertDOTImage(ctx, dot, "png")
+		require.NoError(t, err)
+		assert.Equal(t, byte(0x89), out[0])
+	})
+}
+
+func TestPostProcessSVG(t *testing.T) {
+	// Minimal SVG mimicking graphviz output
+	input := `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="200pt" height="100pt" viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
+<g id="graph0" class="graph">
+<polygon fill="white" stroke="transparent" points="0,0 0,-100 200,0 200,-100"/>
+<g id="node1" class="node">
+<polygon fill="#00A83A" stroke="#5F574F" points="10,10 10,50 100,50 100,10 10,10"/>
+<text>job1</text>
+</g>
+<g id="node2" class="node">
+<polygon fill="#FF004D" stroke="#5F574F" points="110,10 110,50 190,50 190,10"/>
+<text>job2</text>
+</g>
+</g>
+</svg>`
+
+	out, err := postProcessSVG([]byte(input))
+	require.NoError(t, err)
+	result := string(out)
+
+	// Background should be transparent
+	assert.Contains(t, result, `background: transparent`)
+
+	// First polygon (background) should have transparent fill/stroke
+	assert.Contains(t, result, `fill="transparent"`)
+
+	// Filled polygons should be converted to rounded rects
+	assert.Contains(t, result, `rx="4"`)
+	assert.Contains(t, result, `ry="4"`)
+
+	// Font-family should be set on text elements
+	assert.Contains(t, result, `Plus Jakarta Sans`)
+
+	// Cursor pointer on node groups
+	assert.Contains(t, result, `cursor: pointer`)
+
+	// Original filled polygon tags for jobs should be replaced with rect
+	// The 5-point polygon (first node) should become a rect
+	if strings.Contains(result, `<polygon fill="#00A83A"`) {
+		t.Error("expected filled polygon to be converted to rect")
+	}
+}
+
+func TestPostProcessSVG_PreservesNonRectPolygons(t *testing.T) {
+	// A polygon with 3 points (triangle) should not be converted
+	input := `<svg>
+<polygon fill="white" stroke="transparent" points="0,0 0,-100 200,0"/>
+<polygon fill="#00A83A" stroke="black" points="10,10 50,50 90,10"/>
+</svg>`
+
+	out, err := postProcessSVG([]byte(input))
+	require.NoError(t, err)
+	result := string(out)
+
+	// Triangle polygon should remain (not converted to rect)
+	assert.Contains(t, result, `<polygon fill="#00A83A"`)
+}
+
+func TestExtractAttr(t *testing.T) {
+	assert.Equal(t, "red", extractAttr(`<polygon fill="red" stroke="black"/>`, "fill"))
+	assert.Equal(t, "black", extractAttr(`<polygon fill="red" stroke="black"/>`, "stroke"))
+	assert.Equal(t, "", extractAttr(`<polygon fill="red"/>`, "stroke"))
+}
+
+func TestSetAttr(t *testing.T) {
+	t.Run("replace_existing", func(t *testing.T) {
+		result := setAttr(`<polygon fill="red"/>`, "fill", "blue")
+		assert.Contains(t, result, `fill="blue"`)
+		assert.NotContains(t, result, `fill="red"`)
+	})
+
+	t.Run("add_new", func(t *testing.T) {
+		result := setAttr(`<polygon fill="red"/>`, "stroke", "black")
+		assert.Contains(t, result, `stroke="black"`)
+		assert.Contains(t, result, `fill="red"`)
+	})
+}

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -1,8 +1,13 @@
 package pikoci
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"math"
+	"os/exec"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -430,7 +435,7 @@ func (q *PikoCI) GetPipelineImage(ctx context.Context, tc, pCan, format string) 
 		format = strings.Split(format, ".")[1]
 	}
 
-	if format != "dot" {
+	if format != "dot" && format != "svg" && format != "png" {
 		return nil, fmt.Errorf("invalid image format %q", format)
 	}
 
@@ -444,7 +449,7 @@ func (q *PikoCI) GetPipelineImage(ctx context.Context, tc, pCan, format string) 
 		return nil, fmt.Errorf("failed to generate image: %w", err)
 	}
 
-	return img, err
+	return convertDOTImage(ctx, img, format)
 }
 
 // generateImage builds a DOT-format directed graph representing the pipeline's
@@ -681,6 +686,204 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 	return []byte(str), nil
 }
 
+// convertDOTImage converts raw DOT bytes to the requested format.
+// For "dot" it returns the input unchanged. For "svg" or "png" it shells out
+// to graphviz and (for SVG) applies post-processing.
+func convertDOTImage(ctx context.Context, dot []byte, format string) ([]byte, error) {
+	if format == "dot" {
+		return dot, nil
+	}
+	img, err := renderDOT(ctx, dot, format)
+	if err != nil {
+		return nil, fmt.Errorf("failed to render DOT to %s: %w", format, err)
+	}
+	if format == "svg" {
+		img, err = postProcessSVG(img)
+		if err != nil {
+			return nil, fmt.Errorf("failed to post-process SVG: %w", err)
+		}
+	}
+	return img, nil
+}
+
+// renderDOT converts DOT graph bytes to the specified format (svg or png)
+// by shelling out to the graphviz `dot` command with a 30-second timeout.
+func renderDOT(ctx context.Context, dot []byte, format string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "dot", "-T"+format)
+	cmd.Stdin = bytes.NewReader(dot)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("dot command failed: %s: %w", stderr.String(), err)
+	}
+	return stdout.Bytes(), nil
+}
+
+// Precompiled regexes for SVG post-processing.
+var (
+	svgStyleRe  = regexp.MustCompile(`(<svg[^>]*style=")`)
+	textRe      = regexp.MustCompile(`(<text\b)`)
+	nodeGroupRe = regexp.MustCompile(`(<g[^>]*class="node"[^>]*>)`)
+	polygonRe   = regexp.MustCompile(`<polygon\b([^>]*)/>`)
+	rectRe      = regexp.MustCompile(`<rect\b([^>]*)/>`)
+)
+
+// postProcessSVG applies styling transforms to match the frontend rendering:
+// transparent background, rounded rectangles, custom font, and pointer cursor on nodes.
+func postProcessSVG(svg []byte) ([]byte, error) {
+	s := string(svg)
+
+	// Set transparent background on root <svg> element
+	s = svgStyleRe.ReplaceAllString(s, `${1}background: transparent; `)
+	if !strings.Contains(s, `style="background: transparent`) {
+		s = strings.Replace(s, "<svg ", `<svg style="background: transparent" `, 1)
+	}
+
+	// Process polygon and rect elements: make background transparent, convert filled polygons to rounded rects
+	firstBgDone := false
+	s = processPolygonsAndRects(s, &firstBgDone)
+
+	// Set font-family on all <text> elements
+	s = textRe.ReplaceAllString(s, `<text style="font-family: 'Plus Jakarta Sans', system-ui, sans-serif"`)
+	// Fix double <text attributes if text already had style
+	s = strings.ReplaceAll(s, `<text style="font-family: 'Plus Jakarta Sans', system-ui, sans-serif" style="`, `<text style="font-family: 'Plus Jakarta Sans', system-ui, sans-serif; `)
+
+	// Set cursor: pointer on g.node elements
+	s = nodeGroupRe.ReplaceAllStringFunc(s, func(match string) string {
+		if strings.Contains(match, "style=") {
+			return strings.Replace(match, `style="`, `style="cursor: pointer; `, 1)
+		}
+		return strings.Replace(match, ">", ` style="cursor: pointer">`, 1)
+	})
+
+	return []byte(s), nil
+}
+
+// processPolygonsAndRects processes SVG polygon/rect elements to:
+// 1. Make the first polygon/rect (background) transparent
+// 2. Convert filled polygons that are axis-aligned rectangles into <rect> with rounded corners
+func processPolygonsAndRects(s string, firstBgDone *bool) string {
+	// Process polygons
+	s = polygonRe.ReplaceAllStringFunc(s, func(match string) string {
+		fill := extractAttr(match, "fill")
+
+		// First polygon or white-filled: make transparent (background)
+		if !*firstBgDone || strings.EqualFold(fill, "white") || strings.EqualFold(fill, "#ffffff") {
+			*firstBgDone = true
+			match = setAttr(match, "fill", "transparent")
+			match = setAttr(match, "stroke", "transparent")
+			return match
+		}
+
+		// Filled polygons (not none/transparent): convert to rounded rect if axis-aligned
+		if fill != "" && !strings.EqualFold(fill, "none") && !strings.EqualFold(fill, "transparent") {
+			points := extractAttr(match, "points")
+			if rect, ok := polygonToRoundedRect(points, match); ok {
+				return rect
+			}
+		}
+		return match
+	})
+
+	// Process rects similarly for the first-bg rule
+	s = rectRe.ReplaceAllStringFunc(s, func(match string) string {
+		fill := extractAttr(match, "fill")
+		if !*firstBgDone || strings.EqualFold(fill, "white") || strings.EqualFold(fill, "#ffffff") {
+			*firstBgDone = true
+			match = setAttr(match, "fill", "transparent")
+			match = setAttr(match, "stroke", "transparent")
+		}
+		return match
+	})
+
+	return s
+}
+
+// polygonToRoundedRect converts a polygon with 4-5 points forming an axis-aligned
+// rectangle into a <rect> element with rounded corners (rx=4, ry=4).
+func polygonToRoundedRect(points string, original string) (string, bool) {
+	if points == "" {
+		return "", false
+	}
+	parts := strings.Fields(strings.TrimSpace(points))
+	if len(parts) != 4 && len(parts) != 5 {
+		return "", false
+	}
+
+	type pt struct{ x, y float64 }
+	pts := make([]pt, len(parts))
+	for i, p := range parts {
+		xy := strings.Split(p, ",")
+		if len(xy) != 2 {
+			return "", false
+		}
+		x, err := strconv.ParseFloat(xy[0], 64)
+		if err != nil {
+			return "", false
+		}
+		y, err := strconv.ParseFloat(xy[1], 64)
+		if err != nil {
+			return "", false
+		}
+		pts[i] = pt{x, y}
+	}
+
+	// If 5 points, last must equal first (closed polygon)
+	if len(pts) == 5 && (pts[0].x != pts[4].x || pts[0].y != pts[4].y) {
+		return "", false
+	}
+
+	minX, maxX := pts[0].x, pts[0].x
+	minY, maxY := pts[0].y, pts[0].y
+	for _, p := range pts[:4] {
+		minX = math.Min(minX, p.x)
+		maxX = math.Max(maxX, p.x)
+		minY = math.Min(minY, p.y)
+		maxY = math.Max(maxY, p.y)
+	}
+
+	fill := extractAttr(original, "fill")
+	stroke := extractAttr(original, "stroke")
+	if stroke == "" {
+		stroke = "none"
+	}
+
+	return fmt.Sprintf(`<rect x="%.2f" y="%.2f" width="%.2f" height="%.2f" rx="4" ry="4" fill="%s" stroke="%s"/>`,
+		minX, minY, maxX-minX, maxY-minY, fill, stroke), true
+}
+
+// extractAttr extracts the value of an XML attribute from a tag string.
+func extractAttr(tag, name string) string {
+	prefix := name + `="`
+	idx := strings.Index(tag, prefix)
+	if idx < 0 {
+		return ""
+	}
+	start := idx + len(prefix)
+	end := strings.Index(tag[start:], `"`)
+	if end < 0 {
+		return ""
+	}
+	return tag[start : start+end]
+}
+
+// setAttr sets or replaces an XML attribute value in a tag string.
+func setAttr(tag, name, value string) string {
+	prefix := name + `="`
+	idx := strings.Index(tag, prefix)
+	if idx >= 0 {
+		start := idx + len(prefix)
+		end := strings.Index(tag[start:], `"`)
+		if end >= 0 {
+			return tag[:idx] + fmt.Sprintf(`%s="%s"`, name, value) + tag[start+end+1:]
+		}
+	}
+	return strings.Replace(tag, "/>", fmt.Sprintf(` %s="%s"/>`, name, value), 1)
+}
+
 // CreatePipelineImage generates a DOT graph image from raw pipeline configuration
 // bytes without persisting the pipeline. This is useful for previewing a pipeline
 // layout before creating it.
@@ -697,12 +900,22 @@ func (q *PikoCI) CreatePipelineImage(ctx context.Context, tc string, pipeline []
 	pp.Name = "pikoci"
 	pp.Canonical = "pikoci"
 
+	if format == "" {
+		format = "dot"
+	}
+	if strings.Contains(format, ".") {
+		format = strings.Split(format, ".")[1]
+	}
+	if format != "dot" && format != "svg" && format != "png" {
+		return nil, fmt.Errorf("invalid image format %q", format)
+	}
+
 	img, err := q.generateImage(ctx, tc, pp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate image: %w", err)
 	}
 
-	return img, err
+	return convertDOTImage(ctx, img, format)
 }
 
 // sanitizePipelineForPublic returns a copy of the pipeline with sensitive fields
@@ -779,11 +992,16 @@ func (q *PikoCI) GetPublicPipelineImage(ctx context.Context, tc, pCan, format st
 	if strings.Contains(format, ".") {
 		format = strings.Split(format, ".")[1]
 	}
-	if format != "dot" {
+	if format != "dot" && format != "svg" && format != "png" {
 		return nil, fmt.Errorf("invalid image format %q", format)
 	}
 
-	return q.generateImage(ctx, tc, pp)
+	img, err := q.generateImage(ctx, tc, pp)
+	if err != nil {
+		return nil, err
+	}
+
+	return convertDOTImage(ctx, img, format)
 }
 
 // GetPublicPipelineJob retrieves a job from a public pipeline.

--- a/pikoci/transport/http/client/client.go
+++ b/pikoci/transport/http/client/client.go
@@ -470,6 +470,10 @@ func (cl *Client) GetPipeline(ctx context.Context, tc, pn string) (*pipeline.Pip
 
 // GetPipelineImage retrieves the rendered image of a pipeline in the given format.
 func (cl *Client) GetPipelineImage(ctx context.Context, tc, pn, format string) ([]byte, error) {
+	if format == "svg" || format == "png" {
+		return cl.RequestRaw(ctx, http.MethodGet, fmt.Sprintf("%s/teams/%s/pipelines/%s/image.%s", cl.url, tc, pn, format))
+	}
+
 	var resp thttp.GetPipelineImageResponse
 
 	err := cl.Request(ctx, http.MethodGet, fmt.Sprintf("%s/teams/%s/pipelines/%s/image.%s", cl.url, tc, pn, format), nil, &resp)

--- a/pikoci/transport/http/client/client_test.go
+++ b/pikoci/transport/http/client/client_test.go
@@ -422,10 +422,27 @@ func TestDeletePipeline(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestGetPipelineImage(t *testing.T) {
+func TestGetPipelineImage_DOT(t *testing.T) {
 	r := mux.NewRouter()
 	r.HandleFunc("/teams/{tc}/pipelines/{pn}/image.{format}", func(w http.ResponseWriter, req *http.Request) {
-		jsonHandler(w, thttp.GetPipelineImageResponse{Image: "svg-data"})
+		jsonHandler(w, thttp.GetPipelineImageResponse{Image: "dot-data"})
+	}).Methods("GET")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	img, err := c.GetPipelineImage(context.Background(), "team", "mypipe", "dot")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("dot-data"), img)
+}
+
+func TestGetPipelineImage_SVG(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/{pn}/image.{format}", func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "image/svg+xml")
+		w.Write([]byte("svg-data"))
 	}).Methods("GET")
 	ts := httptest.NewServer(r)
 	defer ts.Close()
@@ -436,6 +453,23 @@ func TestGetPipelineImage(t *testing.T) {
 	img, err := c.GetPipelineImage(context.Background(), "team", "mypipe", "svg")
 	require.NoError(t, err)
 	assert.Equal(t, []byte("svg-data"), img)
+}
+
+func TestGetPipelineImage_PNG(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/{pn}/image.{format}", func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write([]byte("png-data"))
+	}).Methods("GET")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	img, err := c.GetPipelineImage(context.Background(), "team", "mypipe", "png")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("png-data"), img)
 }
 
 func TestCreatePipelineImage(t *testing.T) {

--- a/pikoci/transport/http/client/utils.go
+++ b/pikoci/transport/http/client/utils.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"regexp"
@@ -58,6 +59,42 @@ func (c *Client) Request(ctx context.Context, method, url string, body, resp int
 	}
 
 	return nil
+}
+
+// RequestRaw sends an authenticated HTTP request and returns the raw response body.
+// Unlike Request, it does not assume JSON encoding for the response.
+func (c *Client) RequestRaw(ctx context.Context, method, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, method, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request %q: %w", url, err)
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.jwt))
+
+	hresp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to do request %q: %w", url, err)
+	}
+	defer hresp.Body.Close()
+
+	if !successCodeRe.MatchString(strconv.Itoa(hresp.StatusCode)) {
+		var eresp thttp.ErrorResponse
+		err = json.NewDecoder(hresp.Body).Decode(&eresp)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read error body on %q: %w", url, err)
+		}
+		return nil, fmt.Errorf("response error on %q: %s", url, eresp.Err)
+	}
+
+	body, err := io.ReadAll(hresp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read body on %q: %w", url, err)
+	}
+
+	if hresp.Header.Get("X-Refresh-Token") == "true" {
+		c.refreshToken(ctx)
+	}
+
+	return body, nil
 }
 
 func (c *Client) refreshToken(ctx context.Context) {

--- a/pikoci/transport/http/handler.go
+++ b/pikoci/transport/http/handler.go
@@ -271,6 +271,7 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, 
 	binApi := r.PathPrefix("/").Subrouter()
 	binApi.Use(auth)
 	binApi.Methods(http.MethodGet).Path("/admin/export").Name(ExportDatabase.String()).Handler(exportDatabase(db, dbSystem))
+	binApi.Methods(http.MethodGet).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/image{ext}").Name(GetPipelineImage.String()).Handler(getPipelineImage(s))
 
 	r.PathPrefix("/css/").Handler(http.FileServer(http.FS(assets.Assets)))
 	r.PathPrefix("/js/").Handler(http.FileServer(http.FS(assets.Assets)))

--- a/pikoci/transport/http/handler_test.go
+++ b/pikoci/transport/http/handler_test.go
@@ -3,6 +3,7 @@ package http
 import (
 	"database/sql"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -474,4 +475,214 @@ func TestXRefreshTokenHeader(t *testing.T) {
 
 		assert.Empty(t, resp.Header.Get("X-Refresh-Token"))
 	})
+}
+
+func TestGetPipelineImage_DOT_ReturnsJSON(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	handler := Handler(s, secret, logger, nil, "", "test", "abc1234")
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	um := &user.WithMemberships{
+		User:        user.User{Username: "admin", Admin: true},
+		Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+	}
+	jwtToken := signJWT(t, secret, um)
+
+	dotOutput := []byte(`digraph "test" { A -> B; }`)
+	s.EXPECT().GetUser(gomock.Any(), "admin").Return(um, nil).AnyTimes()
+	s.EXPECT().GetPipelineImage(gomock.Any(), "main", "my-pipeline", ".dot").Return(dotOutput, nil)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams/main/pipelines/my-pipeline/image.dot", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+jwtToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/json")
+
+	var result GetPipelineImageResponse
+	json.NewDecoder(resp.Body).Decode(&result)
+	assert.Equal(t, string(dotOutput), result.Image)
+	assert.Empty(t, result.Err)
+}
+
+func TestGetPipelineImage_SVG_ReturnsRawSVG(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	handler := Handler(s, secret, logger, nil, "", "test", "abc1234")
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	um := &user.WithMemberships{
+		User:        user.User{Username: "admin", Admin: true},
+		Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+	}
+	jwtToken := signJWT(t, secret, um)
+
+	svgOutput := []byte(`<svg><text>hello</text></svg>`)
+	s.EXPECT().GetUser(gomock.Any(), "admin").Return(um, nil).AnyTimes()
+	s.EXPECT().GetPipelineImage(gomock.Any(), "main", "my-pipeline", ".svg").Return(svgOutput, nil)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams/main/pipelines/my-pipeline/image.svg", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+jwtToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "image/svg+xml", resp.Header.Get("Content-Type"))
+	assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, string(svgOutput), string(body))
+}
+
+func TestGetPipelineImage_PNG_ReturnsRawPNG(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	handler := Handler(s, secret, logger, nil, "", "test", "abc1234")
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	um := &user.WithMemberships{
+		User:        user.User{Username: "admin", Admin: true},
+		Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+	}
+	jwtToken := signJWT(t, secret, um)
+
+	pngOutput := []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}
+	s.EXPECT().GetUser(gomock.Any(), "admin").Return(um, nil).AnyTimes()
+	s.EXPECT().GetPipelineImage(gomock.Any(), "main", "my-pipeline", ".png").Return(pngOutput, nil)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams/main/pipelines/my-pipeline/image.png", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+jwtToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "image/png", resp.Header.Get("Content-Type"))
+	assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, pngOutput, body)
+}
+
+func TestGetPipelineImage_SVG_NoJSONHeaderRequired(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	handler := Handler(s, secret, logger, nil, "", "test", "abc1234")
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	um := &user.WithMemberships{
+		User:        user.User{Username: "admin", Admin: true},
+		Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+	}
+	jwtToken := signJWT(t, secret, um)
+
+	svgOutput := []byte(`<svg><text>test</text></svg>`)
+	s.EXPECT().GetUser(gomock.Any(), "admin").Return(um, nil).AnyTimes()
+	s.EXPECT().GetPipelineImage(gomock.Any(), "main", "my-pipeline", ".svg").Return(svgOutput, nil)
+
+	// No Content-Type header — simulates browser request
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams/main/pipelines/my-pipeline/image.svg", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+jwtToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "image/svg+xml", resp.Header.Get("Content-Type"))
+}
+
+func TestGetPipelineImage_PublicFallback_SVG(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	handler := Handler(s, secret, logger, nil, "", "test", "abc1234")
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	svgOutput := []byte(`<svg><text>public</text></svg>`)
+	s.EXPECT().GetPublicPipeline(gomock.Any(), "main", "my-pipeline").Return(&pipeline.Pipeline{
+		Name: "my-pipeline", Canonical: "my-pipeline",
+	}, nil)
+	s.EXPECT().GetPublicPipelineImage(gomock.Any(), "main", "my-pipeline", ".svg").Return(svgOutput, nil)
+
+	// No auth header — should fall back to public
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams/main/pipelines/my-pipeline/image.svg", nil)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "image/svg+xml", resp.Header.Get("Content-Type"))
+	assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, string(svgOutput), string(body))
+}
+
+func TestGetPipelineImage_Error_ReturnsJSON(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	handler := Handler(s, secret, logger, nil, "", "test", "abc1234")
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	um := &user.WithMemberships{
+		User:        user.User{Username: "admin", Admin: true},
+		Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+	}
+	jwtToken := signJWT(t, secret, um)
+
+	s.EXPECT().GetUser(gomock.Any(), "admin").Return(um, nil).AnyTimes()
+	s.EXPECT().GetPipelineImage(gomock.Any(), "main", "my-pipeline", ".svg").Return(nil, assert.AnError)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams/main/pipelines/my-pipeline/image.svg", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+jwtToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Errors should still return JSON
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/json")
+
+	var result GetPipelineImageResponse
+	json.NewDecoder(resp.Body).Decode(&result)
+	assert.NotEmpty(t, result.Err)
 }

--- a/pikoci/transport/http/pipelines.go
+++ b/pikoci/transport/http/pipelines.go
@@ -3,6 +3,7 @@ package http
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/pikoci/pikoci/pikoci"
@@ -224,7 +225,7 @@ func getPipelineImage(s pikoci.Service) http.HandlerFunc {
 		vars := mux.Vars(r)
 		req.TeamCanonical = vars["team_canonical"]
 		req.Name = vars["pipeline_canonical"]
-		req.Format = vars["format"]
+		req.Format = vars["ext"]
 		var img []byte
 		var err error
 		if isPublic, _ := ctx.Value(IsPublicAccessKey).(bool); isPublic {
@@ -232,11 +233,11 @@ func getPipelineImage(s pikoci.Service) http.HandlerFunc {
 		} else {
 			img, err = s.GetPipelineImage(ctx, req.TeamCanonical, req.Name, req.Format)
 		}
-		var errs string
 		if err != nil {
-			errs = err.Error()
+			encodeResponse(GetPipelineImageResponse{Err: err.Error()}, w)
+			return
 		}
-		encodeResponse(GetPipelineImageResponse{Image: string(img), Err: errs}, w)
+		writeImageResponse(w, req.Format, img)
 	}
 }
 
@@ -261,17 +262,40 @@ func createPipelineImage(s pikoci.Service) http.HandlerFunc {
 		)
 		vars := mux.Vars(r)
 		req.TeamCanonical = vars["team_canonical"]
-		req.Format = vars["format"]
+		req.Format = vars["ext"]
 		err := json.NewDecoder(r.Body).Decode(&req)
 		if err != nil {
 			encodeResponse(CreatePipelineImageResponse{Err: err.Error()}, w)
 			return
 		}
 		img, err := s.CreatePipelineImage(ctx, req.TeamCanonical, req.Config, req.Vars, req.Format)
-		var errs string
 		if err != nil {
-			errs = err.Error()
+			encodeResponse(CreatePipelineImageResponse{Err: err.Error()}, w)
+			return
 		}
-		encodeResponse(CreatePipelineImageResponse{Image: string(img), Err: errs}, w)
+		writeImageResponse(w, req.Format, img)
+	}
+}
+
+// writeImageResponse writes the image response with the appropriate Content-Type.
+// For SVG/PNG formats, it writes raw binary with CORS headers.
+// For DOT format (or empty), it writes JSON via encodeResponse.
+func writeImageResponse(w http.ResponseWriter, format string, img []byte) {
+	// Normalize the format (strip leading dot)
+	f := strings.TrimPrefix(format, ".")
+	if f == "" {
+		f = "dot"
+	}
+	switch f {
+	case "svg":
+		w.Header().Set("Content-Type", "image/svg+xml")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Write(img)
+	case "png":
+		w.Header().Set("Content-Type", "image/png")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Write(img)
+	default:
+		encodeResponse(GetPipelineImageResponse{Image: string(img)}, w)
 	}
 }


### PR DESCRIPTION
## Summary

- Add server-side DOT→SVG/PNG conversion via graphviz `dot` command with 30s timeout
- Apply SVG post-processing matching the frontend styling (transparent background, rounded rects, custom font, pointer cursor)
- Return raw binary with correct `Content-Type` and CORS headers for SVG/PNG; keep JSON for DOT (backward compatible)
- Register image route on `binApi` so browser requests work without `Content-Type: application/json`
- Add `RequestRaw` to HTTP client for non-JSON responses
- Add `graphviz` to Docker image
- Update docs with embedding examples and public pipeline requirement

Closes #332
