### PR TITLE
Add built-in artifact resource type (#150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Type-level runner overrides: `resource_type`, `notification_type`, `secret_type`, and `service_type` definitions can specify a `runner` block to override where their exec commands execute, e.g. run inside Docker without modifying the type's command definitions ([#221](https://github.com/PikoCI/pikoci/issues/221))
 - Floating toast notifications for success and error feedback on all mutating actions (trigger, delete, retry, cancel, etc.) with auto-dismiss and dark mode support ([#351](https://github.com/PikoCI/pikoci/issues/351))
 - File secret type: auto-detect format from file extension (`json`, `yaml`, `env`, `raw`), add `json` and `yaml` as explicit format options, and fix multi-line JSON parsing ([#435](https://github.com/PikoCI/pikoci/issues/435))
+- Built-in `artifact` resource type for passing build outputs between jobs using local filesystem storage with content-addressable deduplication, implicit get-after-put for `passed` constraint support, and `$CACHE_DIR` for push steps ([#150](https://github.com/PikoCI/pikoci/issues/150))
 - First-class notification entities: `notification_type`, `notification`, and `notify` steps for fire-and-forget notifications with automatic dispatch, job scoping, and `github-check`/`slack`/`discord` notification types ([#154](https://github.com/PikoCI/pikoci/issues/154))
 - SVG and PNG pipeline graph formats for embedding in READMEs and dashboards ([#332](https://github.com/PikoCI/pikoci/issues/332))
 

--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -533,6 +533,68 @@ task "flaky-test" {
 }
 ```
 
+## Built-in resource type: artifact
+
+The `artifact` resource type passes build outputs (compiled binaries, test reports, etc.) between jobs in the same pipeline. It stores tarballs on the local filesystem using the cache directory, so no external storage service is required for single-worker setups.
+
+### Parameters
+
+| Parameter  | Level    | Description                                                    |
+|------------|----------|----------------------------------------------------------------|
+| `dir`      | resource | Directory to extract artifacts into during pull                |
+| `base_dir` | resource | Override the default storage directory (defaults to `$CACHE_DIR`) |
+| `dir`      | put      | Source directory to archive and push as an artifact             |
+
+### Usage example
+
+```hcl
+resource "artifact" "build-output" {
+  params {
+    dir = "build-output"
+  }
+}
+
+job "build" {
+  task "compile" {
+    run "exec" {
+      path = "/bin/sh"
+      args = ["-ec", "mkdir -p output && echo 'hello' > output/result.txt"]
+    }
+  }
+
+  put "artifact" "build-output" {
+    dir = "output"
+  }
+}
+
+job "deploy" {
+  get "artifact" "build-output" {
+    trigger = true
+    passed  = ["build"]
+  }
+
+  task "deploy" {
+    run "exec" {
+      path = "/bin/sh"
+      args = ["-ec", "cat build-output/result.txt"]
+    }
+  }
+}
+```
+
+### Multi-worker deployments
+
+By default, artifacts are stored under the worker's XDG cache directory. In multi-worker setups, use a shared filesystem (NFS, GlusterFS, etc.) and set the `base_dir` parameter to point to the shared mount:
+
+```hcl
+resource "artifact" "build-output" {
+  params {
+    dir      = "build-output"
+    base_dir = "/mnt/shared/artifacts/build-output"
+  }
+}
+```
+
 ## Full example
 
 Using built-in `git` and `docker` (no inline resource_type or runner blocks needed):

--- a/pikoci/builtin/builtin.go
+++ b/pikoci/builtin/builtin.go
@@ -19,7 +19,7 @@ import (
 // embedded. They are resolved via the pikoci:// source scheme, which falls
 // back to the GitHub raw URL when not found in the embedded FS.
 
-//go:embed resource_types/cron.hcl resource_types/git.hcl resource_types/trigger.hcl
+//go:embed resource_types/artifact.hcl resource_types/cron.hcl resource_types/git.hcl resource_types/trigger.hcl
 var resourceTypeFS embed.FS
 
 //go:embed runners/*.hcl

--- a/pikoci/builtin/builtin_test.go
+++ b/pikoci/builtin/builtin_test.go
@@ -35,6 +35,18 @@ func TestResourceTypes(t *testing.T) {
 		assert.Contains(t, rt.Params, "pr")
 	})
 
+	t.Run("artifact", func(t *testing.T) {
+		rt, ok := rts["artifact"]
+		require.True(t, ok)
+		assert.Equal(t, "artifact", rt.Name)
+		assert.True(t, rt.Cache)
+		assert.Equal(t, "exec", rt.Check.Runner)
+		assert.Equal(t, "exec", rt.Pull.Runner)
+		assert.Equal(t, "exec", rt.Push.Runner)
+		assert.Contains(t, rt.Params, "dir")
+		assert.Contains(t, rt.Params, "base_dir")
+	})
+
 	t.Run("trigger", func(t *testing.T) {
 		rt, ok := rts["trigger"]
 		require.True(t, ok)

--- a/pikoci/builtin/resource_types/artifact.hcl
+++ b/pikoci/builtin/resource_types/artifact.hcl
@@ -1,0 +1,80 @@
+resource_type "artifact" {
+  cache = true
+  params = [
+    "dir",
+    "base_dir",
+  ]
+  check "exec" {
+    path = "/bin/sh"
+    args = [
+      "-ec",
+      <<-EOT
+      VERSIONS_DIR="$CACHE_DIR/versions"
+      if [ ! -d "$VERSIONS_DIR" ]; then
+        echo "[]"
+        exit 0
+      fi
+      PREV_TS="$${version_timestamp:-}"
+      if [ -z "$PREV_TS" ]; then
+        # First check: return only latest
+        LATEST=$(ls -1 "$VERSIONS_DIR"/*.json 2>/dev/null | sort | tail -1)
+        if [ -z "$LATEST" ]; then echo "[]"; exit 0; fi
+        echo "[$(cat "$LATEST")]"
+      else
+        # Return all versions newer than previous timestamp
+        RESULT="["
+        FIRST=true
+        for f in $(ls -1 "$VERSIONS_DIR"/*.json 2>/dev/null | sort); do
+          FILE_TS=$(cat "$f" | grep -o '"timestamp":"[^"]*"' | cut -d'"' -f4)
+          if [ "$FILE_TS" \> "$PREV_TS" ]; then
+            if [ "$FIRST" = true ]; then FIRST=false; else RESULT="$RESULT,"; fi
+            RESULT="$RESULT$(cat "$f")"
+          fi
+        done
+        echo "$${RESULT}]"
+      fi
+      EOT
+    ]
+  }
+  pull "exec" {
+    path = "/bin/sh"
+    args = [
+      "-ec",
+      <<-EOT
+      STORE="$${param_base_dir:-$CACHE_DIR}"
+      DEST="$param_dir"
+      TARBALL="$STORE/data/$${version_sha}.tar.gz"
+      if [ ! -f "$TARBALL" ]; then
+        echo "error: artifact not found: $TARBALL" >&2
+        exit 1
+      fi
+      mkdir -p "$DEST"
+      tar -xzf "$TARBALL" -C "$DEST"
+      echo "extracted artifact $version_sha to $DEST"
+      EOT
+    ]
+  }
+  push "exec" {
+    path = "/bin/sh"
+    args = [
+      "-ec",
+      <<-EOT
+      STORE="$${param_base_dir:-$CACHE_DIR}"
+      mkdir -p "$STORE/versions" "$STORE/data"
+      SRC="$put_dir"
+      if [ ! -d "$SRC" ]; then
+        echo "error: directory '$SRC' not found" >&2
+        exit 1
+      fi
+      SHA=$(tar -cf - -C "$SRC" . | sha256sum | cut -d' ' -f1)
+      TARBALL="$STORE/data/$${SHA}.tar.gz"
+      if [ ! -f "$TARBALL" ]; then
+        tar -czf "$TARBALL" -C "$SRC" .
+      fi
+      TS=$(date -u +%Y%m%d%H%M%S%N)
+      echo "{\"sha\":\"$SHA\",\"timestamp\":\"$TS\"}" > "$STORE/versions/$${TS}-$${SHA}.json"
+      echo "[{\"sha\":\"$SHA\",\"timestamp\":\"$TS\"}]"
+      EOT
+    ]
+  }
+}

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -748,14 +748,35 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 		}
 	}
 
+	// Collect put output node names per job+resource so passed edges can reuse them
+	putOutputNodes := make(map[string]string) // key: "jobName-type.name" → node name
+	for _, j := range pp.Jobs {
+		for _, p := range j.AllPutSteps() {
+			rCan := fmt.Sprintf("%s.%s", p.Type, p.Name)
+			key := fmt.Sprintf("%s-%s", j.Name, rCan)
+			putOutputNodes[key] = fmt.Sprintf(`"%s-%s-out"`, j.Name, rCan)
+		}
+	}
+
 	// Now we print all the jobs interconnections depending on resources
 	for _, j := range pp.Jobs {
 		quotedJobName := fmt.Sprintf(`"%s"`, j.Name)
 		for _, g := range j.GetSteps() {
 			if len(g.Passed) != 0 {
 				for _, p := range g.Passed {
-					nn := fmt.Sprintf(`"%s-%s-%s"`, p, g.Name, j.Name)
 					rCan := fmt.Sprintf("%s.%s", g.Type, g.Name)
+
+					// Reuse the put output node if the passed job already has one for this resource
+					key := fmt.Sprintf("%s-%s", p, rCan)
+					if nn, ok := putOutputNodes[key]; ok {
+						err = graph.AddEdge(nn, quotedJobName, false, nil)
+						if err != nil {
+							return nil, fmt.Errorf("failed to add edge to Graph: %w", err)
+						}
+						continue
+					}
+
+					nn := fmt.Sprintf(`"%s-%s-%s"`, p, g.Name, j.Name)
 					vurl := fmt.Sprintf(`"/teams/%s/pipelines/%s/resources/%s/versions"`, tc, pp.Canonical, rCan)
 					border := resourceBorders[rCan]
 					rStyle := resourceStyles[rCan]

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -1510,6 +1510,62 @@ func TestGetPipelineImage_ShowsLinkedResources(t *testing.T) {
 	assert.True(t, strings.Contains(dot, `"git.repo"`), "second linked resource should appear")
 }
 
+func TestGetPipelineImage_PassedReusesPutOutputNode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	pp := &pipeline.Pipeline{
+		Name:      "artifact-pipeline",
+		Canonical: "artifact-pipeline",
+		Resources: []resource.Resource{
+			{ID: 1, Canonical: "cron.timer"},
+			{ID: 2, Canonical: "artifact.output"},
+		},
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "build",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeGet,
+						Get:  &job.GetStep{Type: "cron", Name: "timer", Trigger: true},
+					},
+					{
+						Type: job.StepTypePut,
+						Put:  &job.PutStep{Type: "artifact", Name: "output"},
+					},
+				},
+			},
+			{
+				ID:   2,
+				Name: "deploy",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeGet,
+						Get:  &job.GetStep{Type: "artifact", Name: "output", Trigger: true, Passed: []string{"build"}},
+					},
+				},
+			},
+		},
+	}
+
+	s.Pipelines.EXPECT().Find(ctx, "main", "artifact-pipeline").Return(pp, nil)
+	s.Builds.EXPECT().Filter(ctx, "main", "artifact-pipeline", "build", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
+	s.Builds.EXPECT().Filter(ctx, "main", "artifact-pipeline", "deploy", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
+
+	img, err := s.S.GetPipelineImage(ctx, "main", "artifact-pipeline", "dot")
+	require.NoError(t, err)
+
+	dot := string(img)
+	// The put output node should exist
+	assert.Contains(t, dot, `"build-artifact.output-out"`, "put output node should exist")
+	// The passed edge should reuse the put output node (edge from put-out to deploy)
+	assert.Contains(t, dot, `"build-artifact.output-out"--"deploy"`, "passed edge should reuse put output node")
+	// There should NOT be a separate passed node for the same resource
+	assert.NotContains(t, dot, `"build-output-deploy"`, "should not create a separate passed node when put output exists")
+}
+
 func TestGetPipelineImage_JobStatusColors(t *testing.T) {
 	// Helper to build a simple pipeline with one job triggered by a cron resource.
 	makePipeline := func() *pipeline.Pipeline {

--- a/pikoci/testdata/cron.hcl
+++ b/pikoci/testdata/cron.hcl
@@ -18,23 +18,51 @@ variable "env" {
 }
 
 resource "cron" "my_cron" {
-  check_interval = "@every 10s"
+  check_interval = "@every 20s"
+}
+
+resource "artifact" "cron_output" {
+  params {
+    dir = "cron-output"
+  }
 }
 
 job "gen" {
   get "cron" "my_cron" {
     trigger = true
   }
-  task "logs" {
+  task "create-file" {
     run "exec" {
       path = "/bin/sh"
-      args = ["-c", "for i in $(seq 1 120); do echo \"Log line $i at $(date)\"; sleep 0.5; done"]
+      args = ["-ec", "mkdir -p output && echo \"cron triggered at: $(date)\" > output/timestamp.txt && cat output/timestamp.txt"]
     }
   }
-  task "echo" {
+  put "artifact" "cron_output" {
+    dir = "output"
+  }
+}
+
+job "by-passed" {
+  get "artifact" "cron_output" {
+    trigger = true
+    passed  = ["gen"]
+  }
+  task "print-file" {
     run "exec" {
-      path = "echo"
-      args = ["greeting=${var.greeting} env=${var.env}"]
+      path = "/bin/sh"
+      args = ["-ec", "echo '--- by-passed job ---' && cat cron-output/timestamp.txt"]
+    }
+  }
+}
+
+job "by-check" {
+  get "artifact" "cron_output" {
+    trigger = true
+  }
+  task "print-file" {
+    run "exec" {
+      path = "/bin/sh"
+      args = ["-ec", "echo '--- by-check job ---' && cat cron-output/timestamp.txt"]
     }
   }
 }

--- a/worker/service.go
+++ b/worker/service.go
@@ -538,7 +538,7 @@ func (w *Worker) checkPassedConstraints(ctx context.Context, m queue.Body, b *bu
 				}
 				hasSucceeded = true
 				for _, step := range bu.Steps {
-					if step.Type == "get" && step.Name == g.Name && step.VersionID != 0 {
+					if (step.Type == "get" || step.Type == "put") && step.Name == g.Name && step.VersionID != 0 {
 						versionSet[step.VersionID] = true
 					}
 				}
@@ -1058,6 +1058,15 @@ func (w *Worker) runPutStep(ctx context.Context, m queue.Body, b *build.Build, c
 		delete(rc.Params, "path")
 	}
 
+	if resourceCacheEnabled(rt, r) {
+		cd, err := w.cacheDir(m.TeamCanonical, m.PipelineCanonical, rCan)
+		if err != nil {
+			w.logger.Error("failed to create cache dir for push", "error", err)
+		} else {
+			rc.Params["CACHE_DIR"] = cd
+		}
+	}
+
 	replaceSecretPlaceholders(rc.Params, secretResolved)
 	replaceSecretPlaceholdersInSlice(rc.Args, secretResolved)
 
@@ -1123,9 +1132,65 @@ func (w *Worker) runPutStep(ctx context.Context, m queue.Body, b *build.Build, c
 	if err := w.updateBuild(ctx, m, *b); err != nil {
 		return true
 	}
+
+	// Implicit get-after-put: parse the version from the push script output,
+	// create it in the DB, record it as fetched by this build, and trigger
+	// downstream jobs. This mirrors Concourse's implicit get after put.
+	w.implicitGetAfterPut(ctx, m, b, pp, p, rCan, r, out, stepIdx)
+
 	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, p.Name, ps.OnSuccess, "on_success", secretResolved)
 	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, p.Name, ps.Ensure, "ensure", secretResolved)
 	return false
+}
+
+// implicitGetAfterPut parses the version JSON from the push script output,
+// creates the resource version in the DB, records it as fetched by this build
+// (so that "passed" constraints are satisfied), and triggers downstream jobs.
+func (w *Worker) implicitGetAfterPut(ctx context.Context, m queue.Body, b *build.Build, pp *pipeline.Pipeline, p job.PutStep, rCan string, r resource.Resource, out string, stepIdx int) {
+	sout := strings.Split(strings.Trim(out, "\n"), "\n")
+	rawVers := sout[len(sout)-1]
+	if rawVers == "" {
+		return
+	}
+
+	vers := make([]map[string]interface{}, 0)
+	if err := json.Unmarshal([]byte(rawVers), &vers); err != nil {
+		w.logger.Warn("put step output is not valid version JSON, skipping implicit get", "step", p.Name, "error", err)
+		return
+	}
+
+	for _, v := range vers {
+		cv, err := w.pikoci.CreateResourceVersion(ctx, m.TeamCanonical, m.PipelineCanonical, rCan, resource.Version{
+			Version: v,
+		})
+		if err != nil {
+			if isDuplicateKeyError(err) {
+				w.logger.Info("put: duplicate version skipped", "resource", rCan, "version", v)
+				continue
+			}
+			w.logger.Error("put: failed to create resource version", "resource", rCan, "error", err)
+			return
+		}
+
+		// Record the version on the put step so checkPassedConstraints can find it
+		b.Steps[stepIdx] = build.Step{
+			Type:      b.Steps[stepIdx].Type,
+			Name:      b.Steps[stepIdx].Name,
+			Logs:      b.Steps[stepIdx].Logs,
+			Duration:  b.Steps[stepIdx].Duration,
+			Status:    b.Steps[stepIdx].Status,
+			VersionID: cv.ID,
+		}
+		w.updateBuild(ctx, m, *b)
+
+		if err := w.pikoci.InsertBuildGetVersion(ctx, m.TeamCanonical, m.PipelineCanonical, m.JobName, b.ID, p.Name, cv.ID); err != nil {
+			w.logger.Error("put: failed to insert build get version", "step", p.Name, "error", err)
+		}
+
+		w.logger.Info("put: version created, triggering downstream jobs",
+			"pipeline", m.PipelineCanonical, "resource", rCan, "version_id", cv.ID)
+		w.triggerResourceJobs(ctx, m, pp, r, cv)
+	}
 }
 
 // runNotifyStep runs a single notify step (fire-and-forget notification).

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -1156,6 +1156,117 @@ func TestCheckPassedConstraints_NoPassedField(t *testing.T) {
 	assert.Equal(t, map[string]uint32{}, resolved)
 }
 
+func TestCheckPassedConstraints_PutStepSatisfiesPassed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "downstream-job",
+		BuildID:           10,
+	}
+	b := build.Build{ID: 54, BuildNumber: "54"}
+	j := &job.Job{
+		Name: "downstream-job",
+		Plan: []job.PlanStep{
+			{
+				Type: job.StepTypeGet,
+				Get: &job.GetStep{
+					Type:   "artifact",
+					Name:   "my-artifact",
+					Passed: []string{"upstream-job"},
+				},
+			},
+		},
+	}
+
+	// The upstream job has a put step (not a get step) with the version
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "upstream-job", (*uint32)(nil), (*uint32)(nil), uint32(0)).
+		Return([]*build.Build{{ID: 1, Status: build.Succeeded, Steps: []build.Step{
+			{Type: "put", Name: "my-artifact", VersionID: 7},
+		}}}, false, nil)
+
+	ok, resolved := w.checkPassedConstraints(ctx, m, &b, j)
+	assert.True(t, ok)
+	assert.Equal(t, map[string]uint32{"artifact.my-artifact": 7}, resolved)
+}
+
+func TestImplicitGetAfterPut_CreatesVersionAndRecords(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "gen-job",
+		BuildID:           10,
+	}
+	b := &build.Build{
+		ID:          60,
+		BuildNumber: "60",
+		Steps: []build.Step{
+			{Type: "put", Name: "my-artifact", Status: build.Succeeded, Logs: "some logs"},
+		},
+	}
+	pp := &pipeline.Pipeline{
+		ID:        1,
+		Name:      "test-pipeline",
+		Canonical: "test-pipeline",
+		Jobs:      []job.Job{{ID: 1, Name: "gen-job"}},
+	}
+	p := job.PutStep{Type: "artifact", Name: "my-artifact"}
+	rCan := "artifact.my-artifact"
+	r := resource.Resource{ID: 1, Name: "my-artifact", Type: "artifact", Canonical: rCan}
+
+	// Push script output with valid JSON version on last line
+	out := "some tar output\n[{\"sha\":\"abc123\",\"timestamp\":\"20260603120000\"}]"
+
+	svc.EXPECT().CreateResourceVersion(gomock.Any(), "main", "test-pipeline", rCan, gomock.Any()).
+		Return(&resource.Version{ID: 42, Version: map[string]interface{}{"sha": "abc123", "timestamp": "20260603120000"}}, nil)
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), "main", "test-pipeline", "gen-job", "60", gomock.Any()).
+		Return(nil).AnyTimes()
+
+	w.implicitGetAfterPut(ctx, m, b, pp, p, rCan, r, out, 0)
+
+	// Verify the step's VersionID was set
+	assert.Equal(t, uint32(42), b.Steps[0].VersionID)
+}
+
+func TestImplicitGetAfterPut_InvalidJSON_Skips(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, _, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "gen-job",
+		BuildID:           10,
+	}
+	b := &build.Build{
+		ID:          61,
+		BuildNumber: "61",
+		Steps: []build.Step{
+			{Type: "put", Name: "repo", Status: build.Succeeded},
+		},
+	}
+	pp := &pipeline.Pipeline{ID: 1, Name: "test-pipeline", Canonical: "test-pipeline"}
+	p := job.PutStep{Type: "git", Name: "repo"}
+	r := resource.Resource{ID: 1, Name: "repo", Type: "git", Canonical: "git.repo"}
+
+	// Push output is not JSON (e.g. git push output)
+	out := "Everything up-to-date"
+
+	// Should not call CreateResourceVersion or InsertBuildGetVersion
+	w.implicitGetAfterPut(ctx, m, b, pp, p, "git.repo", r, out, 0)
+
+	// VersionID should remain 0
+	assert.Equal(t, uint32(0), b.Steps[0].VersionID)
+}
+
 func TestRunHooks(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	w, svc, _ := newTestWorker(ctrl)
@@ -1587,6 +1698,88 @@ func TestProcessJob_PutStep_Success(t *testing.T) {
 
 	expectPendingBuild(svc, 10)
 	w.processJob(ctx, m, cwd, pp)
+}
+
+func TestProcessJob_PutStep_CacheDirSet(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "artifact-job",
+		BuildID:           10,
+	}
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "artifact-job",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "build",
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Args:   []string{"building"},
+								Params: map[string]string{"path": "echo"},
+							},
+						},
+					},
+					{
+						Type: job.StepTypePut,
+						Put: &job.PutStep{
+							Type:   "artifact",
+							Name:   "my-artifact",
+							Params: map[string]string{"dir": "output"},
+						},
+					},
+				},
+			},
+		},
+		Resources: []resource.Resource{
+			{ID: 1, Name: "my-artifact", Type: "artifact", Canonical: "artifact.my-artifact", Params: &resource.Params{Params: map[string]string{"dir": "output"}}},
+		},
+		ResourceTypes: []restype.ResourceType{
+			{
+				ID: 1, Name: "artifact",
+				Cache:  true,
+				Params: []string{"dir", "base_dir"},
+				Push: &utils.RunnerCommand{
+					Runner: "exec",
+					Args:   []string{"pushing"},
+					Params: map[string]string{"path": "echo"},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	var capturedBuild *build.Build
+	svc.EXPECT().StartPendingBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, m.BuildID).
+		Return(&build.Build{ID: 81, BuildNumber: "81", StartedAt: time.Now()}, nil)
+	svc.EXPECT().GetPipelineJob(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName).
+		Return(&pp.Jobs[0], nil)
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "81", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, b build.Build) error {
+			capturedBuild = &b
+			return nil
+		}).AnyTimes()
+
+	expectPendingBuild(svc, 10)
+	w.processJob(ctx, m, cwd, pp)
+
+	// The build should have completed successfully (task + put steps)
+	require.NotNil(t, capturedBuild)
+	assert.Equal(t, build.Succeeded, capturedBuild.Status)
 }
 
 func TestProcessJob_OrderedPlan_GetTaskPut(t *testing.T) {


### PR DESCRIPTION
## Summary

- New built-in `artifact` resource type for passing build outputs between jobs via local filesystem with content-addressable tarball deduplication
- Implicit get-after-put: put steps now create resource versions, record them for `passed` constraints, and trigger downstream jobs
- `$CACHE_DIR` is now set for push steps when `cache = true`
- Pipeline graph reuses put output nodes for `passed` edges, eliminating duplicate resource boxes
- Documentation, tests, and testdata cron pipeline updated to exercise artifact put/get flow

Closes #150