### PR TITLE
Add pause/unpause for pipelines and jobs (#148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Pause/unpause pipelines and jobs: temporarily stop build triggering without deleting configuration or history. Pausing a pipeline pauses all its jobs; unpausing individual jobs is supported. Resource checks continue running while paused. Paused jobs appear blue in the pipeline graph ([#148](https://github.com/PikoCI/pikoci/issues/148))
 - Persistent resource caching: `cache = true` on `resource_type` enables a persistent `$CACHE_DIR` for check and pull scripts, with per-resource override support. The built-in `git` resource type uses caching by default — maintaining a bare clone for faster `git fetch` checks and `--reference-if-able` pulls ([#216](https://github.com/PikoCI/pikoci/issues/216))
 - Type-level runner overrides: `resource_type`, `notification_type`, `secret_type`, and `service_type` definitions can specify a `runner` block to override where their exec commands execute, e.g. run inside Docker without modifying the type's command definitions ([#221](https://github.com/PikoCI/pikoci/issues/221))
 - Floating toast notifications for success and error feedback on all mutating actions (trigger, delete, retry, cancel, etc.) with auto-dismiss and dark mode support ([#351](https://github.com/PikoCI/pikoci/issues/351))

--- a/docs/Pause.md
+++ b/docs/Pause.md
@@ -1,0 +1,42 @@
+# Pause / Unpause
+
+Pipelines and individual jobs can be paused to temporarily stop build triggering without deleting configuration or history.
+
+## Pipeline Pause
+
+Pausing a pipeline **pauses all its jobs**. Each job's paused flag is set individually, so they appear blue in the pipeline graph. Resource checks **continue running** and new versions are recorded, but no builds are created. This prevents a flood of builds when the pipeline is unpaused — only versions discovered after unpausing trigger builds.
+
+In-flight builds (already started) continue to completion.
+
+## Job Pause
+
+Pausing a job blocks build triggering for that specific job only. Resource checks and other jobs in the pipeline are unaffected. New versions of resources used by the paused job are still tracked.
+
+## Unpause Pipeline
+
+Unpausing a pipeline unpauses the pipeline **and all its jobs**.
+
+## Unpause Job
+
+Unpauses only that specific job. You can unpause individual jobs while the pipeline itself remains paused — this allows selectively re-enabling jobs.
+
+## Visual Indicator
+
+Paused jobs appear blue (`#29ADFF`) in the pipeline graph.
+
+## API
+
+```
+POST /teams/{tc}/pipelines/{pc}/pause
+POST /teams/{tc}/pipelines/{pc}/unpause
+POST /teams/{tc}/pipelines/{pc}/jobs/{jn}/pause
+POST /teams/{tc}/pipelines/{pc}/jobs/{jn}/unpause
+```
+
+## CLI
+
+```bash
+# Pause/unpause a pipeline
+pikoci client pipelines pause -u <url> --team-canonical <tc> -n <name>
+pikoci client pipelines unpause -u <url> --team-canonical <tc> -n <name>
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ PikoCI is a portable, self-hosted CI/CD system. One binary, any database, any qu
 - [Functions](Functions.md) - HCL functions available in pipelines
 - [Variables](Variables.md) - Pipeline variables
 - [CLI Reference](CLI.md) - Client commands and flags
+- [Pause / Unpause](Pause.md) - Temporarily stop pipelines or jobs
 - [Public Pipelines](Public-Pipelines.md) - Sharing pipeline status publicly
 - [Scaling](Scaling.md) - From single binary to distributed production
 - [Running Workers Separately](Workers.md) - Distributed worker setup

--- a/pikoci/builds.go
+++ b/pikoci/builds.go
@@ -23,6 +23,8 @@ var (
 	// ErrBuildNotPending is returned when attempting to start a build that is not
 	// in the pending state.
 	ErrBuildNotPending = build.ErrNotPending
+	// ErrJobPaused is returned when attempting to start a build for a paused job.
+	ErrJobPaused = errors.New("job is paused")
 )
 
 // CreateJobBuild creates a new pending build for the specified job within a unit
@@ -324,6 +326,9 @@ func (q *PikoCI) StartPendingBuild(ctx context.Context, tc, pn, jn string, build
 		j, err := uow.Jobs().Find(ctx, tc, pn, jn)
 		if err != nil {
 			return fmt.Errorf("failed to find job: %w", err)
+		}
+		if j.Paused {
+			return ErrJobPaused
 		}
 		if j.Concurrency > 0 {
 			running, err := uow.Builds().CountRunning(ctx, tc, pn, jn)

--- a/pikoci/job/job.go
+++ b/pikoci/job/job.go
@@ -43,6 +43,7 @@ type Job struct {
 	ID          uint32     `json:"id"`
 	Name        string     `json:"name" hcl:"name,label"`
 	Concurrency int        `json:"concurrency,omitempty"`
+	Paused      bool       `json:"paused"`
 	Plan        []PlanStep `json:"plan"`
 
 	OnSuccess []HookStep `json:"on_success,omitempty"`

--- a/pikoci/job/repository.go
+++ b/pikoci/job/repository.go
@@ -16,4 +16,10 @@ type Repository interface {
 	Filter(ctx context.Context, tc, pn string) ([]*Job, error)
 	// Delete removes a job identified by team, pipeline, and job name.
 	Delete(ctx context.Context, tc, pn, jn string) error
+	// SetPaused updates the paused flag for a job.
+	SetPaused(ctx context.Context, tc, pn, jn string, paused bool) error
+	// PauseAll sets the paused flag for all jobs in a pipeline.
+	PauseAll(ctx context.Context, tc, pn string) error
+	// UnpauseAll clears the paused flag for all jobs in a pipeline.
+	UnpauseAll(ctx context.Context, tc, pn string) error
 }

--- a/pikoci/jobs.go
+++ b/pikoci/jobs.go
@@ -29,6 +29,10 @@ func (q *PikoCI) TriggerPipelineJob(ctx context.Context, tc, pc, jn string) erro
 		return fmt.Errorf("failed to Find Job %q on Pipeline %q: %w", jn, pc, err)
 	}
 
+	if j.Paused {
+		return fmt.Errorf("job %q is paused", jn)
+	}
+
 	bb := build.Build{Status: build.Pending}
 
 	// Pin the latest version of the first get-step resource so the version
@@ -71,6 +75,30 @@ func (q *PikoCI) TriggerPipelineJob(ctx context.Context, tc, pc, jn string) erro
 	}
 
 	return nil
+}
+
+// PauseJob pauses a specific job within a pipeline.
+func (q *PikoCI) PauseJob(ctx context.Context, tc, pc, jn string) error {
+	if !utils.ValidateCanonical(tc) {
+		return fmt.Errorf("invalid Team Canonical format %q", tc)
+	} else if !utils.ValidateCanonical(pc) {
+		return fmt.Errorf("invalid Pipeline Canonical format %q", pc)
+	} else if !utils.ValidateCanonical(jn) {
+		return fmt.Errorf("invalid Job Name format %q", jn)
+	}
+	return q.Jobs.SetPaused(ctx, tc, pc, jn, true)
+}
+
+// UnpauseJob unpauses a specific job within a pipeline.
+func (q *PikoCI) UnpauseJob(ctx context.Context, tc, pc, jn string) error {
+	if !utils.ValidateCanonical(tc) {
+		return fmt.Errorf("invalid Team Canonical format %q", tc)
+	} else if !utils.ValidateCanonical(pc) {
+		return fmt.Errorf("invalid Pipeline Canonical format %q", pc)
+	} else if !utils.ValidateCanonical(jn) {
+		return fmt.Errorf("invalid Job Name format %q", jn)
+	}
+	return q.Jobs.SetPaused(ctx, tc, pc, jn, false)
 }
 
 // GetPipelineJob retrieves a job by its name within a pipeline.

--- a/pikoci/jobs_test.go
+++ b/pikoci/jobs_test.go
@@ -129,3 +129,37 @@ func TestTriggerPipelineJob_PinsLatestVersion(t *testing.T) {
 	err := s.S.TriggerPipelineJob(ctx, tc, ppc, jn)
 	require.NoError(t, err)
 }
+
+func TestTriggerPipelineJob_JobPaused(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Jobs.EXPECT().Find(ctx, "main", "pp", "jn").Return(&job.Job{ID: 1, Paused: true}, nil)
+
+	err := s.S.TriggerPipelineJob(ctx, "main", "pp", "jn")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is paused")
+}
+
+func TestPausePipeline_PausesAllJobs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Jobs.EXPECT().PauseAll(ctx, "main", "pp").Return(nil)
+
+	err := s.S.PausePipeline(ctx, "main", "pp")
+	require.NoError(t, err)
+}
+
+func TestUnpausePipeline_UnpausesAllJobs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Jobs.EXPECT().UnpauseAll(ctx, "main", "pp").Return(nil)
+
+	err := s.S.UnpausePipeline(ctx, "main", "pp")
+	require.NoError(t, err)
+}

--- a/pikoci/mock/job_repository.go
+++ b/pikoci/mock/job_repository.go
@@ -100,6 +100,48 @@ func (mr *JobRepositoryMockRecorder) Find(ctx, tc, pn, jn any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Find", reflect.TypeOf((*JobRepository)(nil).Find), ctx, tc, pn, jn)
 }
 
+// PauseAll mocks base method.
+func (m *JobRepository) PauseAll(ctx context.Context, tc, pn string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PauseAll", ctx, tc, pn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PauseAll indicates an expected call of PauseAll.
+func (mr *JobRepositoryMockRecorder) PauseAll(ctx, tc, pn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PauseAll", reflect.TypeOf((*JobRepository)(nil).PauseAll), ctx, tc, pn)
+}
+
+// SetPaused mocks base method.
+func (m *JobRepository) SetPaused(ctx context.Context, tc, pn, jn string, paused bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetPaused", ctx, tc, pn, jn, paused)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetPaused indicates an expected call of SetPaused.
+func (mr *JobRepositoryMockRecorder) SetPaused(ctx, tc, pn, jn, paused any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPaused", reflect.TypeOf((*JobRepository)(nil).SetPaused), ctx, tc, pn, jn, paused)
+}
+
+// UnpauseAll mocks base method.
+func (m *JobRepository) UnpauseAll(ctx context.Context, tc, pn string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnpauseAll", ctx, tc, pn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UnpauseAll indicates an expected call of UnpauseAll.
+func (mr *JobRepositoryMockRecorder) UnpauseAll(ctx, tc, pn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnpauseAll", reflect.TypeOf((*JobRepository)(nil).UnpauseAll), ctx, tc, pn)
+}
+
 // Update mocks base method.
 func (m *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job) error {
 	m.ctrl.T.Helper()

--- a/pikoci/mock/service.go
+++ b/pikoci/mock/service.go
@@ -613,6 +613,34 @@ func (mr *ServiceMockRecorder) ListUsers(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUsers", reflect.TypeOf((*Service)(nil).ListUsers), ctx)
 }
 
+// PauseJob mocks base method.
+func (m *Service) PauseJob(ctx context.Context, tc, pCan, jn string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PauseJob", ctx, tc, pCan, jn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PauseJob indicates an expected call of PauseJob.
+func (mr *ServiceMockRecorder) PauseJob(ctx, tc, pCan, jn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PauseJob", reflect.TypeOf((*Service)(nil).PauseJob), ctx, tc, pCan, jn)
+}
+
+// PausePipeline mocks base method.
+func (m *Service) PausePipeline(ctx context.Context, tc, pCan string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PausePipeline", ctx, tc, pCan)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PausePipeline indicates an expected call of PausePipeline.
+func (mr *ServiceMockRecorder) PausePipeline(ctx, tc, pCan any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PausePipeline", reflect.TypeOf((*Service)(nil).PausePipeline), ctx, tc, pCan)
+}
+
 // RefreshToken mocks base method.
 func (m *Service) RefreshToken(ctx context.Context, un string) (*user.WithMemberships, string, error) {
 	m.ctrl.T.Helper()
@@ -713,6 +741,34 @@ func (m *Service) TriggerPipelineResource(ctx context.Context, tc, pn, rCan stri
 func (mr *ServiceMockRecorder) TriggerPipelineResource(ctx, tc, pn, rCan any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TriggerPipelineResource", reflect.TypeOf((*Service)(nil).TriggerPipelineResource), ctx, tc, pn, rCan)
+}
+
+// UnpauseJob mocks base method.
+func (m *Service) UnpauseJob(ctx context.Context, tc, pCan, jn string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnpauseJob", ctx, tc, pCan, jn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UnpauseJob indicates an expected call of UnpauseJob.
+func (mr *ServiceMockRecorder) UnpauseJob(ctx, tc, pCan, jn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnpauseJob", reflect.TypeOf((*Service)(nil).UnpauseJob), ctx, tc, pCan, jn)
+}
+
+// UnpausePipeline mocks base method.
+func (m *Service) UnpausePipeline(ctx context.Context, tc, pCan string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnpausePipeline", ctx, tc, pCan)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UnpausePipeline indicates an expected call of UnpausePipeline.
+func (mr *ServiceMockRecorder) UnpausePipeline(ctx, tc, pCan any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnpausePipeline", reflect.TypeOf((*Service)(nil).UnpausePipeline), ctx, tc, pCan)
 }
 
 // UpdateJobBuild mocks base method.

--- a/pikoci/mysql/job.go
+++ b/pikoci/mysql/job.go
@@ -29,6 +29,7 @@ type dbJob struct {
 	OnCancel    sql.NullString
 	Ensure      sql.NullString
 	Concurrency sql.NullInt64
+	Paused      sql.NullBool
 }
 
 func newDBJob(p job.Job) dbJob {
@@ -45,6 +46,7 @@ func newDBJob(p job.Job) dbJob {
 		OnCancel:    toNullString(string(c)),
 		Ensure:      toNullString(string(e)),
 		Concurrency: sql.NullInt64{Int64: int64(p.Concurrency), Valid: true},
+		Paused:      sql.NullBool{Bool: p.Paused, Valid: true},
 	}
 }
 
@@ -53,6 +55,7 @@ func (dbp *dbJob) toDomainEntity() *job.Job {
 		ID:          uint32(dbp.ID.Int64),
 		Name:        dbp.Name.String,
 		Concurrency: int(dbp.Concurrency.Int64),
+		Paused:      dbp.Paused.Bool,
 	}
 
 	_ = json.Unmarshal([]byte(dbp.Plan.String), &j.Plan)
@@ -67,8 +70,8 @@ func (dbp *dbJob) toDomainEntity() *job.Job {
 func (r *JobRepository) Create(ctx context.Context, tc, pn string, j job.Job) (uint32, error) {
 	dbj := newDBJob(j)
 	res, err := r.querier.ExecContext(ctx, `
-		INSERT INTO jobs(name, plan, on_success, on_failure, on_cancel, ensure, concurrency, pipeline_id)
-		VALUES (?, ?, ?, ?, ?, ?, ?,
+		INSERT INTO jobs(name, plan, on_success, on_failure, on_cancel, ensure, concurrency, paused, pipeline_id)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?,
 			-- pipeline_id
 			(
 				SELECT p.id
@@ -76,7 +79,7 @@ func (r *JobRepository) Create(ctx context.Context, tc, pn string, j job.Job) (u
 				JOIN teams AS t
 					ON p.team_id = t.id
 				WHERE t.canonical = ? AND p.canonical = ?
-			))`, dbj.Name, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, tc, pn)
+			))`, dbj.Name, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Paused, tc, pn)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -93,7 +96,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 	dbj := newDBJob(j)
 	res, err := r.querier.ExecContext(ctx, `
 		UPDATE jobs AS j
-		SET name = ?, plan = ?, on_success = ?, on_failure = ?, on_cancel = ?, ensure = ?, concurrency = ?
+		SET name = ?, plan = ?, on_success = ?, on_failure = ?, on_cancel = ?, ensure = ?, concurrency = ?, paused = ?
 		FROM (
 			SELECT j.id
 			FROM jobs AS j
@@ -104,7 +107,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 			WHERE t.canonical = ? AND p.canonical = ? AND j.name = ?
 		) AS jj
 		WHERE jj.id = j.id
-	`, dbj.Name, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, tc, pn, jn)
+	`, dbj.Name, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Paused, tc, pn, jn)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -119,7 +122,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 
 func (r *JobRepository) Find(ctx context.Context, tc, pn, jn string) (*job.Job, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT j.id, j.name, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency
+		SELECT j.id, j.name, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -138,7 +141,7 @@ func (r *JobRepository) Find(ctx context.Context, tc, pn, jn string) (*job.Job, 
 
 func (r *JobRepository) Filter(ctx context.Context, tc, pn string) ([]*job.Job, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT j.id, j.name, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency
+		SELECT j.id, j.name, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -184,6 +187,75 @@ func (r *JobRepository) Delete(ctx context.Context, tc, pn, jn string) error {
 	return nil
 }
 
+func (r *JobRepository) SetPaused(ctx context.Context, tc, pn, jn string, paused bool) error {
+	res, err := r.querier.ExecContext(ctx, `
+		UPDATE jobs AS j
+		SET paused = ?
+		FROM (
+			SELECT j.id
+			FROM jobs AS j
+			JOIN pipelines AS p
+				ON j.pipeline_id = p.id
+			JOIN teams AS t
+				ON p.team_id = t.id
+			WHERE t.canonical = ? AND p.canonical = ? AND j.name = ?
+		) AS jj
+		WHERE j.id = jj.id
+	`, paused, tc, pn, jn)
+	if err != nil {
+		return fmt.Errorf("failed to execute query: %w", err)
+	}
+
+	err = isEntityFound(res)
+	if err != nil {
+		return fmt.Errorf("failed to set paused on Job: %w", err)
+	}
+
+	return nil
+}
+
+func (r *JobRepository) PauseAll(ctx context.Context, tc, pn string) error {
+	_, err := r.querier.ExecContext(ctx, `
+		UPDATE jobs AS j
+		SET paused = TRUE
+		FROM (
+			SELECT j.id
+			FROM jobs AS j
+			JOIN pipelines AS p
+				ON j.pipeline_id = p.id
+			JOIN teams AS t
+				ON p.team_id = t.id
+			WHERE t.canonical = ? AND p.canonical = ?
+		) AS jj
+		WHERE j.id = jj.id
+	`, tc, pn)
+	if err != nil {
+		return fmt.Errorf("failed to execute query: %w", err)
+	}
+	return nil
+}
+
+func (r *JobRepository) UnpauseAll(ctx context.Context, tc, pn string) error {
+	_, err := r.querier.ExecContext(ctx, `
+		UPDATE jobs AS j
+		SET paused = FALSE
+		FROM (
+			SELECT j.id
+			FROM jobs AS j
+			JOIN pipelines AS p
+				ON j.pipeline_id = p.id
+			JOIN teams AS t
+				ON p.team_id = t.id
+			WHERE t.canonical = ? AND p.canonical = ?
+		) AS jj
+		WHERE j.id = jj.id
+	`, tc, pn)
+	if err != nil {
+		return fmt.Errorf("failed to execute query: %w", err)
+	}
+	return nil
+}
+
 func scanJob(s sqlr.Scanner) (*job.Job, error) {
 	var j dbJob
 
@@ -196,6 +268,7 @@ func scanJob(s sqlr.Scanner) (*job.Job, error) {
 		&j.OnCancel,
 		&j.Ensure,
 		&j.Concurrency,
+		&j.Paused,
 	)
 
 	if err != nil {

--- a/pikoci/mysql/migrate/migrations/V26PausePipelineJob.go
+++ b/pikoci/mysql/migrate/migrations/V26PausePipelineJob.go
@@ -1,0 +1,8 @@
+package migrations
+
+var V26PausePipelineJob = Migration{
+	Name: "PausePipelineJob",
+	SQL: `
+		ALTER TABLE jobs ADD COLUMN paused BOOLEAN NOT NULL DEFAULT FALSE;
+	`,
+}

--- a/pikoci/mysql/migrate/migrations/migrations.go
+++ b/pikoci/mysql/migrate/migrations/migrations.go
@@ -16,7 +16,7 @@ type Migration struct {
 // Migrations is the ordered list of all schema migrations. It is defined as
 // a fixed-size array so that the compiler catches ordering conflicts when
 // multiple developers add migrations concurrently.
-var Migrations = [26]Migration{
+var Migrations = [27]Migration{
 	V0Initial,
 	V1ResourceCheckInterval,
 	V2JobsAndBuilds,
@@ -43,4 +43,5 @@ var Migrations = [26]Migration{
 	V23BackfillWebhookTokens,
 	V24Notifications,
 	V25Cache,
+	V26PausePipelineJob,
 }

--- a/pikoci/mysql/pipeline.go
+++ b/pikoci/mysql/pipeline.go
@@ -181,7 +181,7 @@ func (r *PipelineRepository) FilterAll(ctx context.Context) ([]*pipeline.WithTea
 		SELECT
 			t.id, t.name, t.canonical,
 			p.id, p.name, p.canonical, p.raw, p.public,
-			j.id, j.name, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure,
+			j.id, j.name, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.paused,
 			r.id, r.name, r.type, r.canonical, r.params, r.check_interval, r.logs, r.last_check, r.next_check,
 			rt.id, rt.name, rt.`+"`check`"+`, rt.pull, rt.push, rt.params,
 			ru.id, ru.name, ru.run,
@@ -237,7 +237,7 @@ func scanPipelinesWithTeam(rows *sql.Rows) ([]*pipeline.WithTeam, error) {
 		err := rows.Scan(
 			&tt.ID, &tt.Name, &tt.Canonical,
 			&pp.ID, &pp.Name, &pp.Canonical, &pp.Raw, &pp.Public,
-			&j.ID, &j.Name, &j.Plan, &j.OnSuccess, &j.OnFailure, &j.OnCancel, &j.Ensure,
+			&j.ID, &j.Name, &j.Plan, &j.OnSuccess, &j.OnFailure, &j.OnCancel, &j.Ensure, &j.Paused,
 			&r.ID, &r.Name, &r.Type, &r.Canonical, &r.Params, &r.CheckInterval, &r.Logs, &r.LastCheck, &r.NextCheck,
 			&rt.ID, &rt.Name, &rt.Check, &rt.Pull, &rt.Push, &rt.Params,
 			&ru.ID, &ru.Name, &ru.Run,
@@ -351,7 +351,7 @@ func (r *PipelineRepository) Delete(ctx context.Context, tc, pCan string) error 
 const pipelineQuery = `
 	SELECT
 		p.id, p.name, p.canonical, p.raw, p.public,
-		j.id, j.name, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure,
+		j.id, j.name, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.paused,
 		r.id, r.name, r.type, r.canonical, r.params, r.check_interval, r.logs, r.last_check, r.next_check, r.webhook_token,
 		rt.id, rt.name, rt.` + "`check`" + `, rt.pull, rt.push, rt.params,
 		ru.id, ru.name, ru.run,
@@ -395,7 +395,7 @@ func scanPipelines(rows *sql.Rows) ([]*pipeline.Pipeline, error) {
 
 		err := rows.Scan(
 			&pp.ID, &pp.Name, &pp.Canonical, &pp.Raw, &pp.Public,
-			&j.ID, &j.Name, &j.Plan, &j.OnSuccess, &j.OnFailure, &j.OnCancel, &j.Ensure,
+			&j.ID, &j.Name, &j.Plan, &j.OnSuccess, &j.OnFailure, &j.OnCancel, &j.Ensure, &j.Paused,
 			&r.ID, &r.Name, &r.Type, &r.Canonical, &r.Params, &r.CheckInterval, &r.Logs, &r.LastCheck, &r.NextCheck, &r.WebhookToken,
 			&rt.ID, &rt.Name, &rt.Check, &rt.Pull, &rt.Push, &rt.Params,
 			&ru.ID, &ru.Name, &ru.Run,

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -496,6 +496,8 @@ var (
 	colorDefault        = `"#83769C"`
 	colorDefaultBorder  = `"#5F574F"`
 	colorError          = `"#FF004D"`
+	colorPaused         = `"#29ADFF"`
+	colorPausedBorder   = `"#1D8BD1"`
 )
 
 // GetPipelineImage generates a DOT graph representation of a pipeline's jobs
@@ -640,6 +642,11 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 			if c, ok := jobBorderColors[cb.Status]; ok {
 				borderColor = c
 			}
+		}
+
+		if j.Paused {
+			color = colorPaused
+			borderColor = colorPausedBorder
 		}
 
 		style := "invis"
@@ -1061,6 +1068,26 @@ func (q *PikoCI) SetPipelinePublic(ctx context.Context, tc, pCan string, public 
 	}
 
 	return q.Pipelines.SetPublic(ctx, tc, pCan, public)
+}
+
+// PausePipeline pauses all jobs in a pipeline.
+func (q *PikoCI) PausePipeline(ctx context.Context, tc, pCan string) error {
+	if !utils.ValidateCanonical(tc) {
+		return fmt.Errorf("invalid Team Canonical format %q", tc)
+	} else if !utils.ValidateCanonical(pCan) {
+		return fmt.Errorf("invalid Pipeline Canonical format %q", pCan)
+	}
+	return q.Jobs.PauseAll(ctx, tc, pCan)
+}
+
+// UnpausePipeline unpauses all jobs in a pipeline.
+func (q *PikoCI) UnpausePipeline(ctx context.Context, tc, pCan string) error {
+	if !utils.ValidateCanonical(tc) {
+		return fmt.Errorf("invalid Team Canonical format %q", tc)
+	} else if !utils.ValidateCanonical(pCan) {
+		return fmt.Errorf("invalid Pipeline Canonical format %q", pCan)
+	}
+	return q.Jobs.UnpauseAll(ctx, tc, pCan)
 }
 
 // GetPublicPipeline retrieves a public pipeline with sensitive fields sanitized.

--- a/pikoci/scheduler/scheduler.go
+++ b/pikoci/scheduler/scheduler.go
@@ -123,6 +123,9 @@ func (s *Scheduler) tickJobs(ctx context.Context) {
 
 	for _, pwt := range pps {
 		for _, j := range pwt.Jobs {
+			if j.Paused {
+				continue
+			}
 			s.evaluateJob(ctx, pwt, &j)
 		}
 	}

--- a/pikoci/service.go
+++ b/pikoci/service.go
@@ -92,6 +92,15 @@ type Service interface {
 	// SetPipelinePublic toggles the public visibility of a pipeline.
 	SetPipelinePublic(ctx context.Context, tc, pn string, public bool) error
 
+	// PausePipeline pauses a pipeline, preventing all its jobs from being triggered.
+	PausePipeline(ctx context.Context, tc, pCan string) error
+	// UnpausePipeline unpauses a pipeline and unpauses all its jobs.
+	UnpausePipeline(ctx context.Context, tc, pCan string) error
+	// PauseJob pauses a specific job within a pipeline.
+	PauseJob(ctx context.Context, tc, pCan, jn string) error
+	// UnpauseJob unpauses a specific job within a pipeline.
+	UnpauseJob(ctx context.Context, tc, pCan, jn string) error
+
 	// GetPublicPipeline retrieves a public pipeline with sensitive fields sanitized.
 	GetPublicPipeline(ctx context.Context, tc, pn string) (*pipeline.Pipeline, error)
 	// GetPublicPipelineImage generates a DOT graph image for a public pipeline.

--- a/pikoci/transport/http/assets/js/app/models.js
+++ b/pikoci/transport/http/assets/js/app/models.js
@@ -124,7 +124,13 @@ export var Pipeline = Backbone.Model.extend({
       return response.data;
     }
     return response;
-  }
+  },
+  fetchPause: function(opts) {
+    this.fetch(_.extend({url: this.url()+"/pause", type: "POST"}, opts));
+  },
+  fetchUnpause: function(opts) {
+    this.fetch(_.extend({url: this.url()+"/unpause", type: "POST"}, opts));
+  },
 });
 
 export var PipelineImage = Backbone.Model.extend({
@@ -147,6 +153,12 @@ export var Job = Backbone.Model.extend({
   },
   fetchTrigger: function(opts) {
     this.fetch(_.extend({url: this.url()+"/trigger", type: "POST"}, opts));
+  },
+  fetchPause: function(opts) {
+    this.fetch(_.extend({url: this.url()+"/pause", type: "POST"}, opts));
+  },
+  fetchUnpause: function(opts) {
+    this.fetch(_.extend({url: this.url()+"/unpause", type: "POST"}, opts));
   },
 });
 

--- a/pikoci/transport/http/assets/js/app/models.js
+++ b/pikoci/transport/http/assets/js/app/models.js
@@ -124,13 +124,7 @@ export var Pipeline = Backbone.Model.extend({
       return response.data;
     }
     return response;
-  },
-  fetchPause: function(opts) {
-    this.fetch(_.extend({url: this.url()+"/pause", type: "POST"}, opts));
-  },
-  fetchUnpause: function(opts) {
-    this.fetch(_.extend({url: this.url()+"/unpause", type: "POST"}, opts));
-  },
+  }
 });
 
 export var PipelineImage = Backbone.Model.extend({
@@ -153,12 +147,6 @@ export var Job = Backbone.Model.extend({
   },
   fetchTrigger: function(opts) {
     this.fetch(_.extend({url: this.url()+"/trigger", type: "POST"}, opts));
-  },
-  fetchPause: function(opts) {
-    this.fetch(_.extend({url: this.url()+"/pause", type: "POST"}, opts));
-  },
-  fetchUnpause: function(opts) {
-    this.fetch(_.extend({url: this.url()+"/unpause", type: "POST"}, opts));
   },
 });
 

--- a/pikoci/transport/http/assets/js/app/views/jobs.js
+++ b/pikoci/transport/http/assets/js/app/views/jobs.js
@@ -123,7 +123,8 @@ export var JobBuildsView = Backbone.View.extend({
   clickPauseJob: function(event) {
     event.preventDefault();
     var that = this;
-    this.collection.job.fetchPause({
+    var url = this.collection.job.url() + "/pause";
+    $.ajax({ url: url, type: "POST", contentType: "application/json", headers: { "Authorization": "Bearer " + session.get("jwt") },
       success: function() {
         window.app.apiNotice.setSuccess("Job paused");
         that.collection.job.fetch({ success: function() { that.render(); } });
@@ -133,7 +134,8 @@ export var JobBuildsView = Backbone.View.extend({
   clickUnpauseJob: function(event) {
     event.preventDefault();
     var that = this;
-    this.collection.job.fetchUnpause({
+    var url = this.collection.job.url() + "/unpause";
+    $.ajax({ url: url, type: "POST", contentType: "application/json", headers: { "Authorization": "Bearer " + session.get("jwt") },
       success: function() {
         window.app.apiNotice.setSuccess("Job unpaused");
         that.collection.job.fetch({ success: function() { that.render(); } });

--- a/pikoci/transport/http/assets/js/app/views/jobs.js
+++ b/pikoci/transport/http/assets/js/app/views/jobs.js
@@ -30,6 +30,8 @@ export var JobBuildsView = Backbone.View.extend({
   },
   events: {
     'click #trigger-job': 'clickTriggerJob',
+    'click #pause-job': 'clickPauseJob',
+    'click #unpause-job': 'clickUnpauseJob',
     'click .piko-build-tab': 'clickOnTab',
   },
   addBuilds: function() {
@@ -117,6 +119,26 @@ export var JobBuildsView = Backbone.View.extend({
   clickTriggerJob: function(event) {
     event.preventDefault();
     this.collection.job.fetchTrigger({success: function() { window.app.apiNotice.setSuccess("Job triggered"); }});
+  },
+  clickPauseJob: function(event) {
+    event.preventDefault();
+    var that = this;
+    this.collection.job.fetchPause({
+      success: function() {
+        window.app.apiNotice.setSuccess("Job paused");
+        that.collection.job.fetch({ success: function() { that.render(); } });
+      },
+    });
+  },
+  clickUnpauseJob: function(event) {
+    event.preventDefault();
+    var that = this;
+    this.collection.job.fetchUnpause({
+      success: function() {
+        window.app.apiNotice.setSuccess("Job unpaused");
+        that.collection.job.fetch({ success: function() { that.render(); } });
+      },
+    });
   },
   clickOnTab: function(event) {
     event.preventDefault();

--- a/pikoci/transport/http/assets/js/app/views/jobs.js
+++ b/pikoci/transport/http/assets/js/app/views/jobs.js
@@ -127,7 +127,7 @@ export var JobBuildsView = Backbone.View.extend({
     $.ajax({ url: url, type: "POST", contentType: "application/json", headers: { "Authorization": "Bearer " + session.get("jwt") },
       success: function() {
         window.app.apiNotice.setSuccess("Job paused");
-        that.collection.job.fetch({ success: function() { that.render(); } });
+        that.collection.job.fetch({ success: function() { that.render(); that.addBuilds(); that.collection.setActive(that.currentBuildID); } });
       },
     });
   },
@@ -138,7 +138,7 @@ export var JobBuildsView = Backbone.View.extend({
     $.ajax({ url: url, type: "POST", contentType: "application/json", headers: { "Authorization": "Bearer " + session.get("jwt") },
       success: function() {
         window.app.apiNotice.setSuccess("Job unpaused");
-        that.collection.job.fetch({ success: function() { that.render(); } });
+        that.collection.job.fetch({ success: function() { that.render(); that.addBuilds(); that.collection.setActive(that.currentBuildID); } });
       },
     });
   },

--- a/pikoci/transport/http/assets/js/app/views/pipelines.js
+++ b/pikoci/transport/http/assets/js/app/views/pipelines.js
@@ -164,6 +164,8 @@ export var PipelineShowView = Backbone.View.extend({
     'click': 'clickPipeline',
     'click #edit-pipeline': 'clickEdit',
     'click #delete-pipeline': 'clickDelete',
+    'click #pause-pipeline': 'clickPausePipeline',
+    'click #unpause-pipeline': 'clickUnpausePipeline',
   },
   render: function () {
     this.$el.html(this.template(addSessionFunctions({ pipeline: this.model.toJSON(), team: this.model.collection.team.toJSON() })));
@@ -205,5 +207,25 @@ export var PipelineShowView = Backbone.View.extend({
         },
       });
     }
+  },
+  clickPausePipeline: function(event) {
+    event.preventDefault();
+    var that = this;
+    this.model.fetchPause({
+      success: function() {
+        window.app.apiNotice.setSuccess("Pipeline paused");
+        that.model.fetch({ success: function() { that.render(); } });
+      },
+    });
+  },
+  clickUnpausePipeline: function(event) {
+    event.preventDefault();
+    var that = this;
+    this.model.fetchUnpause({
+      success: function() {
+        window.app.apiNotice.setSuccess("Pipeline unpaused");
+        that.model.fetch({ success: function() { that.render(); } });
+      },
+    });
   },
 });

--- a/pikoci/transport/http/assets/js/app/views/pipelines.js
+++ b/pikoci/transport/http/assets/js/app/views/pipelines.js
@@ -211,7 +211,8 @@ export var PipelineShowView = Backbone.View.extend({
   clickPausePipeline: function(event) {
     event.preventDefault();
     var that = this;
-    this.model.fetchPause({
+    var url = this.model.url() + "/pause";
+    $.ajax({ url: url, type: "POST", contentType: "application/json", headers: { "Authorization": "Bearer " + session.get("jwt") },
       success: function() {
         window.app.apiNotice.setSuccess("Pipeline paused");
         that.model.fetch({ success: function() { that.render(); } });
@@ -221,7 +222,8 @@ export var PipelineShowView = Backbone.View.extend({
   clickUnpausePipeline: function(event) {
     event.preventDefault();
     var that = this;
-    this.model.fetchUnpause({
+    var url = this.model.url() + "/unpause";
+    $.ajax({ url: url, type: "POST", contentType: "application/json", headers: { "Authorization": "Bearer " + session.get("jwt") },
       success: function() {
         window.app.apiNotice.setSuccess("Pipeline unpaused");
         that.model.fetch({ success: function() { that.render(); } });

--- a/pikoci/transport/http/authorization.go
+++ b/pikoci/transport/http/authorization.go
@@ -70,6 +70,11 @@ var (
 		ListTriggersAfter: member,
 
 		ExportDatabase: admin,
+
+		PausePipeline:   member,
+		UnpausePipeline: member,
+		PauseJob:        member,
+		UnpauseJob:      member,
 	}
 )
 

--- a/pikoci/transport/http/client/client.go
+++ b/pikoci/transport/http/client/client.go
@@ -555,6 +555,54 @@ func (cl *Client) TriggerPipelineJob(ctx context.Context, tc, pn, jn string) err
 	return nil
 }
 
+func (cl *Client) PausePipeline(ctx context.Context, tc, pn string) error {
+	var resp thttp.PausePipelineResponse
+	err := cl.Request(ctx, http.MethodPost, fmt.Sprintf("%s/teams/%s/pipelines/%s/pause", cl.url, tc, pn), nil, &resp)
+	if err != nil {
+		return fmt.Errorf("failed to make request: %w", err)
+	}
+	if resp.Err != "" {
+		return fmt.Errorf("error from request: %s", resp.Err)
+	}
+	return nil
+}
+
+func (cl *Client) UnpausePipeline(ctx context.Context, tc, pn string) error {
+	var resp thttp.UnpausePipelineResponse
+	err := cl.Request(ctx, http.MethodPost, fmt.Sprintf("%s/teams/%s/pipelines/%s/unpause", cl.url, tc, pn), nil, &resp)
+	if err != nil {
+		return fmt.Errorf("failed to make request: %w", err)
+	}
+	if resp.Err != "" {
+		return fmt.Errorf("error from request: %s", resp.Err)
+	}
+	return nil
+}
+
+func (cl *Client) PauseJob(ctx context.Context, tc, pn, jn string) error {
+	var resp thttp.PauseJobResponse
+	err := cl.Request(ctx, http.MethodPost, fmt.Sprintf("%s/teams/%s/pipelines/%s/jobs/%s/pause", cl.url, tc, pn, jn), nil, &resp)
+	if err != nil {
+		return fmt.Errorf("failed to make request: %w", err)
+	}
+	if resp.Err != "" {
+		return fmt.Errorf("error from request: %s", resp.Err)
+	}
+	return nil
+}
+
+func (cl *Client) UnpauseJob(ctx context.Context, tc, pn, jn string) error {
+	var resp thttp.UnpauseJobResponse
+	err := cl.Request(ctx, http.MethodPost, fmt.Sprintf("%s/teams/%s/pipelines/%s/jobs/%s/unpause", cl.url, tc, pn, jn), nil, &resp)
+	if err != nil {
+		return fmt.Errorf("failed to make request: %w", err)
+	}
+	if resp.Err != "" {
+		return fmt.Errorf("error from request: %s", resp.Err)
+	}
+	return nil
+}
+
 // GetPipelineJob retrieves a single job from a pipeline.
 func (cl *Client) GetPipelineJob(ctx context.Context, tc, pn, jn string) (*job.Job, error) {
 	var resp thttp.GetPipelineJobResponse

--- a/pikoci/transport/http/handler.go
+++ b/pikoci/transport/http/handler.go
@@ -232,6 +232,10 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, 
 	api.Methods(http.MethodGet).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}").Name(GetPipeline.String()).Handler(getPipeline(s))
 	api.Methods(http.MethodPut).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}").Name(UpdatePipeline.String()).Handler(updatePipeline(s))
 	api.Methods(http.MethodDelete).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}").Name(DeletePipeline.String()).Handler(deletePipeline(s))
+	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/pause").Name(PausePipeline.String()).Handler(pausePipeline(s))
+	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/unpause").Name(UnpausePipeline.String()).Handler(unpausePipeline(s))
+	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/pause").Name(PauseJob.String()).Handler(pauseJob(s))
+	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/unpause").Name(UnpauseJob.String()).Handler(unpauseJob(s))
 
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/trigger").Name(TriggerPipelineJob.String()).Handler(triggerPipelineJob(s))
 	api.Methods(http.MethodGet).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}").Name(GetPipelineJob.String()).Handler(getPipelineJob(s))

--- a/pikoci/transport/http/jobs.go
+++ b/pikoci/transport/http/jobs.go
@@ -74,3 +74,45 @@ func getPipelineJob(s pikoci.Service) http.HandlerFunc {
 		encodeResponse(GetPipelineJobResponse{Job: j, Err: errs}, w)
 	}
 }
+
+type PauseJobResponse struct {
+	Err string `json:"error,omitempty"`
+}
+
+func (r PauseJobResponse) Error() string { return r.Err }
+
+func pauseJob(s pikoci.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		tc := vars["team_canonical"]
+		pc := vars["pipeline_canonical"]
+		jn := vars["job_name"]
+		err := s.PauseJob(r.Context(), tc, pc, jn)
+		var errs string
+		if err != nil {
+			errs = err.Error()
+		}
+		encodeResponse(PauseJobResponse{Err: errs}, w)
+	}
+}
+
+type UnpauseJobResponse struct {
+	Err string `json:"error,omitempty"`
+}
+
+func (r UnpauseJobResponse) Error() string { return r.Err }
+
+func unpauseJob(s pikoci.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		tc := vars["team_canonical"]
+		pc := vars["pipeline_canonical"]
+		jn := vars["job_name"]
+		err := s.UnpauseJob(r.Context(), tc, pc, jn)
+		var errs string
+		if err != nil {
+			errs = err.Error()
+		}
+		encodeResponse(UnpauseJobResponse{Err: errs}, w)
+	}
+}

--- a/pikoci/transport/http/pipelines.go
+++ b/pikoci/transport/http/pipelines.go
@@ -277,6 +277,46 @@ func createPipelineImage(s pikoci.Service) http.HandlerFunc {
 	}
 }
 
+type PausePipelineResponse struct {
+	Err string `json:"error,omitempty"`
+}
+
+func (r PausePipelineResponse) Error() string { return r.Err }
+
+func pausePipeline(s pikoci.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		tc := vars["team_canonical"]
+		pc := vars["pipeline_canonical"]
+		err := s.PausePipeline(r.Context(), tc, pc)
+		var errs string
+		if err != nil {
+			errs = err.Error()
+		}
+		encodeResponse(PausePipelineResponse{Err: errs}, w)
+	}
+}
+
+type UnpausePipelineResponse struct {
+	Err string `json:"error,omitempty"`
+}
+
+func (r UnpausePipelineResponse) Error() string { return r.Err }
+
+func unpausePipeline(s pikoci.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		tc := vars["team_canonical"]
+		pc := vars["pipeline_canonical"]
+		err := s.UnpausePipeline(r.Context(), tc, pc)
+		var errs string
+		if err != nil {
+			errs = err.Error()
+		}
+		encodeResponse(UnpausePipelineResponse{Err: errs}, w)
+	}
+}
+
 // writeImageResponse writes the image response with the appropriate Content-Type.
 // For SVG/PNG formats, it writes raw binary with CORS headers.
 // For DOT format (or empty), it writes JSON via encodeResponse.

--- a/pikoci/transport/http/route_names.go
+++ b/pikoci/transport/http/route_names.go
@@ -115,6 +115,15 @@ const (
 	// ExportDatabase is the route for exporting the database as a binary dump.
 	ExportDatabase
 
+	// PausePipeline is the route for pausing a pipeline.
+	PausePipeline
+	// UnpausePipeline is the route for unpausing a pipeline.
+	UnpausePipeline
+	// PauseJob is the route for pausing a job.
+	PauseJob
+	// UnpauseJob is the route for unpausing a job.
+	UnpauseJob
+
 	// GetVersion is the route for retrieving the application version.
 	GetVersion
 )

--- a/pikoci/transport/http/route_names_string.go
+++ b/pikoci/transport/http/route_names_string.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _RouteNameName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionswebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databaseget_version"
+const _RouteNameName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionswebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_version"
 
-var _RouteNameIndex = [...]uint16{0, 10, 23, 34, 44, 52, 63, 74, 89, 103, 114, 124, 132, 143, 154, 172, 190, 208, 223, 238, 250, 265, 279, 297, 318, 338, 354, 370, 392, 408, 424, 439, 463, 486, 499, 515, 530, 549, 574, 595, 619, 644, 667, 689, 704, 728, 742, 761, 776, 787}
+var _RouteNameIndex = [...]uint16{0, 10, 23, 34, 44, 52, 63, 74, 89, 103, 114, 124, 132, 143, 154, 172, 190, 208, 223, 238, 250, 265, 279, 297, 318, 338, 354, 370, 392, 408, 424, 439, 463, 486, 499, 515, 530, 549, 574, 595, 619, 644, 667, 689, 704, 728, 742, 761, 776, 790, 806, 815, 826, 837}
 
-const _RouteNameLowerName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionswebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databaseget_version"
+const _RouteNameLowerName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionswebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_version"
 
 func (i RouteName) String() string {
 	if i < 0 || i >= RouteName(len(_RouteNameIndex)-1) {
@@ -72,10 +72,14 @@ func _RouteNameNoOp() {
 	_ = x[CreateTrigger-(45)]
 	_ = x[ListTriggersAfter-(46)]
 	_ = x[ExportDatabase-(47)]
-	_ = x[GetVersion-(48)]
+	_ = x[PausePipeline-(48)]
+	_ = x[UnpausePipeline-(49)]
+	_ = x[PauseJob-(50)]
+	_ = x[UnpauseJob-(51)]
+	_ = x[GetVersion-(52)]
 }
 
-var _RouteNameValues = []RouteName{UserLogin, RefreshToken, CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser, ChangePassword, UpdateProfile, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, GetPipelineJob, CreateJobBuild, CreateRetryJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, InsertBuildGetVersion, FindBuildGetVersions, GetJobBuild, CancelJobBuild, RetryJobBuild, StartPendingBuild, FindOldestPendingBuild, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions, WebhookTrigger, RegenerateWebhookToken, CreateTrigger, ListTriggersAfter, ExportDatabase, GetVersion}
+var _RouteNameValues = []RouteName{UserLogin, RefreshToken, CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser, ChangePassword, UpdateProfile, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, GetPipelineJob, CreateJobBuild, CreateRetryJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, InsertBuildGetVersion, FindBuildGetVersions, GetJobBuild, CancelJobBuild, RetryJobBuild, StartPendingBuild, FindOldestPendingBuild, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions, WebhookTrigger, RegenerateWebhookToken, CreateTrigger, ListTriggersAfter, ExportDatabase, PausePipeline, UnpausePipeline, PauseJob, UnpauseJob, GetVersion}
 
 var _RouteNameNameToValueMap = map[string]RouteName{
 	_RouteNameName[0:10]:         UserLogin,
@@ -174,8 +178,16 @@ var _RouteNameNameToValueMap = map[string]RouteName{
 	_RouteNameLowerName[742:761]: ListTriggersAfter,
 	_RouteNameName[761:776]:      ExportDatabase,
 	_RouteNameLowerName[761:776]: ExportDatabase,
-	_RouteNameName[776:787]:      GetVersion,
-	_RouteNameLowerName[776:787]: GetVersion,
+	_RouteNameName[776:790]:      PausePipeline,
+	_RouteNameLowerName[776:790]: PausePipeline,
+	_RouteNameName[790:806]:      UnpausePipeline,
+	_RouteNameLowerName[790:806]: UnpausePipeline,
+	_RouteNameName[806:815]:      PauseJob,
+	_RouteNameLowerName[806:815]: PauseJob,
+	_RouteNameName[815:826]:      UnpauseJob,
+	_RouteNameLowerName[815:826]: UnpauseJob,
+	_RouteNameName[826:837]:      GetVersion,
+	_RouteNameLowerName[826:837]: GetVersion,
 }
 
 var _RouteNameNames = []string{
@@ -227,7 +239,11 @@ var _RouteNameNames = []string{
 	_RouteNameName[728:742],
 	_RouteNameName[742:761],
 	_RouteNameName[761:776],
-	_RouteNameName[776:787],
+	_RouteNameName[776:790],
+	_RouteNameName[790:806],
+	_RouteNameName[806:815],
+	_RouteNameName[815:826],
+	_RouteNameName[826:837],
 }
 
 // RouteNameString retrieves an enum value from the enum constants string name.

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -267,6 +267,13 @@
             <button type="button" id="delete-pipeline" class="btn btn-danger"><i class="bi bi-trash"></i> Delete</button>
           </div>
         <% } %>
+        <% if (isMember(team.canonical) && pipeline.jobs && pipeline.jobs.length > 0) { %>
+          <% if (pipeline.jobs.some(function(j) { return j.paused; })) { %>
+            <button type="button" id="unpause-pipeline" class="btn btn-primary ms-2"><i class="bi bi-play-circle"></i> Unpause</button>
+          <% } else { %>
+            <button type="button" id="pause-pipeline" class="btn btn-primary ms-2"><i class="bi bi-pause-circle"></i> Pause</button>
+          <% } %>
+        <% } %>
       </div>
       <div class="piko-graph-container" id="graphviz"></div>
       <div class="piko-graph-legend">
@@ -293,6 +300,10 @@
         <span class="piko-graph-legend-item">
           <span class="piko-graph-legend-swatch" style="background:#83769C;"></span>
           No builds
+        </span>
+        <span class="piko-graph-legend-item">
+          <span class="piko-graph-legend-swatch" style="background:#29ADFF;"></span>
+          Paused
         </span>
       </div>
     </script>
@@ -389,7 +400,12 @@
       <div class="d-flex align-items-center justify-content-between mb-3">
         <h1 class="h4 fw-bold mb-0"><%- job.name %></h1>
         <% if (isMember(team.canonical)) { %>
-          <button type="button" id="trigger-job" class="btn btn-warning"><i class="bi bi-play-circle"></i> Trigger Job</button>
+          <% if (job.paused) { %>
+            <button type="button" id="unpause-job" class="btn btn-primary"><i class="bi bi-play-circle"></i> Unpause Job</button>
+          <% } else { %>
+            <button type="button" id="trigger-job" class="btn btn-warning"><i class="bi bi-play-circle"></i> Trigger Job</button>
+            <button type="button" id="pause-job" class="btn btn-primary ms-2"><i class="bi bi-pause-circle"></i> Pause Job</button>
+          <% } %>
         <% } %>
       </div>
       <div class="piko-build-tabs" id="builds-tabs">

--- a/worker/service.go
+++ b/worker/service.go
@@ -1703,6 +1703,9 @@ func (w *Worker) runPutStepTrigger(ctx context.Context, m queue.Body, b *build.B
 // triggerResourceJobs triggers jobs that depend on a resource via "get" with trigger=true.
 func (w *Worker) triggerResourceJobs(ctx context.Context, m queue.Body, pp *pipeline.Pipeline, r resource.Resource, cv *resource.Version) {
 	for _, j := range pp.Jobs {
+		if j.Paused {
+			continue
+		}
 		for _, ps := range j.Plan {
 			if ps.Type != job.StepTypeGet || ps.Get == nil {
 				continue

--- a/worker/service.go
+++ b/worker/service.go
@@ -337,8 +337,8 @@ func (w *Worker) processJob(ctx context.Context, m queue.Body, cwd string, pp *p
 
 	nb, err := w.pikoci.StartPendingBuild(ctx, m.TeamCanonical, m.PipelineCanonical, m.JobName, m.BuildID)
 	if err != nil {
-		if errors.Is(err, pikoci.ErrConcurrencyLimit) {
-			w.logger.Info("concurrency limit, re-queuing",
+		if errors.Is(err, pikoci.ErrConcurrencyLimit) || errors.Is(err, pikoci.ErrJobPaused) {
+			w.logger.Info("concurrency limit or job paused, re-queuing",
 				"pipeline", m.PipelineCanonical, "job", m.JobName, "build_id", m.BuildID)
 			mb, _ := json.Marshal(m)
 			if err := w.jobTopic.Send(ctx, &pubsub.Message{Body: mb}); err != nil {


### PR DESCRIPTION
## Summary

- Pause individual jobs or entire pipelines to temporarily stop build triggering
- Pausing a pipeline pauses all its jobs; individual jobs can be unpaused independently
- Resource checks continue running while paused (prevents version flood on unpause)
- In-flight builds complete normally
- Paused jobs appear blue (#29ADFF) in the pipeline graph
- UI shows Pause/Unpause buttons on pipeline and job views
- 4 new API endpoints: `POST .../pause` and `.../unpause` for pipelines and jobs

Closes #148