### PR TITLE
Add loading indicators to action buttons (#453)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Loading indicators on action buttons: all mutating buttons (trigger, cancel, retry, delete, pause, unpause, pin, etc.) now show a spinner and loading text while the request is in flight, preventing double-clicks and providing visual feedback ([#453](https://github.com/PikoCI/pikoci/issues/453))
 - Built-in `shell` runner for simplified shell command execution. Supports inline `cmd` mode (`run "shell" { cmd = "..." }`) and script `file` mode (`run "shell" { file = "script.sh" }`), with optional `shell` param to override the default `/bin/sh` ([#458](https://github.com/PikoCI/pikoci/issues/458))
 
 ## [0.3.0] - 2026-06-03

--- a/pikoci/transport/http/assets/css/pikoci.css
+++ b/pikoci/transport/http/assets/css/pikoci.css
@@ -269,6 +269,15 @@ a:hover { color: var(--primary-hover); }
 .btn-info { background: transparent !important; color: var(--primary) !important; border: 1px solid var(--primary) !important; }
 .btn-info:hover { background: var(--primary-light) !important; }
 
+.piko-btn-loading {
+  opacity: 0.65;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+.piko-btn-loading .spinner-border {
+  vertical-align: -0.125em;
+}
+
 /* ============================================================
    FORMS
    ============================================================ */

--- a/pikoci/transport/http/assets/js/app/models.js
+++ b/pikoci/transport/http/assets/js/app/models.js
@@ -146,7 +146,7 @@ export var Job = Backbone.Model.extend({
     return response;
   },
   fetchTrigger: function(opts) {
-    this.fetch(_.extend({url: this.url()+"/trigger", type: "POST"}, opts));
+    return this.fetch(_.extend({url: this.url()+"/trigger", type: "POST"}, opts));
   },
 });
 
@@ -177,7 +177,7 @@ export var Resource = Backbone.Model.extend({
   },
   pinVersion: function(versionID, opts) {
     opts = opts || {};
-    $.ajax(_.extend({
+    return $.ajax(_.extend({
       url: this.url()+"/pin",
       type: "POST",
       contentType: "application/json",
@@ -186,7 +186,7 @@ export var Resource = Backbone.Model.extend({
   },
   unpinVersion: function(opts) {
     opts = opts || {};
-    $.ajax(_.extend({
+    return $.ajax(_.extend({
       url: this.url()+"/unpin",
       type: "POST",
       contentType: "application/json",

--- a/pikoci/transport/http/assets/js/app/namespace.js
+++ b/pikoci/transport/http/assets/js/app/namespace.js
@@ -100,6 +100,20 @@ export var processLogs = function(text) {
   }).join('\n');
 };
 
+export function withLoading(btn, ajaxFn) {
+  var $btn = $(btn);
+  var originalHTML = $btn.html();
+  var loadingText = $btn.attr('data-loading-text') || 'Loading...';
+  $btn.html(loadingText + ' <span class="spinner-border spinner-border-sm" role="status"></span>');
+  $btn.prop('disabled', true).addClass('piko-btn-loading');
+  var xhr = ajaxFn();
+  xhr.always(function() {
+    $btn.html(originalHTML);
+    $btn.prop('disabled', false).removeClass('piko-btn-loading');
+  });
+  return xhr;
+}
+
 export var addSessionFunctions = function(data) {
   return _.extend(window.app.session.data(), data);
 };

--- a/pikoci/transport/http/assets/js/app/views/jobs.js
+++ b/pikoci/transport/http/assets/js/app/views/jobs.js
@@ -2,7 +2,7 @@
 
 import { session } from '../collections.js';
 import { Build } from '../models.js';
-import { addSessionFunctions, fetchInterval, pikoTimeAgo } from '../namespace.js';
+import { addSessionFunctions, fetchInterval, pikoTimeAgo, withLoading } from '../namespace.js';
 
 export var JobBuildsView = Backbone.View.extend({
   template: _.template($('#job-builds-view').html()),
@@ -129,28 +129,35 @@ export var JobBuildsView = Backbone.View.extend({
   },
   clickTriggerJob: function(event) {
     event.preventDefault();
-    this.collection.job.fetchTrigger({success: function() { window.app.apiNotice.setSuccess("Job triggered"); }});
+    var that = this;
+    withLoading(this.$('#trigger-job'), function() {
+      return that.collection.job.fetchTrigger({success: function() { window.app.apiNotice.setSuccess("Job triggered"); }});
+    });
   },
   clickPauseJob: function(event) {
     event.preventDefault();
     var that = this;
     var url = this.collection.job.url() + "/pause";
-    $.ajax({ url: url, type: "POST", contentType: "application/json", headers: { "Authorization": "Bearer " + session.get("jwt") },
-      success: function() {
-        window.app.apiNotice.setSuccess("Job paused");
-        that.collection.job.fetch({ success: function() { that.render(); that.addBuilds(); that.collection.setActive(that.currentBuildID); } });
-      },
+    withLoading(this.$('#pause-job'), function() {
+      return $.ajax({ url: url, type: "POST", contentType: "application/json", headers: { "Authorization": "Bearer " + session.get("jwt") },
+        success: function() {
+          window.app.apiNotice.setSuccess("Job paused");
+          that.collection.job.fetch({ success: function() { that.render(); that.addBuilds(); that.collection.setActive(that.currentBuildID); } });
+        },
+      });
     });
   },
   clickUnpauseJob: function(event) {
     event.preventDefault();
     var that = this;
     var url = this.collection.job.url() + "/unpause";
-    $.ajax({ url: url, type: "POST", contentType: "application/json", headers: { "Authorization": "Bearer " + session.get("jwt") },
-      success: function() {
-        window.app.apiNotice.setSuccess("Job unpaused");
-        that.collection.job.fetch({ success: function() { that.render(); that.addBuilds(); that.collection.setActive(that.currentBuildID); } });
-      },
+    withLoading(this.$('#unpause-job'), function() {
+      return $.ajax({ url: url, type: "POST", contentType: "application/json", headers: { "Authorization": "Bearer " + session.get("jwt") },
+        success: function() {
+          window.app.apiNotice.setSuccess("Job unpaused");
+          that.collection.job.fetch({ success: function() { that.render(); that.addBuilds(); that.collection.setActive(that.currentBuildID); } });
+        },
+      });
     });
   },
   clickOnTab: function(event) {
@@ -214,8 +221,10 @@ var JobBuildsContentView = Backbone.View.extend({
     var that = this;
     var bid = this.model.get("build_number");
     var url = this.model.collection.url() + "/" + bid + "/cancel";
-    $.ajax({ url: url, type: "POST", contentType: "application/json", headers: { "Authorization": "Bearer " + session.get("jwt") },
-      success: function() { window.app.apiNotice.setSuccess("Build cancelled"); that.model.fetch(); },
+    withLoading($(e.currentTarget), function() {
+      return $.ajax({ url: url, type: "POST", contentType: "application/json", headers: { "Authorization": "Bearer " + session.get("jwt") },
+        success: function() { window.app.apiNotice.setSuccess("Build cancelled"); that.model.fetch(); },
+      });
     });
   },
   retryBuild: function(e) {
@@ -223,8 +232,10 @@ var JobBuildsContentView = Backbone.View.extend({
     var bid = this.model.get("build_number");
     var collection = this.model.collection;
     var url = collection.url() + "/" + bid + "/retry";
-    $.ajax({ url: url, type: "POST", contentType: "application/json", headers: { "Authorization": "Bearer " + session.get("jwt") },
-      success: function() { window.app.apiNotice.setSuccess("Build retried"); collection.fetchNew(); },
+    withLoading($(e.currentTarget), function() {
+      return $.ajax({ url: url, type: "POST", contentType: "application/json", headers: { "Authorization": "Bearer " + session.get("jwt") },
+        success: function() { window.app.apiNotice.setSuccess("Build retried"); collection.fetchNew(); },
+      });
     });
   },
   toggleFollow: function(e) {

--- a/pikoci/transport/http/assets/js/app/views/pipelines.js
+++ b/pikoci/transport/http/assets/js/app/views/pipelines.js
@@ -2,7 +2,7 @@
 
 import { session } from '../collections.js';
 import { PipelineImage } from '../models.js';
-import { addSessionFunctions, fetchInterval, pikoTimeAgo } from '../namespace.js';
+import { addSessionFunctions, fetchInterval, pikoTimeAgo, withLoading } from '../namespace.js';
 import { PipelineGraphView, PikoGraphZoom } from './editor.js';
 
 export var PipelinesView = Backbone.View.extend({
@@ -201,10 +201,13 @@ export var PipelineShowView = Backbone.View.extend({
     event.preventDefault();
     if (confirm("Are you sure you want to delete Pipeline '"+this.model.get("name")+"'")) {
       var pps = this.model.collection;
-      this.model.destroy({
-        success: function() {
-          window.app.router.navigate(pps.url(), { trigger: true });
-        },
+      var that = this;
+      withLoading(this.$('#delete-pipeline'), function() {
+        return that.model.destroy({
+          success: function() {
+            window.app.router.navigate(pps.url(), { trigger: true });
+          },
+        });
       });
     }
   },
@@ -212,22 +215,26 @@ export var PipelineShowView = Backbone.View.extend({
     event.preventDefault();
     var that = this;
     var url = this.model.url() + "/pause";
-    $.ajax({ url: url, type: "POST", contentType: "application/json", headers: { "Authorization": "Bearer " + session.get("jwt") },
-      success: function() {
-        window.app.apiNotice.setSuccess("Pipeline paused");
-        that.model.fetch({ success: function() { that.render(); } });
-      },
+    withLoading(this.$('#pause-pipeline'), function() {
+      return $.ajax({ url: url, type: "POST", contentType: "application/json", headers: { "Authorization": "Bearer " + session.get("jwt") },
+        success: function() {
+          window.app.apiNotice.setSuccess("Pipeline paused");
+          that.model.fetch({ success: function() { that.render(); } });
+        },
+      });
     });
   },
   clickUnpausePipeline: function(event) {
     event.preventDefault();
     var that = this;
     var url = this.model.url() + "/unpause";
-    $.ajax({ url: url, type: "POST", contentType: "application/json", headers: { "Authorization": "Bearer " + session.get("jwt") },
-      success: function() {
-        window.app.apiNotice.setSuccess("Pipeline unpaused");
-        that.model.fetch({ success: function() { that.render(); } });
-      },
+    withLoading(this.$('#unpause-pipeline'), function() {
+      return $.ajax({ url: url, type: "POST", contentType: "application/json", headers: { "Authorization": "Bearer " + session.get("jwt") },
+        success: function() {
+          window.app.apiNotice.setSuccess("Pipeline unpaused");
+          that.model.fetch({ success: function() { that.render(); } });
+        },
+      });
     });
   },
 });

--- a/pikoci/transport/http/assets/js/app/views/resources.js
+++ b/pikoci/transport/http/assets/js/app/views/resources.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import { session } from '../collections.js';
-import { addSessionFunctions, fetchInterval } from '../namespace.js';
+import { addSessionFunctions, fetchInterval, withLoading } from '../namespace.js';
 
 export var ResourceVersionsView = Backbone.View.extend({
   template: _.template($('#resource-versions-view').html()),
@@ -91,12 +91,16 @@ export var ResourceVersionsView = Backbone.View.extend({
   clickUnpinBanner: function(event) {
     event.preventDefault();
     var rs = this.collection.resource;
-    rs.unpinVersion({
-      headers: { 'Authorization': 'Bearer ' + session.get('jwt') },
-      success: function() {
-        rs.set('pinned_version_id', null);
-        window.app.apiNotice.setSuccess("Resource unpinned");
-      },
+    var $btn = $(event.currentTarget);
+    $btn.attr('data-loading-text', 'Unpinning...');
+    withLoading($btn, function() {
+      return rs.unpinVersion({
+        headers: { 'Authorization': 'Bearer ' + session.get('jwt') },
+        success: function() {
+          rs.set('pinned_version_id', null);
+          window.app.apiNotice.setSuccess("Resource unpinned");
+        },
+      });
     });
   },
   addVersion: function(m, isReset) {
@@ -132,7 +136,10 @@ export var ResourceVersionsView = Backbone.View.extend({
   },
   clickTriggerResource: function(event) {
     event.preventDefault();
-    this.collection.resource.fetchTrigger({success: function() { window.app.apiNotice.setSuccess("Resource check triggered"); }});
+    var rs = this.collection.resource;
+    withLoading(this.$('#trigger-resource'), function() {
+      return rs.fetchTrigger({success: function() { window.app.apiNotice.setSuccess("Resource check triggered"); }});
+    });
   },
   clickToggleWebhookPanel: function(event) {
     event.preventDefault();
@@ -158,19 +165,21 @@ export var ResourceVersionsView = Backbone.View.extend({
     var tc = rs.collection.pipeline.collection.team.get('canonical');
     var pn = rs.collection.pipeline.get('canonical');
     var rCan = rs.get('canonical');
-    $.ajax({
-      url: '/teams/' + tc + '/pipelines/' + pn + '/resources/' + rCan + '/webhook_token',
-      type: 'POST',
-      contentType: 'application/json',
-      headers: { 'Authorization': 'Bearer ' + session.get('jwt') },
-      success: function(resp) {
-        if (resp.token) {
-          rs.set('webhook_token', resp.token);
-          var url = window.location.origin + '/webhooks/' + resp.token + '';
-          that.$('#webhook-url').text(url);
-          window.app.apiNotice.setSuccess("Webhook token regenerated");
+    withLoading(this.$('#regenerate-webhook'), function() {
+      return $.ajax({
+        url: '/teams/' + tc + '/pipelines/' + pn + '/resources/' + rCan + '/webhook_token',
+        type: 'POST',
+        contentType: 'application/json',
+        headers: { 'Authorization': 'Bearer ' + session.get('jwt') },
+        success: function(resp) {
+          if (resp.token) {
+            rs.set('webhook_token', resp.token);
+            var url = window.location.origin + '/webhooks/' + resp.token + '';
+            that.$('#webhook-url').text(url);
+            window.app.apiNotice.setSuccess("Webhook token regenerated");
+          }
         }
-      }
+      });
     });
   },
 });
@@ -202,14 +211,16 @@ var ResourceVersionView = Backbone.View.extend({
     var tc = rs.collection.pipeline.collection.team.get('canonical');
     var pn = rs.collection.pipeline.get('canonical');
     var rCan = rs.get('canonical');
-    $.ajax({
-      url: '/teams/' + tc + '/pipelines/' + pn + '/resources/' + rCan + '/versions/' + versionID + '/trigger',
-      type: 'POST',
-      contentType: 'application/json',
-      headers: { 'Authorization': 'Bearer ' + session.get('jwt') },
-      success: function() {
-        window.app.apiNotice.setSuccess("Triggered downstream jobs with version #" + versionID);
-      },
+    withLoading($(event.currentTarget), function() {
+      return $.ajax({
+        url: '/teams/' + tc + '/pipelines/' + pn + '/resources/' + rCan + '/versions/' + versionID + '/trigger',
+        type: 'POST',
+        contentType: 'application/json',
+        headers: { 'Authorization': 'Bearer ' + session.get('jwt') },
+        success: function() {
+          window.app.apiNotice.setSuccess("Triggered downstream jobs with version #" + versionID);
+        },
+      });
     });
   },
   clickPinVersion: function(event) {
@@ -218,22 +229,26 @@ var ResourceVersionView = Backbone.View.extend({
     var versionID = this.model.get('id');
     var rs = this.resource;
     var isPinned = rs.get('pinned_version_id') === versionID;
-    if (isPinned) {
-      rs.unpinVersion({
-        headers: { 'Authorization': 'Bearer ' + session.get('jwt') },
-        success: function() {
-          rs.set('pinned_version_id', null);
-          window.app.apiNotice.setSuccess("Resource unpinned");
-        },
-      });
-    } else {
-      rs.pinVersion(versionID, {
-        headers: { 'Authorization': 'Bearer ' + session.get('jwt') },
-        success: function() {
-          rs.set('pinned_version_id', versionID);
-          window.app.apiNotice.setSuccess("Resource pinned to version #" + versionID);
-        },
-      });
-    }
+    var $btn = $(event.currentTarget);
+    $btn.attr('data-loading-text', isPinned ? 'Unpinning...' : 'Pinning...');
+    withLoading($btn, function() {
+      if (isPinned) {
+        return rs.unpinVersion({
+          headers: { 'Authorization': 'Bearer ' + session.get('jwt') },
+          success: function() {
+            rs.set('pinned_version_id', null);
+            window.app.apiNotice.setSuccess("Resource unpinned");
+          },
+        });
+      } else {
+        return rs.pinVersion(versionID, {
+          headers: { 'Authorization': 'Bearer ' + session.get('jwt') },
+          success: function() {
+            rs.set('pinned_version_id', versionID);
+            window.app.apiNotice.setSuccess("Resource pinned to version #" + versionID);
+          },
+        });
+      }
+    });
   },
 });

--- a/pikoci/transport/http/assets/js/app/views/session.js
+++ b/pikoci/transport/http/assets/js/app/views/session.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import { session, userSessionKey } from '../collections.js';
+import { withLoading } from '../namespace.js';
 
 export var SessionNewView = Backbone.View.extend({
   template: _.template($('#session-new-view').html()),
@@ -17,18 +18,20 @@ export var SessionNewView = Backbone.View.extend({
     var username = this.$el.find("#username").get(0).value;
     var password = this.$el.find("#password").get(0).value;
 
-    session.save({username: username, password: password}, {
-      success: function(resp) {
-        session.unset("password");
-        session.unset("username");
-        window.localStorage.setItem(userSessionKey, JSON.stringify(session.toJSON()));
-        var u = session.get("user");
-        if (u && u.must_change_password) {
-          window.app.router.navigate('profile', { trigger: true });
-        } else {
-          window.app.router.navigate('', { trigger: true });
-        }
-      },
+    withLoading(this.$('#login'), function() {
+      return session.save({username: username, password: password}, {
+        success: function(resp) {
+          session.unset("password");
+          session.unset("username");
+          window.localStorage.setItem(userSessionKey, JSON.stringify(session.toJSON()));
+          var u = session.get("user");
+          if (u && u.must_change_password) {
+            window.app.router.navigate('profile', { trigger: true });
+          } else {
+            window.app.router.navigate('', { trigger: true });
+          }
+        },
+      });
     });
   },
 });

--- a/pikoci/transport/http/assets/js/app/views/teams.js
+++ b/pikoci/transport/http/assets/js/app/views/teams.js
@@ -180,18 +180,23 @@ var TeamNewMemberRowView = Backbone.View.extend({
     var username = this.$el.find("#username").get(0).value;
     var admin = this.$el.find("#admin").get(0).checked;
     var that = this;
-    withLoading(this.$('#create'), function() {
-      var member = new Backbone.Model({admin: admin, user: {username: username}});
-      member.url = that.members.url();
-      return member.save(null, {
-        type: "POST",
-        wait: true,
-        success: function(m) {
-          that.members.add(m, {team: that.members.team});
-          window.app.apiNotice.setSuccess("Member added");
-          Backbone.View.prototype.remove.call(that);
-        },
-      });
+    var $btn = this.$('#create');
+    var originalHTML = $btn.html();
+    var loadingText = $btn.attr('data-loading-text') || 'Loading...';
+    $btn.html(loadingText + ' <span class="spinner-border spinner-border-sm" role="status"></span>');
+    $btn.prop('disabled', true).addClass('piko-btn-loading');
+    this.members.create({admin: admin, user: {
+      username: username,
+    }}, {url: this.members.url(), method: "POST",
+      wait: true,
+      success: function(){
+        window.app.apiNotice.setSuccess("Member added");
+        Backbone.View.prototype.remove.call(that);
+      },
+      error: function() {
+        $btn.html(originalHTML);
+        $btn.prop('disabled', false).removeClass('piko-btn-loading');
+      },
     });
   },
 });

--- a/pikoci/transport/http/assets/js/app/views/teams.js
+++ b/pikoci/transport/http/assets/js/app/views/teams.js
@@ -2,7 +2,7 @@
 
 import { session, teams, Users } from '../collections.js';
 import { Team } from '../models.js';
-import { addSessionFunctions } from '../namespace.js';
+import { addSessionFunctions, withLoading } from '../namespace.js';
 
 export var TeamsView = Backbone.View.extend({
   template: _.template($('#teams-view').html()),
@@ -57,8 +57,10 @@ var TeamRowView = Backbone.View.extend({
   clickDelete: function(event) {
     event.preventDefault();
     event.stopPropagation();
-
-    this.model.destroy({success: function() { window.app.apiNotice.setSuccess("Team deleted"); }});
+    var that = this;
+    withLoading(this.$('#delete'), function() {
+      return that.model.destroy({success: function() { window.app.apiNotice.setSuccess("Team deleted"); }});
+    });
   },
 });
 
@@ -128,10 +130,13 @@ export var TeamShowView = Backbone.View.extend({
   clickUpdate: function(event){
     event.preventDefault();
     var name = this.$el.find("#name").get(0).value;
-    this.model.save({name: name}, {
-      success: function(m) {
-        window.app.router.navigate('teams/'+m.get("canonical"), { trigger: true });
-      },
+    var that = this;
+    withLoading(this.$('button[type="submit"]'), function() {
+      return that.model.save({name: name}, {
+        success: function(m) {
+          window.app.router.navigate('teams/'+m.get("canonical"), { trigger: true });
+        },
+      });
     });
   },
   clickNewMember: function(event){
@@ -175,14 +180,18 @@ var TeamNewMemberRowView = Backbone.View.extend({
     var username = this.$el.find("#username").get(0).value;
     var admin = this.$el.find("#admin").get(0).checked;
     var that = this;
-    this.members.create({admin: admin, user: {
-      username: username,
-    }}, {url: this.members.url(), method: "POST",
-      wait: true,
-      success: function(){
-        window.app.apiNotice.setSuccess("Member added");
-        Backbone.View.prototype.remove.call(that);
-      },
+    withLoading(this.$('#create'), function() {
+      var member = new Backbone.Model({admin: admin, user: {username: username}});
+      member.url = that.members.url();
+      return member.save(null, {
+        type: "POST",
+        wait: true,
+        success: function(m) {
+          that.members.add(m, {team: that.members.team});
+          window.app.apiNotice.setSuccess("Member added");
+          Backbone.View.prototype.remove.call(that);
+        },
+      });
     });
   },
 });
@@ -211,6 +220,9 @@ var TeamShowMemberRowView = Backbone.View.extend({
   },
   deleteMember: function(event) {
     event.preventDefault();
-    this.model.destroy({success: function() { window.app.apiNotice.setSuccess("Member removed"); }});
+    var that = this;
+    withLoading(this.$('#delete'), function() {
+      return that.model.destroy({success: function() { window.app.apiNotice.setSuccess("Member removed"); }});
+    });
   },
 });

--- a/pikoci/transport/http/assets/js/app/views/users.js
+++ b/pikoci/transport/http/assets/js/app/views/users.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import { session, userSessionKey } from '../collections.js';
+import { withLoading } from '../namespace.js';
 
 export var UsersListView = Backbone.View.extend({
   template: _.template($('#users-list-view').html()),
@@ -68,26 +69,28 @@ export var UserShowView = Backbone.View.extend({
     var originalUsername = this.model.get("username");
     var that = this;
 
-    $.ajax({
-      url: '/users/' + originalUsername + '',
-      type: 'PUT',
-      headers: {
-        'Authorization': 'Bearer ' + session.get("jwt"),
-        'Content-Type': 'application/json',
-      },
-      data: JSON.stringify({full_name: fullName, username: username, admin: admin}),
-      success: function(resp) {
-        if (resp.error) {
-          window.app.apiNotice.set({error: resp.error});
-          return;
-        }
-        if (username !== originalUsername) {
-          window.app.router.navigate('users/' + username, { trigger: true });
-        } else {
-          that.model.set(resp.data);
-          that.render();
-        }
-      },
+    withLoading(this.$('#user-form button[type="submit"]'), function() {
+      return $.ajax({
+        url: '/users/' + originalUsername + '',
+        type: 'PUT',
+        headers: {
+          'Authorization': 'Bearer ' + session.get("jwt"),
+          'Content-Type': 'application/json',
+        },
+        data: JSON.stringify({full_name: fullName, username: username, admin: admin}),
+        success: function(resp) {
+          if (resp.error) {
+            window.app.apiNotice.set({error: resp.error});
+            return;
+          }
+          if (username !== originalUsername) {
+            window.app.router.navigate('users/' + username, { trigger: true });
+          } else {
+            that.model.set(resp.data);
+            that.render();
+          }
+        },
+      });
     });
   },
   resetPassword: function(event) {
@@ -95,22 +98,25 @@ export var UserShowView = Backbone.View.extend({
     var newPassword = this.$('#new_password').val();
     if (!newPassword) return;
     var username = this.model.get("username");
+    var admin = this.model.get("admin");
 
-    $.ajax({
-      url: '/users/' + username + '',
-      type: 'PUT',
-      headers: {
-        'Authorization': 'Bearer ' + session.get("jwt"),
-        'Content-Type': 'application/json',
-      },
-      data: JSON.stringify({password: newPassword, admin: this.model.get("admin")}),
-      success: function(resp) {
-        if (resp.error) {
-          window.app.apiNotice.set({error: resp.error});
-          return;
-        }
-        window.app.apiNotice.setSuccess("Password reset successfully");
-      },
+    withLoading(this.$('#reset-password-form button[type="submit"]'), function() {
+      return $.ajax({
+        url: '/users/' + username + '',
+        type: 'PUT',
+        headers: {
+          'Authorization': 'Bearer ' + session.get("jwt"),
+          'Content-Type': 'application/json',
+        },
+        data: JSON.stringify({password: newPassword, admin: admin}),
+        success: function(resp) {
+          if (resp.error) {
+            window.app.apiNotice.set({error: resp.error});
+            return;
+          }
+          window.app.apiNotice.setSuccess("Password reset successfully");
+        },
+      });
     });
   },
   deleteUser: function(event) {
@@ -118,20 +124,22 @@ export var UserShowView = Backbone.View.extend({
     var username = this.model.get("username");
     if (!confirm("Are you sure you want to delete user '" + username + "'?")) return;
 
-    $.ajax({
-      url: '/users/' + username + '',
-      type: 'DELETE',
-      headers: {
-        'Authorization': 'Bearer ' + session.get("jwt"),
-        'Content-Type': 'application/json',
-      },
-      success: function(resp) {
-        if (resp.error) {
-          window.app.apiNotice.set({error: resp.error});
-          return;
-        }
-        window.app.router.navigate('users', { trigger: true });
-      },
+    withLoading(this.$('#delete-user'), function() {
+      return $.ajax({
+        url: '/users/' + username + '',
+        type: 'DELETE',
+        headers: {
+          'Authorization': 'Bearer ' + session.get("jwt"),
+          'Content-Type': 'application/json',
+        },
+        success: function(resp) {
+          if (resp.error) {
+            window.app.apiNotice.set({error: resp.error});
+            return;
+          }
+          window.app.router.navigate('users', { trigger: true });
+        },
+      });
     });
   },
 });
@@ -152,21 +160,23 @@ export var UsersNewView = Backbone.View.extend({
     var password = this.$('#password').val();
     var admin = this.$('#admin').is(':checked');
 
-    $.ajax({
-      url: '/users',
-      type: 'POST',
-      headers: {
-        'Authorization': 'Bearer ' + session.get("jwt"),
-        'Content-Type': 'application/json',
-      },
-      data: JSON.stringify({username: username, password: password, full_name: fullName, admin: admin}),
-      success: function(resp) {
-        if (resp.error) {
-          window.app.apiNotice.set({error: resp.error});
-          return;
-        }
-        window.app.router.navigate('users/' + username, { trigger: true });
-      },
+    withLoading(this.$('button[type="submit"]'), function() {
+      return $.ajax({
+        url: '/users',
+        type: 'POST',
+        headers: {
+          'Authorization': 'Bearer ' + session.get("jwt"),
+          'Content-Type': 'application/json',
+        },
+        data: JSON.stringify({username: username, password: password, full_name: fullName, admin: admin}),
+        success: function(resp) {
+          if (resp.error) {
+            window.app.apiNotice.set({error: resp.error});
+            return;
+          }
+          window.app.router.navigate('users/' + username, { trigger: true });
+        },
+      });
     });
   },
 });
@@ -194,35 +204,37 @@ export var ProfileView = Backbone.View.extend({
     var fullName = this.$('#full_name').val();
     var username = this.$('#username').val();
 
-    $.ajax({
-      url: '/profile',
-      type: 'PUT',
-      headers: {
-        'Authorization': 'Bearer ' + session.get("jwt"),
-        'Content-Type': 'application/json',
-      },
-      data: JSON.stringify({full_name: fullName, username: username}),
-      success: function(resp) {
-        if (resp.error) {
-          window.app.apiNotice.set({error: resp.error});
-          return;
-        }
-        $.ajax({
-          url: '/refresh-token',
-          type: 'POST',
-          headers: {
-            'Authorization': 'Bearer ' + session.get("jwt"),
-            'Content-Type': 'application/json',
-          },
-          success: function(refreshResp) {
-            if (refreshResp.data && refreshResp.data.jwt) {
-              session.set({jwt: refreshResp.data.jwt, user: refreshResp.data.user});
-              window.localStorage.setItem(userSessionKey, JSON.stringify(session.toJSON()));
-            }
-          },
-        });
-        window.app.apiNotice.setSuccess("Profile updated successfully");
-      },
+    withLoading(this.$('#profile-form button[type="submit"]'), function() {
+      return $.ajax({
+        url: '/profile',
+        type: 'PUT',
+        headers: {
+          'Authorization': 'Bearer ' + session.get("jwt"),
+          'Content-Type': 'application/json',
+        },
+        data: JSON.stringify({full_name: fullName, username: username}),
+        success: function(resp) {
+          if (resp.error) {
+            window.app.apiNotice.set({error: resp.error});
+            return;
+          }
+          $.ajax({
+            url: '/refresh-token',
+            type: 'POST',
+            headers: {
+              'Authorization': 'Bearer ' + session.get("jwt"),
+              'Content-Type': 'application/json',
+            },
+            success: function(refreshResp) {
+              if (refreshResp.data && refreshResp.data.jwt) {
+                session.set({jwt: refreshResp.data.jwt, user: refreshResp.data.user});
+                window.localStorage.setItem(userSessionKey, JSON.stringify(session.toJSON()));
+              }
+            },
+          });
+          window.app.apiNotice.setSuccess("Profile updated successfully");
+        },
+      });
     });
   },
   changePassword: function(event) {
@@ -237,37 +249,39 @@ export var ProfileView = Backbone.View.extend({
     }
 
     var that = this;
-    $.ajax({
-      url: '/users/change-password',
-      type: 'POST',
-      headers: {
-        'Authorization': 'Bearer ' + session.get("jwt"),
-        'Content-Type': 'application/json',
-      },
-      data: JSON.stringify({old_password: currentPassword, new_password: newPassword}),
-      success: function(resp) {
-        if (resp.error) {
-          window.app.apiNotice.set({error: resp.error});
-          return;
-        }
-        var wasForcedChange = that.mustChangePassword;
-        that.mustChangePassword = false;
-        that.$('#must-change-password-banner').remove();
-        var u = session.get("user");
-        if (u) {
-          u.must_change_password = false;
-          session.set({user: u});
-          window.localStorage.setItem(userSessionKey, JSON.stringify(session.toJSON()));
-        }
-        window.app.apiNotice.setSuccess("Password changed successfully");
-        if (wasForcedChange) {
-          window.app.router.navigate('', { trigger: true });
-        }
-      },
-      error: function(response) {
-        var msg = (response.responseJSON && response.responseJSON.error) || response.statusText || "Unknown error";
-        window.app.apiNotice.set({error: msg});
-      },
+    withLoading(this.$('#change-password-form button[type="submit"]'), function() {
+      return $.ajax({
+        url: '/users/change-password',
+        type: 'POST',
+        headers: {
+          'Authorization': 'Bearer ' + session.get("jwt"),
+          'Content-Type': 'application/json',
+        },
+        data: JSON.stringify({old_password: currentPassword, new_password: newPassword}),
+        success: function(resp) {
+          if (resp.error) {
+            window.app.apiNotice.set({error: resp.error});
+            return;
+          }
+          var wasForcedChange = that.mustChangePassword;
+          that.mustChangePassword = false;
+          that.$('#must-change-password-banner').remove();
+          var u = session.get("user");
+          if (u) {
+            u.must_change_password = false;
+            session.set({user: u});
+            window.localStorage.setItem(userSessionKey, JSON.stringify(session.toJSON()));
+          }
+          window.app.apiNotice.setSuccess("Password changed successfully");
+          if (wasForcedChange) {
+            window.app.router.navigate('', { trigger: true });
+          }
+        },
+        error: function(response) {
+          var msg = (response.responseJSON && response.responseJSON.error) || response.statusText || "Unknown error";
+          window.app.apiNotice.set({error: msg});
+        },
+      });
     });
   },
 });

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -97,7 +97,7 @@
               <label for="password" class="form-label">Password</label>
               <input type="password" class="form-control" id="password" placeholder="Enter password">
             </div>
-            <button type="submit" id="login" class="btn btn-primary w-100">Log In</button>
+            <button type="submit" id="login" class="btn btn-primary w-100" data-loading-text="Logging in...">Log In</button>
           </form>
         </div>
       </div>
@@ -133,7 +133,7 @@
         <a id="pipelines" href="/teams/<%- canonical %>/pipelines" type="button" class="btn btn-primary"><i class="bi bi-diagram-2"></i> Pipelines</a>
         <a id="manage" href="/teams/<%- canonical %>" type="button" class="btn btn-info"><i class="bi bi-gear"></i> Manage</a>
         <% if (isAdmin(canonical)) { %>
-          <button id="delete" type="button" class="btn btn-danger"><i class="bi bi-trash"></i> Delete</button>
+          <button id="delete" type="button" class="btn btn-danger" data-loading-text="Deleting..."><i class="bi bi-trash"></i> Delete</button>
         <% } %>
       </div>
     </script>
@@ -153,7 +153,7 @@
           >
         </div>
         <% if (isAdmin(canonical)) { %>
-          <button type="submit" class="btn btn-primary">Update</button>
+          <button type="submit" class="btn btn-primary" data-loading-text="Saving...">Update</button>
         <% } %>
       </form>
       <hr style="border-color: var(--border); margin: 1.5rem 0;">
@@ -191,7 +191,7 @@
       </td>
       <td>
 				<div class="btn-group" role="group">
-					<button id="create" type="button" class="btn btn-success">Create</button>
+					<button id="create" type="button" class="btn btn-success" data-loading-text="Adding...">Create</button>
 				</div>
       </td>
     </script>
@@ -214,7 +214,7 @@
       <td>
 				<div class="btn-group" role="group">
           <% if (isAdmin(team.canonical)) { %>
-					  <button id="delete" type="button" class="btn btn-danger"><i class="bi bi-trash"></i> Delete</button>
+					  <button id="delete" type="button" class="btn btn-danger" data-loading-text="Removing..."><i class="bi bi-trash"></i> Delete</button>
           <% } %>
 				</div>
       </td>
@@ -264,14 +264,14 @@
         <div class="d-flex gap-2">
           <% if (isMember(team.canonical) && pipeline.jobs && pipeline.jobs.length > 0) { %>
             <% if (pipeline.jobs.some(function(j) { return j.paused; })) { %>
-              <button type="button" id="unpause-pipeline" class="btn btn-primary"><i class="bi bi-play-circle"></i> Unpause</button>
+              <button type="button" id="unpause-pipeline" class="btn btn-primary" data-loading-text="Unpausing..."><i class="bi bi-play-circle"></i> Unpause</button>
             <% } else { %>
-              <button type="button" id="pause-pipeline" class="btn btn-primary"><i class="bi bi-pause-circle"></i> Pause</button>
+              <button type="button" id="pause-pipeline" class="btn btn-primary" data-loading-text="Pausing..."><i class="bi bi-pause-circle"></i> Pause</button>
             <% } %>
           <% } %>
           <% if (isAdmin(team.canonical)) { %>
             <button type="button" id="edit-pipeline" class="btn btn-info"><i class="bi bi-pencil"></i> Edit</button>
-            <button type="button" id="delete-pipeline" class="btn btn-danger"><i class="bi bi-trash"></i> Delete</button>
+            <button type="button" id="delete-pipeline" class="btn btn-danger" data-loading-text="Deleting..."><i class="bi bi-trash"></i> Delete</button>
           <% } %>
         </div>
       </div>
@@ -402,10 +402,10 @@
         <div class="d-flex gap-2">
           <% if (isMember(team.canonical)) { %>
             <% if (job.paused) { %>
-              <button type="button" id="unpause-job" class="btn btn-primary"><i class="bi bi-play-circle"></i> Unpause Job</button>
+              <button type="button" id="unpause-job" class="btn btn-primary" data-loading-text="Unpausing..."><i class="bi bi-play-circle"></i> Unpause Job</button>
             <% } else { %>
-              <button type="button" id="trigger-job" class="btn btn-warning"><i class="bi bi-play-circle"></i> Trigger Job</button>
-              <button type="button" id="pause-job" class="btn btn-primary"><i class="bi bi-pause-circle"></i> Pause Job</button>
+              <button type="button" id="trigger-job" class="btn btn-warning" data-loading-text="Triggering..."><i class="bi bi-play-circle"></i> Trigger Job</button>
+              <button type="button" id="pause-job" class="btn btn-primary" data-loading-text="Pausing..."><i class="bi bi-pause-circle"></i> Pause Job</button>
             <% } %>
           <% } %>
         </div>
@@ -491,13 +491,13 @@
               </button>
               <% } %>
               <% if (!app.session.isEmpty()) { %>
-              <button type="button" class="btn btn-sm btn-outline-danger piko-cancel-build" data-build-number="<%- build_number %>">
+              <button type="button" class="btn btn-sm btn-outline-danger piko-cancel-build" data-build-number="<%- build_number %>" data-loading-text="Cancelling...">
                 <i class="bi bi-x-circle"></i> Cancel
               </button>
               <% } %>
             </span>
           <% } else if (!app.session.isEmpty()) { %>
-            <button type="button" class="btn btn-sm btn-outline-warning piko-retry-build" style="margin-left:auto;">
+            <button type="button" class="btn btn-sm btn-outline-warning piko-retry-build" style="margin-left:auto;" data-loading-text="Retrying...">
               <i class="bi bi-arrow-clockwise"></i> Retry
             </button>
           <% } %>
@@ -585,7 +585,7 @@
         <h1 class="h4 fw-bold mb-0"><%- resource.canonical %></h1>
         <% if (isMember(team.canonical)) { %>
           <div class="btn-group">
-            <button type="button" id="trigger-resource" class="btn btn-warning"><i class="bi bi-play-circle"></i> Trigger Resource</button>
+            <button type="button" id="trigger-resource" class="btn btn-warning" data-loading-text="Triggering..."><i class="bi bi-play-circle"></i> Trigger Resource</button>
             <% if (isAdmin(team.canonical)) { %>
               <button type="button" class="btn btn-warning dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown">
                 <span class="visually-hidden">Toggle Dropdown</span>
@@ -605,7 +605,7 @@
         </div>
         <div class="mt-2 d-flex justify-content-between align-items-center">
           <small class="text-muted">Regenerating invalidates the current URL</small>
-          <button id="regenerate-webhook" class="btn btn-sm btn-outline-danger"><i class="bi bi-arrow-clockwise"></i> Regenerate Token</button>
+          <button id="regenerate-webhook" class="btn btn-sm btn-outline-danger" data-loading-text="Regenerating..."><i class="bi bi-arrow-clockwise"></i> Regenerate Token</button>
         </div>
       </div>
       <div class="piko-resource-info">
@@ -634,7 +634,7 @@
           </span>
           <% if (isMember) { %>
             <span class="piko-version-actions">
-              <button class="btn btn-sm btn-outline-warning trigger-version" title="Trigger downstream jobs with this version"><i class="bi bi-play-fill"></i></button>
+              <button class="btn btn-sm btn-outline-warning trigger-version" title="Trigger downstream jobs with this version" data-loading-text="Triggering..."><i class="bi bi-play-fill"></i></button>
               <button class="btn btn-sm <%= pinned_version_id === id ? 'btn-warning' : 'btn-outline-secondary' %> pin-version" title="<%= pinned_version_id === id ? 'Unpin version' : 'Pin to this version' %>"><i class="bi <%= pinned_version_id === id ? 'bi-pin-fill' : 'bi-pin' %>"></i></button>
             </span>
           <% } %>
@@ -691,7 +691,7 @@
           <input type="checkbox" class="form-check-input" id="admin" <% if (admin) { %>checked<% } %>>
           <label class="form-check-label" for="admin">Admin</label>
         </div>
-        <button type="submit" class="btn btn-primary">Save Changes</button>
+        <button type="submit" class="btn btn-primary" data-loading-text="Saving...">Save Changes</button>
       </form>
       <hr style="border-color: var(--border); margin: 1.5rem 0;">
       <h3 class="h5 fw-bold mb-3">Reset Password</h3>
@@ -700,10 +700,10 @@
           <label for="new_password" class="form-label">New Password</label>
           <input type="password" class="form-control" id="new_password" placeholder="Enter new password">
         </div>
-        <button type="submit" class="btn btn-warning">Reset Password</button>
+        <button type="submit" class="btn btn-warning" data-loading-text="Resetting...">Reset Password</button>
       </form>
       <hr style="border-color: var(--border); margin: 1.5rem 0;">
-      <button type="button" id="delete-user" class="btn btn-danger"><i class="bi bi-trash"></i> Delete User</button>
+      <button type="button" id="delete-user" class="btn btn-danger" data-loading-text="Deleting..."><i class="bi bi-trash"></i> Delete User</button>
     </script>
 
     <script type="text/template" id="users-new-view">
@@ -727,7 +727,7 @@
           <input type="checkbox" class="form-check-input" id="admin">
           <label class="form-check-label" for="admin">Admin</label>
         </div>
-        <button type="submit" class="btn btn-primary">Create User</button>
+        <button type="submit" class="btn btn-primary" data-loading-text="Creating...">Create User</button>
       </form>
     </script>
 
@@ -749,7 +749,7 @@
           <label for="username" class="form-label">Username</label>
           <input type="text" class="form-control" id="username" value="<%- currentUsername %>">
         </div>
-        <button type="submit" class="btn btn-primary">Save Changes</button>
+        <button type="submit" class="btn btn-primary" data-loading-text="Saving...">Save Changes</button>
       </form>
       <hr style="border-color: var(--border); margin: 1.5rem 0;">
       <h3 class="h5 fw-bold mb-3">Change Password</h3>
@@ -766,7 +766,7 @@
           <label for="confirm_password" class="form-label">Confirm New Password</label>
           <input type="password" class="form-control" id="confirm_password" placeholder="Confirm new password">
         </div>
-        <button type="submit" class="btn btn-warning">Change Password</button>
+        <button type="submit" class="btn btn-warning" data-loading-text="Changing...">Change Password</button>
       </form>
     </script>
 


### PR DESCRIPTION
## Summary

- Add a shared `withLoading(btn, ajaxFn)` helper in `namespace.js` that replaces button content with loading text + Bootstrap spinner, disables the button, and restores it on completion
- Wrap all 24 action buttons across the UI: login, trigger/pause/unpause job, cancel/retry build, delete/pause/unpause pipeline, trigger resource, regenerate webhook, trigger/pin/unpin version, team CRUD, user CRUD, profile save, and change password
- Add `.piko-btn-loading` CSS class for visual disabled state (reduced opacity, `pointer-events: none`)
- Fix 4 model methods (`Job.fetchTrigger`, `Resource.fetchTrigger`, `Resource.pinVersion`, `Resource.unpinVersion`) to return jqXHR so the helper can attach `.always()`
- Refactor `members.create()` to use `Backbone.Model.save()` which returns jqXHR

Closes #453