### PR TITLE
Redirect to teams page after first-login password change (#442)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- After first-login forced password change, user stays on profile page instead of being redirected to the teams page ([#442](https://github.com/PikoCI/pikoci/issues/442))
 - Build status transitions not visible in real-time on non-active build tabs in the job builds page ([#444](https://github.com/PikoCI/pikoci/issues/444))
 - Toast notifications overlap action buttons on wide screens and cannot be dismissed by clicking ([#443](https://github.com/PikoCI/pikoci/issues/443))
 - Job builds view defaults to newest build instead of navigating to the running/pending build ([#441](https://github.com/PikoCI/pikoci/issues/441))

--- a/pikoci/transport/http/assets/js/app/views/users.js
+++ b/pikoci/transport/http/assets/js/app/views/users.js
@@ -250,6 +250,7 @@ export var ProfileView = Backbone.View.extend({
           window.app.apiNotice.set({error: resp.error});
           return;
         }
+        var wasForcedChange = that.mustChangePassword;
         that.mustChangePassword = false;
         that.$('#must-change-password-banner').remove();
         var u = session.get("user");
@@ -259,6 +260,9 @@ export var ProfileView = Backbone.View.extend({
           window.localStorage.setItem(userSessionKey, JSON.stringify(session.toJSON()));
         }
         window.app.apiNotice.setSuccess("Password changed successfully");
+        if (wasForcedChange) {
+          window.app.router.navigate('', { trigger: true });
+        }
       },
       error: function(response) {
         var msg = (response.responseJSON && response.responseJSON.error) || response.statusText || "Unknown error";


### PR DESCRIPTION
## Summary
- After the forced first-login password change, redirect the user to the teams page instead of leaving them on the profile page with no clear next step.
- Voluntary password changes from the profile page remain unaffected.

Closes #442