### PR TITLE
Fix pipeline graph showing gray for jobs with multiple active builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Git resource tag mode returns all tags on every check, triggering builds for every historical tag after pipeline recreation ([#419](https://github.com/PikoCI/pikoci/issues/419))
 - Pipeline graph shows original build color instead of successful retry when a new build is running ([#421](https://github.com/PikoCI/pikoci/issues/421))
+- Pipeline graph shows gray (pending) for jobs with pending + running + succeeded builds instead of the succeeded color ([#429](https://github.com/PikoCI/pikoci/issues/429))
 
 ## [0.2.2] - 2026-05-29
 

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -529,33 +529,27 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 				latestMain = b.BuildNumber
 			}
 		}
-		// Find the latest terminal build in that group (main + retries)
-		if latestMain != "" {
+		// Find the latest terminal build by walking back through main build
+		// groups until one with a completed (non-running, non-pending) build
+		// is found.
+		seen := map[string]bool{} // track which main groups we've checked
+		for cb == nil {
+			var mainBN string
 			for _, b := range builds {
-				if b.BuildNumber == latestMain || strings.HasPrefix(b.BuildNumber, latestMain+".") {
+				if !strings.Contains(b.BuildNumber, ".") && !seen[b.BuildNumber] {
+					mainBN = b.BuildNumber
+					break
+				}
+			}
+			if mainBN == "" {
+				break
+			}
+			seen[mainBN] = true
+			for _, b := range builds {
+				if b.BuildNumber == mainBN || strings.HasPrefix(b.BuildNumber, mainBN+".") {
 					if b.Status != build.Started && b.Status != build.Pending {
 						cb = b
 						break
-					}
-				}
-			}
-			// If all builds in the group are running, fall back to previous main build's group
-			if cb == nil {
-				var prevMain string
-				for _, b := range builds {
-					if !strings.Contains(b.BuildNumber, ".") && b.BuildNumber != latestMain {
-						prevMain = b.BuildNumber
-						break
-					}
-				}
-				if prevMain != "" {
-					for _, b := range builds {
-						if b.BuildNumber == prevMain || strings.HasPrefix(b.BuildNumber, prevMain+".") {
-							if b.Status != build.Started && b.Status != build.Pending {
-								cb = b
-								break
-							}
-						}
 					}
 				}
 			}

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -1596,6 +1596,17 @@ func TestGetPipelineImage_JobStatusColors(t *testing.T) {
 			wantDashedStyle: true,
 			wantBorderColor: colorDefaultBorder,
 		},
+		{
+			name: "pending + running + succeeded across 3 main builds - shows succeeded color",
+			builds: []*build.Build{
+				{ID: 3, BuildNumber: "3", Status: build.Pending},
+				{ID: 2, BuildNumber: "2", Status: build.Started},
+				{ID: 1, BuildNumber: "1", Status: build.Succeeded},
+			},
+			wantFillColor:   colorSucceeded,
+			wantDashedStyle: true,
+			wantBorderColor: colorStartedBorder,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Fixed graph color fallback that only checked one previous build group, causing gray nodes when 3+ main builds existed with pending/running status
- Replaced one-level fallback with a loop that walks back through all main build groups until a terminal build is found
- Added test case for the pending + running + succeeded scenario

Closes #429