### PR TITLE
Fix JSON cache causing SPA to display raw API responses (#456)

### DIFF
--- a/pikoci/transport/http/assets/js/app/views/layout.js
+++ b/pikoci/transport/http/assets/js/app/views/layout.js
@@ -22,7 +22,12 @@ export var HeaderView = Backbone.View.extend({
     this.listenTo(session, "change", this.render);
     this.versionText = '';
     var self = this;
-    $.getJSON('/version').done(function(data) {
+    $.ajax({
+      url: '/version',
+      type: 'GET',
+      headers: {'Content-Type': 'application/json'},
+      dataType: 'json',
+    }).done(function(data) {
       self.versionText = 'Version: ' + data.version + ' (' + data.commit + ')';
       self.render();
     });

--- a/pikoci/transport/http/handler.go
+++ b/pikoci/transport/http/handler.go
@@ -197,6 +197,7 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, 
 	jsonr.Methods(http.MethodPost).Path("/login").Handler(userLogin(s))
 	jsonr.Methods(http.MethodGet).Path("/version").Name(GetVersion.String()).HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-store")
 		json.NewEncoder(w).Encode(map[string]string{
 			"version": version,
 			"commit":  commit,
@@ -269,6 +270,7 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, 
 	api.NotFoundHandler = http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			w.Header().Set("Cache-Control", "no-store")
 			w.WriteHeader(http.StatusNotFound)
 			fmt.Fprintf(w, `{"error": "Path not found"}`)
 		},
@@ -360,6 +362,7 @@ func membershipsDiffer(jwtUser map[string]interface{}, dbUser *user.WithMembersh
 
 func encodeResponse(r interface{}, w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
 	e, ok := r.(Errorer)
 	if !ok {
 		w.WriteHeader(http.StatusBadRequest)

--- a/pikoci/transport/http/handler_test.go
+++ b/pikoci/transport/http/handler_test.go
@@ -20,6 +20,56 @@ import (
 	_ "modernc.org/sqlite"
 )
 
+func TestSPAFallback_BrowserNavigation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	handler := Handler(s, secret, logger, nil, "", "test", "abc1234")
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// Simulate browser navigation (no Content-Type, no Authorization)
+	// to SPA URLs that share paths with API endpoints.
+	paths := []string{
+		"/",
+		"/teams",
+		"/teams/main",
+		"/teams/main/pipelines",
+		"/teams/main/pipelines/my-pipeline",
+		"/teams/main/pipelines/my-pipeline/jobs/build/builds",
+		"/teams/main/pipelines/my-pipeline/resources/my-res/versions",
+		"/login",
+		"/users",
+		"/profile",
+	}
+
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, server.URL+path, nil)
+			require.NoError(t, err)
+			// No Content-Type, no Authorization — just like a browser
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			body, _ := io.ReadAll(resp.Body)
+			assert.Equal(t, http.StatusOK, resp.StatusCode, "path %s should return 200", path)
+			assert.Contains(t, string(body), "<!DOCTYPE html>", "path %s should return SPA HTML, not JSON", path)
+		})
+	}
+}
+
+func TestEncodeResponse_CacheControl(t *testing.T) {
+	w := httptest.NewRecorder()
+	resp := ErrorResponse{Err: ""}
+	encodeResponse(resp, w)
+
+	assert.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+}
+
 func TestEncodeResponse_WithError(t *testing.T) {
 	w := httptest.NewRecorder()
 	resp := ErrorResponse{Err: "something went wrong"}


### PR DESCRIPTION
## Summary
- Add `Cache-Control: no-store` to all JSON API responses (`encodeResponse`, `/version`, `api.NotFoundHandler`) to prevent browsers/proxies from caching them
- Fix `$.getJSON('/version')` → `$.ajax` with `Content-Type: application/json` header so the version endpoint is actually reachable
- Add tests for SPA fallback (browser navigation returns HTML, not JSON) and cache-control header

Closes #456
