### PR TITLE
Export step metadata as env vars for subsequent steps (#459)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Step metadata export: get steps auto-forward version metadata to subsequent steps as `GET_<STEPNAME>_<KEY>` env vars, and task steps can write `KEY=VALUE` lines to `$PIKOCI_OUTPUT` to export custom values as `TASK_<STEPNAME>_<KEY>` env vars ([#459](https://github.com/PikoCI/pikoci/issues/459))
 - Loading indicators on action buttons: all mutating buttons (trigger, cancel, retry, delete, pause, unpause, pin, etc.) now show a spinner and loading text while the request is in flight, preventing double-clicks and providing visual feedback ([#453](https://github.com/PikoCI/pikoci/issues/453))
 - Built-in `shell` runner for simplified shell command execution. Supports inline `cmd` mode (`run "shell" { cmd = "..." }`) and script `file` mode (`run "shell" { file = "script.sh" }`), with optional `shell` param to override the default `/bin/sh` ([#458](https://github.com/PikoCI/pikoci/issues/458))
 

--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -331,6 +331,22 @@ After a get step succeeds, its version metadata is automatically forwarded to al
 
 For example, a `get "git" "my-repo"` step that fetches version `{ref: "abc123"}` will export `GET_MY_REPO_REF=abc123` to all subsequent steps.
 
+Nested version objects are recursively flattened with `_` separators. For example, a version like:
+
+```json
+{"ref": "abc123", "metadata": {"sha": "def456", "author": "alice"}}
+```
+
+produces the following environment variables for the pull command and subsequent steps:
+
+| Version key | Pull env var | Exported env var |
+|---|---|---|
+| `ref` | `version_ref=abc123` | `GET_MY_REPO_REF=abc123` |
+| `metadata.sha` | `version_metadata_sha=def456` | `GET_MY_REPO_METADATA_SHA=def456` |
+| `metadata.author` | `version_metadata_author=alice` | `GET_MY_REPO_METADATA_AUTHOR=alice` |
+
+Arrays are flattened with numeric indices (e.g. `tags: ["v1", "v2"]` → `version_tags_0=v1`, `version_tags_1=v2`). Numbers and booleans are converted to their string representation.
+
 ### task
 
 Runs a command via a runner.

--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -325,6 +325,12 @@ get "git" "my_repo" {
 | `attempts` | no       | Maximum number of times to try the step (default `1`, no retry) |
 | `secrets`  | no       | Map of secret_type name to path (e.g. `{"vault" = "secret/data/db"}`) |
 
+#### Exported version metadata
+
+After a get step succeeds, its version metadata is automatically forwarded to all subsequent steps as environment variables. The naming convention is `GET_<STEPNAME>_<KEY>`, where the step name is uppercased with non-alphanumeric characters replaced by `_`, and the `version_` prefix is stripped from the key.
+
+For example, a `get "git" "my-repo"` step that fetches version `{ref: "abc123"}` will export `GET_MY_REPO_REF=abc123` to all subsequent steps.
+
 ### task
 
 Runs a command via a runner.
@@ -361,6 +367,38 @@ task "build" {
 ```
 
 Paths are checked with `os.Stat` relative to `$WORKDIR` and work for both files and directories. If an input is missing, the task fails immediately with a clear error. If an output is missing after the task finishes, the build fails with a descriptive message.
+
+#### Exporting values with `$PIKOCI_OUTPUT`
+
+Task steps can export key-value pairs to subsequent steps by writing `KEY=VALUE` lines to the file pointed to by the `$PIKOCI_OUTPUT` environment variable. After the task succeeds, the worker parses this file and makes the values available to all subsequent steps as `TASK_<STEPNAME>_<KEY>` environment variables.
+
+```hcl
+task "build" {
+  run "exec" {
+    path = "bash"
+    args = ["-c", "echo VERSION=1.2.3 >> $PIKOCI_OUTPUT"]
+  }
+}
+
+task "deploy" {
+  run "exec" {
+    path = "bash"
+    args = ["-c", "echo Deploying version $TASK_BUILD_VERSION"]
+  }
+}
+```
+
+Rules for the output file:
+- One `KEY=VALUE` per line (split on first `=`, values can contain `=`)
+- Lines starting with `#` are treated as comments and skipped
+- Empty lines are skipped
+- Keys are uppercased with non-alphanumeric characters replaced by `_`
+- Maximum file size is 1MB
+- If the task fails, its output is not parsed
+
+#### Naming convention
+
+Step names are sanitized for use in environment variable names: uppercased with all non-alphanumeric characters replaced by `_`. For example, `my-repo` becomes `MY_REPO` and `build.app` becomes `BUILD_APP`. Note that different step names may map to the same prefix (e.g. `my-repo` and `my.repo` both become `MY_REPO`); in that case, the last writer wins.
 
 ### put
 

--- a/worker/service.go
+++ b/worker/service.go
@@ -1642,7 +1642,7 @@ func (w *Worker) processResourceCheck(ctx context.Context, m queue.Body, cwd str
 	}
 	if len(dbvers) != 0 {
 		for k, v := range dbvers[0].Version {
-			params["version_"+k] = fmt.Sprintf("%s", v)
+			flattenVersionValue(params, "version_"+k, v)
 		}
 	}
 	for k, v := range r.GetParams() {

--- a/worker/service.go
+++ b/worker/service.go
@@ -1489,7 +1489,7 @@ func (w *Worker) buildPullParams(ctx context.Context, m queue.Body, b *build.Bui
 			if ver.ID == versionID {
 				found = true
 				for k, v := range ver.Version {
-					params["version_"+k] = versionValueToString(v)
+					flattenVersionValue(params, "version_"+k, v)
 				}
 				break
 			}
@@ -1506,7 +1506,7 @@ func (w *Worker) buildPullParams(ctx context.Context, m queue.Body, b *build.Bui
 		slices.Reverse(dbvers)
 		versionID = dbvers[0].ID
 		for k, v := range dbvers[0].Version {
-			params["version_"+k] = versionValueToString(v)
+			flattenVersionValue(params, "version_"+k, v)
 		}
 	}
 
@@ -2272,28 +2272,34 @@ func buildMetadataParams(b *build.Build, m queue.Body) map[string]string {
 	}
 }
 
-// versionValueToString converts a version metadata value to a string suitable
-// for use as an environment variable. Strings are returned as-is; nested
-// objects/arrays are JSON-encoded so the value is always a flat string.
-func versionValueToString(v interface{}) string {
+// flattenVersionValue flattens a version metadata value into params with the
+// given key prefix. Nested maps are recursively flattened with "_" separators
+// (e.g. prefix "version_metadata" + {"sha": "abc"} → "version_metadata_sha" = "abc").
+// Scalar values are converted to strings directly.
+func flattenVersionValue(params map[string]string, prefix string, v interface{}) {
 	switch val := v.(type) {
+	case map[string]interface{}:
+		for k, nested := range val {
+			flattenVersionValue(params, prefix+"_"+k, nested)
+		}
+	case []interface{}:
+		for i, item := range val {
+			flattenVersionValue(params, fmt.Sprintf("%s_%d", prefix, i), item)
+		}
 	case string:
-		return val
+		params[prefix] = val
 	case float64:
 		if val == float64(int64(val)) {
-			return fmt.Sprintf("%d", int64(val))
+			params[prefix] = fmt.Sprintf("%d", int64(val))
+		} else {
+			params[prefix] = fmt.Sprintf("%g", val)
 		}
-		return fmt.Sprintf("%g", val)
 	case bool:
-		return fmt.Sprintf("%t", val)
+		params[prefix] = fmt.Sprintf("%t", val)
 	case nil:
-		return ""
+		params[prefix] = ""
 	default:
-		b, err := json.Marshal(val)
-		if err != nil {
-			return fmt.Sprintf("%v", val)
-		}
-		return string(b)
+		params[prefix] = fmt.Sprintf("%v", val)
 	}
 }
 

--- a/worker/service.go
+++ b/worker/service.go
@@ -633,6 +633,10 @@ func (w *Worker) runPlan(ctx context.Context, m queue.Body, b *build.Build, cwd 
 		return true, nil
 	}
 
+	// exportedVars accumulates key-value pairs exported by get and task steps
+	// so that subsequent steps can consume them as environment variables.
+	exportedVars := make(map[string]string)
+
 	// Run plan steps in declaration order
 	for _, ps := range j.Plan {
 		switch ps.Type {
@@ -654,28 +658,28 @@ func (w *Worker) runPlan(ctx context.Context, m queue.Body, b *build.Build, cwd 
 			if ps.Get == nil {
 				continue
 			}
-			if w.runGetStep(ctx, m, b, cwd, pp, *ps.Get, ps, resolvedVersions, resolved) {
+			if w.runGetStep(ctx, m, b, cwd, pp, *ps.Get, ps, resolvedVersions, exportedVars, resolved) {
 				return true, resolved
 			}
 		case job.StepTypeTask:
 			if ps.Task == nil {
 				continue
 			}
-			if w.runTaskStep(ctx, m, b, cwd, pp, *ps.Task, ps, resolved) {
+			if w.runTaskStep(ctx, m, b, cwd, pp, *ps.Task, ps, exportedVars, resolved) {
 				return true, resolved
 			}
 		case job.StepTypePut:
 			if ps.Put == nil {
 				continue
 			}
-			if w.runPutStep(ctx, m, b, cwd, pp, *ps.Put, ps, resolved) {
+			if w.runPutStep(ctx, m, b, cwd, pp, *ps.Put, ps, exportedVars, resolved) {
 				return true, resolved
 			}
 		case job.StepTypeNotify:
 			if ps.Notify == nil {
 				continue
 			}
-			if w.runNotifyStep(ctx, m, b, cwd, pp, *ps.Notify, ps, resolved) {
+			if w.runNotifyStep(ctx, m, b, cwd, pp, *ps.Notify, ps, exportedVars, resolved) {
 				return true, resolved
 			}
 		}
@@ -685,7 +689,7 @@ func (w *Worker) runPlan(ctx context.Context, m queue.Body, b *build.Build, cwd 
 
 // runGetStep runs a single get step (resource pull).
 // Returns true if the step failed.
-func (w *Worker) runGetStep(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, g job.GetStep, ps job.PlanStep, resolvedVersions map[string]uint32, resolved ...map[string]string) bool {
+func (w *Worker) runGetStep(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, g job.GetStep, ps job.PlanStep, resolvedVersions map[string]uint32, exportedVars map[string]string, resolved ...map[string]string) bool {
 	var secretResolved map[string]string
 	if len(resolved) > 0 {
 		secretResolved = resolved[0]
@@ -729,6 +733,9 @@ func (w *Worker) runGetStep(ctx context.Context, m queue.Body, b *build.Build, c
 		rc.Params[k] = v
 	}
 	for k, v := range buildMetadataParams(b, m) {
+		rc.Params[k] = v
+	}
+	for k, v := range exportedVars {
 		rc.Params[k] = v
 	}
 	if rt.Runner != nil {
@@ -822,6 +829,15 @@ func (w *Worker) runGetStep(ctx context.Context, m queue.Body, b *build.Build, c
 			w.logger.Error("failed to insert build get version", "step", g.Name, "error", err)
 		}
 	}
+
+	// Export version_* params as GET_<STEPNAME>_<KEY> for subsequent steps.
+	prefix := "GET_" + sanitizeStepName(g.Name) + "_"
+	for k, v := range params {
+		if strings.HasPrefix(k, "version_") {
+			exportedVars[prefix+strings.ToUpper(strings.TrimPrefix(k, "version_"))] = v
+		}
+	}
+
 	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, g.Name, ps.OnSuccess, "on_success", secretResolved)
 	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, g.Name, ps.Ensure, "ensure", secretResolved)
 	return false
@@ -883,7 +899,7 @@ func (w *Worker) runGetStepLocal(ctx context.Context, m queue.Body, b *build.Bui
 
 // runTaskStep runs a single task step.
 // Returns true if the step failed.
-func (w *Worker) runTaskStep(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, t job.TaskStep, ps job.PlanStep, resolved ...map[string]string) bool {
+func (w *Worker) runTaskStep(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, t job.TaskStep, ps job.PlanStep, exportedVars map[string]string, resolved ...map[string]string) bool {
 	var secretResolved map[string]string
 	if len(resolved) > 0 {
 		secretResolved = resolved[0]
@@ -902,6 +918,19 @@ func (w *Worker) runTaskStep(ctx context.Context, m queue.Body, b *build.Build, 
 
 	for k, v := range buildMetadataParams(b, m) {
 		t.Run.Params[k] = v
+	}
+	for k, v := range exportedVars {
+		t.Run.Params[k] = v
+	}
+
+	// Create the PIKOCI_OUTPUT file inside cwd so Docker-mounted tasks can write to it.
+	if outputFile, oerr := os.CreateTemp(cwd, ".pikoci-output-*"); oerr != nil {
+		w.logger.Error("failed to create PIKOCI_OUTPUT file", "error", oerr)
+	} else {
+		outputPath := outputFile.Name()
+		outputFile.Close()
+		defer os.Remove(outputPath)
+		t.Run.Params["PIKOCI_OUTPUT"] = outputPath
 	}
 
 	for _, input := range t.Inputs {
@@ -987,6 +1016,16 @@ func (w *Worker) runTaskStep(ctx context.Context, m queue.Body, b *build.Build, 
 		}
 	}
 
+	// Parse PIKOCI_OUTPUT and export values for subsequent steps.
+	// Done after output validation so failed steps don't pollute exportedVars.
+	if outputPath, ok := t.Run.Params["PIKOCI_OUTPUT"]; ok {
+		parsed := parseOutputFile(outputPath, w.logger)
+		prefix := "TASK_" + sanitizeStepName(t.Name) + "_"
+		for k, v := range parsed {
+			exportedVars[prefix+k] = v
+		}
+	}
+
 	if err := w.updateBuild(ctx, m, *b); err != nil {
 		return true
 	}
@@ -997,7 +1036,7 @@ func (w *Worker) runTaskStep(ctx context.Context, m queue.Body, b *build.Build, 
 
 // runPutStep runs a single put step (resource push).
 // Returns true if the step failed.
-func (w *Worker) runPutStep(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, p job.PutStep, ps job.PlanStep, resolved ...map[string]string) bool {
+func (w *Worker) runPutStep(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, p job.PutStep, ps job.PlanStep, exportedVars map[string]string, resolved ...map[string]string) bool {
 	if w.LocalMode {
 		rCan := utils.ResourceCanonical(p.Type, p.Name)
 		logMsg := fmt.Sprintf("skipping put step (local execution): %s", rCan)
@@ -1043,6 +1082,9 @@ func (w *Worker) runPutStep(ctx context.Context, m queue.Body, b *build.Build, c
 		params["put_"+k] = v
 	}
 	for k, v := range buildMetadataParams(b, m) {
+		params[k] = v
+	}
+	for k, v := range exportedVars {
 		params[k] = v
 	}
 
@@ -1195,7 +1237,7 @@ func (w *Worker) implicitGetAfterPut(ctx context.Context, m queue.Body, b *build
 
 // runNotifyStep runs a single notify step (fire-and-forget notification).
 // Returns true if the step failed.
-func (w *Worker) runNotifyStep(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, n job.NotifyStep, ps job.PlanStep, resolved ...map[string]string) bool {
+func (w *Worker) runNotifyStep(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, n job.NotifyStep, ps job.PlanStep, exportedVars map[string]string, resolved ...map[string]string) bool {
 	if w.LocalMode {
 		nCan := utils.NotificationCanonical(n.Type, n.Name)
 		logMsg := fmt.Sprintf("skipping notify step (local execution): %s", nCan)
@@ -1250,6 +1292,9 @@ func (w *Worker) runNotifyStep(ctx context.Context, m queue.Body, b *build.Build
 	}
 	// Build metadata
 	for k, v := range buildMetadataParams(b, m) {
+		params[k] = v
+	}
+	for k, v := range exportedVars {
 		params[k] = v
 	}
 
@@ -1408,7 +1453,7 @@ func (w *Worker) runAutoNotifications(ctx context.Context, m queue.Body, b *buil
 				Message: n.Message,
 			},
 		}
-		w.runNotifyStep(ctx, m, b, cwd, pp, *ps.Notify, ps, resolved)
+		w.runNotifyStep(ctx, m, b, cwd, pp, *ps.Notify, ps, nil, resolved)
 	}
 }
 
@@ -1543,7 +1588,7 @@ func (w *Worker) runHooks(ctx context.Context, m queue.Body, b *build.Build, ste
 				Type: job.StepTypePut,
 				Put:  h.Put,
 			}
-			w.runPutStep(ctx, m, b, cwd, pp, *h.Put, ps, resolved)
+			w.runPutStep(ctx, m, b, cwd, pp, *h.Put, ps, nil, resolved)
 			continue
 		case job.StepTypeNotify:
 			if h.Notify == nil {
@@ -1553,7 +1598,7 @@ func (w *Worker) runHooks(ctx context.Context, m queue.Body, b *build.Build, ste
 				Type:   job.StepTypeNotify,
 				Notify: h.Notify,
 			}
-			w.runNotifyStep(ctx, m, b, cwd, pp, *h.Notify, ps, resolved)
+			w.runNotifyStep(ctx, m, b, cwd, pp, *h.Notify, ps, nil, resolved)
 			continue
 		default:
 			continue
@@ -2225,6 +2270,65 @@ func buildMetadataParams(b *build.Build, m queue.Body) map[string]string {
 		"BUILD_PIPELINE_NAME": m.PipelineCanonical,
 		"BUILD_TEAM_NAME":     m.TeamCanonical,
 	}
+}
+
+// sanitizeStepName converts a step name to a safe environment variable prefix
+// by uppercasing it and replacing non-alphanumeric characters with underscores.
+func sanitizeStepName(name string) string {
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range strings.ToUpper(name) {
+		if (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune('_')
+		}
+	}
+	return b.String()
+}
+
+// maxOutputFileSize is the maximum size of the $PIKOCI_OUTPUT file (1MB).
+const maxOutputFileSize = 1 << 20
+
+// parseOutputFile reads a KEY=VALUE file written by a task step and returns
+// the parsed key-value pairs. Keys are uppercased with non-alphanumeric chars
+// replaced by underscores. Empty lines and lines starting with # are skipped.
+// Returns an empty map if the file doesn't exist, is empty, or exceeds maxOutputFileSize.
+func parseOutputFile(path string, logger *slog.Logger) map[string]string {
+	result := make(map[string]string)
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return result
+	}
+	if info.Size() > maxOutputFileSize {
+		logger.Warn("PIKOCI_OUTPUT file exceeds 1MB limit, ignoring", "path", path, "size", info.Size())
+		return result
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		logger.Warn("failed to read PIKOCI_OUTPUT file", "path", path, "error", err)
+		return result
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			logger.Warn("invalid line in PIKOCI_OUTPUT (no '=')", "line", line)
+			continue
+		}
+		key := sanitizeStepName(strings.TrimSpace(k))
+		if key == "" {
+			continue
+		}
+		result[key] = strings.TrimSpace(v)
+	}
+	return result
 }
 
 // serviceParams builds the environment parameters for a service command,

--- a/worker/service.go
+++ b/worker/service.go
@@ -1489,7 +1489,7 @@ func (w *Worker) buildPullParams(ctx context.Context, m queue.Body, b *build.Bui
 			if ver.ID == versionID {
 				found = true
 				for k, v := range ver.Version {
-					params["version_"+k] = fmt.Sprintf("%s", v)
+					params["version_"+k] = versionValueToString(v)
 				}
 				break
 			}
@@ -1506,7 +1506,7 @@ func (w *Worker) buildPullParams(ctx context.Context, m queue.Body, b *build.Bui
 		slices.Reverse(dbvers)
 		versionID = dbvers[0].ID
 		for k, v := range dbvers[0].Version {
-			params["version_"+k] = fmt.Sprintf("%s", v)
+			params["version_"+k] = versionValueToString(v)
 		}
 	}
 
@@ -2269,6 +2269,31 @@ func buildMetadataParams(b *build.Build, m queue.Body) map[string]string {
 		"BUILD_JOB_NAME":      m.JobName,
 		"BUILD_PIPELINE_NAME": m.PipelineCanonical,
 		"BUILD_TEAM_NAME":     m.TeamCanonical,
+	}
+}
+
+// versionValueToString converts a version metadata value to a string suitable
+// for use as an environment variable. Strings are returned as-is; nested
+// objects/arrays are JSON-encoded so the value is always a flat string.
+func versionValueToString(v interface{}) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case float64:
+		if val == float64(int64(val)) {
+			return fmt.Sprintf("%d", int64(val))
+		}
+		return fmt.Sprintf("%g", val)
+	case bool:
+		return fmt.Sprintf("%t", val)
+	case nil:
+		return ""
+	default:
+		b, err := json.Marshal(val)
+		if err != nil {
+			return fmt.Sprintf("%v", val)
+		}
+		return string(b)
 	}
 }
 

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -716,6 +716,70 @@ func TestProcessResourceCheck_NewVersions(t *testing.T) {
 	w.processResourceCheck(ctx, m, cwd, pp)
 }
 
+func TestProcessResourceCheck_NestedVersionFlattened(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		ResourceCanonical: "custom.my-res",
+	}
+	// The check script prints env vars starting with "version_" to stderr,
+	// then outputs an empty JSON array (no new versions). If the nested
+	// version is flattened correctly, the script will see version_metadata_sha
+	// and version_metadata_author instead of a Go-formatted map.
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Resources: []resource.Resource{
+			{ID: 1, Name: "my-res", Type: "custom", Canonical: "custom.my-res"},
+		},
+		ResourceTypes: []restype.ResourceType{
+			{
+				ID: 1, Name: "custom",
+				Check: &utils.RunnerCommand{
+					Runner: "exec",
+					Args: []string{"-ec", `
+# Verify flattened env vars exist
+test "$version_metadata_sha" = "abc123" || { echo "FAIL: version_metadata_sha=$version_metadata_sha" >&2; exit 1; }
+test "$version_metadata_author" = "bob" || { echo "FAIL: version_metadata_author=$version_metadata_author" >&2; exit 1; }
+# Also verify the flat key
+test "$version_ref" = "def456" || { echo "FAIL: version_ref=$version_ref" >&2; exit 1; }
+printf "[]"
+`},
+					Params: map[string]string{"path": "/bin/sh"},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	// Return an existing version with nested metadata
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "custom.my-res", (*uint32)(nil), (*uint32)(nil), uint32(0)).
+		Return([]*resource.Version{
+			{ID: 1, Version: map[string]interface{}{
+				"ref": "def456",
+				"metadata": map[string]interface{}{
+					"sha":    "abc123",
+					"author": "bob",
+				},
+			}},
+		}, false, nil).AnyTimes()
+
+	svc.EXPECT().UpdatePipelineResource(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "custom.my-res", gomock.Any()).
+		Return(nil).AnyTimes()
+
+	// If flattening is broken, the check script will exit 1 and the test
+	// will see an error log. We just need processResourceCheck to not panic.
+	// The script outputs "[]" (no new versions), so no CreateResourceVersion call.
+	w.processResourceCheck(ctx, m, cwd, pp)
+}
+
 func TestProcessResourceCheck_DuplicateVersionSkipped_FirstCheck(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	w, svc, topic := newTestWorker(ctrl)

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -4379,34 +4379,66 @@ func TestRunRunner_ShellFileMode(t *testing.T) {
 	assert.Contains(t, out, "file_works")
 }
 
-func TestVersionValueToString(t *testing.T) {
-	tests := []struct {
-		name string
-		in   interface{}
-		want string
-	}{
-		{"string", "abc", "abc"},
-		{"float64 int", float64(42), "42"},
-		{"float64 decimal", 3.14, "3.14"},
-		{"bool", true, "true"},
-		{"nil", nil, ""},
-		{"nested map", map[string]interface{}{"sha": "abc", "num": float64(1)}, ""},
-		{"slice", []interface{}{"a", "b"}, ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := versionValueToString(tt.in)
-			if tt.name == "nested map" {
-				// JSON encoding, order may vary
-				assert.Contains(t, got, `"sha":"abc"`)
-				assert.Contains(t, got, `"num":1`)
-			} else if tt.name == "slice" {
-				assert.Equal(t, `["a","b"]`, got)
-			} else {
-				assert.Equal(t, tt.want, got)
-			}
+func TestFlattenVersionValue(t *testing.T) {
+	t.Run("string", func(t *testing.T) {
+		m := make(map[string]string)
+		flattenVersionValue(m, "version_ref", "abc")
+		assert.Equal(t, map[string]string{"version_ref": "abc"}, m)
+	})
+
+	t.Run("number int", func(t *testing.T) {
+		m := make(map[string]string)
+		flattenVersionValue(m, "version_count", float64(42))
+		assert.Equal(t, map[string]string{"version_count": "42"}, m)
+	})
+
+	t.Run("number decimal", func(t *testing.T) {
+		m := make(map[string]string)
+		flattenVersionValue(m, "version_score", 3.14)
+		assert.Equal(t, map[string]string{"version_score": "3.14"}, m)
+	})
+
+	t.Run("bool", func(t *testing.T) {
+		m := make(map[string]string)
+		flattenVersionValue(m, "version_ok", true)
+		assert.Equal(t, map[string]string{"version_ok": "true"}, m)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		m := make(map[string]string)
+		flattenVersionValue(m, "version_empty", nil)
+		assert.Equal(t, map[string]string{"version_empty": ""}, m)
+	})
+
+	t.Run("nested map", func(t *testing.T) {
+		m := make(map[string]string)
+		flattenVersionValue(m, "version_metadata", map[string]interface{}{
+			"sha":    "abc123",
+			"author": "bob",
 		})
-	}
+		assert.Equal(t, "abc123", m["version_metadata_sha"])
+		assert.Equal(t, "bob", m["version_metadata_author"])
+		assert.Len(t, m, 2)
+	})
+
+	t.Run("deeply nested", func(t *testing.T) {
+		m := make(map[string]string)
+		flattenVersionValue(m, "version_info", map[string]interface{}{
+			"commit": map[string]interface{}{
+				"sha":    "def456",
+				"author": "alice",
+			},
+		})
+		assert.Equal(t, "def456", m["version_info_commit_sha"])
+		assert.Equal(t, "alice", m["version_info_commit_author"])
+	})
+
+	t.Run("array", func(t *testing.T) {
+		m := make(map[string]string)
+		flattenVersionValue(m, "version_tags", []interface{}{"v1", "v2"})
+		assert.Equal(t, "v1", m["version_tags_0"])
+		assert.Equal(t, "v2", m["version_tags_1"])
+	})
 }
 
 func TestSanitizeStepName(t *testing.T) {

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -4378,3 +4378,412 @@ func TestRunRunner_ShellFileMode(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, out, "file_works")
 }
+
+func TestSanitizeStepName(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"my-repo", "MY_REPO"},
+		{"build.app", "BUILD_APP"},
+		{"a-b.c_d", "A_B_C_D"},
+		{"simple", "SIMPLE"},
+		{"ALREADY_UPPER", "ALREADY_UPPER"},
+		{"has spaces", "HAS_SPACES"},
+		{"123num", "123NUM"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			assert.Equal(t, tt.want, sanitizeStepName(tt.in))
+		})
+	}
+}
+
+func TestParseOutputFile(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	t.Run("missing file", func(t *testing.T) {
+		result := parseOutputFile("/nonexistent/path", logger)
+		assert.Empty(t, result)
+	})
+
+	t.Run("empty file", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "out")
+		require.NoError(t, os.WriteFile(f, []byte(""), 0644))
+		result := parseOutputFile(f, logger)
+		assert.Empty(t, result)
+	})
+
+	t.Run("valid lines", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "out")
+		require.NoError(t, os.WriteFile(f, []byte("VERSION=1.2.3\nCOMMIT=abc"), 0644))
+		result := parseOutputFile(f, logger)
+		assert.Equal(t, map[string]string{"VERSION": "1.2.3", "COMMIT": "abc"}, result)
+	})
+
+	t.Run("equals in value", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "out")
+		require.NoError(t, os.WriteFile(f, []byte("DATA=a=b=c"), 0644))
+		result := parseOutputFile(f, logger)
+		assert.Equal(t, map[string]string{"DATA": "a=b=c"}, result)
+	})
+
+	t.Run("comments and blank lines", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "out")
+		require.NoError(t, os.WriteFile(f, []byte("# comment\n\nKEY=val\n  \n"), 0644))
+		result := parseOutputFile(f, logger)
+		assert.Equal(t, map[string]string{"KEY": "val"}, result)
+	})
+
+	t.Run("whitespace trimming", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "out")
+		require.NoError(t, os.WriteFile(f, []byte("  MY_KEY  =  value  \n"), 0644))
+		result := parseOutputFile(f, logger)
+		assert.Equal(t, map[string]string{"MY_KEY": "value"}, result)
+	})
+
+	t.Run("key sanitization", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "out")
+		require.NoError(t, os.WriteFile(f, []byte("my-key=val\n"), 0644))
+		result := parseOutputFile(f, logger)
+		assert.Equal(t, map[string]string{"MY_KEY": "val"}, result)
+	})
+
+	t.Run("file exceeds size limit", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "out")
+		data := make([]byte, maxOutputFileSize+1)
+		for i := range data {
+			data[i] = 'x'
+		}
+		require.NoError(t, os.WriteFile(f, data, 0644))
+		result := parseOutputFile(f, logger)
+		assert.Empty(t, result)
+	})
+}
+
+func TestProcessJob_GetStepExportsVersionMetadata(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "test-job",
+		BuildID:           10,
+		VersionID:         1,
+	}
+	// The task step uses "printenv" to dump all env vars. We'll capture the
+	// build step logs and check for the exported GET_* vars.
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "test-job",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeGet,
+						Get:  &job.GetStep{Type: "cron", Name: "my-cron", Trigger: true},
+					},
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "check-env",
+							Run:  utils.RunnerCommand{Runner: "exec", Args: []string{"-c", "printenv | grep GET_MY_CRON"}, Params: map[string]string{"path": "bash"}},
+						},
+					},
+				},
+			},
+		},
+		Resources: []resource.Resource{
+			{ID: 1, Name: "my-cron", Type: "cron", Canonical: "cron.my-cron"},
+		},
+		ResourceTypes: []restype.ResourceType{
+			{
+				ID: 1, Name: "cron",
+				Pull: &utils.RunnerCommand{
+					Runner: "exec",
+					Args:   []string{"pulling"},
+					Params: map[string]string{"path": "echo"},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().StartPendingBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, m.BuildID).
+		Return(&build.Build{ID: 10, BuildNumber: "10", StartedAt: time.Now()}, nil)
+	svc.EXPECT().GetPipelineJob(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName).
+		Return(&pp.Jobs[0], nil)
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron", (*uint32)(nil), (*uint32)(nil), uint32(0)).
+		Return([]*resource.Version{
+			{ID: 1, Version: map[string]interface{}{"date": "2024-01-01"}},
+		}, false, nil).AnyTimes()
+
+	var finalBuild *build.Build
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "10", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, b build.Build) error {
+			bc := b
+			finalBuild = &bc
+			return nil
+		}).AnyTimes()
+
+	expectPendingBuild(svc, 10)
+	w.processJob(ctx, m, cwd, pp)
+
+	// Verify that the task step received GET_MY_CRON_DATE env var.
+	// The task step runs: bash -c "printenv | grep GET_MY_CRON"
+	// If the env var is present, the output should contain it.
+	require.NotNil(t, finalBuild)
+	require.GreaterOrEqual(t, len(finalBuild.Steps), 2)
+	taskStep := finalBuild.Steps[1]
+	assert.Equal(t, build.Succeeded, taskStep.Status, "task step should succeed")
+	assert.Contains(t, taskStep.Logs, "GET_MY_CRON_DATE=2024-01-01")
+}
+
+func TestProcessJob_TaskExportsPikoOutput(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "test-job",
+		BuildID:           10,
+	}
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "test-job",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "produce",
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Args:   []string{"-c", `echo "MY_VAR=hello123" >> "$PIKOCI_OUTPUT"`},
+								Params: map[string]string{"path": "bash"},
+							},
+						},
+					},
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "consume",
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Args:   []string{"-c", "printenv | grep TASK_PRODUCE_MY_VAR"},
+								Params: map[string]string{"path": "bash"},
+							},
+						},
+					},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().StartPendingBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, m.BuildID).
+		Return(&build.Build{ID: 10, BuildNumber: "10", StartedAt: time.Now()}, nil)
+	svc.EXPECT().GetPipelineJob(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName).
+		Return(&pp.Jobs[0], nil)
+
+	var finalBuild *build.Build
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "10", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, b build.Build) error {
+			bc := b
+			finalBuild = &bc
+			return nil
+		}).AnyTimes()
+
+	expectPendingBuild(svc, 10)
+	w.processJob(ctx, m, cwd, pp)
+
+	require.NotNil(t, finalBuild)
+	require.GreaterOrEqual(t, len(finalBuild.Steps), 2)
+	consumeStep := finalBuild.Steps[1]
+	assert.Equal(t, build.Succeeded, consumeStep.Status, "consume step should succeed")
+	assert.Contains(t, consumeStep.Logs, "TASK_PRODUCE_MY_VAR=hello123")
+}
+
+func TestProcessJob_ExportedVarsAccumulate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "test-job",
+		BuildID:           10,
+		VersionID:         1,
+	}
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "test-job",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeGet,
+						Get:  &job.GetStep{Type: "cron", Name: "my-cron", Trigger: true},
+					},
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "build",
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Args:   []string{"-c", `echo "VERSION=1.0.0" >> "$PIKOCI_OUTPUT"`},
+								Params: map[string]string{"path": "bash"},
+							},
+						},
+					},
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "verify",
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Args:   []string{"-c", "printenv | grep -E '(GET_MY_CRON_|TASK_BUILD_)' | sort"},
+								Params: map[string]string{"path": "bash"},
+							},
+						},
+					},
+				},
+			},
+		},
+		Resources: []resource.Resource{
+			{ID: 1, Name: "my-cron", Type: "cron", Canonical: "cron.my-cron"},
+		},
+		ResourceTypes: []restype.ResourceType{
+			{
+				ID: 1, Name: "cron",
+				Pull: &utils.RunnerCommand{
+					Runner: "exec",
+					Args:   []string{"pulling"},
+					Params: map[string]string{"path": "echo"},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().StartPendingBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, m.BuildID).
+		Return(&build.Build{ID: 10, BuildNumber: "10", StartedAt: time.Now()}, nil)
+	svc.EXPECT().GetPipelineJob(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName).
+		Return(&pp.Jobs[0], nil)
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron", (*uint32)(nil), (*uint32)(nil), uint32(0)).
+		Return([]*resource.Version{
+			{ID: 1, Version: map[string]interface{}{"date": "2024-01-01"}},
+		}, false, nil).AnyTimes()
+
+	var finalBuild *build.Build
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "10", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, b build.Build) error {
+			bc := b
+			finalBuild = &bc
+			return nil
+		}).AnyTimes()
+
+	expectPendingBuild(svc, 10)
+	w.processJob(ctx, m, cwd, pp)
+
+	require.NotNil(t, finalBuild)
+	require.GreaterOrEqual(t, len(finalBuild.Steps), 3)
+	verifyStep := finalBuild.Steps[2]
+	assert.Equal(t, build.Succeeded, verifyStep.Status, "verify step should succeed")
+	assert.Contains(t, verifyStep.Logs, "GET_MY_CRON_DATE=2024-01-01")
+	assert.Contains(t, verifyStep.Logs, "TASK_BUILD_VERSION=1.0.0")
+}
+
+func TestProcessJob_FailedStepDoesNotExport(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "test-job",
+		BuildID:           10,
+	}
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "test-job",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "failing",
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Args:   []string{"-c", `echo "LEAKED=secret" >> "$PIKOCI_OUTPUT"; exit 1`},
+								Params: map[string]string{"path": "bash"},
+							},
+						},
+					},
+					{
+						// This step should never run because the previous failed.
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "consume",
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Args:   []string{"-c", "printenv | grep TASK_FAILING"},
+								Params: map[string]string{"path": "bash"},
+							},
+						},
+					},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().StartPendingBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, m.BuildID).
+		Return(&build.Build{ID: 10, BuildNumber: "10", StartedAt: time.Now()}, nil)
+	svc.EXPECT().GetPipelineJob(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName).
+		Return(&pp.Jobs[0], nil)
+
+	var finalBuild *build.Build
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "10", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, b build.Build) error {
+			bc := b
+			finalBuild = &bc
+			return nil
+		}).AnyTimes()
+
+	expectPendingBuild(svc, 10)
+	w.processJob(ctx, m, cwd, pp)
+
+	require.NotNil(t, finalBuild)
+	assert.Equal(t, build.Failed, finalBuild.Status)
+	// Only 1 step should have run (the failing one)
+	require.Equal(t, 1, len(finalBuild.Steps))
+	assert.Equal(t, build.Failed, finalBuild.Steps[0].Status)
+}

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -4379,6 +4379,36 @@ func TestRunRunner_ShellFileMode(t *testing.T) {
 	assert.Contains(t, out, "file_works")
 }
 
