### PR TITLE
Remove .json URL suffix trick from API endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SVG and PNG pipeline graph formats for embedding in READMEs and dashboards ([#332](https://github.com/PikoCI/pikoci/issues/332))
 
+### Changed
+
+- Removed `.json` URL suffix trick from API endpoints ([#427](https://github.com/PikoCI/pikoci/issues/427))
+
 ### Fixed
 
 - Git resource tag mode returns all tags on every check, triggering builds for every historical tag after pipeline recreation ([#419](https://github.com/PikoCI/pikoci/issues/419))

--- a/integration/pikoci_test.go
+++ b/integration/pikoci_test.go
@@ -873,8 +873,9 @@ job "gen" {
 			Username: "admin",
 			Password: "newadmin123",
 		})
-		loginReq, err := http.NewRequest(http.MethodPost, pikoURL+"/login.json", bytes.NewReader(loginBody))
+		loginReq, err := http.NewRequest(http.MethodPost, pikoURL+"/login", bytes.NewReader(loginBody))
 		require.NoError(t, err)
+		loginReq.Header.Set("Content-Type", "application/json")
 		loginResp, err := http.DefaultClient.Do(loginReq)
 		require.NoError(t, err)
 		defer loginResp.Body.Close()
@@ -888,8 +889,9 @@ job "gen" {
 		updateBody, _ := json.Marshal(struct {
 			Public *bool `json:"public"`
 		}{Public: &pub})
-		updateReq, err := http.NewRequest(http.MethodPut, pikoURL+"/teams/main/pipelines/cron.json", bytes.NewReader(updateBody))
+		updateReq, err := http.NewRequest(http.MethodPut, pikoURL+"/teams/main/pipelines/cron", bytes.NewReader(updateBody))
 		require.NoError(t, err)
+		updateReq.Header.Set("Content-Type", "application/json")
 		updateReq.Header.Set("Authorization", "Bearer "+adminJWT)
 		updateResp, err := http.DefaultClient.Do(updateReq)
 		require.NoError(t, err)
@@ -980,8 +982,9 @@ job "gen" {
 				Username: "pepito",
 				Password: "pepito",
 			})
-			pepitoReq, err := http.NewRequest(http.MethodPost, pikoURL+"/login.json", bytes.NewReader(pepitoBody))
+			pepitoReq, err := http.NewRequest(http.MethodPost, pikoURL+"/login", bytes.NewReader(pepitoBody))
 			require.NoError(t, err)
+			pepitoReq.Header.Set("Content-Type", "application/json")
 			pepitoResp, err := http.DefaultClient.Do(pepitoReq)
 			require.NoError(t, err)
 			defer pepitoResp.Body.Close()
@@ -1031,8 +1034,9 @@ job "gen" {
 			Username: "admin",
 			Password: "newadmin123",
 		})
-		loginReq, err := http.NewRequest(http.MethodPost, pikoURL+"/login.json", bytes.NewReader(loginBody))
+		loginReq, err := http.NewRequest(http.MethodPost, pikoURL+"/login", bytes.NewReader(loginBody))
 		require.NoError(t, err)
+		loginReq.Header.Set("Content-Type", "application/json")
 		loginResp, err := http.DefaultClient.Do(loginReq)
 		require.NoError(t, err)
 		defer loginResp.Body.Close()
@@ -1044,8 +1048,9 @@ job "gen" {
 
 		// Step 2: Promote pepito to admin on "main" team via HTTP
 		updateBody, _ := json.Marshal(thttp.UpdateTeamMemberRequest{Admin: true})
-		updateReq, err := http.NewRequest(http.MethodPut, pikoURL+"/teams/main/members/pepito.json", bytes.NewReader(updateBody))
+		updateReq, err := http.NewRequest(http.MethodPut, pikoURL+"/teams/main/members/pepito", bytes.NewReader(updateBody))
 		require.NoError(t, err)
+		updateReq.Header.Set("Content-Type", "application/json")
 		updateReq.Header.Set("Authorization", "Bearer "+adminJWT)
 		updateResp, err := http.DefaultClient.Do(updateReq)
 		require.NoError(t, err)
@@ -1059,8 +1064,9 @@ job "gen" {
 		require.NotNil(t, pepitoJWT)
 
 		// Verify the header is returned
-		checkReq, err := http.NewRequest(http.MethodGet, pikoURL+"/teams.json", nil)
+		checkReq, err := http.NewRequest(http.MethodGet, pikoURL+"/teams", nil)
 		require.NoError(t, err)
+		checkReq.Header.Set("Content-Type", "application/json")
 		checkReq.Header.Set("Authorization", "Bearer "+pepitoJWT.(string))
 		checkResp, err := http.DefaultClient.Do(checkReq)
 		require.NoError(t, err)

--- a/pikoci/transport/http/assets/js/app/init.js
+++ b/pikoci/transport/http/assets/js/app/init.js
@@ -40,7 +40,7 @@ Backbone.sync = function (method, model, options) {
     }
     if (jqXHR && jqXHR.getResponseHeader('X-Refresh-Token') === 'true') {
       $.ajax({
-        url: '/refresh-token.json',
+        url: '/refresh-token',
         type: 'POST',
         headers: {
           'Authorization': 'Bearer ' + session.get("jwt"),

--- a/pikoci/transport/http/assets/js/app/views/jobs.js
+++ b/pikoci/transport/http/assets/js/app/views/jobs.js
@@ -178,7 +178,7 @@ var JobBuildsContentView = Backbone.View.extend({
     e.preventDefault();
     var that = this;
     var bid = this.model.get("build_number");
-    var url = this.model.collection.url() + "/" + bid + "/cancel.json";
+    var url = this.model.collection.url() + "/" + bid + "/cancel";
     $.ajax({ url: url, type: "POST", headers: { "Authorization": "Bearer " + session.get("jwt") },
       success: function() { that.model.fetch(); },
     });
@@ -187,7 +187,7 @@ var JobBuildsContentView = Backbone.View.extend({
     e.preventDefault();
     var bid = this.model.get("build_number");
     var collection = this.model.collection;
-    var url = collection.url() + "/" + bid + "/retry.json";
+    var url = collection.url() + "/" + bid + "/retry";
     $.ajax({ url: url, type: "POST", headers: { "Authorization": "Bearer " + session.get("jwt") },
       success: function() { collection.fetchNew(); },
     });

--- a/pikoci/transport/http/assets/js/app/views/layout.js
+++ b/pikoci/transport/http/assets/js/app/views/layout.js
@@ -22,7 +22,7 @@ export var HeaderView = Backbone.View.extend({
     this.listenTo(session, "change", this.render);
     this.versionText = '';
     var self = this;
-    $.getJSON('/version.json').done(function(data) {
+    $.getJSON('/version').done(function(data) {
       self.versionText = 'Version: ' + data.version + ' (' + data.commit + ')';
       self.render();
     });

--- a/pikoci/transport/http/assets/js/app/views/resources.js
+++ b/pikoci/transport/http/assets/js/app/views/resources.js
@@ -42,7 +42,7 @@ export var ResourceVersionsView = Backbone.View.extend({
     })));
     if (webhookPanelOpen) {
       var token = this.collection.resource.get('webhook_token');
-      var url = window.location.origin + '/webhooks/' + token + '.json';
+      var url = window.location.origin + '/webhooks/' + token + '';
       this.$('#webhook-url').text(url);
       this.$('#webhook-panel').show();
     }
@@ -104,7 +104,7 @@ export var ResourceVersionsView = Backbone.View.extend({
       panel.hide();
     } else {
       var token = this.collection.resource.get('webhook_token');
-      var url = window.location.origin + '/webhooks/' + token + '.json';
+      var url = window.location.origin + '/webhooks/' + token + '';
       this.$('#webhook-url').text(url);
       panel.show();
     }
@@ -122,14 +122,14 @@ export var ResourceVersionsView = Backbone.View.extend({
     var pn = rs.collection.pipeline.get('canonical');
     var rCan = rs.get('canonical');
     $.ajax({
-      url: '/teams/' + tc + '/pipelines/' + pn + '/resources/' + rCan + '/webhook_token.json',
+      url: '/teams/' + tc + '/pipelines/' + pn + '/resources/' + rCan + '/webhook_token',
       type: 'POST',
       contentType: 'application/json',
       headers: { 'Authorization': 'Bearer ' + session.get('jwt') },
       success: function(resp) {
         if (resp.token) {
           rs.set('webhook_token', resp.token);
-          var url = window.location.origin + '/webhooks/' + resp.token + '.json';
+          var url = window.location.origin + '/webhooks/' + resp.token + '';
           that.$('#webhook-url').text(url);
         }
       }

--- a/pikoci/transport/http/assets/js/app/views/users.js
+++ b/pikoci/transport/http/assets/js/app/views/users.js
@@ -69,7 +69,7 @@ export var UserShowView = Backbone.View.extend({
     var that = this;
 
     $.ajax({
-      url: '/users/' + originalUsername + '.json',
+      url: '/users/' + originalUsername + '',
       type: 'PUT',
       headers: {
         'Authorization': 'Bearer ' + session.get("jwt"),
@@ -97,7 +97,7 @@ export var UserShowView = Backbone.View.extend({
     var username = this.model.get("username");
 
     $.ajax({
-      url: '/users/' + username + '.json',
+      url: '/users/' + username + '',
       type: 'PUT',
       headers: {
         'Authorization': 'Bearer ' + session.get("jwt"),
@@ -119,7 +119,7 @@ export var UserShowView = Backbone.View.extend({
     if (!confirm("Are you sure you want to delete user '" + username + "'?")) return;
 
     $.ajax({
-      url: '/users/' + username + '.json',
+      url: '/users/' + username + '',
       type: 'DELETE',
       headers: {
         'Authorization': 'Bearer ' + session.get("jwt"),
@@ -153,7 +153,7 @@ export var UsersNewView = Backbone.View.extend({
     var admin = this.$('#admin').is(':checked');
 
     $.ajax({
-      url: '/users.json',
+      url: '/users',
       type: 'POST',
       headers: {
         'Authorization': 'Bearer ' + session.get("jwt"),
@@ -195,7 +195,7 @@ export var ProfileView = Backbone.View.extend({
     var username = this.$('#username').val();
 
     $.ajax({
-      url: '/profile.json',
+      url: '/profile',
       type: 'PUT',
       headers: {
         'Authorization': 'Bearer ' + session.get("jwt"),
@@ -208,7 +208,7 @@ export var ProfileView = Backbone.View.extend({
           return;
         }
         $.ajax({
-          url: '/refresh-token.json',
+          url: '/refresh-token',
           type: 'POST',
           headers: {
             'Authorization': 'Bearer ' + session.get("jwt"),
@@ -238,7 +238,7 @@ export var ProfileView = Backbone.View.extend({
 
     var that = this;
     $.ajax({
-      url: '/users/change-password.json',
+      url: '/users/change-password',
       type: 'POST',
       headers: {
         'Authorization': 'Bearer ' + session.get("jwt"),

--- a/pikoci/transport/http/handler.go
+++ b/pikoci/transport/http/handler.go
@@ -289,15 +289,7 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, 
 		}
 	})
 
-	// Wrap the router: strip .json suffix and set Content-Type before
-	// mux route matching, so the jsonr subrouter matches correctly.
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if strings.HasSuffix(req.URL.Path, ".json") {
-			req.URL.Path = strings.TrimSuffix(req.URL.Path, ".json")
-			req.Header.Set("Content-Type", "application/json")
-		}
-		r.ServeHTTP(w, req)
-	})
+	return r
 }
 
 // encodeError writes an error response as JSON to the response writer.

--- a/pikoci/transport/http/handler_test.go
+++ b/pikoci/transport/http/handler_test.go
@@ -216,8 +216,9 @@ func TestRefreshTokenEndpoint(t *testing.T) {
 	s.EXPECT().GetUser(gomock.Any(), "pepito").Return(updatedUM, nil)
 	s.EXPECT().RefreshToken(gomock.Any(), "pepito").Return(updatedUM, signJWT(t, secret, updatedUM), nil)
 
-	req, err := http.NewRequest(http.MethodPost, server.URL+"/refresh-token.json", nil)
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/refresh-token", nil)
 	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+jwtToken)
 
 	resp, err := http.DefaultClient.Do(req)
@@ -244,8 +245,9 @@ func TestGetVersion(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	req, err := http.NewRequest(http.MethodGet, server.URL+"/version.json", nil)
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/version", nil)
 	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
@@ -411,8 +413,9 @@ func TestXRefreshTokenHeader(t *testing.T) {
 		s.EXPECT().GetUser(gomock.Any(), "pepito").Return(updatedUM, nil).Times(2)
 		s.EXPECT().ListTeams(gomock.Any(), "pepito").Return(nil, nil)
 
-		req, err := http.NewRequest(http.MethodGet, server.URL+"/teams.json", nil)
+		req, err := http.NewRequest(http.MethodGet, server.URL+"/teams", nil)
 		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Authorization", "Bearer "+jwtToken)
 
 		resp, err := http.DefaultClient.Do(req)
@@ -438,8 +441,9 @@ func TestXRefreshTokenHeader(t *testing.T) {
 		s.EXPECT().GetUser(gomock.Any(), "pepito").Return(um, nil).Times(2)
 		s.EXPECT().ListTeams(gomock.Any(), "pepito").Return(nil, nil)
 
-		req, err := http.NewRequest(http.MethodGet, server.URL+"/teams.json", nil)
+		req, err := http.NewRequest(http.MethodGet, server.URL+"/teams", nil)
 		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Authorization", "Bearer "+jwtToken)
 
 		resp, err := http.DefaultClient.Do(req)
@@ -465,8 +469,9 @@ func TestXRefreshTokenHeader(t *testing.T) {
 		// Workers skip authz and stale-check; the handler itself will fail
 		// because there's no username in context, but the important thing
 		// is that X-Refresh-Token is NOT set.
-		req, err := http.NewRequest(http.MethodGet, server.URL+"/teams.json", nil)
+		req, err := http.NewRequest(http.MethodGet, server.URL+"/teams", nil)
 		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Authorization", "Bearer "+workerJWT)
 
 		resp, err := http.DefaultClient.Do(req)

--- a/pikoci/transport/http/local.go
+++ b/pikoci/transport/http/local.go
@@ -73,14 +73,7 @@ func LocalEditorHandler(s pikoci.Service, filePath string, l *slog.Logger) http.
 		w.Write([]byte(localEditorHTML))
 	})
 
-	// JSON content-type wrapper (same as main handler)
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if len(req.URL.Path) > 5 && req.URL.Path[len(req.URL.Path)-5:] == ".json" {
-			req.URL.Path = req.URL.Path[:len(req.URL.Path)-5]
-			req.Header.Set("Content-Type", "application/json")
-		}
-		r.ServeHTTP(w, req)
-	})
+	return r
 }
 
 const localEditorHTML = `<!DOCTYPE html>


### PR DESCRIPTION
## Summary

- Removed the `.json` suffix stripping wrapper from `handler.go` and `local.go`
- Removed `.json` from all frontend JS API URLs (init, layout, users, resources, jobs views)
- Updated handler and integration tests to use plain URLs with explicit `Content-Type: application/json` headers

Closes #427