### PR TITLE
Add built-in shell runner (#458)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Built-in `shell` runner for simplified shell command execution. Supports inline `cmd` mode (`run "shell" { cmd = "..." }`) and script `file` mode (`run "shell" { file = "script.sh" }`), with optional `shell` param to override the default `/bin/sh` ([#458](https://github.com/PikoCI/pikoci/issues/458))
+
 ## [0.3.0] - 2026-06-03
 
 ### Added

--- a/deploy/pipeline.hcl
+++ b/deploy/pipeline.hcl
@@ -179,26 +179,21 @@ job "build-latest" {
     trigger = true
   }
   task "docker-build-push-latest" {
-    run "exec" {
-      path = "/bin/sh"
-      args = [
-        "-ec",
-        <<-EOT
+    run "shell" {
+      cmd = <<-EOT
         cd ${var.git_name}
 
         echo "${var.ghcr_token}" | docker login ghcr.io -u "${var.ghcr_username}" --password-stdin
 
         docker buildx create --use --name pikoci-builder 2>/dev/null || docker buildx use pikoci-builder
         docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/pikoci/pikoci:latest --push .
-        EOT
-      ]
+      EOT
     }
   }
   ensure {
     task "docker-prune" {
-      run "exec" {
-        path = "/bin/sh"
-        args = ["-ec", "docker buildx prune -f && docker image prune -f"]
+      run "shell" {
+        cmd = "docker buildx prune -f && docker image prune -f"
       }
     }
   }
@@ -225,9 +220,8 @@ job "deploy" {
       ]
     }
   }
-  on_success "exec" {
-    path = "/bin/sh"
-    args = ["-ec", "kill -QUIT $(pidof pikoci)"]
+  on_success "shell" {
+    cmd = "kill -QUIT $(pidof pikoci)"
   }
 }
 
@@ -236,19 +230,15 @@ job "deploy-docs" {
     trigger = true
   }
   task "build-and-deploy" {
-    run "exec" {
-      path = "/bin/sh"
-      args = [
-        "-ec",
-        <<-EOT
+    run "shell" {
+      cmd = <<-EOT
         cd ${var.git_name}
         python3 -m venv .venv
         .venv/bin/pip install --quiet mkdocs-material
         .venv/bin/mkdocs build --clean
         rm -rf /var/www/docs.pikoci.com/*
         cp -a site/. /var/www/docs.pikoci.com/
-        EOT
-      ]
+      EOT
     }
   }
 }
@@ -258,15 +248,11 @@ job "deploy-website" {
     trigger = true
   }
   task "copy-to-server" {
-    run "exec" {
-      path = "/bin/sh"
-      args = [
-        "-ec",
-        <<-EOT
+    run "shell" {
+      cmd = <<-EOT
         mkdir -p /var/www/pikoci.com
         cp -a pikoci.com/. /var/www/pikoci.com/
-        EOT
-      ]
+      EOT
     }
   }
 }
@@ -276,11 +262,8 @@ job "build-release" {
     trigger = true
   }
   task "docker-build-push-tag" {
-    run "exec" {
-      path = "/bin/sh"
-      args = [
-        "-ec",
-        <<-EOT
+    run "shell" {
+      cmd = <<-EOT
         cd ${var.git_name}
         TAG=$(git describe --tags --exact-match)
 
@@ -288,15 +271,13 @@ job "build-release" {
 
         docker buildx create --use --name pikoci-builder 2>/dev/null || docker buildx use pikoci-builder
         docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/pikoci/pikoci:$TAG --push .
-        EOT
-      ]
+      EOT
     }
   }
   ensure {
     task "docker-prune" {
-      run "exec" {
-        path = "/bin/sh"
-        args = ["-ec", "docker buildx prune -f && docker image prune -f"]
+      run "shell" {
+        cmd = "docker buildx prune -f && docker image prune -f"
       }
     }
   }

--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -161,6 +161,65 @@ runner_type "docker" {
 
 When `source` is set, inline `run` block is not needed.
 
+## Built-in runner: shell
+
+The `shell` runner simplifies running shell commands in tasks and hooks. It has two mutually exclusive modes: **inline** (`cmd`) and **file** (`file`).
+
+### Inline mode (`cmd`)
+
+Runs a shell command string via `<shell> -ec "<cmd>"`:
+
+```hcl
+task "test" {
+  run "shell" {
+    cmd = <<-EOT
+      cd app
+      make test
+      make lint
+    EOT
+  }
+}
+```
+
+### File mode (`file`)
+
+Runs a script file. Relative paths are resolved against the build working directory:
+
+```hcl
+task "deploy" {
+  run "shell" {
+    file = "app/scripts/deploy.sh"
+  }
+}
+```
+
+When no `shell` param is set, the file is executed directly (chmod +x is applied), so the OS uses the script's shebang line. When `shell` is set, the file is passed as an argument to the specified shell.
+
+### Shell selection (optional)
+
+Both modes accept an optional `shell` param. Default is `/bin/sh`:
+
+```hcl
+task "test" {
+  run "shell" {
+    shell = "/bin/bash"
+    cmd   = "set -o pipefail; make test 2>&1 | tee test.log"
+  }
+}
+```
+
+| Param   | Required | Description                                              |
+|---------|----------|----------------------------------------------------------|
+| `cmd`   | no*      | Shell command string to run inline                       |
+| `file`  | no*      | Path to a script file to execute                         |
+| `shell` | no       | Shell binary to use (default `/bin/sh`)                  |
+
+\* Exactly one of `cmd` or `file` must be set.
+
+### Comparison with `exec`
+
+The `shell` runner replaces the common pattern of `run "exec" { path = "/bin/sh" args = ["-ec", "..."] }`. Use `shell` for shell commands and scripts. Use `exec` when you need to run a binary directly with specific arguments.
+
 ## secret_type
 
 Defines how to fetch secrets. See [Secret Types](Secret-Types.md). The `get` command should print a JSON object on its last stdout line with key-value pairs that become `secret_<key>` environment variables. Connection config (address, token, etc.) is set as attributes on the block.

--- a/pikoci/builtin/builtin_test.go
+++ b/pikoci/builtin/builtin_test.go
@@ -79,6 +79,14 @@ func TestRunners(t *testing.T) {
 		assert.Contains(t, ru.Run.Args, "run")
 		assert.Contains(t, ru.Run.Args, "--rm")
 	})
+
+	t.Run("shell", func(t *testing.T) {
+		ru, ok := rus["shell"]
+		require.True(t, ok)
+		assert.Equal(t, "shell", ru.Name)
+		assert.Equal(t, "$shell", ru.Run.Path)
+		assert.Equal(t, []string{"-ec", "$cmd"}, ru.Run.Args)
+	})
 }
 
 func TestResourceTypeHCL(t *testing.T) {

--- a/pikoci/builtin/runners/shell.hcl
+++ b/pikoci/builtin/runners/shell.hcl
@@ -1,0 +1,6 @@
+runner_type "shell" {
+  run {
+    path = "$shell"
+    args = ["-ec", "$cmd"]
+  }
+}

--- a/worker/service.go
+++ b/worker/service.go
@@ -1917,7 +1917,55 @@ func (sw *streamWriter) String() string {
 	return sw.buf.String()
 }
 
+// prepareShellRunner adjusts the runner and command for the built-in "shell"
+// runner. It handles defaulting the shell to /bin/sh, validates that exactly
+// one of cmd/file is set, and rewrites the runner for file mode execution.
+func prepareShellRunner(ru *runner.Runner, rc *utils.RunnerCommand, cwd string) error {
+	_, cmdSet := rc.Params["cmd"]
+	_, fileSet := rc.Params["file"]
+	if cmdSet && fileSet {
+		return fmt.Errorf("shell runner: cannot set both \"cmd\" and \"file\"")
+	}
+	if !cmdSet && !fileSet {
+		return fmt.Errorf("shell runner: must set either \"cmd\" or \"file\"")
+	}
+
+	_, shellExplicit := rc.Params["shell"]
+
+	if !shellExplicit {
+		if rc.Params == nil {
+			rc.Params = make(map[string]string)
+		}
+		rc.Params["shell"] = "/bin/sh"
+	}
+
+	if fileSet {
+		file := rc.Params["file"]
+		if !filepath.IsAbs(file) {
+			file = filepath.Join(cwd, file)
+		}
+		if shellExplicit {
+			ru.Run = utils.RunCommand{Path: rc.Params["shell"], Args: []string{file}}
+		} else {
+			if err := os.Chmod(file, 0755); err != nil {
+				return fmt.Errorf("shell runner: chmod file: %w", err)
+			}
+			ru.Run = utils.RunCommand{Path: file, Args: nil}
+		}
+		// Remove file param so it doesn't leak into env vars.
+		delete(rc.Params, "file")
+	}
+
+	return nil
+}
+
 func (w *Worker) runRunner(ctx context.Context, ru runner.Runner, cwd string, rc utils.RunnerCommand, onPartialLog ...func(string)) (string, time.Duration, error) {
+	if ru.Name == "shell" {
+		if err := prepareShellRunner(&ru, &rc, cwd); err != nil {
+			return err.Error(), 0, err
+		}
+	}
+
 	envs := map[string]string{"WORKDIR": cwd}
 	for k, v := range rc.Params {
 		envs[k] = v

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -4205,3 +4205,176 @@ func TestProcessJob_JobTimeout_NotReached(t *testing.T) {
 
 	assert.Equal(t, build.Succeeded, capturedBuild.Status)
 }
+
+func TestPrepareShellRunner_CmdModeDefaultShell(t *testing.T) {
+	ru := runner.Runner{
+		Name: "shell",
+		Run:  utils.RunCommand{Path: "$shell", Args: []string{"-ec", "$cmd"}},
+	}
+	rc := utils.RunnerCommand{
+		Runner: "shell",
+		Params: map[string]string{"cmd": "echo hello"},
+	}
+	cwd := t.TempDir()
+
+	err := prepareShellRunner(&ru, &rc, cwd)
+	require.NoError(t, err)
+	assert.Equal(t, "/bin/sh", rc.Params["shell"])
+	// Run command should remain unchanged (template handles cmd mode)
+	assert.Equal(t, "$shell", ru.Run.Path)
+	assert.Equal(t, []string{"-ec", "$cmd"}, ru.Run.Args)
+}
+
+func TestPrepareShellRunner_CmdModeCustomShell(t *testing.T) {
+	ru := runner.Runner{
+		Name: "shell",
+		Run:  utils.RunCommand{Path: "$shell", Args: []string{"-ec", "$cmd"}},
+	}
+	rc := utils.RunnerCommand{
+		Runner: "shell",
+		Params: map[string]string{"cmd": "echo hello", "shell": "/bin/bash"},
+	}
+	cwd := t.TempDir()
+
+	err := prepareShellRunner(&ru, &rc, cwd)
+	require.NoError(t, err)
+	assert.Equal(t, "/bin/bash", rc.Params["shell"])
+}
+
+func TestPrepareShellRunner_FileModeNoShell(t *testing.T) {
+	cwd := t.TempDir()
+	scriptPath := filepath.Join(cwd, "test.sh")
+	os.WriteFile(scriptPath, []byte("#!/bin/sh\necho hello\n"), 0644)
+
+	ru := runner.Runner{
+		Name: "shell",
+		Run:  utils.RunCommand{Path: "$shell", Args: []string{"-ec", "$cmd"}},
+	}
+	rc := utils.RunnerCommand{
+		Runner: "shell",
+		Params: map[string]string{"file": "test.sh"},
+	}
+
+	err := prepareShellRunner(&ru, &rc, cwd)
+	require.NoError(t, err)
+	assert.Equal(t, scriptPath, ru.Run.Path)
+	assert.Nil(t, ru.Run.Args)
+	// file param should be removed from params
+	_, hasFile := rc.Params["file"]
+	assert.False(t, hasFile)
+}
+
+func TestPrepareShellRunner_FileModeWithShell(t *testing.T) {
+	cwd := t.TempDir()
+	scriptPath := filepath.Join(cwd, "test.sh")
+	os.WriteFile(scriptPath, []byte("echo hello\n"), 0644)
+
+	ru := runner.Runner{
+		Name: "shell",
+		Run:  utils.RunCommand{Path: "$shell", Args: []string{"-ec", "$cmd"}},
+	}
+	rc := utils.RunnerCommand{
+		Runner: "shell",
+		Params: map[string]string{"file": "test.sh", "shell": "/bin/bash"},
+	}
+
+	err := prepareShellRunner(&ru, &rc, cwd)
+	require.NoError(t, err)
+	assert.Equal(t, "/bin/bash", ru.Run.Path)
+	assert.Equal(t, []string{scriptPath}, ru.Run.Args)
+}
+
+func TestPrepareShellRunner_FileModeAbsolutePath(t *testing.T) {
+	cwd := t.TempDir()
+	scriptPath := filepath.Join(cwd, "abs.sh")
+	os.WriteFile(scriptPath, []byte("#!/bin/sh\necho abs\n"), 0644)
+
+	ru := runner.Runner{
+		Name: "shell",
+		Run:  utils.RunCommand{Path: "$shell", Args: []string{"-ec", "$cmd"}},
+	}
+	rc := utils.RunnerCommand{
+		Runner: "shell",
+		Params: map[string]string{"file": scriptPath},
+	}
+
+	err := prepareShellRunner(&ru, &rc, cwd)
+	require.NoError(t, err)
+	// Absolute path should be used as-is
+	assert.Equal(t, scriptPath, ru.Run.Path)
+}
+
+func TestPrepareShellRunner_ErrorBothCmdAndFile(t *testing.T) {
+	ru := runner.Runner{
+		Name: "shell",
+		Run:  utils.RunCommand{Path: "$shell", Args: []string{"-ec", "$cmd"}},
+	}
+	rc := utils.RunnerCommand{
+		Runner: "shell",
+		Params: map[string]string{"cmd": "echo hello", "file": "test.sh"},
+	}
+
+	err := prepareShellRunner(&ru, &rc, t.TempDir())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot set both")
+}
+
+func TestPrepareShellRunner_ErrorNeitherCmdNorFile(t *testing.T) {
+	ru := runner.Runner{
+		Name: "shell",
+		Run:  utils.RunCommand{Path: "$shell", Args: []string{"-ec", "$cmd"}},
+	}
+	rc := utils.RunnerCommand{
+		Runner: "shell",
+		Params: map[string]string{},
+	}
+
+	err := prepareShellRunner(&ru, &rc, t.TempDir())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must set either")
+}
+
+func TestRunRunner_ShellCmdMode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, _, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	cwd := t.TempDir()
+
+	ru := runner.Runner{
+		Name: "shell",
+		Run:  utils.RunCommand{Path: "$shell", Args: []string{"-ec", "$cmd"}},
+	}
+	rc := utils.RunnerCommand{
+		Runner: "shell",
+		Params: map[string]string{"cmd": "echo shell_works"},
+	}
+
+	out, _, err := w.runRunner(ctx, ru, cwd, rc)
+	require.NoError(t, err)
+	assert.Contains(t, out, "shell_works")
+}
+
+func TestRunRunner_ShellFileMode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, _, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	cwd := t.TempDir()
+
+	scriptPath := filepath.Join(cwd, "hello.sh")
+	os.WriteFile(scriptPath, []byte("#!/bin/sh\necho file_works\n"), 0644)
+
+	ru := runner.Runner{
+		Name: "shell",
+		Run:  utils.RunCommand{Path: "$shell", Args: []string{"-ec", "$cmd"}},
+	}
+	rc := utils.RunnerCommand{
+		Runner: "shell",
+		Params: map[string]string{"file": "hello.sh"},
+	}
+
+	out, _, err := w.runRunner(ctx, ru, cwd, rc)
+	require.NoError(t, err)
+	assert.Contains(t, out, "file_works")
+}


### PR DESCRIPTION
## Summary

- Adds a built-in `shell` runner with inline `cmd` mode and script `file` mode, defaulting to `/bin/sh` with optional `shell` param override
- Migrates all `exec` + `/bin/sh` blocks in `deploy/pipeline.hcl` to the new `shell` runner
- Adds documentation in `docs/Pipeline.md` and tests for both modes

Closes #458