### PR TITLE
Add file secret format auto-detection and multi-line JSON/YAML support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- File secret type: auto-detect format from file extension (`json`, `yaml`, `env`, `raw`), add `json` and `yaml` as explicit format options, and fix multi-line JSON parsing ([#435](https://github.com/PikoCI/pikoci/issues/435))
 - First-class notification entities: `notification_type`, `notification`, and `notify` steps for fire-and-forget notifications with automatic dispatch, job scoping, and `github-check`/`slack`/`discord` notification types ([#154](https://github.com/PikoCI/pikoci/issues/154))
 - SVG and PNG pipeline graph formats for embedding in READMEs and dashboards ([#332](https://github.com/PikoCI/pikoci/issues/332))
 

--- a/deploy/pipeline.hcl
+++ b/deploy/pipeline.hcl
@@ -425,13 +425,11 @@ service_type "vault" {
 
 secret_type "env" {
   source = "pikoci://file"
-  format = "env"
   path   = "/etc/pikoci/pikoci.env"
 }
 
 secret_type "pikoci_github_pem" {
   source = "pikoci://file"
-  format = "raw"
   path   = "/etc/pikoci/pikoci_github_app.pem"
 }
 

--- a/docs/Secret-Types.md
+++ b/docs/Secret-Types.md
@@ -194,13 +194,26 @@ secret_type "my-file" {
 
 | Attribute | Required | Default | Description                                      |
 |-----------|----------|---------|--------------------------------------------------|
-| `format`  | no       | `json`  | File format: `json`, `env`, or `raw`              |
+| `format`  | no       | auto    | File format: `json`, `yaml`, `env`, or `raw`. When omitted, inferred from the file extension (see below). |
 | `path`    | no       |         | Default file path; can be overridden per-variable. Relative paths resolve from the server's working directory. |
+
+### Format auto-detection
+
+When `format` is not explicitly set, it is inferred from the file extension of `path`:
+
+| Extension        | Inferred format |
+|------------------|-----------------|
+| `.json`          | `json`          |
+| `.env`           | `env`           |
+| `.yml`, `.yaml`  | `yaml`          |
+| anything else    | `raw`           |
+
+An explicit `format` always takes precedence over auto-detection. This is useful for files whose extension doesn't match their content (e.g. a JSON file without a `.json` extension).
 
 The file path can be set on the `secret_type` block as a default, on each variable's `secret` block, or both (the variable-level `path` takes precedence):
 
 ```hcl
-# Default path on the secret_type — variables just pick keys
+# Default path on the secret_type — format is inferred from extension
 secret_type "db-file" {
   source = "pikoci://file"
   path   = "/run/secrets/db.json"
@@ -246,12 +259,24 @@ variable "db_user" {
 }
 ```
 
-### JSON format (default)
+### JSON format
 
-When `format` is omitted or set to `"json"`, the file must contain a JSON object:
+When `format` is `"json"` (or inferred from a `.json` extension), the file must contain a JSON object:
 
 ```json
 {"username": "admin", "password": "s3cret", "host": "db.example.com"}
+```
+
+Multi-line JSON is fully supported — the entire file content is parsed as a single JSON object.
+
+### YAML format
+
+When `format` is `"yaml"` (or inferred from a `.yml`/`.yaml` extension), the file must contain a YAML mapping with string values:
+
+```yaml
+username: admin
+password: s3cret
+host: db.example.com
 ```
 
 ### `.env` format
@@ -261,7 +286,6 @@ When `format = "env"`, the file is parsed as a `.env` file with `KEY=VALUE` line
 ```hcl
 secret_type "env-creds" {
   source = "pikoci://file"
-  format = "env"
 }
 
 variable "db_password" {
@@ -289,7 +313,6 @@ When `format = "raw"`, the entire file content is returned as a single value und
 ```hcl
 secret_type "app-key" {
   source = "pikoci://file"
-  format = "raw"
   path   = "/etc/pikoci/github-app.pem"
 }
 
@@ -301,7 +324,7 @@ variable "github_app_key" {
 }
 ```
 
-The variable receives the full file content as-is.
+The variable receives the full file content as-is. The `.pem` extension is automatically detected as `raw`, so no explicit `format` is needed.
 
 ## Example: custom secret type
 

--- a/worker/service.go
+++ b/worker/service.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pikoci/pikoci/pikoci/service"
 	"github.com/pikoci/pikoci/pikoci/utils"
 	"gocloud.dev/pubsub"
+	"gopkg.in/yaml.v3"
 )
 
 // Service is the interface for running the worker event loop. Implementations
@@ -1912,6 +1913,20 @@ func (w *Worker) fetchSecrets(ctx context.Context, cwd string, pp *pipeline.Pipe
 
 		// Parse output based on format config
 		format := st.Config["format"]
+		if format == "" {
+			if p := st.Config["path"]; p != "" {
+				switch strings.ToLower(filepath.Ext(p)) {
+				case ".json":
+					format = "json"
+				case ".env":
+					format = "env"
+				case ".yml", ".yaml":
+					format = "yaml"
+				default:
+					format = "raw"
+				}
+			}
+		}
 		var secretData map[string]string
 		switch format {
 		case "env":
@@ -1919,6 +1934,14 @@ func (w *Worker) fetchSecrets(ctx context.Context, cwd string, pp *pipeline.Pipe
 		case "raw":
 			// Raw format: entire file content as a single "content" key.
 			secretData = map[string]string{"content": out}
+		case "json":
+			if err := json.Unmarshal([]byte(out), &secretData); err != nil {
+				return nil, fmt.Errorf("failed to parse secret output from %q as JSON: %w", stName, err)
+			}
+		case "yaml", "yml":
+			if err := yaml.Unmarshal([]byte(out), &secretData); err != nil {
+				return nil, fmt.Errorf("failed to parse secret output from %q as YAML: %w", stName, err)
+			}
 		default:
 			// Default: parse last line of stdout as JSON object
 			sout := strings.Split(strings.Trim(out, "\n"), "\n")


### PR DESCRIPTION
## Summary

- Infer `format` from file extension (`.json`→json, `.env`→env, `.yml`/`.yaml`→yaml, else→raw) when not explicitly set
- Add `json` and `yaml` as explicit format options, parsing the full file content instead of only the last line — fixes multi-line JSON files
- Remove redundant `format` from deploy pipeline (now auto-detected)
- Update docs with auto-detection table, YAML format section, and format-free examples

Closes #435