### PR TITLE
Poll non-terminal builds for real-time status updates on job builds page (#444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Build status transitions not visible in real-time on non-active build tabs in the job builds page ([#444](https://github.com/PikoCI/pikoci/issues/444))
 - Toast notifications overlap action buttons on wide screens and cannot be dismissed by clicking ([#443](https://github.com/PikoCI/pikoci/issues/443))
 - Job builds view defaults to newest build instead of navigating to the running/pending build ([#441](https://github.com/PikoCI/pikoci/issues/441))
 - Pipelines link on team edit page causes full page reload instead of client-side navigation ([#445](https://github.com/PikoCI/pikoci/issues/445))

--- a/pikoci/transport/http/assets/js/app/views/jobs.js
+++ b/pikoci/transport/http/assets/js/app/views/jobs.js
@@ -111,10 +111,21 @@ export var JobBuildsView = Backbone.View.extend({
   },
   fetchActiveBuild: function() {
     var active = this.collection.find(function(m) { return m.get("active"); });
-    if (!active) return;
-    var status = active.get("status");
-    if (status === "succeeded" || status === "failed" || status === "cancelled") return;
-    active.fetch();
+    // Fetch the active build if it's in a non-terminal state
+    if (active) {
+      var status = active.get("status");
+      if (status !== "succeeded" && status !== "failed" && status !== "cancelled") {
+        active.fetch();
+      }
+    }
+    // Also fetch any other non-terminal builds so their tabs update
+    this.collection.each(function(m) {
+      if (m === active) return;
+      var s = m.get("status");
+      if (s === "started" || s === "pending") {
+        m.fetch();
+      }
+    });
   },
   clickTriggerJob: function(event) {
     event.preventDefault();


### PR DESCRIPTION
## Summary

- On the job builds page, `fetchActiveBuild` now also polls non-active builds that are in `started` or `pending` state, so their tabs reflect status transitions (pending → running → succeeded/failed) in real-time without requiring a click or page refresh.
- Adds changelog entry for #444.