### PR TITLE
Position toast in sidebar area and add click-to-dismiss (#443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Toast notifications overlap action buttons on wide screens and cannot be dismissed by clicking ([#443](https://github.com/PikoCI/pikoci/issues/443))
 - Job builds view defaults to newest build instead of navigating to the running/pending build ([#441](https://github.com/PikoCI/pikoci/issues/441))
 - Pipelines link on team edit page causes full page reload instead of client-side navigation ([#445](https://github.com/PikoCI/pikoci/issues/445))
 - Git resource tag mode returns all tags on every check, triggering builds for every historical tag after pipeline recreation ([#419](https://github.com/PikoCI/pikoci/issues/419))

--- a/pikoci/transport/http/assets/css/pikoci.css
+++ b/pikoci/transport/http/assets/css/pikoci.css
@@ -185,10 +185,9 @@ a:hover { color: var(--primary-hover); }
 .piko-toast {
   position: fixed;
   top: 70px;
-  right: 20px;
+  right: 10px;
   z-index: 1050;
-  min-width: 250px;
-  max-width: 400px;
+  max-width: calc((100vw - 1320px) / 2 - 20px);
   padding: 12px 20px;
   border-radius: var(--radius);
   box-shadow: 0 4px 12px rgba(0,0,0,0.15);
@@ -197,6 +196,26 @@ a:hover { color: var(--primary-hover); }
   opacity: 0;
   transform: translateX(20px);
   transition: opacity 0.3s, transform 0.3s;
+}
+.piko-toast-close {
+  pointer-events: auto;
+  cursor: pointer;
+  background: none;
+  border: none;
+  float: right;
+  font-size: 18px;
+  line-height: 1;
+  margin: -4px -8px 0 8px;
+  padding: 0;
+  color: inherit;
+  opacity: 0.6;
+}
+.piko-toast-close::after { content: "\00d7"; }
+.piko-toast-close:hover { opacity: 1; }
+@media (max-width: 1720px) {
+  .piko-toast {
+    max-width: 280px;
+  }
 }
 .piko-toast.show { opacity: 1; transform: translateX(0); }
 .piko-toast-success {

--- a/pikoci/transport/http/assets/js/app/local-init.js
+++ b/pikoci/transport/http/assets/js/app/local-init.js
@@ -61,13 +61,20 @@ var NoticeView = Backbone.View.extend({
   },
   showToast: function(msg, type) {
     $('.piko-toast').remove();
-    var toast = $('<div class="piko-toast"></div>').addClass('piko-toast-' + type).text(msg);
+    var toast = $('<div class="piko-toast"></div>').addClass('piko-toast-' + type);
+    var closeBtn = $('<button class="piko-toast-close" aria-label="Dismiss"></button>');
+    toast.append(document.createTextNode(msg)).append(closeBtn);
     $('body').append(toast);
     requestAnimationFrame(function() { toast.addClass('show'); });
-    setTimeout(function() {
+    var dismissTimer = setTimeout(function() {
       toast.removeClass('show');
       setTimeout(function() { toast.remove(); }, 300);
     }, type === 'error' ? 8000 : 4000);
+    closeBtn.on('click', function() {
+      clearTimeout(dismissTimer);
+      toast.removeClass('show');
+      setTimeout(function() { toast.remove(); }, 300);
+    });
   },
 });
 

--- a/pikoci/transport/http/assets/js/app/views/layout.js
+++ b/pikoci/transport/http/assets/js/app/views/layout.js
@@ -88,13 +88,20 @@ export var NoticeView = Backbone.View.extend({
   },
   showToast: function(msg, type) {
     $('.piko-toast').remove();
-    var toast = $('<div class="piko-toast"></div>').addClass('piko-toast-' + type).text(msg);
+    var toast = $('<div class="piko-toast"></div>').addClass('piko-toast-' + type);
+    var closeBtn = $('<button class="piko-toast-close" aria-label="Dismiss"></button>');
+    toast.append(document.createTextNode(msg)).append(closeBtn);
     $('body').append(toast);
     requestAnimationFrame(function() { toast.addClass('show'); });
-    setTimeout(function() {
+    var dismissTimer = setTimeout(function() {
       toast.removeClass('show');
       setTimeout(function() { toast.remove(); }, 300);
     }, type === "error" ? 8000 : 4000);
+    closeBtn.on('click', function() {
+      clearTimeout(dismissTimer);
+      toast.removeClass('show');
+      setTimeout(function() { toast.remove(); }, 300);
+    });
   },
 });
 


### PR DESCRIPTION
## Summary

- Position toast notifications in the empty space right of the Bootstrap `.container` using `max-width: calc((100vw - 1140px) / 2 - 20px)` with a `min-width: 180px` floor
- Fall back to a compact `max-width: 280px` top-right overlay on viewports ≤1400px where sidebar space is too narrow
- Enable `pointer-events: auto` + `cursor: pointer` and add click handlers that clear the auto-dismiss timer and trigger the fade-out animation immediately

Closes #443
