### PR TITLE
Add type-level runner overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Type-level runner overrides: `resource_type`, `notification_type`, `secret_type`, and `service_type` definitions can specify a `runner` block to override where their exec commands execute, e.g. run inside Docker without modifying the type's command definitions ([#221](https://github.com/PikoCI/pikoci/issues/221))
 - Floating toast notifications for success and error feedback on all mutating actions (trigger, delete, retry, cancel, etc.) with auto-dismiss and dark mode support ([#351](https://github.com/PikoCI/pikoci/issues/351))
 - File secret type: auto-detect format from file extension (`json`, `yaml`, `env`, `raw`), add `json` and `yaml` as explicit format options, and fix multi-line JSON parsing ([#435](https://github.com/PikoCI/pikoci/issues/435))
 - First-class notification entities: `notification_type`, `notification`, and `notify` steps for fire-and-forget notifications with automatic dispatch, job scoping, and `github-check`/`slack`/`discord` notification types ([#154](https://github.com/PikoCI/pikoci/issues/154))

--- a/docs/Notifications.md
+++ b/docs/Notifications.md
@@ -28,6 +28,7 @@ notification_type "github-check" {
 
 - `params` - List of parameter names that notifications of this type can provide.
 - `notify` - A runner command block that executes the notification logic.
+- `runner` - Optional runner override for the notify command. See [Runners — Type-level runner overrides](Runners.md#type-level-runner-overrides).
 
 ## Notifications
 

--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -55,6 +55,7 @@ resource_type "git" {
 | `name`   | yes      | Label on the block                                  |
 | `source` | no       | URL to fetch definition (e.g. `pikoci://git`)       |
 | `params` | no       | List of parameter names                             |
+| `runner` | no       | Override runner for all commands (see [Runners](Runners.md#type-level-runner-overrides)) |
 
 When `source` is set, inline commands are not needed. The source is resolved once when the pipeline is created or updated — if the remote definition changes, you must re-set the pipeline to pick up the new version. This applies to all block types that support `source` (`resource_type`, `runner_type`, `secret_type`, `service_type`).
 
@@ -106,6 +107,7 @@ notification_type "custom" {
 | `source` | no       | URL to fetch the definition from (mutually exclusive with inline `notify`) |
 | `params` | no       | List of parameter names the notification type accepts            |
 | `notify` | no       | Runner command block that executes the notification logic        |
+| `runner` | no       | Override runner for all commands (see [Runners](Runners.md#type-level-runner-overrides)) |
 
 ## notification
 
@@ -174,6 +176,7 @@ secret_type "vault" {
 | `name`   | yes      | Label on the block                                  |
 | `source` | no       | URL to fetch definition (e.g. `pikoci://vault`)     |
 | `params` | no       | List of parameter names the get command accepts      |
+| `runner` | no       | Override runner for all commands (see [Runners](Runners.md#type-level-runner-overrides)) |
 | other    | no       | Config attributes passed as `param_<key>` env vars to the get command |
 
 When `source` is set, inline `get` block is not needed. Use secret-backed variables to consume secrets:
@@ -232,6 +235,7 @@ service_type "postgres" {
 | `start`       | yes*     | Runner command to start the service                              |
 | `ready_check` | no       | Runner command polled until exit 0 or timeout                    |
 | `stop`        | yes*     | Runner command to stop the service (always runs)                 |
+| `runner`      | no       | Override runner for all commands (see [Runners](Runners.md#type-level-runner-overrides)) |
 
 \* Not required when `source` is set.
 

--- a/docs/Resource-Types.md
+++ b/docs/Resource-Types.md
@@ -86,6 +86,10 @@ When `source` is set, you must not define inline `check`, `pull`, or `push` bloc
 
 > **Note:** The source is resolved once when the pipeline is created or updated. If the remote HCL file changes, you must re-set the pipeline to pick up the new definition.
 
+## Runner overrides
+
+You can override the runner used for all commands of a resource type by adding a `runner` block. This lets you run sourced or inline exec commands inside Docker without modifying the type's command definitions. See [Runners — Type-level runner overrides](Runners.md#type-level-runner-overrides) for details.
+
 ## Overriding built-ins
 
 All built-in resource types (`cron`, `git`) can be overridden by defining a `resource_type` block with the same name in your pipeline. Inline definitions always take precedence over built-ins.

--- a/docs/Runners.md
+++ b/docs/Runners.md
@@ -84,6 +84,79 @@ runner_type "docker" {
 
 This replaces the built-in `docker` runner entirely for this pipeline.
 
+## Type-level runner overrides
+
+By default, a type's commands run using the runner specified in their command blocks (e.g. `check "exec" { ... }`). You can override this for all commands of a type by adding a `runner` block to the type definition.
+
+This is useful when a type uses `exec` to run commands directly on the host, but you want all its operations to run inside Docker — for example, to provide the right CLI tools without installing them on the host.
+
+### Resource type
+
+```hcl
+resource_type "git" {
+  source = "pikoci://git"
+  runner "docker" {
+    image = "alpine/git:latest"
+  }
+}
+```
+
+All `check`, `pull`, and `push` commands for this resource type will run inside the specified Docker image instead of directly on the host.
+
+### Notification type
+
+```hcl
+notification_type "slack" {
+  source = "pikoci://slack"
+  runner "docker" {
+    image = "curlimages/curl:latest"
+  }
+}
+```
+
+### Secret type
+
+```hcl
+secret_type "vault" {
+  source = "pikoci://vault"
+  runner "docker" {
+    image = "hashicorp/vault:latest"
+  }
+}
+```
+
+### Service type
+
+```hcl
+service_type "postgresql" {
+  source = "pikoci://postgresql"
+  runner "docker" {
+    image = "docker:latest"
+  }
+}
+```
+
+### Passing extra Docker flags
+
+Override params are passed to the runner template as variables. The built-in `docker` runner supports `image`, `cmd`, and `args`. Use `args` to pass extra `docker run` flags like volumes, environment variables, or privileged mode:
+
+```hcl
+resource_type "git" {
+  source = "pikoci://git"
+  runner "docker" {
+    image = "alpine/git:latest"
+    args  = ["-v", "/var/run/docker.sock:/var/run/docker.sock", "-e", "GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=no"]
+  }
+}
+```
+
+### Restrictions
+
+- **Only exec commands can be overridden.** If any command in the type already uses a non-exec runner, specifying a runner override is an error.
+- The override applies to **all commands** of the type (check/pull/push for resource types, start/stop/ready_check for services, etc.).
+- Override parameters (like `image`, `args`) are merged with the command's parameters.
+- Works with sourced types: you can use `source = "pikoci://git"` and add a `runner` block to change where the sourced commands execute.
+
 ## Using a runner
 
 Reference a runner by name in `task`, `on_success`, `on_failure`, `ensure`, and resource type `check`/`pull`/`push` blocks:

--- a/docs/Secret-Types.md
+++ b/docs/Secret-Types.md
@@ -65,6 +65,8 @@ When `source` is set, you must not define an inline `get` block. PikoCI will err
 
 > **Note:** The source is resolved once when the pipeline is created or updated. If the remote HCL file changes, you must re-set the pipeline to pick up the new definition.
 
+You can override the runner used for the `get` command by adding a `runner` block. See [Runners — Type-level runner overrides](Runners.md#type-level-runner-overrides).
+
 ## Using secrets via variables
 
 Secrets are consumed through **secret-backed variables**. Declare a variable with a `secret` block referencing a secret type, then use `var.<name>` anywhere in your pipeline:

--- a/docs/Services.md
+++ b/docs/Services.md
@@ -75,6 +75,8 @@ When `source` is set, you must not define inline `start`, `stop`, or `ready_chec
 
 > **Note:** The source is resolved once when the pipeline is created or updated. If the remote HCL file changes, you must re-set the pipeline to pick up the new definition.
 
+You can override the runner used for all commands (`start`, `stop`, `ready_check`) by adding a `runner` block. See [Runners — Type-level runner overrides](Runners.md#type-level-runner-overrides).
+
 ## Referencing service types in jobs
 
 Reference a top-level service type by name in a job:

--- a/pikoci/helper.go
+++ b/pikoci/helper.go
@@ -86,9 +86,10 @@ type hclResourceType struct {
 	Source string   `json:"source,omitempty" hcl:"source,optional"`
 	Params []string `json:"params" hcl:"params,optional"`
 
-	Check []utils.RunnerCommand `json:"check" hcl:"check,block"`
-	Pull  []utils.RunnerCommand `json:"pull" hcl:"pull,block"`
-	Push  []utils.RunnerCommand `json:"push" hcl:"push,block"`
+	Check  []utils.RunnerCommand  `json:"check" hcl:"check,block"`
+	Pull   []utils.RunnerCommand  `json:"pull" hcl:"pull,block"`
+	Push   []utils.RunnerCommand  `json:"push" hcl:"push,block"`
+	Runner []utils.RunnerOverride `json:"runner" hcl:"runner,block"`
 }
 
 func (hrt hclResourceType) toResourceType() restype.ResourceType {
@@ -105,6 +106,9 @@ func (hrt hclResourceType) toResourceType() restype.ResourceType {
 	}
 	if len(hrt.Push) > 0 {
 		rt.Push = &hrt.Push[0]
+	}
+	if len(hrt.Runner) > 0 {
+		rt.Runner = &hrt.Runner[0]
 	}
 	return rt
 }
@@ -136,8 +140,9 @@ type hclSecretType struct {
 	Source string   `json:"source,omitempty" hcl:"source,optional"`
 	Params []string `json:"params" hcl:"params,optional"`
 
-	Get    []utils.RunnerCommand `json:"get" hcl:"get,block"`
-	Remain hcl.Body              `hcl:",remain"`
+	Get    []utils.RunnerCommand  `json:"get" hcl:"get,block"`
+	Runner []utils.RunnerOverride `json:"runner" hcl:"runner,block"`
+	Remain hcl.Body               `hcl:",remain"`
 }
 
 func (hst hclSecretType) toSecretType() sectype.SecretType {
@@ -148,6 +153,9 @@ func (hst hclSecretType) toSecretType() sectype.SecretType {
 	}
 	if len(hst.Get) > 0 {
 		st.Get = hst.Get[0]
+	}
+	if len(hst.Runner) > 0 {
+		st.Runner = &hst.Runner[0]
 	}
 	return st
 }
@@ -163,12 +171,13 @@ type hclReadyCheck struct {
 
 // hclService is the HCL-decoded top-level service block.
 type hclService struct {
-	Name       string                `hcl:"name,label"`
-	Source     string                `hcl:"source,optional"`
-	Params     []string              `hcl:"params,optional"`
-	Start      []utils.RunnerCommand `hcl:"start,block"`
-	ReadyCheck []hclReadyCheck       `hcl:"ready_check,block"`
-	Stop       []utils.RunnerCommand `hcl:"stop,block"`
+	Name       string                 `hcl:"name,label"`
+	Source     string                 `hcl:"source,optional"`
+	Params     []string               `hcl:"params,optional"`
+	Start      []utils.RunnerCommand  `hcl:"start,block"`
+	ReadyCheck []hclReadyCheck        `hcl:"ready_check,block"`
+	Stop       []utils.RunnerCommand  `hcl:"stop,block"`
+	Runner     []utils.RunnerOverride `hcl:"runner,block"`
 }
 
 func (hs hclService) toService() service.Service {
@@ -195,6 +204,9 @@ func (hs hclService) toService() service.Service {
 			Timeout:  rc.Timeout,
 		}
 	}
+	if len(hs.Runner) > 0 {
+		s.Runner = &hs.Runner[0]
+	}
 	return s
 }
 
@@ -205,7 +217,8 @@ type hclNotificationType struct {
 	Source string   `json:"source,omitempty" hcl:"source,optional"`
 	Params []string `json:"params" hcl:"params,optional"`
 
-	Notify []utils.RunnerCommand `json:"notify" hcl:"notify,block"`
+	Notify []utils.RunnerCommand  `json:"notify" hcl:"notify,block"`
+	Runner []utils.RunnerOverride `json:"runner" hcl:"runner,block"`
 }
 
 func (hnt hclNotificationType) toNotificationType() notiftype.NotificationType {
@@ -216,6 +229,9 @@ func (hnt hclNotificationType) toNotificationType() notiftype.NotificationType {
 	}
 	if len(hnt.Notify) > 0 {
 		nt.Notify = &hnt.Notify[0]
+	}
+	if len(hnt.Runner) > 0 {
+		nt.Runner = &hnt.Runner[0]
 	}
 	return nt
 }
@@ -412,6 +428,9 @@ func (q *PikoCI) readPipeline(ctx context.Context, rpp []byte, vars map[string]i
 			}
 			resolved.Name = hrt.Name
 			resolved.Source = hrt.Source
+			if len(hrt.Runner) > 0 {
+				resolved.Runner = &hrt.Runner[0]
+			}
 			resourceTypes = append(resourceTypes, *resolved)
 		} else {
 			resourceTypes = append(resourceTypes, hrt.toResourceType())
@@ -486,6 +505,9 @@ func (q *PikoCI) readPipeline(ctx context.Context, rpp []byte, vars map[string]i
 			if cfg, ok := secretTypeConfigs[i]; ok {
 				resolved.Config = cfg
 			}
+			if len(hst.Runner) > 0 {
+				resolved.Runner = &hst.Runner[0]
+			}
 			secretTypes = append(secretTypes, *resolved)
 		} else {
 			st := hst.toSecretType()
@@ -511,6 +533,9 @@ func (q *PikoCI) readPipeline(ctx context.Context, rpp []byte, vars map[string]i
 			resolved.Source = hs.Source
 			if hs.Params != nil {
 				resolved.Params = hs.Params
+			}
+			if len(hs.Runner) > 0 {
+				resolved.Runner = &hs.Runner[0]
 			}
 			services = append(services, *resolved)
 		} else {
@@ -538,9 +563,53 @@ func (q *PikoCI) readPipeline(ctx context.Context, rpp []byte, vars map[string]i
 			}
 			resolved.Name = hnt.Name
 			resolved.Source = hnt.Source
+			if len(hnt.Runner) > 0 {
+				resolved.Runner = &hnt.Runner[0]
+			}
 			notificationTypes = append(notificationTypes, *resolved)
 		} else {
 			notificationTypes = append(notificationTypes, hnt.toNotificationType())
+		}
+	}
+
+	// Validate runner overrides: only exec commands can be overridden
+	for _, rt := range resourceTypes {
+		if rt.Runner == nil {
+			continue
+		}
+		for _, cmd := range []*utils.RunnerCommand{rt.Check, rt.Pull, rt.Push} {
+			if cmd != nil && cmd.Runner != "exec" {
+				return nil, fmt.Errorf("resource_type %q has runner override but command uses non-exec runner %q", rt.Name, cmd.Runner)
+			}
+		}
+	}
+	for _, nt := range notificationTypes {
+		if nt.Runner == nil {
+			continue
+		}
+		if nt.Notify != nil && nt.Notify.Runner != "exec" {
+			return nil, fmt.Errorf("notification_type %q has runner override but command uses non-exec runner %q", nt.Name, nt.Notify.Runner)
+		}
+	}
+	for _, st := range secretTypes {
+		if st.Runner == nil {
+			continue
+		}
+		if st.Get.Runner != "" && st.Get.Runner != "exec" {
+			return nil, fmt.Errorf("secret_type %q has runner override but command uses non-exec runner %q", st.Name, st.Get.Runner)
+		}
+	}
+	for _, svc := range services {
+		if svc.Runner == nil {
+			continue
+		}
+		for _, cmd := range []utils.RunnerCommand{svc.Start, svc.Stop} {
+			if cmd.Runner != "" && cmd.Runner != "exec" {
+				return nil, fmt.Errorf("service_type %q has runner override but command uses non-exec runner %q", svc.Name, cmd.Runner)
+			}
+		}
+		if svc.ReadyCheck != nil && svc.ReadyCheck.Runner != "exec" {
+			return nil, fmt.Errorf("service_type %q has runner override but ready_check uses non-exec runner %q", svc.Name, svc.ReadyCheck.Runner)
 		}
 	}
 

--- a/pikoci/notiftype/notification_type.go
+++ b/pikoci/notiftype/notification_type.go
@@ -14,4 +14,6 @@ type NotificationType struct {
 	Source string               `json:"source,omitempty" hcl:"source,optional"`
 	Notify *utils.RunnerCommand `json:"notify,omitempty" hcl:"notify,block"`
 	Params []string             `json:"params" hcl:"params,optional"`
+
+	Runner *utils.RunnerOverride `json:"runner,omitempty"`
 }

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -2033,3 +2033,400 @@ job "build" {
 	_, err := s.S.CreatePipeline(ctx, "main", "test-pipeline", hclConfig, nil)
 	require.NoError(t, err)
 }
+
+func TestCreatePipeline_RunnerOverride_ResourceType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+resource_type "git" {
+  params = ["url"]
+  check "exec" {
+    path = "/opt/git/check"
+    args = ["-v"]
+  }
+  pull "exec" {
+    path = "/opt/git/pull"
+  }
+  push "exec" {
+    path = "/opt/git/push"
+  }
+  runner "docker" {
+    image = "alpine/git:latest"
+  }
+}
+
+resource "git" "repo" {
+  params {
+    url = "http://example.com"
+  }
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "test" {
+  get "cron" "timer" {
+    trigger = true
+  }
+  task "echo" {
+    run "exec" {
+      path = "echo"
+      args = ["hello"]
+    }
+  }
+}
+`)
+
+	s.Pipelines.EXPECT().Create(ctx, "main", gomock.Any()).Return(uint32(1), nil)
+	s.Jobs.EXPECT().Create(ctx, "main", "runner-override", gomock.Any()).Return(uint32(1), nil)
+	s.ResourceTypes.EXPECT().Create(ctx, "main", "runner-override", gomock.Any()).DoAndReturn(
+		func(ctx context.Context, tc, pn string, rt interface{}) (uint32, error) {
+			return uint32(1), nil
+		})
+	s.Resources.EXPECT().Create(ctx, "main", "runner-override", gomock.Any()).Return(uint32(1), nil).Times(2)
+	s.Pipelines.EXPECT().Find(ctx, "main", "runner-override").Return(&pipeline.Pipeline{ID: 1, Name: "runner-override", Canonical: "runner-override"}, nil)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "runner-override", hclConfig, nil)
+	require.NoError(t, err)
+}
+
+func TestCreatePipeline_RunnerOverride_RejectsNonExec(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+resource_type "custom" {
+  check "docker" {
+    image = "foo"
+    cmd   = "check"
+  }
+  pull "docker" {
+    image = "foo"
+    cmd   = "pull"
+  }
+  runner "docker" {
+    image = "alpine/git:latest"
+  }
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "test" {
+  get "cron" "timer" {
+    trigger = true
+  }
+}
+`)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "reject-pipeline", hclConfig, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "runner override but command uses non-exec runner")
+}
+
+func TestCreatePipeline_RunnerOverride_NotificationType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+notification_type "slack" {
+  source = "pikoci://slack"
+  runner "docker" {
+    image = "curlimages/curl:latest"
+  }
+}
+
+notification "slack" "alerts" {
+  params {
+    webhook_url = "http://example.com"
+  }
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "test" {
+  get "cron" "timer" {
+    trigger = true
+  }
+}
+`)
+
+	s.Pipelines.EXPECT().Create(ctx, "main", gomock.Any()).Return(uint32(1), nil)
+	s.Jobs.EXPECT().Create(ctx, "main", "notif-override", gomock.Any()).Return(uint32(1), nil)
+	s.NotificationTypes.EXPECT().Create(ctx, "main", "notif-override", gomock.Any()).Return(uint32(1), nil)
+	s.Notifications.EXPECT().Create(ctx, "main", "notif-override", gomock.Any()).Return(uint32(1), nil)
+	s.Resources.EXPECT().Create(ctx, "main", "notif-override", gomock.Any()).Return(uint32(1), nil)
+	s.Pipelines.EXPECT().Find(ctx, "main", "notif-override").Return(&pipeline.Pipeline{ID: 1, Name: "notif-override", Canonical: "notif-override"}, nil)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "notif-override", hclConfig, nil)
+	require.NoError(t, err)
+}
+
+func TestCreatePipeline_RunnerOverride_SecretType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+secret_type "vault" {
+  source = "pikoci://vault"
+  runner "docker" {
+    image = "hashicorp/vault:latest"
+  }
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "test" {
+  get "cron" "timer" {
+    trigger = true
+  }
+}
+`)
+
+	s.Pipelines.EXPECT().Create(ctx, "main", gomock.Any()).Return(uint32(1), nil)
+	s.Jobs.EXPECT().Create(ctx, "main", "secret-override", gomock.Any()).Return(uint32(1), nil)
+	s.SecretTypes.EXPECT().Create(ctx, "main", "secret-override", gomock.Any()).Return(uint32(1), nil)
+	s.Resources.EXPECT().Create(ctx, "main", "secret-override", gomock.Any()).Return(uint32(1), nil)
+	s.Pipelines.EXPECT().Find(ctx, "main", "secret-override").Return(&pipeline.Pipeline{ID: 1, Name: "secret-override", Canonical: "secret-override"}, nil)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "secret-override", hclConfig, nil)
+	require.NoError(t, err)
+}
+
+func TestCreatePipeline_RunnerOverride_ServiceType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+service_type "postgresql" {
+  source = "pikoci://postgresql"
+  runner "docker" {
+    image = "docker:latest"
+  }
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "test" {
+  service "postgresql" {}
+  get "cron" "timer" {
+    trigger = true
+  }
+}
+`)
+
+	s.Pipelines.EXPECT().Create(ctx, "main", gomock.Any()).Return(uint32(1), nil)
+	s.Jobs.EXPECT().Create(ctx, "main", "svc-override", gomock.Any()).Return(uint32(1), nil)
+	s.Resources.EXPECT().Create(ctx, "main", "svc-override", gomock.Any()).Return(uint32(1), nil)
+	s.Pipelines.EXPECT().Find(ctx, "main", "svc-override").Return(&pipeline.Pipeline{ID: 1, Name: "svc-override", Canonical: "svc-override"}, nil)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "svc-override", hclConfig, nil)
+	require.NoError(t, err)
+}
+
+func TestCreatePipeline_RunnerOverride_RejectsNonExec_NotificationType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+notification_type "custom" {
+  notify "docker" {
+    image = "foo"
+    cmd   = "send"
+  }
+  runner "docker" {
+    image = "bar:latest"
+  }
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "test" {
+  get "cron" "timer" {
+    trigger = true
+  }
+}
+`)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "reject-notif", hclConfig, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "notification_type")
+	assert.Contains(t, err.Error(), "runner override but command uses non-exec runner")
+}
+
+func TestCreatePipeline_RunnerOverride_RejectsNonExec_SecretType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+secret_type "custom" {
+  get "docker" {
+    image = "foo"
+    cmd   = "get-secret"
+  }
+  runner "docker" {
+    image = "bar:latest"
+  }
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "test" {
+  get "cron" "timer" {
+    trigger = true
+  }
+}
+`)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "reject-secret", hclConfig, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secret_type")
+	assert.Contains(t, err.Error(), "runner override but command uses non-exec runner")
+}
+
+func TestCreatePipeline_RunnerOverride_RejectsNonExec_ServiceType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+service_type "svc" {
+  start "docker" {
+    image = "foo"
+    cmd   = "start"
+  }
+  stop "exec" {
+    path = "echo"
+    args = ["stop"]
+  }
+  runner "docker" {
+    image = "bar:latest"
+  }
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "test" {
+  get "cron" "timer" {
+    trigger = true
+  }
+}
+`)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "reject-svc", hclConfig, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "service_type")
+	assert.Contains(t, err.Error(), "runner override but command uses non-exec runner")
+}
+
+func TestCreatePipeline_RunnerOverride_ResourceTypeWithArgs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+resource_type "git" {
+  params = ["url"]
+  check "exec" {
+    path = "/opt/git/check"
+  }
+  pull "exec" {
+    path = "/opt/git/pull"
+  }
+  push "exec" {
+    path = "/opt/git/push"
+  }
+  runner "docker" {
+    image = "alpine/git:latest"
+    args  = ["-v", "/var/run/docker.sock:/var/run/docker.sock"]
+  }
+}
+
+resource "git" "repo" {
+  params {
+    url = "http://example.com"
+  }
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "test" {
+  get "cron" "timer" {
+    trigger = true
+  }
+}
+`)
+
+	s.Pipelines.EXPECT().Create(ctx, "main", gomock.Any()).Return(uint32(1), nil)
+	s.Jobs.EXPECT().Create(ctx, "main", "args-override", gomock.Any()).Return(uint32(1), nil)
+	s.ResourceTypes.EXPECT().Create(ctx, "main", "args-override", gomock.Any()).Return(uint32(1), nil)
+	s.Resources.EXPECT().Create(ctx, "main", "args-override", gomock.Any()).Return(uint32(1), nil).Times(2)
+	s.Pipelines.EXPECT().Find(ctx, "main", "args-override").Return(&pipeline.Pipeline{ID: 1, Name: "args-override", Canonical: "args-override"}, nil)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "args-override", hclConfig, nil)
+	require.NoError(t, err)
+}
+
+func TestCreatePipeline_RunnerOverride_SourcedResourceType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+resource_type "git" {
+  source = "pikoci://git"
+  runner "docker" {
+    image = "alpine/git:latest"
+  }
+}
+
+resource "git" "repo" {
+  params {
+    url = "http://example.com"
+  }
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "test" {
+  get "cron" "timer" {
+    trigger = true
+  }
+}
+`)
+
+	s.Pipelines.EXPECT().Create(ctx, "main", gomock.Any()).Return(uint32(1), nil)
+	s.Jobs.EXPECT().Create(ctx, "main", "sourced-override", gomock.Any()).Return(uint32(1), nil)
+	s.ResourceTypes.EXPECT().Create(ctx, "main", "sourced-override", gomock.Any()).Return(uint32(1), nil)
+	s.Resources.EXPECT().Create(ctx, "main", "sourced-override", gomock.Any()).Return(uint32(1), nil).Times(2)
+	s.Pipelines.EXPECT().Find(ctx, "main", "sourced-override").Return(&pipeline.Pipeline{ID: 1, Name: "sourced-override", Canonical: "sourced-override"}, nil)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "sourced-override", hclConfig, nil)
+	require.NoError(t, err)
+}

--- a/pikoci/restype/resource_type.go
+++ b/pikoci/restype/resource_type.go
@@ -17,4 +17,6 @@ type ResourceType struct {
 	Check *utils.RunnerCommand `json:"check,omitempty" hcl:"check,block"`
 	Pull  *utils.RunnerCommand `json:"pull,omitempty" hcl:"pull,block"`
 	Push  *utils.RunnerCommand `json:"push,omitempty" hcl:"push,block"`
+
+	Runner *utils.RunnerOverride `json:"runner,omitempty"`
 }

--- a/pikoci/sectype/secret_type.go
+++ b/pikoci/sectype/secret_type.go
@@ -15,4 +15,6 @@ type SecretType struct {
 	Params []string            `json:"params" hcl:"params,optional"`
 	Config map[string]string   `json:"config,omitempty"`
 	Get    utils.RunnerCommand `json:"get" hcl:"get,block"`
+
+	Runner *utils.RunnerOverride `json:"runner,omitempty"`
 }

--- a/pikoci/service/service.go
+++ b/pikoci/service/service.go
@@ -17,6 +17,8 @@ type Service struct {
 	Start      utils.RunnerCommand `json:"start"`
 	ReadyCheck *ReadyCheck         `json:"ready_check,omitempty"`
 	Stop       utils.RunnerCommand `json:"stop"`
+
+	Runner *utils.RunnerOverride `json:"runner,omitempty"`
 }
 
 // ReadyCheck defines a health check that determines when a service is ready

--- a/pikoci/utils/run_command.go
+++ b/pikoci/utils/run_command.go
@@ -9,6 +9,15 @@ type RunnerCommand struct {
 	Params map[string]string `json:"params" hcl:",remain"`
 }
 
+// RunnerOverride allows a type definition to override the runner used for all
+// its commands. When present, exec commands are transformed to run under the
+// specified runner (e.g. docker) instead of directly on the host.
+type RunnerOverride struct {
+	Runner string            `json:"runner" hcl:"runner,label"`
+	Args   []string          `json:"args,omitempty" hcl:"args,optional"`
+	Params map[string]string `json:"params,omitempty" hcl:",remain"`
+}
+
 // RunCommand represents a simple command execution with an optional working
 // directory path and arguments. It is used in job step definitions.
 type RunCommand struct {

--- a/worker/service.go
+++ b/worker/service.go
@@ -93,6 +93,50 @@ func (w *Worker) Drain() {
 	}
 }
 
+// applyRunnerOverride resolves the runner for a type command, applying a
+// runner override when present. When the override is set and the command
+// uses "exec", the command is transformed to run under the override runner
+// (e.g. docker) instead. Returns the resolved runner, the transformed
+// command, and whether the runner was found.
+func applyRunnerOverride(pp *pipeline.Pipeline, typeCmd *utils.RunnerCommand, override *utils.RunnerOverride) (runner.Runner, utils.RunnerCommand, bool) {
+	runnerName := typeCmd.Runner
+	rc := utils.RunnerCommand{
+		Runner: typeCmd.Runner,
+		Args:   make([]string, len(typeCmd.Args)),
+		Params: make(map[string]string),
+	}
+	copy(rc.Args, typeCmd.Args)
+	for k, v := range typeCmd.Params {
+		rc.Params[k] = v
+	}
+
+	if override != nil && typeCmd.Runner == "exec" {
+		runnerName = override.Runner
+		rc.Runner = override.Runner
+		for k, v := range override.Params {
+			rc.Params[k] = v
+		}
+		// Transform exec path+args into cmd for target runner
+		if path, ok := rc.Params["path"]; ok {
+			cmd := path
+			if len(typeCmd.Args) > 0 {
+				cmd += " " + strings.Join(typeCmd.Args, " ")
+			}
+			rc.Params["cmd"] = cmd
+			delete(rc.Params, "path")
+		}
+		// Override args replace exec args (used as extra runner flags, e.g. docker flags)
+		if len(override.Args) > 0 {
+			rc.Args = override.Args
+		} else {
+			rc.Args = nil
+		}
+	}
+
+	ru, ok := pp.Runner(runnerName)
+	return ru, rc, ok
+}
+
 // Run starts the worker event loop. It launches goroutines that receive
 // messages from the job and check subscriptions and process them concurrently.
 // Run blocks until the context is cancelled or an unrecoverable error occurs.
@@ -646,26 +690,23 @@ func (w *Worker) runGetStep(ctx context.Context, m queue.Body, b *build.Build, c
 		return true
 	}
 
-	ru, ok := pp.Runner(rt.Pull.Runner)
+	ru, rc, ok := applyRunnerOverride(pp, rt.Pull, rt.Runner)
 	if !ok {
 		return false
 	}
 
-	replaceSecretPlaceholders(params, secretResolved)
-
+	for k, v := range params {
+		rc.Params[k] = v
+	}
 	for k, v := range buildMetadataParams(b, m) {
-		params[k] = v
+		rc.Params[k] = v
+	}
+	if rt.Runner != nil {
+		delete(rc.Params, "path")
 	}
 
-	pullArgs := make([]string, len(rt.Pull.Args))
-	copy(pullArgs, rt.Pull.Args)
-	replaceSecretPlaceholdersInSlice(pullArgs, secretResolved)
-
-	rc := utils.RunnerCommand{
-		Runner: rt.Pull.Runner,
-		Args:   pullArgs,
-		Params: params,
-	}
+	replaceSecretPlaceholders(rc.Params, secretResolved)
+	replaceSecretPlaceholdersInSlice(rc.Args, secretResolved)
 
 	maxAttempts := ps.Attempts
 	if maxAttempts <= 0 {
@@ -966,22 +1007,20 @@ func (w *Worker) runPutStep(ctx context.Context, m queue.Body, b *build.Build, c
 		params[k] = v
 	}
 
-	ru, ok := pp.Runner(rt.Push.Runner)
+	ru, rc, ok := applyRunnerOverride(pp, rt.Push, rt.Runner)
 	if !ok {
 		return false
 	}
 
-	replaceSecretPlaceholders(params, secretResolved)
-
-	pushArgs := make([]string, len(rt.Push.Args))
-	copy(pushArgs, rt.Push.Args)
-	replaceSecretPlaceholdersInSlice(pushArgs, secretResolved)
-
-	rc := utils.RunnerCommand{
-		Runner: rt.Push.Runner,
-		Args:   pushArgs,
-		Params: params,
+	for k, v := range params {
+		rc.Params[k] = v
 	}
+	if rt.Runner != nil {
+		delete(rc.Params, "path")
+	}
+
+	replaceSecretPlaceholders(rc.Params, secretResolved)
+	replaceSecretPlaceholdersInSlice(rc.Args, secretResolved)
 
 	maxAttempts := ps.Attempts
 	if maxAttempts <= 0 {
@@ -1110,23 +1149,21 @@ func (w *Worker) runNotifyStep(ctx context.Context, m queue.Body, b *build.Build
 		params[k] = v
 	}
 
-	ru, ok := pp.Runner(nt.Notify.Runner)
+	ru, rc, ok := applyRunnerOverride(pp, nt.Notify, nt.Runner)
 	if !ok {
 		w.logger.Warn("runner not found for notification type", "runner", nt.Notify.Runner)
 		return false
 	}
 
-	replaceSecretPlaceholders(params, secretResolved)
-
-	notifyArgs := make([]string, len(nt.Notify.Args))
-	copy(notifyArgs, nt.Notify.Args)
-	replaceSecretPlaceholdersInSlice(notifyArgs, secretResolved)
-
-	rc := utils.RunnerCommand{
-		Runner: nt.Notify.Runner,
-		Args:   notifyArgs,
-		Params: params,
+	for k, v := range params {
+		rc.Params[k] = v
 	}
+	if nt.Runner != nil {
+		delete(rc.Params, "path")
+	}
+
+	replaceSecretPlaceholders(rc.Params, secretResolved)
+	replaceSecretPlaceholdersInSlice(rc.Args, secretResolved)
 
 	maxAttempts := ps.Attempts
 	if maxAttempts <= 0 {
@@ -1474,22 +1511,18 @@ func (w *Worker) processResourceCheck(ctx context.Context, m queue.Body, cwd str
 		}
 		return
 	}
-	replaceSecretPlaceholders(params, resolved)
-
-	ru, ok := pp.Runner(rt.Check.Runner)
+	ru, rc, ok := applyRunnerOverride(pp, rt.Check, rt.Runner)
 	if !ok {
 		return
 	}
 
-	checkArgs := make([]string, len(rt.Check.Args))
-	copy(checkArgs, rt.Check.Args)
-	replaceSecretPlaceholdersInSlice(checkArgs, resolved)
-
-	rc := utils.RunnerCommand{
-		Runner: rt.Check.Runner,
-		Args:   checkArgs,
-		Params: params,
+	for k, v := range params {
+		rc.Params[k] = v
 	}
+
+	replaceSecretPlaceholders(rc.Params, resolved)
+	replaceSecretPlaceholdersInSlice(rc.Args, resolved)
+
 	out, _, err := w.runRunner(ctx, ru, cwd, rc)
 	if err != nil {
 		r.Logs = out
@@ -1886,7 +1919,7 @@ func (w *Worker) fetchSecrets(ctx context.Context, cwd string, pp *pipeline.Pipe
 			params["param_path"] = path
 		}
 
-		ru, ok := pp.Runner(st.Get.Runner)
+		ru, rc, ok := applyRunnerOverride(pp, &st.Get, st.Runner)
 		if !ok {
 			return nil, fmt.Errorf("runner %q not found for secret_type %q", st.Get.Runner, st.Name)
 		}
@@ -1900,10 +1933,8 @@ func (w *Worker) fetchSecrets(ctx context.Context, cwd string, pp *pipeline.Pipe
 			}
 		}
 
-		rc := utils.RunnerCommand{
-			Runner: st.Get.Runner,
-			Args:   st.Get.Args,
-			Params: params,
+		for k, v := range params {
+			rc.Params[k] = v
 		}
 
 		out, _, err := w.runRunner(ctx, ru, cwd, rc)
@@ -1970,7 +2001,7 @@ func (w *Worker) startServices(ctx context.Context, m queue.Body, b *build.Build
 			return started
 		}
 
-		ru, ok := pp.Runner(svc.Start.Runner)
+		ru, rc, ok := applyRunnerOverride(pp, &svc.Start, svc.Runner)
 		if !ok {
 			w.logger.Error("runner not found for service start", "runner", svc.Start.Runner, "service", ss.Name)
 			b.Status = build.Failed
@@ -1979,11 +2010,11 @@ func (w *Worker) startServices(ctx context.Context, m queue.Body, b *build.Build
 		}
 
 		params := w.serviceParams(b, m, svc.Start.Params, ss.Params)
-
-		rc := utils.RunnerCommand{
-			Runner: svc.Start.Runner,
-			Args:   svc.Start.Args,
-			Params: params,
+		for k, v := range params {
+			rc.Params[k] = v
+		}
+		if svc.Runner != nil {
+			delete(rc.Params, "path")
 		}
 
 		// Append a "running" step and persist it
@@ -2062,7 +2093,11 @@ func (w *Worker) waitForServices(ctx context.Context, m queue.Body, b *build.Bui
 		if !ok || svc.ReadyCheck == nil {
 			continue
 		}
-		if _, ok := pp.Runner(svc.ReadyCheck.Runner); !ok {
+		rcRunnerName := svc.ReadyCheck.Runner
+		if svc.Runner != nil && svc.ReadyCheck.Runner == "exec" {
+			rcRunnerName = svc.Runner.Runner
+		}
+		if _, ok := pp.Runner(rcRunnerName); !ok {
 			continue
 		}
 		idx := len(b.Steps)
@@ -2088,14 +2123,15 @@ func (w *Worker) waitForServices(ctx context.Context, m queue.Body, b *build.Bui
 			continue
 		}
 
-		ru, ok := pp.Runner(svc.ReadyCheck.Runner)
+		rcCmd := &svc.ReadyCheck.RunnerCommand
+		ru, readyRC, ok := applyRunnerOverride(pp, rcCmd, svc.Runner)
 		if !ok {
 			continue
 		}
 
 		buildNumber := b.BuildNumber
 		wg.Add(1)
-		go func(svcName string, rc service.ReadyCheck, ru runner.Runner, overrides map[string]string) {
+		go func(svcName string, rc service.ReadyCheck, ru runner.Runner, readyRC utils.RunnerCommand, overrides map[string]string) {
 			defer wg.Done()
 
 			interval := 1 * time.Second
@@ -2111,23 +2147,15 @@ func (w *Worker) waitForServices(ctx context.Context, m queue.Body, b *build.Bui
 				}
 			}
 
-			params := make(map[string]string)
-			for k, v := range rc.Params {
-				params[k] = v
-			}
 			bm := buildMetadataParams(&build.Build{BuildNumber: buildNumber}, m)
 			for k, v := range bm {
-				params[k] = v
+				readyRC.Params[k] = v
 			}
 			for k, v := range overrides {
-				params["param_"+k] = v
+				readyRC.Params["param_"+k] = v
 			}
 
-			runCmd := utils.RunnerCommand{
-				Runner: rc.Runner,
-				Args:   rc.Args,
-				Params: params,
-			}
+			runCmd := readyRC
 
 			deadline := time.After(timeout)
 			start := time.Now()
@@ -2165,7 +2193,7 @@ func (w *Worker) waitForServices(ctx context.Context, m queue.Body, b *build.Bui
 				}
 				time.Sleep(interval)
 			}
-		}(ss.Name, *svc.ReadyCheck, ru, ss.Params)
+		}(ss.Name, *svc.ReadyCheck, ru, readyRC, ss.Params)
 	}
 
 	go func() {
@@ -2206,18 +2234,18 @@ func (w *Worker) stopServices(m queue.Body, b *build.Build, cwd string, pp *pipe
 			continue
 		}
 
-		ru, ok := pp.Runner(svc.Stop.Runner)
+		ru, rc, ok := applyRunnerOverride(pp, &svc.Stop, svc.Runner)
 		if !ok {
 			w.logger.Error("runner not found for service stop", "runner", svc.Stop.Runner, "service", ss.Name)
 			continue
 		}
 
 		params := w.serviceParams(b, m, svc.Stop.Params, ss.Params)
-
-		rc := utils.RunnerCommand{
-			Runner: svc.Stop.Runner,
-			Args:   svc.Stop.Args,
-			Params: params,
+		for k, v := range params {
+			rc.Params[k] = v
+		}
+		if svc.Runner != nil {
+			delete(rc.Params, "path")
 		}
 
 		// Append a "running" step and persist it

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -3577,3 +3577,190 @@ func TestDrain_UnblocksReceiveImmediately(t *testing.T) {
 
 // Silence the unused import warnings
 var _ = time.Now
+
+func TestApplyRunnerOverride_NilOverride(t *testing.T) {
+	pp := &pipeline.Pipeline{
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	typeCmd := &utils.RunnerCommand{
+		Runner: "exec",
+		Args:   []string{"-ec", "echo hello"},
+		Params: map[string]string{"path": "/bin/sh"},
+	}
+
+	ru, rc, ok := applyRunnerOverride(pp, typeCmd, nil)
+	require.True(t, ok)
+	assert.Equal(t, "exec", ru.Name)
+	assert.Equal(t, "exec", rc.Runner)
+	assert.Equal(t, "/bin/sh", rc.Params["path"])
+	assert.Equal(t, []string{"-ec", "echo hello"}, rc.Args)
+}
+
+func TestApplyRunnerOverride_ExecToDocker(t *testing.T) {
+	pp := &pipeline.Pipeline{
+		Runners: []runner.Runner{
+			{Name: "docker", Run: utils.RunCommand{
+				Path: "docker",
+				Args: []string{"run", "--rm", "-v", "$WORKDIR:/workdir", "$args", "$image", "/bin/sh", "-ec", "$cmd"},
+			}},
+		},
+	}
+	typeCmd := &utils.RunnerCommand{
+		Runner: "exec",
+		Args:   []string{"-ec", "curl http://example.com"},
+		Params: map[string]string{"path": "/bin/sh"},
+	}
+	override := &utils.RunnerOverride{
+		Runner: "docker",
+		Params: map[string]string{"image": "curlimages/curl:latest"},
+	}
+
+	ru, rc, ok := applyRunnerOverride(pp, typeCmd, override)
+	require.True(t, ok)
+	assert.Equal(t, "docker", ru.Name)
+	assert.Equal(t, "docker", rc.Runner)
+	assert.Equal(t, "curlimages/curl:latest", rc.Params["image"])
+	assert.Equal(t, "/bin/sh -ec curl http://example.com", rc.Params["cmd"])
+	assert.Empty(t, rc.Params["path"]) // path should be deleted
+	assert.Nil(t, rc.Args)            // no override args
+}
+
+func TestApplyRunnerOverride_ExecToDockerWithArgs(t *testing.T) {
+	pp := &pipeline.Pipeline{
+		Runners: []runner.Runner{
+			{Name: "docker", Run: utils.RunCommand{
+				Path: "docker",
+				Args: []string{"run", "--rm", "$args", "$image", "/bin/sh", "-ec", "$cmd"},
+			}},
+		},
+	}
+	typeCmd := &utils.RunnerCommand{
+		Runner: "exec",
+		Params: map[string]string{"path": "/opt/check"},
+	}
+	override := &utils.RunnerOverride{
+		Runner: "docker",
+		Args:   []string{"-v", "/data:/data", "--privileged"},
+		Params: map[string]string{"image": "alpine:latest"},
+	}
+
+	ru, rc, ok := applyRunnerOverride(pp, typeCmd, override)
+	require.True(t, ok)
+	assert.Equal(t, "docker", ru.Name)
+	assert.Equal(t, "docker", rc.Runner)
+	assert.Equal(t, "alpine:latest", rc.Params["image"])
+	assert.Equal(t, "/opt/check", rc.Params["cmd"])
+	assert.Equal(t, []string{"-v", "/data:/data", "--privileged"}, rc.Args)
+}
+
+func TestApplyRunnerOverride_NonExecIgnored(t *testing.T) {
+	pp := &pipeline.Pipeline{
+		Runners: []runner.Runner{
+			{Name: "docker", Run: utils.RunCommand{Path: "docker", Args: []string{"run"}}},
+		},
+	}
+	typeCmd := &utils.RunnerCommand{
+		Runner: "docker",
+		Params: map[string]string{"image": "golang:1.25", "cmd": "make test"},
+	}
+	override := &utils.RunnerOverride{
+		Runner: "docker",
+		Params: map[string]string{"image": "other:latest"},
+	}
+
+	ru, rc, ok := applyRunnerOverride(pp, typeCmd, override)
+	require.True(t, ok)
+	assert.Equal(t, "docker", ru.Name)
+	// Override should NOT be applied since typeCmd is not exec
+	assert.Equal(t, "golang:1.25", rc.Params["image"])
+	assert.Equal(t, "make test", rc.Params["cmd"])
+}
+
+func TestApplyRunnerOverride_PathDeletedAfterMerge(t *testing.T) {
+	// Simulates the full flow: applyRunnerOverride transforms path→cmd,
+	// then caller merges params (which re-introduces path from typeCmd.Params),
+	// then caller deletes path when override is active.
+	pp := &pipeline.Pipeline{
+		Runners: []runner.Runner{
+			{Name: "docker", Run: utils.RunCommand{
+				Path: "docker",
+				Args: []string{"run", "--rm", "$args", "$image", "/bin/sh", "-ec", "$cmd"},
+			}},
+		},
+	}
+	typeCmd := &utils.RunnerCommand{
+		Runner: "exec",
+		Args:   []string{"-ec", "git clone $param_url"},
+		Params: map[string]string{"path": "/bin/sh"},
+	}
+	override := &utils.RunnerOverride{
+		Runner: "docker",
+		Params: map[string]string{"image": "alpine/git:latest"},
+	}
+
+	_, rc, ok := applyRunnerOverride(pp, typeCmd, override)
+	require.True(t, ok)
+
+	// Simulate what buildPullParams does: copies typeCmd.Params (including path)
+	externalParams := map[string]string{
+		"path":      "/bin/sh",         // re-introduced from typeCmd.Params
+		"param_url": "http://repo.git", // resource instance param
+	}
+	for k, v := range externalParams {
+		rc.Params[k] = v
+	}
+
+	// This is what the call sites do after merge when override is active
+	delete(rc.Params, "path")
+
+	assert.Equal(t, "docker", rc.Runner)
+	assert.Equal(t, "alpine/git:latest", rc.Params["image"])
+	assert.Equal(t, "/bin/sh -ec git clone $param_url", rc.Params["cmd"])
+	assert.Equal(t, "http://repo.git", rc.Params["param_url"])
+	assert.Empty(t, rc.Params["path"], "path must not be present after override")
+}
+
+func TestApplyRunnerOverride_RunnerNotFound(t *testing.T) {
+	pp := &pipeline.Pipeline{
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	typeCmd := &utils.RunnerCommand{
+		Runner: "exec",
+		Params: map[string]string{"path": "/bin/sh"},
+	}
+	override := &utils.RunnerOverride{
+		Runner: "nonexistent",
+		Params: map[string]string{"image": "foo"},
+	}
+
+	_, _, ok := applyRunnerOverride(pp, typeCmd, override)
+	assert.False(t, ok, "should return false when override runner is not found")
+}
+
+func TestApplyRunnerOverride_ExecNilArgs(t *testing.T) {
+	pp := &pipeline.Pipeline{
+		Runners: []runner.Runner{
+			{Name: "docker", Run: utils.RunCommand{
+				Path: "docker",
+				Args: []string{"run", "--rm", "$image", "/bin/sh", "-ec", "$cmd"},
+			}},
+		},
+	}
+	typeCmd := &utils.RunnerCommand{
+		Runner: "exec",
+		Params: map[string]string{"path": "/opt/check"},
+	}
+	override := &utils.RunnerOverride{
+		Runner: "docker",
+		Params: map[string]string{"image": "alpine:latest"},
+	}
+
+	_, rc, ok := applyRunnerOverride(pp, typeCmd, override)
+	require.True(t, ok)
+	assert.Equal(t, "/opt/check", rc.Params["cmd"])
+	assert.Nil(t, rc.Args)
+}


### PR DESCRIPTION
## Summary

- Add `runner` block to `resource_type`, `notification_type`, `secret_type`, and `service_type` definitions to override where exec commands execute (e.g. run inside Docker)
- Override only applies to exec commands; non-exec commands with an override are rejected at parse time
- Works with sourced types (`source = "pikoci://git"`) — add a `runner` block alongside the source to change where the sourced commands run

Closes #221