+func TestVersionValueToString(t *testing.T) {
+	tests := []struct {
+		name string
+		in   interface{}
+		want string
+	}{
+		{"string", "abc", "abc"},
+		{"float64 int", float64(42), "42"},
+		{"float64 decimal", 3.14, "3.14"},
+		{"bool", true, "true"},
+		{"nil", nil, ""},
+		{"nested map", map[string]interface{}{"sha": "abc", "num": float64(1)}, ""},
+		{"slice", []interface{}{"a", "b"}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := versionValueToString(tt.in)
+			if tt.name == "nested map" {
+				// JSON encoding, order may vary
+				assert.Contains(t, got, `"sha":"abc"`)
+				assert.Contains(t, got, `"num":1`)
+			} else if tt.name == "slice" {
+				assert.Equal(t, `["a","b"]`, got)
+			} else {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
 func TestSanitizeStepName(t *testing.T) {
 	tests := []struct {
 		in, want string


### PR DESCRIPTION
## Summary

- Get steps auto-forward version metadata to subsequent steps as `GET_<STEPNAME>_<KEY>` env vars
- Task steps can write `KEY=VALUE` lines to `$PIKOCI_OUTPUT` to export custom values as `TASK_<STEPNAME>_<KEY>` env vars
- Step names are sanitized (uppercased, non-alphanumeric → `_`)
- `parseOutputFile` handles edge cases: missing file, 1MB size limit, comments, blank lines, equals in values
- `$PIKOCI_OUTPUT` temp file created inside `cwd` for Docker container compatibility
- Failed steps do not export vars
