### PR TITLE
Add job-level timeout (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Job-level timeout: set `timeout` on a job (e.g. `timeout = "30m"`) to limit total wall-clock time for plan steps. When exceeded the build fails with a "job timed out" error and `on_cancel`/`ensure` hooks still run ([#60](https://github.com/PikoCI/pikoci/issues/60))
 - Resource pinning and trigger with specific version: pin a resource to lock the pipeline to a known-good version — the scheduler, worker, and manual job triggers all respect the pin. Trigger downstream jobs with any specific version via the play button. Pinned resources show an amber border in the pipeline graph and a sticky banner on the versions page. Pinning cancels mismatched pending builds. Cron resource GET steps now print the trigger date ([#151](https://github.com/PikoCI/pikoci/issues/151))
 - Pause/unpause pipelines and jobs: temporarily stop build triggering without deleting configuration or history. Pausing a pipeline pauses all its jobs; unpausing individual jobs is supported. Resource checks continue running while paused. Paused jobs appear blue in the pipeline graph ([#148](https://github.com/PikoCI/pikoci/issues/148))
 - Persistent resource caching: `cache = true` on `resource_type` enables a persistent `$CACHE_DIR` for check and pull scripts, with per-resource override support. The built-in `git` resource type uses caching by default — maintaining a bare clone for faster `git fetch` checks and `--reference-if-able` pulls ([#216](https://github.com/PikoCI/pikoci/issues/216))

--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -249,9 +249,12 @@ Jobs contain a plan of steps executed in order. Each step is one of `get`, `task
 
 The optional `concurrency` attribute limits how many builds of the job can run simultaneously. When the limit is reached, new builds are re-queued and wait until a slot frees up. The default value `0` means unlimited.
 
+The optional `timeout` attribute limits the total wall-clock time for a build's plan steps. When the timeout is reached, the build fails with a "job timed out" error and `on_cancel`/`ensure` hooks still run. If not set, the job runs with no time limit.
+
 ```hcl
 job "deploy" {
   concurrency = 1
+  timeout     = "30m"
 
   get "git" "my_repo" {
     trigger = true
@@ -489,6 +492,27 @@ task "long-build" {
   }
 }
 ```
+
+### Job timeout
+
+Jobs can set a `timeout` to limit the total wall-clock time for all plan steps. The value is a Go duration string (e.g. `"30m"`, `"1h"`, `"2h30m"`). If the build exceeds the timeout, the running step is killed, the build is marked as failed with a "job timed out after ..." message, and `on_cancel`/`ensure` hooks still run — just like user-initiated cancellation. If no timeout is set, the job runs with no time limit.
+
+```hcl
+job "integration" {
+  timeout = "2h"
+
+  get "git" "my-repo" { trigger = true }
+  task "test" {
+    timeout = "30m"
+    run "exec" {
+      path = "make"
+      args = ["integration-test"]
+    }
+  }
+}
+```
+
+When both a job timeout and a step timeout are set, whichever expires first takes effect.
 
 ### Step retry
 

--- a/pikoci/helper.go
+++ b/pikoci/helper.go
@@ -70,6 +70,7 @@ type hclPutStep struct {
 type hclJob struct {
 	Name        string           `hcl:"name,label"`
 	Concurrency int              `hcl:"concurrency,optional"`
+	Timeout     string           `hcl:"timeout,optional"`
 	Get         []hclGetStep     `hcl:"get,block"`
 	Task        []hclTaskStep    `hcl:"task,block"`
 	Put         []hclPutStep     `hcl:"put,block"`
@@ -666,10 +667,18 @@ func (q *PikoCI) readPipeline(ctx context.Context, rpp []byte, vars map[string]i
 		if hj.Concurrency < 0 {
 			return nil, fmt.Errorf("job %q: concurrency must be >= 0", hj.Name)
 		}
+		var jobTimeout time.Duration
+		if hj.Timeout != "" {
+			jobTimeout, err = time.ParseDuration(hj.Timeout)
+			if err != nil {
+				return nil, fmt.Errorf("invalid timeout %q on job %q: %w", hj.Timeout, hj.Name, err)
+			}
+		}
 		jh := jobHooksMap[hj.Name]
 		j := job.Job{
 			Name:        hj.Name,
 			Concurrency: hj.Concurrency,
+			Timeout:     jobTimeout,
 			Plan:        jobPlans[hj.Name],
 			OnSuccess:   jh.OnSuccess,
 			OnFailure:   jh.OnFailure,

--- a/pikoci/job/job.go
+++ b/pikoci/job/job.go
@@ -43,8 +43,9 @@ type Job struct {
 	ID          uint32     `json:"id"`
 	Name        string     `json:"name" hcl:"name,label"`
 	Concurrency int        `json:"concurrency,omitempty"`
-	Paused      bool       `json:"paused"`
-	Plan        []PlanStep `json:"plan"`
+	Paused      bool          `json:"paused"`
+	Timeout     time.Duration `json:"timeout,omitempty"`
+	Plan        []PlanStep    `json:"plan"`
 
 	OnSuccess []HookStep `json:"on_success,omitempty"`
 	OnFailure []HookStep `json:"on_failure,omitempty"`

--- a/pikoci/mysql/job.go
+++ b/pikoci/mysql/job.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/cycloidio/sqlr"
 	"github.com/pikoci/pikoci/pikoci/job"
@@ -30,6 +31,7 @@ type dbJob struct {
 	Ensure      sql.NullString
 	Concurrency sql.NullInt64
 	Paused      sql.NullBool
+	Timeout     sql.NullInt64
 }
 
 func newDBJob(p job.Job) dbJob {
@@ -38,7 +40,7 @@ func newDBJob(p job.Job) dbJob {
 	f, _ := json.Marshal(p.OnFailure)
 	c, _ := json.Marshal(p.OnCancel)
 	e, _ := json.Marshal(p.Ensure)
-	return dbJob{
+	dbj := dbJob{
 		Name:        toNullString(p.Name),
 		Plan:        toNullString(string(pl)),
 		OnSuccess:   toNullString(string(s)),
@@ -48,6 +50,10 @@ func newDBJob(p job.Job) dbJob {
 		Concurrency: sql.NullInt64{Int64: int64(p.Concurrency), Valid: true},
 		Paused:      sql.NullBool{Bool: p.Paused, Valid: true},
 	}
+	if p.Timeout > 0 {
+		dbj.Timeout = sql.NullInt64{Int64: int64(p.Timeout), Valid: true}
+	}
+	return dbj
 }
 
 func (dbp *dbJob) toDomainEntity() *job.Job {
@@ -56,6 +62,9 @@ func (dbp *dbJob) toDomainEntity() *job.Job {
 		Name:        dbp.Name.String,
 		Concurrency: int(dbp.Concurrency.Int64),
 		Paused:      dbp.Paused.Bool,
+	}
+	if dbp.Timeout.Valid {
+		j.Timeout = time.Duration(dbp.Timeout.Int64)
 	}
 
 	_ = json.Unmarshal([]byte(dbp.Plan.String), &j.Plan)
@@ -70,8 +79,8 @@ func (dbp *dbJob) toDomainEntity() *job.Job {
 func (r *JobRepository) Create(ctx context.Context, tc, pn string, j job.Job) (uint32, error) {
 	dbj := newDBJob(j)
 	res, err := r.querier.ExecContext(ctx, `
-		INSERT INTO jobs(name, plan, on_success, on_failure, on_cancel, ensure, concurrency, paused, pipeline_id)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?,
+		INSERT INTO jobs(name, plan, on_success, on_failure, on_cancel, ensure, concurrency, paused, timeout, pipeline_id)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,
 			-- pipeline_id
 			(
 				SELECT p.id
@@ -79,7 +88,7 @@ func (r *JobRepository) Create(ctx context.Context, tc, pn string, j job.Job) (u
 				JOIN teams AS t
 					ON p.team_id = t.id
 				WHERE t.canonical = ? AND p.canonical = ?
-			))`, dbj.Name, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Paused, tc, pn)
+			))`, dbj.Name, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Paused, dbj.Timeout, tc, pn)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -96,7 +105,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 	dbj := newDBJob(j)
 	res, err := r.querier.ExecContext(ctx, `
 		UPDATE jobs AS j
-		SET name = ?, plan = ?, on_success = ?, on_failure = ?, on_cancel = ?, ensure = ?, concurrency = ?, paused = ?
+		SET name = ?, plan = ?, on_success = ?, on_failure = ?, on_cancel = ?, ensure = ?, concurrency = ?, paused = ?, timeout = ?
 		FROM (
 			SELECT j.id
 			FROM jobs AS j
@@ -107,7 +116,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 			WHERE t.canonical = ? AND p.canonical = ? AND j.name = ?
 		) AS jj
 		WHERE jj.id = j.id
-	`, dbj.Name, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Paused, tc, pn, jn)
+	`, dbj.Name, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Paused, dbj.Timeout, tc, pn, jn)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -122,7 +131,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 
 func (r *JobRepository) Find(ctx context.Context, tc, pn, jn string) (*job.Job, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT j.id, j.name, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused
+		SELECT j.id, j.name, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -141,7 +150,7 @@ func (r *JobRepository) Find(ctx context.Context, tc, pn, jn string) (*job.Job, 
 
 func (r *JobRepository) Filter(ctx context.Context, tc, pn string) ([]*job.Job, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT j.id, j.name, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused
+		SELECT j.id, j.name, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -269,6 +278,7 @@ func scanJob(s sqlr.Scanner) (*job.Job, error) {
 		&j.Ensure,
 		&j.Concurrency,
 		&j.Paused,
+		&j.Timeout,
 	)
 
 	if err != nil {

--- a/pikoci/mysql/migrate/migrations/V28JobTimeout.go
+++ b/pikoci/mysql/migrate/migrations/V28JobTimeout.go
@@ -1,0 +1,6 @@
+package migrations
+
+var V28JobTimeout = Migration{
+	Name: "JobTimeout",
+	SQL:  `ALTER TABLE jobs ADD COLUMN timeout BIGINT;`,
+}

--- a/pikoci/mysql/migrate/migrations/migrations.go
+++ b/pikoci/mysql/migrate/migrations/migrations.go
@@ -16,7 +16,7 @@ type Migration struct {
 // Migrations is the ordered list of all schema migrations. It is defined as
 // a fixed-size array so that the compiler catches ordering conflicts when
 // multiple developers add migrations concurrently.
-var Migrations = [28]Migration{
+var Migrations = [29]Migration{
 	V0Initial,
 	V1ResourceCheckInterval,
 	V2JobsAndBuilds,
@@ -45,4 +45,5 @@ var Migrations = [28]Migration{
 	V25Cache,
 	V26PausePipelineJob,
 	V27ResourcePin,
+	V28JobTimeout,
 }

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -482,6 +482,72 @@ job "test" {
 	assert.Contains(t, err.Error(), "invalid timeout")
 }
 
+func TestCreatePipeline_WithJobTimeout(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "test" {
+  timeout = "30m"
+  get "cron" "timer" {
+    trigger = true
+  }
+  task "build" {
+    run "exec" {
+      path = "echo"
+      args = ["building"]
+    }
+  }
+}
+`)
+
+	s.Pipelines.EXPECT().Create(ctx, "main", gomock.Any()).Return(uint32(1), nil)
+	s.Jobs.EXPECT().Create(ctx, "main", "job-timeout-pipeline", gomock.Any()).DoAndReturn(
+		func(ctx context.Context, tc, pn string, j job.Job) (uint32, error) {
+			assert.Equal(t, 30*time.Minute, j.Timeout)
+			return uint32(1), nil
+		})
+	s.Resources.EXPECT().Create(ctx, "main", "job-timeout-pipeline", gomock.Any()).Return(uint32(1), nil)
+	s.Pipelines.EXPECT().Find(ctx, "main", "job-timeout-pipeline").Return(&pipeline.Pipeline{ID: 1, Name: "job-timeout-pipeline", Canonical: "job-timeout-pipeline"}, nil)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "job-timeout-pipeline", hclConfig, nil)
+	require.NoError(t, err)
+}
+
+func TestCreatePipeline_InvalidJobTimeout(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "test" {
+  timeout = "bad"
+  get "cron" "timer" {
+    trigger = true
+  }
+  task "build" {
+    run "exec" {
+      path = "echo"
+      args = ["building"]
+    }
+  }
+}
+`)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "invalid-job-timeout-pipeline", hclConfig, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid timeout")
+}
+
 func TestCreatePipeline_WithAttempts(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := newService(ctrl)

--- a/worker/service.go
+++ b/worker/service.go
@@ -394,6 +394,12 @@ func (w *Worker) processJob(ctx context.Context, m queue.Body, cwd string, pp *p
 		return
 	}
 
+	if j.Timeout > 0 {
+		var timeoutCancel context.CancelFunc
+		jobCtx, timeoutCancel = context.WithTimeout(jobCtx, j.Timeout)
+		defer timeoutCancel()
+	}
+
 	var resolvedVersions map[string]uint32
 	if w.LocalMode {
 		resolvedVersions = make(map[string]uint32)
@@ -430,6 +436,15 @@ func (w *Worker) processJob(ctx context.Context, m queue.Body, cwd string, pp *p
 	}
 
 	failed, resolved := w.runPlan(jobCtx, m, &b, cwd, pp, j, resolvedVersions)
+
+	// Handle job-level timeout
+	if jobCtx.Err() == context.DeadlineExceeded {
+		w.failBuild(ctx, m, b, fmt.Errorf("job timed out after %s", j.Timeout))
+		w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.OnCancel, "on_cancel", resolved, "cancelled")
+		w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.Ensure, "ensure", resolved, "cancelled")
+		w.runAutoNotifications(ctx, m, &b, cwd, pp, resolved)
+		return
+	}
 
 	// Handle user-initiated cancellation
 	if jobCtx.Err() == context.Canceled {

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -3889,3 +3889,126 @@ func TestCacheDir(t *testing.T) {
 	// Clean up
 	os.RemoveAll(dir)
 }
+
+func TestProcessJob_JobTimeout(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "job-timeout-job",
+		BuildID:           10,
+	}
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:      1,
+				Name:    "job-timeout-job",
+				Timeout: 2 * time.Second,
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "slow-task",
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Args:   []string{"10"},
+								Params: map[string]string{
+									"path": "sleep",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().StartPendingBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, m.BuildID).
+		Return(&build.Build{ID: 100, BuildNumber: "100", StartedAt: time.Now()}, nil)
+	svc.EXPECT().GetPipelineJob(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName).
+		Return(&pp.Jobs[0], nil)
+
+	var capturedBuild build.Build
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "100", gomock.Any()).
+		DoAndReturn(func(ctx context.Context, tc, pn, jn string, bID string, b build.Build) error {
+			capturedBuild = b
+			return nil
+		}).AnyTimes()
+
+	expectPendingBuild(svc, 10)
+	w.processJob(ctx, m, cwd, pp)
+
+	assert.Equal(t, build.Failed, capturedBuild.Status)
+	assert.Contains(t, capturedBuild.Error, "job timed out after 2s")
+}
+
+func TestProcessJob_JobTimeout_NotReached(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "job-timeout-ok",
+		BuildID:           10,
+	}
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:      1,
+				Name:    "job-timeout-ok",
+				Timeout: 10 * time.Second,
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "fast-task",
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Args:   []string{"hello"},
+								Params: map[string]string{
+									"path": "echo",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().StartPendingBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, m.BuildID).
+		Return(&build.Build{ID: 100, BuildNumber: "100", StartedAt: time.Now()}, nil)
+	svc.EXPECT().GetPipelineJob(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName).
+		Return(&pp.Jobs[0], nil)
+
+	var capturedBuild build.Build
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "100", gomock.Any()).
+		DoAndReturn(func(ctx context.Context, tc, pn, jn string, bID string, b build.Build) error {
+			capturedBuild = b
+			return nil
+		}).AnyTimes()
+
+	expectPendingBuild(svc, 10)
+	w.processJob(ctx, m, cwd, pp)
+
+	assert.Equal(t, build.Succeeded, capturedBuild.Status)
+}


### PR DESCRIPTION
## Summary

- Adds a `timeout` attribute to jobs that limits total wall-clock time for plan step execution
- When exceeded, the build fails with "job timed out after ..." and `on_cancel`/`ensure` hooks still run (same pattern as user-initiated cancellation)
- No default timeout — users opt in per-job with a Go duration string (e.g. `timeout = "30m"`)
- Includes DB migration (V28), HCL parsing, worker enforcement, documentation, and tests

Closes #60