### PR TITLE
Add persistent resource caching (#216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Persistent resource caching: `cache = true` on `resource_type` enables a persistent `$CACHE_DIR` for check and pull scripts, with per-resource override support. The built-in `git` resource type uses caching by default — maintaining a bare clone for faster `git fetch` checks and `--reference-if-able` pulls ([#216](https://github.com/PikoCI/pikoci/issues/216))
 - Type-level runner overrides: `resource_type`, `notification_type`, `secret_type`, and `service_type` definitions can specify a `runner` block to override where their exec commands execute, e.g. run inside Docker without modifying the type's command definitions ([#221](https://github.com/PikoCI/pikoci/issues/221))
 - Floating toast notifications for success and error feedback on all mutating actions (trigger, delete, retry, cancel, etc.) with auto-dismiss and dark mode support ([#351](https://github.com/PikoCI/pikoci/issues/351))
 - File secret type: auto-detect format from file extension (`json`, `yaml`, `env`, `raw`), add `json` and `yaml` as explicit format options, and fix multi-line JSON parsing ([#435](https://github.com/PikoCI/pikoci/issues/435))

--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -56,6 +56,7 @@ resource_type "git" {
 | `source` | no       | URL to fetch definition (e.g. `pikoci://git`)       |
 | `params` | no       | List of parameter names                             |
 | `runner` | no       | Override runner for all commands (see [Runners](Runners.md#type-level-runner-overrides)) |
+| `cache`  | no       | Enable persistent cache for check/pull (see [Resource Types](Resource-Types.md#caching)) |
 
 When `source` is set, inline commands are not needed. The source is resolved once when the pipeline is created or updated — if the remote definition changes, you must re-set the pipeline to pick up the new version. This applies to all block types that support `source` (`resource_type`, `runner_type`, `secret_type`, `service_type`).
 
@@ -82,6 +83,7 @@ resource "cron" "every_10s" {
 | `name`           | yes      | Label, unique name for this resource              |
 | `params`         | no       | Block with key/value pairs passed to the resource type |
 | `check_interval` | no       | Cron expression or `@every <duration>` for automatic checks |
+| `cache`          | no       | Override the resource type's cache setting (see [Resource Types](Resource-Types.md#caching)) |
 
 ## notification_type
 

--- a/docs/Resource-Types.md
+++ b/docs/Resource-Types.md
@@ -30,6 +30,7 @@ resource_type "git" {
 | `name`   | yes      | Label on the block                                  |
 | `source` | no       | URL to fetch the definition from (mutually exclusive with inline commands) |
 | `params` | no       | List of parameter names the resource type accepts   |
+| `cache`  | no       | Enable persistent cache for check/pull (see [Caching](#caching)) |
 | `check`  | no       | Runner command to detect new versions               |
 | `pull`   | no       | Runner command to fetch a specific version           |
 | `push`   | no       | Runner command to publish (used by `put` steps)     |
@@ -65,6 +66,7 @@ Inside `check`, `pull`, and `push` commands, PikoCI exposes:
 | `$BUILD_PIPELINE_NAME` | Name of the current pipeline              |
 | `$BUILD_TEAM_NAME`   | Canonical name of the team                   |
 | `$BUILD_STATUS`      | Build status: `succeeded` or `failed` (hooks only) |
+| `$CACHE_DIR`         | Persistent cache directory (check/pull only, when [caching](#caching) is enabled) |
 | `$path`, `$args`     | Runner `run` block values (for the exec runner) |
 
 ## Sourcing from URL
@@ -135,6 +137,7 @@ resource "git" "my_repo" {
 | `name`           | yes      | Unique name for this resource instance                |
 | `params`         | yes      | Key/value pairs matching the resource type's `params` |
 | `check_interval` | no       | Schedule for automatic checks (cron syntax or `@every <duration>`) |
+| `cache`          | no       | Override the resource type's cache setting (`true`/`false`) |
 
 ### Webhook triggers
 
@@ -149,6 +152,74 @@ You can regenerate a webhook token via the API:
 ```
 POST /teams/{team}/pipelines/{pipeline}/resources/{resource}/webhook_token
 ```
+
+## Caching
+
+Resource types can enable persistent caching so that check and pull scripts can reuse state across runs instead of starting from scratch every time. This is especially useful for large Git repositories where a full clone on every pull is slow.
+
+### Enabling cache
+
+Set `cache = true` on a `resource_type` to enable caching for all resources of that type:
+
+```hcl
+resource_type "git" {
+  source = "pikoci://git"
+  cache  = true
+}
+```
+
+Individual resources can override the type default:
+
+```hcl
+resource "git" "small-repo" {
+  cache = false   # opt out even though type defaults to true
+  params {
+    url = "https://github.com/small/repo"
+  }
+}
+```
+
+### How it works
+
+When caching is enabled, PikoCI creates a persistent directory for each resource instance and passes it as the `$CACHE_DIR` environment variable to **check** and **pull** scripts (not push). The directory is namespaced per team, pipeline, and resource:
+
+```
+~/.cache/pikoci/cache/{team}/{pipeline}/{resource_canonical}/
+```
+
+Scripts are responsible for managing the cache contents. PikoCI only creates the directory and passes the path — it does not manage the data inside.
+
+### Writing cache-aware scripts
+
+A cache-aware check script should populate the cache as a side effect:
+
+```sh
+if [ -n "$CACHE_DIR" ]; then
+  if [ -d "$CACHE_DIR/repo" ]; then
+    git -C "$CACHE_DIR/repo" fetch --prune
+  else
+    git clone --bare "$URL" "$CACHE_DIR/repo"
+  fi
+fi
+```
+
+A cache-aware pull script can use `--reference-if-able` to avoid re-downloading objects:
+
+```sh
+if [ -n "$CACHE_DIR" ] && [ -d "$CACHE_DIR/repo" ]; then
+  git clone --reference-if-able "$CACHE_DIR/repo" "$URL" "$name"
+else
+  git clone "$URL" "$name"
+fi
+```
+
+The built-in `git` resource type has `cache = true` by default and uses this pattern automatically.
+
+### Notes
+
+- Each worker has its own cache — there is no shared state between workers.
+- Cache directories persist indefinitely. No automatic cleanup is performed in the current version.
+- If `$CACHE_DIR` is not set (caching disabled), scripts should fall back to their normal behavior.
 
 ## Built-in: cron
 

--- a/pikoci/builtin/builtin_test.go
+++ b/pikoci/builtin/builtin_test.go
@@ -17,6 +17,7 @@ func TestResourceTypes(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, "cron", rt.Name)
 		assert.Equal(t, "exec", rt.Check.Runner)
+		assert.False(t, rt.Cache)
 	})
 
 	t.Run("git", func(t *testing.T) {
@@ -26,6 +27,7 @@ func TestResourceTypes(t *testing.T) {
 		assert.Equal(t, "exec", rt.Check.Runner)
 		assert.Equal(t, "exec", rt.Pull.Runner)
 		assert.Equal(t, "exec", rt.Push.Runner)
+		assert.True(t, rt.Cache)
 		assert.Contains(t, rt.Params, "url")
 		assert.Contains(t, rt.Params, "name")
 		assert.Contains(t, rt.Params, "token")

--- a/pikoci/builtin/resource_types/git.hcl
+++ b/pikoci/builtin/resource_types/git.hcl
@@ -1,4 +1,5 @@
 resource_type "git" {
+  cache = true
   params = [
     "url",
     "branch",
@@ -17,6 +18,21 @@ resource_type "git" {
       TOKEN="$param_token"
       PR="$param_pr"
       TAG="$param_tag"
+
+      # Maintain a bare clone in CACHE_DIR for faster operations
+      if [ -n "$CACHE_DIR" ]; then
+        if [ -n "$TOKEN" ]; then
+          CACHE_URL=$(echo "$URL" | sed -E "s|https://|https://oauth2:$TOKEN@|")
+        else
+          CACHE_URL="$URL"
+        fi
+        if [ -d "$CACHE_DIR/repo" ]; then
+          git -C "$CACHE_DIR/repo" remote set-url origin "$CACHE_URL" 2>/dev/null || true
+          git -C "$CACHE_DIR/repo" fetch --prune 2>/dev/null || true
+        else
+          git clone --bare "$CACHE_URL" "$CACHE_DIR/repo" 2>/dev/null || true
+        fi
+      fi
 
       # First check: version vars are empty when no previous versions exist.
       # Return only the latest item to avoid triggering a build per historical entry.
@@ -158,21 +174,28 @@ resource_type "git" {
         URL=$(echo "$URL" | sed -E "s|https://|https://oauth2:$TOKEN@|")
       fi
 
+      # Use local cache as reference for faster clones
+      REFERENCE_ARGS=""
+      if [ -n "$CACHE_DIR" ] && [ -d "$CACHE_DIR/repo" ]; then
+        git -C "$CACHE_DIR/repo" fetch --prune 2>/dev/null || true
+        REFERENCE_ARGS="--reference-if-able $CACHE_DIR/repo"
+      fi
+
       if [ "$TAG" = "true" ] && [ -n "$version_tag" ]; then
         # Tag mode: clone at the specific tag
-        git clone -b "$version_tag" --depth 1 "$URL" "$param_name"
+        git clone $REFERENCE_ARGS -b "$version_tag" --depth 1 "$URL" "$param_name"
       elif [ "$PR" = "true" ] && [ -n "$version_pr" ]; then
         # PR mode: fetch the PR head ref
-        git clone "$URL" "$param_name"
+        git clone $REFERENCE_ARGS "$URL" "$param_name"
         cd "$param_name"
         git fetch origin "pull/$version_pr/head:pr-$version_pr"
         git checkout "pr-$version_pr"
       elif [ -n "$BRANCH" ]; then
-        git clone -b "$BRANCH" "$URL" "$param_name"
+        git clone $REFERENCE_ARGS -b "$BRANCH" "$URL" "$param_name"
         cd "$param_name"
         git checkout "$version_ref"
       else
-        git clone "$URL" "$param_name"
+        git clone $REFERENCE_ARGS "$URL" "$param_name"
         cd "$param_name"
         git checkout "$version_ref"
       fi

--- a/pikoci/helper.go
+++ b/pikoci/helper.go
@@ -85,6 +85,7 @@ type hclResourceType struct {
 	Name   string   `json:"name" hcl:"name,label"`
 	Source string   `json:"source,omitempty" hcl:"source,optional"`
 	Params []string `json:"params" hcl:"params,optional"`
+	Cache  bool     `json:"cache" hcl:"cache,optional"`
 
 	Check  []utils.RunnerCommand  `json:"check" hcl:"check,block"`
 	Pull   []utils.RunnerCommand  `json:"pull" hcl:"pull,block"`
@@ -97,6 +98,7 @@ func (hrt hclResourceType) toResourceType() restype.ResourceType {
 		Name:   hrt.Name,
 		Source: hrt.Source,
 		Params: hrt.Params,
+		Cache:  hrt.Cache,
 	}
 	if len(hrt.Check) > 0 {
 		rt.Check = &hrt.Check[0]
@@ -428,6 +430,9 @@ func (q *PikoCI) readPipeline(ctx context.Context, rpp []byte, vars map[string]i
 			}
 			resolved.Name = hrt.Name
 			resolved.Source = hrt.Source
+			if hrt.Cache {
+				resolved.Cache = true
+			}
 			if len(hrt.Runner) > 0 {
 				resolved.Runner = &hrt.Runner[0]
 			}

--- a/pikoci/mysql/migrate/migrations/V25Cache.go
+++ b/pikoci/mysql/migrate/migrations/V25Cache.go
@@ -1,0 +1,10 @@
+package migrations
+
+// V25Cache adds cache columns to resource_types and resources tables.
+var V25Cache = Migration{
+	Name: "Cache",
+	SQL: `
+		ALTER TABLE resource_types ADD COLUMN cache BOOLEAN NOT NULL DEFAULT FALSE;
+		ALTER TABLE resources ADD COLUMN cache BOOLEAN DEFAULT NULL;
+	`,
+}

--- a/pikoci/mysql/migrate/migrations/migrations.go
+++ b/pikoci/mysql/migrate/migrations/migrations.go
@@ -16,7 +16,7 @@ type Migration struct {
 // Migrations is the ordered list of all schema migrations. It is defined as
 // a fixed-size array so that the compiler catches ordering conflicts when
 // multiple developers add migrations concurrently.
-var Migrations = [25]Migration{
+var Migrations = [26]Migration{
 	V0Initial,
 	V1ResourceCheckInterval,
 	V2JobsAndBuilds,
@@ -42,4 +42,5 @@ var Migrations = [25]Migration{
 	V22PendingBuilds,
 	V23BackfillWebhookTokens,
 	V24Notifications,
+	V25Cache,
 }

--- a/pikoci/mysql/resource.go
+++ b/pikoci/mysql/resource.go
@@ -34,6 +34,7 @@ type dbResource struct {
 	LastCheck     sql.NullTime
 	NextCheck     sql.NullTime
 	WebhookToken  sql.NullString
+	Cache         sql.NullBool
 }
 
 type dbResourceVersion struct {
@@ -43,7 +44,7 @@ type dbResourceVersion struct {
 
 func newDBResource(r resource.Resource) dbResource {
 	i, _ := json.Marshal(r.Params)
-	return dbResource{
+	dbr := dbResource{
 		Name:          toNullString(r.Name),
 		Type:          toNullString(r.Type),
 		Canonical:     toNullString(r.Canonical),
@@ -54,6 +55,10 @@ func newDBResource(r resource.Resource) dbResource {
 		NextCheck:     toNullTime(r.NextCheck),
 		WebhookToken:  toNullString(r.WebhookToken),
 	}
+	if r.Cache != nil {
+		dbr.Cache = sql.NullBool{Bool: *r.Cache, Valid: true}
+	}
+	return dbr
 }
 
 func (dbr *dbResource) toDomainEntity() *resource.Resource {
@@ -70,6 +75,11 @@ func (dbr *dbResource) toDomainEntity() *resource.Resource {
 	}
 
 	_ = json.Unmarshal([]byte(dbr.Params.String), &r.Params)
+
+	if dbr.Cache.Valid {
+		c := dbr.Cache.Bool
+		r.Cache = &c
+	}
 
 	return r
 }
@@ -93,8 +103,8 @@ func (dbrv *dbResourceVersion) toDomainEntity() *resource.Version {
 func (r *ResourceRepository) Create(ctx context.Context, tc, pn string, rs resource.Resource) (uint32, error) {
 	dbrs := newDBResource(rs)
 	res, err := r.querier.ExecContext(ctx, `
-		INSERT INTO resources(name, `+"`type`"+`, canonical, params, check_interval, last_check, next_check, webhook_token, pipeline_id)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?,
+		INSERT INTO resources(name, `+"`type`"+`, canonical, params, check_interval, last_check, next_check, webhook_token, cache, pipeline_id)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,
 			-- pipeline_id
 			(
 				SELECT p.id
@@ -102,7 +112,7 @@ func (r *ResourceRepository) Create(ctx context.Context, tc, pn string, rs resou
 				JOIN teams AS t
 					ON p.team_id = t.id
 				WHERE t.canonical = ? AND p.canonical = ?
-			))`, dbrs.Name, dbrs.Type, dbrs.Canonical, dbrs.Params, dbrs.CheckInterval, dbrs.LastCheck, dbrs.NextCheck, dbrs.WebhookToken, tc, pn)
+			))`, dbrs.Name, dbrs.Type, dbrs.Canonical, dbrs.Params, dbrs.CheckInterval, dbrs.LastCheck, dbrs.NextCheck, dbrs.WebhookToken, dbrs.Cache, tc, pn)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -119,7 +129,7 @@ func (r *ResourceRepository) Update(ctx context.Context, tc, pn, rCan string, rs
 	dbrs := newDBResource(rs)
 	res, err := r.querier.ExecContext(ctx, `
 		UPDATE resources AS r
-		SET name = ?, type = ?, canonical = ?, params = ?, check_interval = ?, logs = ?, last_check = ?, next_check = ?, webhook_token = ?
+		SET name = ?, type = ?, canonical = ?, params = ?, check_interval = ?, logs = ?, last_check = ?, next_check = ?, webhook_token = ?, cache = ?
 		FROM (
 			SELECT r.id
 			FROM resources AS r
@@ -130,7 +140,7 @@ func (r *ResourceRepository) Update(ctx context.Context, tc, pn, rCan string, rs
 			WHERE t.canonical = ? AND p.canonical = ? AND r.canonical = ?
 		) AS rr
 		WHERE rr.id = r.id
-	`, dbrs.Name, dbrs.Type, dbrs.Canonical, dbrs.Params, dbrs.CheckInterval, dbrs.Logs, dbrs.LastCheck, dbrs.NextCheck, dbrs.WebhookToken, tc, pn, rCan)
+	`, dbrs.Name, dbrs.Type, dbrs.Canonical, dbrs.Params, dbrs.CheckInterval, dbrs.Logs, dbrs.LastCheck, dbrs.NextCheck, dbrs.WebhookToken, dbrs.Cache, tc, pn, rCan)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -145,7 +155,7 @@ func (r *ResourceRepository) Update(ctx context.Context, tc, pn, rCan string, rs
 
 func (r *ResourceRepository) Find(ctx context.Context, tc, pn, rCan string) (*resource.Resource, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT r.id, r.name, r.type, r.canonical, r.params, r.check_interval, r.logs, r.last_check, r.next_check, r.webhook_token
+		SELECT r.id, r.name, r.type, r.canonical, r.params, r.check_interval, r.logs, r.last_check, r.next_check, r.webhook_token, r.cache
 		FROM resources AS r
 		JOIN pipelines AS p
 			ON r.pipeline_id = p.id
@@ -165,7 +175,7 @@ func (r *ResourceRepository) Find(ctx context.Context, tc, pn, rCan string) (*re
 func (r *ResourceRepository) FindByWebhookToken(ctx context.Context, token string) (*resource.Resource, string, string, error) {
 	var tc, pn sql.NullString
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT r.id, r.name, r.type, r.canonical, r.params, r.check_interval, r.logs, r.last_check, r.next_check, r.webhook_token,
+		SELECT r.id, r.name, r.type, r.canonical, r.params, r.check_interval, r.logs, r.last_check, r.next_check, r.webhook_token, r.cache,
 			t.canonical, p.canonical
 		FROM resources AS r
 		JOIN pipelines AS p
@@ -187,6 +197,7 @@ func (r *ResourceRepository) FindByWebhookToken(ctx context.Context, token strin
 		&dbr.LastCheck,
 		&dbr.NextCheck,
 		&dbr.WebhookToken,
+		&dbr.Cache,
 		&tc,
 		&pn,
 	)
@@ -202,7 +213,7 @@ func (r *ResourceRepository) FindByWebhookToken(ctx context.Context, token strin
 
 func (r *ResourceRepository) Filter(ctx context.Context, tc, pn string) ([]*resource.Resource, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT r.id, r.name, r.type, r.canonical, r.params, r.check_interval, r.logs, r.last_check, r.next_check, r.webhook_token
+		SELECT r.id, r.name, r.type, r.canonical, r.params, r.check_interval, r.logs, r.last_check, r.next_check, r.webhook_token, r.cache
 		FROM resources AS r
 		JOIN pipelines AS p
 			ON r.pipeline_id = p.id
@@ -224,7 +235,7 @@ func (r *ResourceRepository) Filter(ctx context.Context, tc, pn string) ([]*reso
 
 func (r *ResourceRepository) FilterDueResources(ctx context.Context) ([]*resource.ResourceWithPipeline, error) {
 	q := `
-		SELECT r.id, r.name, r.type, r.canonical, r.params, r.check_interval, r.logs, r.last_check, r.next_check, r.webhook_token,
+		SELECT r.id, r.name, r.type, r.canonical, r.params, r.check_interval, r.logs, r.last_check, r.next_check, r.webhook_token, r.cache,
 			t.canonical, p.canonical
 		FROM resources AS r
 		JOIN pipelines AS p
@@ -261,6 +272,7 @@ func (r *ResourceRepository) FilterDueResources(ctx context.Context) ([]*resourc
 			&dbr.LastCheck,
 			&dbr.NextCheck,
 			&dbr.WebhookToken,
+			&dbr.Cache,
 			&tc,
 			&pn,
 		)
@@ -391,6 +403,7 @@ func scanResource(s sqlr.Scanner) (*resource.Resource, error) {
 		&r.LastCheck,
 		&r.NextCheck,
 		&r.WebhookToken,
+		&r.Cache,
 	)
 
 	if err != nil {

--- a/pikoci/mysql/resource_type.go
+++ b/pikoci/mysql/resource_type.go
@@ -28,6 +28,7 @@ type dbResourceType struct {
 	Check  sql.NullString
 	Pull   sql.NullString
 	Push   sql.NullString
+	Cache  sql.NullBool
 }
 
 func newDBResourceType(rt restype.ResourceType) dbResourceType {
@@ -42,6 +43,7 @@ func newDBResourceType(rt restype.ResourceType) dbResourceType {
 		Check:  toNullString(string(c)),
 		Pull:   toNullString(string(pl)),
 		Push:   toNullString(string(ps)),
+		Cache:  sql.NullBool{Bool: rt.Cache, Valid: true},
 	}
 }
 
@@ -50,6 +52,7 @@ func (dbrt *dbResourceType) toDomainEntity() *restype.ResourceType {
 		ID:     uint32(dbrt.ID.Int64),
 		Name:   dbrt.Name.String,
 		Source: dbrt.Source.String,
+		Cache:  dbrt.Cache.Bool,
 	}
 
 	_ = json.Unmarshal([]byte(dbrt.Params.String), &rt.Params)
@@ -63,8 +66,8 @@ func (dbrt *dbResourceType) toDomainEntity() *restype.ResourceType {
 func (r *ResourceTypeRepository) Create(ctx context.Context, tc, pn string, rt restype.ResourceType) (uint32, error) {
 	dbrt := newDBResourceType(rt)
 	res, err := r.querier.ExecContext(ctx, `
-		INSERT INTO resource_types(name, source, `+"`check`"+`, pull, push, params, pipeline_id)
-		VALUES (?, ?, ?, ?, ?, ?,
+		INSERT INTO resource_types(name, source, `+"`check`"+`, pull, push, params, cache, pipeline_id)
+		VALUES (?, ?, ?, ?, ?, ?, ?,
 			-- pipeline_id
 			(
 				SELECT p.id
@@ -72,7 +75,7 @@ func (r *ResourceTypeRepository) Create(ctx context.Context, tc, pn string, rt r
 				JOIN teams AS t
 					ON p.team_id = t.id
 				WHERE t.canonical = ? AND p.canonical = ?
-			))`, dbrt.Name, dbrt.Source, dbrt.Check, dbrt.Pull, dbrt.Push, dbrt.Params, tc, pn)
+			))`, dbrt.Name, dbrt.Source, dbrt.Check, dbrt.Pull, dbrt.Push, dbrt.Params, dbrt.Cache, tc, pn)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -89,7 +92,7 @@ func (r *ResourceTypeRepository) Update(ctx context.Context, tc, pn, rtn string,
 	dbrt := newDBResourceType(rt)
 	res, err := r.querier.ExecContext(ctx, `
 		UPDATE resource_types AS rt
-		SET name = ?, source = ?, `+"`check`"+` = ?, pull = ?, push = ?, params = ?
+		SET name = ?, source = ?, `+"`check`"+` = ?, pull = ?, push = ?, params = ?, cache = ?
 		FROM (
 			SELECT rt.id
 			FROM resource_types AS rt
@@ -100,7 +103,7 @@ func (r *ResourceTypeRepository) Update(ctx context.Context, tc, pn, rtn string,
 			WHERE t.canonical = ? AND p.canonical = ? AND rt.name = ?
 		) AS rtt
 		WHERE rtt.id = rt.id
-	`, dbrt.Name, dbrt.Source, dbrt.Check, dbrt.Pull, dbrt.Push, dbrt.Params, tc, pn, rtn)
+	`, dbrt.Name, dbrt.Source, dbrt.Check, dbrt.Pull, dbrt.Push, dbrt.Params, dbrt.Cache, tc, pn, rtn)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -115,7 +118,7 @@ func (r *ResourceTypeRepository) Update(ctx context.Context, tc, pn, rtn string,
 
 func (r *ResourceTypeRepository) Find(ctx context.Context, tc, pn, rtn string) (*restype.ResourceType, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT rt.id, rt.name, rt.source, `+"rt.`check`"+`, rt.pull, rt.push, rt.params
+		SELECT rt.id, rt.name, rt.source, `+"rt.`check`"+`, rt.pull, rt.push, rt.params, rt.cache
 		FROM resource_types AS rt
 		JOIN pipelines AS p
 			ON rt.pipeline_id = p.id
@@ -134,7 +137,7 @@ func (r *ResourceTypeRepository) Find(ctx context.Context, tc, pn, rtn string) (
 
 func (r *ResourceTypeRepository) Filter(ctx context.Context, tc, pn string) ([]*restype.ResourceType, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT rt.id, rt.name, rt.source, `+"rt.`check`"+`, rt.pull, rt.push, rt.params
+		SELECT rt.id, rt.name, rt.source, `+"rt.`check`"+`, rt.pull, rt.push, rt.params, rt.cache
 		FROM resource_types AS rt
 		JOIN pipelines AS p
 			ON rt.pipeline_id = p.id
@@ -191,6 +194,7 @@ func scanResourceType(s sqlr.Scanner) (*restype.ResourceType, error) {
 		&rt.Pull,
 		&rt.Push,
 		&rt.Params,
+		&rt.Cache,
 	)
 
 	if err != nil {

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pikoci/pikoci/pikoci/job"
 	"github.com/pikoci/pikoci/pikoci/pipeline"
 	"github.com/pikoci/pikoci/pikoci/resource"
+	"github.com/pikoci/pikoci/pikoci/restype"
 	"github.com/pikoci/pikoci/pikoci/sectype"
 	"go.uber.org/mock/gomock"
 )
@@ -2429,4 +2430,124 @@ job "test" {
 
 	_, err := s.S.CreatePipeline(ctx, "main", "sourced-override", hclConfig, nil)
 	require.NoError(t, err)
+}
+
+func TestCreatePipeline_CacheOnResourceType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+resource_type "git" {
+  cache  = true
+  params = ["url"]
+  check "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo '[{\"ref\":\"abc\"}]'"]
+  }
+  pull "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo pull"]
+  }
+  push "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo push"]
+  }
+}
+
+resource "git" "repo" {
+  params {
+    url = "http://example.com"
+  }
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "test" {
+  get "cron" "timer" {
+    trigger = true
+  }
+}
+`)
+
+	var capturedRT interface{}
+	s.Pipelines.EXPECT().Create(ctx, "main", gomock.Any()).Return(uint32(1), nil)
+	s.Jobs.EXPECT().Create(ctx, "main", "cache-test", gomock.Any()).Return(uint32(1), nil)
+	s.ResourceTypes.EXPECT().Create(ctx, "main", "cache-test", gomock.Any()).DoAndReturn(
+		func(ctx context.Context, tc, pn string, rt interface{}) (uint32, error) {
+			capturedRT = rt
+			return uint32(1), nil
+		})
+	s.Resources.EXPECT().Create(ctx, "main", "cache-test", gomock.Any()).Return(uint32(1), nil).Times(2)
+	s.Pipelines.EXPECT().Find(ctx, "main", "cache-test").Return(&pipeline.Pipeline{ID: 1, Name: "cache-test", Canonical: "cache-test"}, nil)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "cache-test", hclConfig, nil)
+	require.NoError(t, err)
+
+	rt, ok := capturedRT.(restype.ResourceType)
+	require.True(t, ok)
+	assert.True(t, rt.Cache)
+}
+
+func TestCreatePipeline_CacheResourceOverridesType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+resource_type "git" {
+  cache  = true
+  params = ["url"]
+  check "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo '[{\"ref\":\"abc\"}]'"]
+  }
+  pull "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo pull"]
+  }
+  push "exec" {
+    path = "/bin/sh"
+    args = ["-ec", "echo push"]
+  }
+}
+
+resource "git" "repo" {
+  cache = false
+  params {
+    url = "http://example.com"
+  }
+}
+
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "test" {
+  get "cron" "timer" {
+    trigger = true
+  }
+}
+`)
+
+	var capturedResource resource.Resource
+	s.Pipelines.EXPECT().Create(ctx, "main", gomock.Any()).Return(uint32(1), nil)
+	s.Jobs.EXPECT().Create(ctx, "main", "cache-override", gomock.Any()).Return(uint32(1), nil)
+	s.ResourceTypes.EXPECT().Create(ctx, "main", "cache-override", gomock.Any()).Return(uint32(1), nil)
+	s.Resources.EXPECT().Create(ctx, "main", "cache-override", gomock.Any()).DoAndReturn(
+		func(ctx context.Context, tc, pn string, r resource.Resource) (uint32, error) {
+			if r.Name == "repo" {
+				capturedResource = r
+			}
+			return uint32(1), nil
+		}).Times(2)
+	s.Pipelines.EXPECT().Find(ctx, "main", "cache-override").Return(&pipeline.Pipeline{ID: 1, Name: "cache-override", Canonical: "cache-override"}, nil)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "cache-override", hclConfig, nil)
+	require.NoError(t, err)
+
+	require.NotNil(t, capturedResource.Cache)
+	assert.False(t, *capturedResource.Cache)
 }

--- a/pikoci/resource/resource.go
+++ b/pikoci/resource/resource.go
@@ -16,6 +16,8 @@ type Resource struct {
 	Params        *Params `json:"params,omitempty" hcl:"params,block"`
 	CheckInterval string  `json:"check_interval" hcl:"check_interval,optional"`
 
+	Cache *bool `json:"cache,omitempty" hcl:"cache,optional"`
+
 	Canonical    string    `json:"canonical"`
 	Logs         string    `json:"logs"`
 	LastCheck    time.Time `json:"last_check"`

--- a/pikoci/restype/resource_type.go
+++ b/pikoci/restype/resource_type.go
@@ -19,4 +19,5 @@ type ResourceType struct {
 	Push  *utils.RunnerCommand `json:"push,omitempty" hcl:"push,block"`
 
 	Runner *utils.RunnerOverride `json:"runner,omitempty"`
+	Cache  bool                  `json:"cache" hcl:"cache,optional"`
 }

--- a/worker/service.go
+++ b/worker/service.go
@@ -71,6 +71,21 @@ type Worker struct {
 	LocalMode bool
 }
 
+func (w *Worker) cacheDir(teamCanonical, pipelineCanonical, resourceCanonical string) (string, error) {
+	p, err := xdg.CacheFile(filepath.Join("pikoci", "cache", teamCanonical, pipelineCanonical, resourceCanonical, ".keep"))
+	if err != nil {
+		return "", fmt.Errorf("failed to create cache dir: %w", err)
+	}
+	return filepath.Dir(p), nil
+}
+
+func resourceCacheEnabled(rt restype.ResourceType, r resource.Resource) bool {
+	if r.Cache != nil {
+		return *r.Cache
+	}
+	return rt.Cache
+}
+
 // New creates a new Worker with the given PikoCI service, job topic, job and
 // check subscriptions, and logger. The returned Worker is ready to be started
 // with Run.
@@ -703,6 +718,15 @@ func (w *Worker) runGetStep(ctx context.Context, m queue.Body, b *build.Build, c
 	}
 	if rt.Runner != nil {
 		delete(rc.Params, "path")
+	}
+
+	if resourceCacheEnabled(rt, r) {
+		cd, err := w.cacheDir(m.TeamCanonical, m.PipelineCanonical, rCan)
+		if err != nil {
+			w.logger.Error("failed to create cache dir for pull", "error", err)
+		} else {
+			rc.Params["CACHE_DIR"] = cd
+		}
 	}
 
 	replaceSecretPlaceholders(rc.Params, secretResolved)
@@ -1518,6 +1542,15 @@ func (w *Worker) processResourceCheck(ctx context.Context, m queue.Body, cwd str
 
 	for k, v := range params {
 		rc.Params[k] = v
+	}
+
+	if resourceCacheEnabled(rt, r) {
+		cd, err := w.cacheDir(m.TeamCanonical, m.PipelineCanonical, r.Canonical)
+		if err != nil {
+			w.logger.Error("failed to create cache dir", "error", err)
+		} else {
+			rc.Params["CACHE_DIR"] = cd
+		}
 	}
 
 	replaceSecretPlaceholders(rc.Params, resolved)

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -3764,3 +3764,48 @@ func TestApplyRunnerOverride_ExecNilArgs(t *testing.T) {
 	assert.Equal(t, "/opt/check", rc.Params["cmd"])
 	assert.Nil(t, rc.Args)
 }
+
+func TestResourceCacheEnabled(t *testing.T) {
+	t.Run("type true, resource nil", func(t *testing.T) {
+		rt := restype.ResourceType{Cache: true}
+		r := resource.Resource{}
+		assert.True(t, resourceCacheEnabled(rt, r))
+	})
+
+	t.Run("type false, resource nil", func(t *testing.T) {
+		rt := restype.ResourceType{Cache: false}
+		r := resource.Resource{}
+		assert.False(t, resourceCacheEnabled(rt, r))
+	})
+
+	t.Run("type true, resource false", func(t *testing.T) {
+		rt := restype.ResourceType{Cache: true}
+		f := false
+		r := resource.Resource{Cache: &f}
+		assert.False(t, resourceCacheEnabled(rt, r))
+	})
+
+	t.Run("type false, resource true", func(t *testing.T) {
+		rt := restype.ResourceType{Cache: false}
+		tr := true
+		r := resource.Resource{Cache: &tr}
+		assert.True(t, resourceCacheEnabled(rt, r))
+	})
+}
+
+func TestCacheDir(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, _, _ := newTestWorker(ctrl)
+
+	dir, err := w.cacheDir("myteam", "mypipeline", "git.myrepo")
+	require.NoError(t, err)
+	assert.Contains(t, dir, filepath.Join("pikoci", "cache", "myteam", "mypipeline", "git.myrepo"))
+
+	// Verify the directory was actually created
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+
+	// Clean up
+	os.RemoveAll(dir)
+}


### PR DESCRIPTION
## Summary

- Add `cache = true` on `resource_type` to enable a persistent `$CACHE_DIR` env var for check and pull scripts
- Add `cache = true/false` on `resource` instances to override the type default (pointer semantics: unset = inherit)
- Built-in `git` resource type enables caching by default — maintains a bare clone in `$CACHE_DIR/repo` for fast `git fetch` checks and `--reference-if-able` pulls
- Cache dir lives at `~/.cache/pikoci/cache/{team}/{pipeline}/{resource_canonical}/`, per-worker with no shared state
- DB migration V25 adds `cache` columns to `resource_types` (NOT NULL DEFAULT FALSE) and `resources` (DEFAULT NULL)
- No automatic cleanup in v1 — cache dirs persist indefinitely

Closes #216
