### PR TITLE
Route Pipelines link on team edit page through Backbone router (#445)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Pipelines link on team edit page causes full page reload instead of client-side navigation ([#445](https://github.com/PikoCI/pikoci/issues/445))
 - Git resource tag mode returns all tags on every check, triggering builds for every historical tag after pipeline recreation ([#419](https://github.com/PikoCI/pikoci/issues/419))
 - Pipeline graph shows original build color instead of successful retry when a new build is running ([#421](https://github.com/PikoCI/pikoci/issues/421))
 - Pipeline graph shows gray (pending) for jobs with pending + running + succeeded builds instead of the succeeded color ([#429](https://github.com/PikoCI/pikoci/issues/429))

--- a/pikoci/transport/http/assets/js/app/views/teams.js
+++ b/pikoci/transport/http/assets/js/app/views/teams.js
@@ -99,6 +99,7 @@ export var TeamShowView = Backbone.View.extend({
   events: {
     'submit form': 'clickUpdate',
     'click #new-member': 'clickNewMember',
+    'click a.btn-primary': 'clickLink',
   },
   render: function () {
     this.$el.html(this.template(addSessionFunctions(this.model.toJSON())));
@@ -118,6 +119,11 @@ export var TeamShowView = Backbone.View.extend({
   renderMember: function(m) {
     var view = new TeamShowMemberRowView({team: this.model, model: m});
     this.$el.find('tbody').append(view.render().el);
+  },
+  clickLink: function(event) {
+    event.preventDefault();
+    var url = new URL(event.currentTarget.href);
+    window.app.router.navigate(url.pathname, { trigger: true });
   },
   clickUpdate: function(event){
     event.preventDefault();


### PR DESCRIPTION
## Summary

- Fix Pipelines button on team manage page using plain `<a href>` instead of Backbone router, causing full page reload
- Add `clickLink` handler to `TeamShowView` for client-side navigation
- Verified all other `<a href>` links in templates already have click handlers wired up

Closes #445