### PR TITLE
Navigate to running/pending build by default on job builds view (#441)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Job builds view defaults to newest build instead of navigating to the running/pending build ([#441](https://github.com/PikoCI/pikoci/issues/441))
 - Pipelines link on team edit page causes full page reload instead of client-side navigation ([#445](https://github.com/PikoCI/pikoci/issues/445))
 - Git resource tag mode returns all tags on every check, triggering builds for every historical tag after pipeline recreation ([#419](https://github.com/PikoCI/pikoci/issues/419))
 - Pipeline graph shows original build color instead of successful retry when a new build is running ([#421](https://github.com/PikoCI/pikoci/issues/421))

--- a/pikoci/transport/http/assets/js/app/collections.js
+++ b/pikoci/transport/http/assets/js/app/collections.js
@@ -114,8 +114,12 @@ export var Builds = Backbone.Collection.extend({
     }, opts));
   },
   setActive: function(id) {
-    if (!id && this.first()) {
-      id = this.first().get("build_number");
+    if (!id) {
+      var started = this.filter(function(m) { return m.get("status") === "started"; });
+      var pending = this.filter(function(m) { return m.get("status") === "pending"; });
+      var running = (started.length ? started[started.length - 1] : null)
+        || (pending.length ? pending[pending.length - 1] : null);
+      id = running ? running.get("build_number") : (this.first() ? this.first().get("build_number") : null);
     }
     this.each(function(m){
       m.set("active", m.get("build_number") === id);


### PR DESCRIPTION
## Summary

- Auto-navigate to the oldest running (started) build when opening a job's builds page without a specific build ID
- Falls back to oldest pending build, then newest build if none are active

Closes #441