### PR TITLE
Add floating toast notifications for success and error feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Floating toast notifications for success and error feedback on all mutating actions (trigger, delete, retry, cancel, etc.) with auto-dismiss and dark mode support ([#351](https://github.com/PikoCI/pikoci/issues/351))
 - File secret type: auto-detect format from file extension (`json`, `yaml`, `env`, `raw`), add `json` and `yaml` as explicit format options, and fix multi-line JSON parsing ([#435](https://github.com/PikoCI/pikoci/issues/435))
 - First-class notification entities: `notification_type`, `notification`, and `notify` steps for fire-and-forget notifications with automatic dispatch, job scoping, and `github-check`/`slack`/`discord` notification types ([#154](https://github.com/PikoCI/pikoci/issues/154))
 - SVG and PNG pipeline graph formats for embedding in READMEs and dashboards ([#332](https://github.com/PikoCI/pikoci/issues/332))

--- a/integration/pikoci_test.go
+++ b/integration/pikoci_test.go
@@ -71,7 +71,7 @@ func TestPikoCI(t *testing.T) {
 			err = changeBtn.Click()
 			require.NoError(t, err)
 
-			waitFor(t, wd, eqText(selenium.ByCSSSelector, ".alert-success", "Password changed successfully"), 15*time.Second)
+			waitFor(t, wd, eqText(selenium.ByCSSSelector, ".piko-toast", "Password changed successfully"), 15*time.Second)
 
 			// Navigate to teams
 			wd.Get(pikoURL + "/")

--- a/pikoci/mysql/team.go
+++ b/pikoci/mysql/team.go
@@ -109,6 +109,10 @@ func (r *TeamRepository) Find(ctx context.Context, tc string) (*team.WithMembers
 		return nil, fmt.Errorf("failed to scan Team: %w", err)
 	}
 
+	if len(t) == 0 {
+		return nil, fmt.Errorf("team not found: %s", tc)
+	}
+
 	return t[0], nil
 }
 

--- a/pikoci/transport/http/assets/css/pikoci.css
+++ b/pikoci/transport/http/assets/css/pikoci.css
@@ -193,6 +193,7 @@ a:hover { color: var(--primary-hover); }
   border-radius: var(--radius);
   box-shadow: 0 4px 12px rgba(0,0,0,0.15);
   word-wrap: break-word;
+  pointer-events: none;
   opacity: 0;
   transform: translateX(20px);
   transition: opacity 0.3s, transform 0.3s;

--- a/pikoci/transport/http/assets/css/pikoci.css
+++ b/pikoci/transport/http/assets/css/pikoci.css
@@ -180,6 +180,50 @@ a:hover { color: var(--primary-hover); }
 }
 
 /* ============================================================
+   TOASTS
+   ============================================================ */
+.piko-toast {
+  position: fixed;
+  top: 70px;
+  right: 20px;
+  z-index: 1050;
+  min-width: 250px;
+  max-width: 400px;
+  padding: 12px 20px;
+  border-radius: var(--radius);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  word-wrap: break-word;
+  opacity: 0;
+  transform: translateX(20px);
+  transition: opacity 0.3s, transform 0.3s;
+}
+.piko-toast.show { opacity: 1; transform: translateX(0); }
+.piko-toast-success {
+  background: #d0f5d8;
+  border: 1px solid #a0e0b0;
+  border-left: 3px solid var(--success);
+  color: #006020;
+}
+.piko-toast-error {
+  background: #ffe0e8;
+  border: 1px solid #ffb0c8;
+  border-left: 3px solid var(--danger);
+  color: #cc003e;
+}
+[data-theme="dark"] .piko-toast-success {
+  background: #0a2a14;
+  border: 1px solid #1a5a30;
+  border-left: 3px solid #00E436;
+  color: #00E436;
+}
+[data-theme="dark"] .piko-toast-error {
+  background: #2a0a14;
+  border: 1px solid #5a1a2a;
+  border-left: 3px solid #FF004D;
+  color: #FF77A8;
+}
+
+/* ============================================================
    BUTTONS
    ============================================================ */
 .btn {

--- a/pikoci/transport/http/assets/js/app/local-init.js
+++ b/pikoci/transport/http/assets/js/app/local-init.js
@@ -47,7 +47,27 @@ var NoticeView = Backbone.View.extend({
   },
   render: function() {
     this.$el.html(this.template(this.model.toJSON()));
+    var success = this.model.get('success');
+    if (success) {
+      this.showToast(success, 'success');
+      this.model.set({success: ''}, {silent: true});
+    }
+    var error = this.model.get('error');
+    if (error) {
+      this.showToast(error, 'error');
+      this.model.set({error: ''}, {silent: true});
+    }
     return this;
+  },
+  showToast: function(msg, type) {
+    $('.piko-toast').remove();
+    var toast = $('<div class="piko-toast"></div>').addClass('piko-toast-' + type).text(msg);
+    $('body').append(toast);
+    requestAnimationFrame(function() { toast.addClass('show'); });
+    setTimeout(function() {
+      toast.removeClass('show');
+      setTimeout(function() { toast.remove(); }, 300);
+    }, type === 'error' ? 8000 : 4000);
   },
 });
 

--- a/pikoci/transport/http/assets/js/app/models.js
+++ b/pikoci/transport/http/assets/js/app/models.js
@@ -145,8 +145,8 @@ export var Job = Backbone.Model.extend({
     }
     return response;
   },
-  fetchTrigger: function() {
-    this.fetch({url: this.url()+"/trigger", type: "POST"});
+  fetchTrigger: function(opts) {
+    this.fetch(_.extend({url: this.url()+"/trigger", type: "POST"}, opts));
   },
 });
 
@@ -172,8 +172,8 @@ export var Resource = Backbone.Model.extend({
   parse: function(response) {
     return response.data;
   },
-  fetchTrigger: function() {
-    this.fetch({url: this.url()+"/trigger", type: "POST"});
+  fetchTrigger: function(opts) {
+    this.fetch(_.extend({url: this.url()+"/trigger", type: "POST"}, opts));
   },
 });
 

--- a/pikoci/transport/http/assets/js/app/views/jobs.js
+++ b/pikoci/transport/http/assets/js/app/views/jobs.js
@@ -116,7 +116,7 @@ export var JobBuildsView = Backbone.View.extend({
   },
   clickTriggerJob: function(event) {
     event.preventDefault();
-    this.collection.job.fetchTrigger();
+    this.collection.job.fetchTrigger({success: function() { window.app.apiNotice.setSuccess("Job triggered"); }});
   },
   clickOnTab: function(event) {
     event.preventDefault();
@@ -180,7 +180,7 @@ var JobBuildsContentView = Backbone.View.extend({
     var bid = this.model.get("build_number");
     var url = this.model.collection.url() + "/" + bid + "/cancel";
     $.ajax({ url: url, type: "POST", contentType: "application/json", headers: { "Authorization": "Bearer " + session.get("jwt") },
-      success: function() { that.model.fetch(); },
+      success: function() { window.app.apiNotice.setSuccess("Build cancelled"); that.model.fetch(); },
     });
   },
   retryBuild: function(e) {
@@ -189,7 +189,7 @@ var JobBuildsContentView = Backbone.View.extend({
     var collection = this.model.collection;
     var url = collection.url() + "/" + bid + "/retry";
     $.ajax({ url: url, type: "POST", contentType: "application/json", headers: { "Authorization": "Bearer " + session.get("jwt") },
-      success: function() { collection.fetchNew(); },
+      success: function() { window.app.apiNotice.setSuccess("Build retried"); collection.fetchNew(); },
     });
   },
   toggleFollow: function(e) {

--- a/pikoci/transport/http/assets/js/app/views/layout.js
+++ b/pikoci/transport/http/assets/js/app/views/layout.js
@@ -74,7 +74,27 @@ export var NoticeView = Backbone.View.extend({
   },
   render: function() {
     this.$el.html(this.template(this.model.toJSON()));
+    var success = this.model.get("success");
+    if (success) {
+      this.showToast(success, "success");
+      this.model.set({success: ""}, {silent: true});
+    }
+    var error = this.model.get("error");
+    if (error) {
+      this.showToast(error, "error");
+      this.model.set({error: ""}, {silent: true});
+    }
     return this;
+  },
+  showToast: function(msg, type) {
+    $('.piko-toast').remove();
+    var toast = $('<div class="piko-toast"></div>').addClass('piko-toast-' + type).text(msg);
+    $('body').append(toast);
+    requestAnimationFrame(function() { toast.addClass('show'); });
+    setTimeout(function() {
+      toast.removeClass('show');
+      setTimeout(function() { toast.remove(); }, 300);
+    }, type === "error" ? 8000 : 4000);
   },
 });
 

--- a/pikoci/transport/http/assets/js/app/views/resources.js
+++ b/pikoci/transport/http/assets/js/app/views/resources.js
@@ -95,7 +95,7 @@ export var ResourceVersionsView = Backbone.View.extend({
   },
   clickTriggerResource: function(event) {
     event.preventDefault();
-    this.collection.resource.fetchTrigger();
+    this.collection.resource.fetchTrigger({success: function() { window.app.apiNotice.setSuccess("Resource check triggered"); }});
   },
   clickToggleWebhookPanel: function(event) {
     event.preventDefault();
@@ -131,6 +131,7 @@ export var ResourceVersionsView = Backbone.View.extend({
           rs.set('webhook_token', resp.token);
           var url = window.location.origin + '/webhooks/' + resp.token + '';
           that.$('#webhook-url').text(url);
+          window.app.apiNotice.setSuccess("Webhook token regenerated");
         }
       }
     });

--- a/pikoci/transport/http/assets/js/app/views/teams.js
+++ b/pikoci/transport/http/assets/js/app/views/teams.js
@@ -58,7 +58,7 @@ var TeamRowView = Backbone.View.extend({
     event.preventDefault();
     event.stopPropagation();
 
-    this.model.destroy();
+    this.model.destroy({success: function() { window.app.apiNotice.setSuccess("Team deleted"); }});
   },
 });
 
@@ -174,6 +174,7 @@ var TeamNewMemberRowView = Backbone.View.extend({
     }}, {url: this.members.url(), method: "POST",
       wait: true,
       success: function(){
+        window.app.apiNotice.setSuccess("Member added");
         Backbone.View.prototype.remove.call(that);
       },
     });
@@ -199,10 +200,11 @@ var TeamShowMemberRowView = Backbone.View.extend({
     event.preventDefault();
     this.model.save({admin: !this.model.get("admin")},{
       wait: true,
+      success: function() { window.app.apiNotice.setSuccess("Member role updated"); },
     });
   },
   deleteMember: function(event) {
     event.preventDefault();
-    this.model.destroy();
+    this.model.destroy({success: function() { window.app.apiNotice.setSuccess("Member removed"); }});
   },
 });

--- a/pikoci/transport/http/local.go
+++ b/pikoci/transport/http/local.go
@@ -109,18 +109,7 @@ const localEditorHTML = `<!DOCTYPE html>
     </script>
 
     <script type="text/template" id="notice-view">
-      <div>
-        <% if (error) { %>
-          <div class="alert alert-danger" role="alert">
-            <%- error %>
-          </div>
-        <% } %>
-        <% if (success) { %>
-          <div class="alert alert-success" role="alert">
-            <%- success %>
-          </div>
-        <% } %>
-      </div>
+      <div></div>
     </script>
 
     <script type="text/template" id="pipeline-graph-view">

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -78,18 +78,7 @@
     </script>
 
     <script type="text/template" id="notice-view">
-      <div>
-        <% if (error) { %>
-          <div class="alert alert-danger" role="alert">
-            <%- error %>
-          </div>
-        <% } %>
-        <% if (success) { %>
-          <div class="alert alert-success" role="alert">
-            <%- success %>
-          </div>
-        <% } %>
-      </div>
+      <div></div>
     </script>
 
     <script type="text/template" id="session-new-view">


### PR DESCRIPTION
## Summary

- Replace inline alert banners with floating toasts in the top-right corner that slide in and auto-dismiss (4s success, 8s errors)
- Add success feedback to all mutating actions: trigger job/resource, cancel/retry build, delete/create team members, toggle admin, regenerate webhook
- Support both light and dark mode with opaque backgrounds
- Fix index-out-of-range panic in `TeamRepository.Find` when team has no members

Closes #351