### PR TITLE
Add Forgejo/Gitea support for git resource type (#463)

### DIFF
--- a/docs/Resource-Types.md
+++ b/docs/Resource-Types.md
@@ -250,7 +250,7 @@ Manual triggers (via the UI or API) and webhook triggers reset the check timer, 
 
 ## Built-in: git
 
-The `git` resource type is built in with API-aware check support for GitHub and GitLab. You do not need to define it, just use it directly:
+The `git` resource type is built in with API-aware check support for GitHub, GitLab, and Gitea/Forgejo. You do not need to define it, just use it directly:
 
 ```hcl
 resource "git" "my-repo" {
@@ -265,18 +265,21 @@ resource "git" "my-repo" {
 
 | Param    | Required | Description                                      |
 |----------|----------|--------------------------------------------------|
-| `url`    | yes      | Repository URL (HTTPS)                           |
-| `name`   | yes      | Directory name to clone into                     |
-| `branch` | no       | Branch to track (defaults to HEAD)               |
-| `token`  | no       | API/HTTPS auth token for private repos           |
-| `pr`     | no       | Set to `"true"` to check for open pull requests instead of commits (requires `token`, GitHub/GitLab only) |
-| `tag`    | no       | Set to `true` to check for tags instead of commits (requires `token`, GitHub/GitLab only) |
+| `url`      | yes      | Repository URL (HTTPS)                           |
+| `name`     | yes      | Directory name to clone into                     |
+| `branch`   | no       | Branch to track (defaults to HEAD)               |
+| `token`    | no       | API/HTTPS auth token for private repos           |
+| `pr`       | no       | Set to `"true"` to check for open pull requests instead of commits (requires `token`) |
+| `tag`      | no       | Set to `true` to check for tags instead of commits (requires `token`) |
+| `provider` | no       | Git hosting provider: `github`, `gitlab`, `gitea`, or `forgejo`. Auto-detected from URL for `github.com` and `gitlab.com`. Required for self-hosted instances when using tag or PR mode. |
 
 ### Token setup
 
 **GitHub**: Create a personal access token at **Settings > Developer settings > Personal access tokens > Fine-grained tokens**. The token needs **Contents** (read) permission for commit checks and cloning. For PR mode, it also needs **Pull requests** (read). For private repos, the token must have access to the repository.
 
 **GitLab**: Create a project or personal access token at **Settings > Access Tokens**. The token needs the `read_repository` scope for commit checks and cloning. For PR mode (merge requests), it also needs `read_api`.
+
+**Gitea/Forgejo**: Create a personal access token at **Settings > Applications > Manage Access Tokens**. The token needs `read:repository` scope. For PR mode, it also needs `read:issue`. Pass the token the same way as GitHub (uses `Authorization: token` header).
 
 Pass the token via a pipeline variable to avoid hardcoding it:
 
@@ -302,7 +305,10 @@ When `token` is provided and the URL matches a supported provider, the check use
 
 - **GitHub** (`github.com`): Uses `GET /repos/{owner}/{repo}/commits?sha={branch}` with `Authorization: token` header
 - **GitLab** (`gitlab.com`): Uses `GET /api/v4/projects/{id}/repository/commits?ref_name={branch}` with `PRIVATE-TOKEN` header
+- **Gitea/Forgejo** (with `provider` param): Uses `GET /api/v1/repos/{owner}/{repo}/commits?sha={branch}` with `Authorization: token` header
 - **Other providers**: Falls back to `git ls-remote`
+
+For self-hosted instances (GitLab, Gitea, Forgejo), set the `provider` param to use the correct API. Without it, PikoCI only auto-detects `github.com` and `gitlab.com` domains. For unknown domains without a `provider` param, the check falls back to trying GitLab and Gitea APIs in sequence before using `git ls-remote`.
 
 Without a token, all providers use `git ls-remote`.
 
@@ -316,7 +322,7 @@ When `pr = "true"` is set, the check command lists open pull requests (or merge 
 
 When a new PR is opened or an existing PR is updated (new commits pushed), PikoCI detects the change and triggers the job. The pull step fetches the PR's head ref so your CI runs against the PR code.
 
-This requires a `token` and is supported on GitHub and GitLab.
+This requires a `token` and is supported on GitHub, GitLab, and Gitea/Forgejo.
 
 ### Tag mode
 
@@ -328,7 +334,7 @@ When `tag = "true"` is set, the check command lists tags instead of checking for
 
 When a new tag is pushed, PikoCI detects it and triggers the job. The pull step clones the repository at the specific tag. Since version variables (`$version_tag`) are only available in pull steps, use `git describe --tags --exact-match` in task steps to retrieve the tag name.
 
-This requires a `token` and is supported on GitHub and GitLab.
+This requires a `token` and is supported on GitHub, GitLab, and Gitea/Forgejo.
 
 ### Pull behavior
 
@@ -386,6 +392,34 @@ job "ci" {
       image = "golang:1.25"
       cmd   = "cd my-repo && make test"
     }
+  }
+}
+```
+
+Forgejo/Gitea repository with PR mode:
+
+```hcl
+resource "git" "forgejo-prs" {
+  params {
+    url      = "https://forgejo.example.com/myorg/my-repo.git"
+    name     = "my-repo"
+    token    = var.forgejo_token
+    provider = "forgejo"
+    pr       = "true"
+  }
+}
+```
+
+Self-hosted GitLab with tag mode:
+
+```hcl
+resource "git" "gitlab-tags" {
+  params {
+    url      = "https://gitlab.mycompany.com/team/project.git"
+    name     = "project"
+    token    = var.gitlab_token
+    provider = "gitlab"
+    tag      = true
   }
 }
 ```

--- a/pikoci/builtin/resource_check_test.go
+++ b/pikoci/builtin/resource_check_test.go
@@ -53,6 +53,30 @@ RESP
 	return dir, logFile
 }
 
+// fakeCurlDirFailThenSucceed creates a fake curl that fails (exit 22, like
+// curl -f on 404) on the first invocation and returns the canned response on
+// the second. This simulates the fallback chain where the GitLab API probe
+// fails and the Gitea API probe succeeds.
+func fakeCurlDirFailThenSucceed(t *testing.T, response string) (dir string, logFile string) {
+	t.Helper()
+	dir = t.TempDir()
+	logFile = filepath.Join(dir, "curl.log")
+	counterFile := filepath.Join(dir, "curl.count")
+
+	script := `#!/bin/sh
+echo "$@" >> ` + logFile + `
+if [ ! -f ` + counterFile + ` ]; then
+  echo 1 > ` + counterFile + `
+  exit 22
+fi
+cat << 'RESP'
+` + response + `
+RESP
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "curl"), []byte(script), 0755))
+	return dir, logFile
+}
+
 // initBareRepo creates a bare git repo with one commit and returns the
 // bare dir, the work dir, and a helper to run git in the work dir.
 func initBareRepo(t *testing.T) (bareDir, workDir string, runWork func(args ...string)) {
@@ -438,6 +462,363 @@ func TestGitCheck_PRMode_GitLab_SubsequentCheck(t *testing.T) {
 	var versions []map[string]interface{}
 	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &versions))
 	assert.Len(t, versions, 2)
+}
+
+// --- Git resource type: Gitea/Forgejo check ---
+
+func TestGitCheck_TagMode_Gitea_FirstCheck(t *testing.T) {
+	cannedTags := `[{"name":"v3","commit":{"sha":"aaa"}},{"name":"v2","commit":{"sha":"bbb"}}]`
+	curlDir, logFile := fakeCurlDir(t, cannedTags)
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":      "https://forgejo.example.com/myorg/myrepo",
+		"param_token":    "fake-token",
+		"param_tag":      "true",
+		"param_provider": "gitea",
+		"PATH":           curlDir + ":" + os.Getenv("PATH"),
+	})
+	require.NoError(t, err, "git check (Gitea tag, first) failed: %s", out)
+
+	curlLog, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(curlLog), "forgejo.example.com/api/v1/repos/myorg/myrepo/tags")
+	assert.Contains(t, string(curlLog), "limit=1")
+}
+
+func TestGitCheck_TagMode_Gitea_SubsequentCheck(t *testing.T) {
+	cannedTags := `[{"name":"v4","commit":{"sha":"ddd"}},{"name":"v3","commit":{"sha":"aaa"}},{"name":"v2","commit":{"sha":"bbb"}},{"name":"v1","commit":{"sha":"ccc"}}]`
+	curlDir, logFile := fakeCurlDir(t, cannedTags)
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":      "https://forgejo.example.com/myorg/myrepo",
+		"param_token":    "fake-token",
+		"param_tag":      "true",
+		"param_provider": "gitea",
+		"version_tag":    "v2",
+		"version_ref":    "bbb",
+		"PATH":           curlDir + ":" + os.Getenv("PATH"),
+	})
+	require.NoError(t, err, "git check (Gitea tag, subsequent) failed: %s", out)
+
+	curlLog, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(curlLog), "limit=100")
+
+	var versions []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &versions))
+	assert.Len(t, versions, 2, "should only return tags newer than known tag v2")
+	assert.Equal(t, "v4", versions[0]["tag"])
+	assert.Equal(t, "v3", versions[1]["tag"])
+}
+
+func TestGitCheck_TagMode_Gitea_NoNewTags(t *testing.T) {
+	cannedTags := `[{"name":"v2","commit":{"sha":"bbb"}},{"name":"v1","commit":{"sha":"ccc"}}]`
+	curlDir, _ := fakeCurlDir(t, cannedTags)
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":      "https://forgejo.example.com/myorg/myrepo",
+		"param_token":    "fake-token",
+		"param_tag":      "true",
+		"param_provider": "gitea",
+		"version_tag":    "v2",
+		"version_ref":    "bbb",
+		"PATH":           curlDir + ":" + os.Getenv("PATH"),
+	})
+	require.NoError(t, err, "git check (Gitea tag, no new) failed: %s", out)
+
+	var versions []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &versions))
+	assert.Len(t, versions, 0, "should return empty list when no new tags exist")
+}
+
+func TestGitCheck_PRMode_Gitea_FirstCheck(t *testing.T) {
+	cannedPRs := `[{"number":10,"head":{"sha":"aaa"}},{"number":9,"head":{"sha":"bbb"}}]`
+	curlDir, logFile := fakeCurlDir(t, cannedPRs)
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":      "https://forgejo.example.com/myorg/myrepo",
+		"param_token":    "fake-token",
+		"param_pr":       "true",
+		"param_provider": "gitea",
+		"PATH":           curlDir + ":" + os.Getenv("PATH"),
+	})
+	require.NoError(t, err, "git check (Gitea PR, first) failed: %s", out)
+
+	curlLog, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(curlLog), "forgejo.example.com/api/v1/repos/myorg/myrepo/pulls")
+	assert.Contains(t, string(curlLog), "limit=1")
+}
+
+func TestGitCheck_PRMode_Gitea_SubsequentCheck(t *testing.T) {
+	cannedPRs := `[{"number":10,"head":{"sha":"aaa"}},{"number":9,"head":{"sha":"bbb"}}]`
+	curlDir, logFile := fakeCurlDir(t, cannedPRs)
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":      "https://forgejo.example.com/myorg/myrepo",
+		"param_token":    "fake-token",
+		"param_pr":       "true",
+		"param_provider": "gitea",
+		"version_pr":     "8",
+		"version_ref":    "old-sha",
+		"PATH":           curlDir + ":" + os.Getenv("PATH"),
+	})
+	require.NoError(t, err, "git check (Gitea PR, subsequent) failed: %s", out)
+
+	curlLog, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(curlLog), "limit=100")
+
+	var versions []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &versions))
+	assert.Len(t, versions, 2)
+}
+
+func TestGitCheck_GiteaAPI_ReturnsSingleVersion(t *testing.T) {
+	cannedCommits := `[{"sha":"ggg789"}]`
+	curlDir, logFile := fakeCurlDir(t, cannedCommits)
+
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":      "https://forgejo.example.com/myorg/myrepo",
+		"param_token":    "fake-token",
+		"param_provider": "gitea",
+		"PATH":           curlDir + ":" + os.Getenv("PATH"),
+	})
+	require.NoError(t, err, "git check (Gitea API) failed: %s", out)
+
+	curlLog, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(curlLog), "forgejo.example.com/api/v1/repos/myorg/myrepo/commits")
+	assert.Contains(t, string(curlLog), "limit=1")
+
+	var versions []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &versions))
+	assert.Len(t, versions, 1)
+	assert.Equal(t, "ggg789", versions[0]["ref"])
+}
+
+func TestGitCheck_ProviderParam_Gitea(t *testing.T) {
+	cannedCommits := `[{"sha":"ggg789"}]`
+	curlDir, logFile := fakeCurlDir(t, cannedCommits)
+
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":      "https://git.mycompany.com/team/project",
+		"param_token":    "fake-token",
+		"param_provider": "gitea",
+		"PATH":           curlDir + ":" + os.Getenv("PATH"),
+	})
+	require.NoError(t, err, "git check (provider=gitea) failed: %s", out)
+
+	curlLog, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(curlLog), "git.mycompany.com/api/v1/repos/team/project/commits")
+}
+
+func TestGitCheck_ProviderParam_Forgejo_Alias(t *testing.T) {
+	cannedCommits := `[{"sha":"ggg789"}]`
+	curlDir, logFile := fakeCurlDir(t, cannedCommits)
+
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":      "https://forgejo.example.com/myorg/myrepo",
+		"param_token":    "fake-token",
+		"param_provider": "forgejo",
+		"PATH":           curlDir + ":" + os.Getenv("PATH"),
+	})
+	require.NoError(t, err, "git check (provider=forgejo) failed: %s", out)
+
+	curlLog, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(curlLog), "forgejo.example.com/api/v1/repos/myorg/myrepo/commits",
+		"forgejo should be treated as gitea")
+}
+
+func TestGitCheck_ProviderParam_GitLab_SelfHosted(t *testing.T) {
+	cannedCommits := `[{"id":"def456"}]`
+	curlDir, logFile := fakeCurlDir(t, cannedCommits)
+
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":      "https://gitlab.mycompany.com/team/project",
+		"param_token":    "fake-token",
+		"param_provider": "gitlab",
+		"PATH":           curlDir + ":" + os.Getenv("PATH"),
+	})
+	require.NoError(t, err, "git check (provider=gitlab self-hosted) failed: %s", out)
+
+	curlLog, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(curlLog), "gitlab.mycompany.com/api/v4/projects/team%2Fproject/repository/commits")
+
+	var versions []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &versions))
+	assert.Len(t, versions, 1)
+	assert.Equal(t, "def456", versions[0]["ref"])
+}
+
+func TestGitCheck_TagMode_Fallback_GiteaAfterGitLabFails(t *testing.T) {
+	// Single tag — simulates what the API returns with limit=1 on first check
+	cannedTags := `[{"name":"v2","commit":{"sha":"aaa"}}]`
+	curlDir, logFile := fakeCurlDirFailThenSucceed(t, cannedTags)
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":   "https://gitea.example.com/myorg/myrepo",
+		"param_token": "fake-token",
+		"param_tag":   "true",
+		"PATH":        curlDir + ":" + os.Getenv("PATH"),
+	})
+	require.NoError(t, err, "git check (fallback tag) failed: %s", out)
+
+	curlLog, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	logStr := string(curlLog)
+	assert.Contains(t, logStr, "api/v4/projects",
+		"should try GitLab API first")
+	assert.Contains(t, logStr, "api/v1/repos",
+		"should fall back to Gitea API")
+
+	var versions []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &versions))
+	assert.Len(t, versions, 1)
+	assert.Equal(t, "v2", versions[0]["tag"])
+}
+
+func TestGitCheck_PRMode_Fallback_GiteaAfterGitLabFails(t *testing.T) {
+	cannedPRs := `[{"number":5,"head":{"sha":"fff"}}]`
+	curlDir, logFile := fakeCurlDirFailThenSucceed(t, cannedPRs)
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":   "https://gitea.example.com/myorg/myrepo",
+		"param_token": "fake-token",
+		"param_pr":    "true",
+		"PATH":        curlDir + ":" + os.Getenv("PATH"),
+	})
+	require.NoError(t, err, "git check (fallback PR) failed: %s", out)
+
+	curlLog, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	logStr := string(curlLog)
+	assert.Contains(t, logStr, "api/v4/projects",
+		"should try GitLab API first")
+	assert.Contains(t, logStr, "api/v1/repos",
+		"should fall back to Gitea API")
+
+	var versions []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &versions))
+	assert.Len(t, versions, 1)
+	assert.Equal(t, "5", versions[0]["pr"])
+}
+
+func TestGitPull_PRMode_Gitea_PullRefFormat(t *testing.T) {
+	bareDir, _, runWork := initBareRepo(t)
+	_ = runWork
+
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "git.log")
+	script := `#!/bin/sh
+if [ "$1" = "fetch" ]; then
+  echo "$@" >> ` + logFile + `
+  exit 0
+fi
+exec /usr/bin/git "$@"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "git"), []byte(script), 0755))
+
+	pullDir := t.TempDir()
+	_, _ = runScript(t, rt.Pull, pullDir, map[string]string{
+		"param_url":      bareDir,
+		"param_name":     "myrepo",
+		"param_pr":       "true",
+		"param_provider": "gitea",
+		"version_pr":     "7",
+		"version_ref":    "abc123",
+		"PATH":           dir + ":" + os.Getenv("PATH"),
+	})
+
+	gitLog, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(gitLog), "pull/7/head",
+		"Gitea PR mode should use pull/N/head ref")
+}
+
+func TestGitCheck_ProviderParam_Invalid(t *testing.T) {
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":      "https://bitbucket.org/example/repo",
+		"param_token":    "fake-token",
+		"param_provider": "bitbucket",
+	})
+	assert.Error(t, err, "invalid provider should fail")
+	assert.Contains(t, out, "invalid provider")
+}
+
+func TestGitPull_PRMode_GitLab_MergeRequestRef(t *testing.T) {
+	bareDir, _, runWork := initBareRepo(t)
+	_ = runWork
+
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	// We can't fully test the fetch (no real MR ref in the bare repo),
+	// but we can verify the script constructs the right ref by checking
+	// that it attempts the merge-requests/N/head pattern.
+	// Use a fake git wrapper to capture the fetch command.
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "git.log")
+	// Create a fake git that logs fetch commands but delegates everything else
+	script := `#!/bin/sh
+if [ "$1" = "fetch" ]; then
+  echo "$@" >> ` + logFile + `
+  exit 0
+fi
+exec /usr/bin/git "$@"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "git"), []byte(script), 0755))
+
+	pullDir := t.TempDir()
+	_, _ = runScript(t, rt.Pull, pullDir, map[string]string{
+		"param_url":      bareDir,
+		"param_name":     "myrepo",
+		"param_pr":       "true",
+		"param_provider": "gitlab",
+		"version_pr":     "42",
+		"version_ref":    "abc123",
+		"PATH":           dir + ":" + os.Getenv("PATH"),
+	})
+
+	gitLog, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(gitLog), "merge-requests/42/head",
+		"GitLab PR mode should use merge-requests/N/head ref")
 }
 
 func TestGitCheck_TagMode_RequiresToken(t *testing.T) {

--- a/pikoci/builtin/resource_types/git.hcl
+++ b/pikoci/builtin/resource_types/git.hcl
@@ -7,6 +7,7 @@ resource_type "git" {
     "token",
     "pr",
     "tag",
+    "provider",
   ]
   check "exec" {
     path = "/bin/sh"
@@ -18,6 +19,27 @@ resource_type "git" {
       TOKEN="$param_token"
       PR="$param_pr"
       TAG="$param_tag"
+      PROVIDER="$param_provider"
+
+      # Resolve provider
+      if [ -n "$PROVIDER" ]; then
+        case "$PROVIDER" in
+          github|gitlab|gitea) ;;
+          forgejo) PROVIDER="gitea" ;;
+          *) echo "error: invalid provider '$PROVIDER' (must be github, gitlab, gitea, or forgejo)" >&2; exit 1 ;;
+        esac
+      else
+        if echo "$URL" | grep -q "github.com"; then
+          PROVIDER="github"
+        elif echo "$URL" | grep -q "gitlab.com"; then
+          PROVIDER="gitlab"
+        fi
+      fi
+
+      # Extract host and repo path from URL
+      HOST=$(echo "$URL" | sed -E 's|https?://([^/]+).*|\1|')
+      REPO_PATH=$(echo "$URL" | sed -E 's|https?://[^/]+/||;s|\.git$||')
+      PROJECT=$(echo "$REPO_PATH" | sed 's|/|%2F|g')
 
       # Maintain a bare clone in CACHE_DIR for faster operations
       if [ -n "$CACHE_DIR" ]; then
@@ -52,10 +74,9 @@ resource_type "git" {
         fi
 
         # GitHub tags
-        if echo "$URL" | grep -q "github.com"; then
-          REPO=$(echo "$URL" | sed -E 's|https?://github\.com/||;s|\.git$||')
+        if [ "$PROVIDER" = "github" ]; then
           curl -sf -H "Authorization: token $TOKEN" \
-            "https://api.github.com/repos/$REPO/tags?per_page=$PER_PAGE" \
+            "https://api.github.com/repos/$REPO_PATH/tags?per_page=$PER_PAGE" \
             | jq -c --arg known "$version_tag" \
               'map({"ref": .commit.sha, "tag": .name})
                | if $known == "" then .
@@ -67,10 +88,9 @@ resource_type "git" {
         fi
 
         # GitLab tags
-        if echo "$URL" | grep -q "gitlab.com"; then
-          PROJECT=$(echo "$URL" | sed -E 's|https?://gitlab\.com/||;s|\.git$||' | sed 's|/|%2F|g')
+        if [ "$PROVIDER" = "gitlab" ]; then
           curl -sf -H "PRIVATE-TOKEN: $TOKEN" \
-            "https://gitlab.com/api/v4/projects/$PROJECT/repository/tags?order_by=updated&sort=desc&per_page=$PER_PAGE" \
+            "https://$HOST/api/v4/projects/$PROJECT/repository/tags?order_by=updated&sort=desc&per_page=$PER_PAGE" \
             | jq -c --arg known "$version_tag" \
               'map({"ref": .commit.id, "tag": .name})
                | if $known == "" then .
@@ -81,7 +101,42 @@ resource_type "git" {
           exit 0
         fi
 
-        echo "error: tag=true is only supported for github.com and gitlab.com" >&2
+        # Gitea/Forgejo tags
+        if [ "$PROVIDER" = "gitea" ]; then
+          curl -sf -H "Authorization: token $TOKEN" \
+            "https://$HOST/api/v1/repos/$REPO_PATH/tags?limit=$PER_PAGE" \
+            | jq -c --arg known "$version_tag" \
+              'map({"ref": .commit.sha, "tag": .name})
+               | if $known == "" then .
+                 else reduce .[] as $t ({out:[], done:false};
+                   if .done then . else (if $t.tag == $known then .done=true else .out += [$t] end) end
+                 ) | .out
+                 end'
+          exit 0
+        fi
+
+        # Fallback: try GitLab API, then Gitea API
+        RESULT=$(curl -sf -H "PRIVATE-TOKEN: $TOKEN" \
+          "https://$HOST/api/v4/projects/$PROJECT/repository/tags?order_by=updated&sort=desc&per_page=$PER_PAGE" 2>/dev/null \
+          | jq -c --arg known "$version_tag" \
+            'map({"ref": .commit.id, "tag": .name})
+             | if $known == "" then .
+               else reduce .[] as $t ({out:[], done:false};
+                 if .done then . else (if $t.tag == $known then .done=true else .out += [$t] end) end
+               ) | .out
+               end' 2>/dev/null) && [ -n "$RESULT" ] && echo "$RESULT" && exit 0
+
+        RESULT=$(curl -sf -H "Authorization: token $TOKEN" \
+          "https://$HOST/api/v1/repos/$REPO_PATH/tags?limit=$PER_PAGE" 2>/dev/null \
+          | jq -c --arg known "$version_tag" \
+            'map({"ref": .commit.sha, "tag": .name})
+             | if $known == "" then .
+               else reduce .[] as $t ({out:[], done:false};
+                 if .done then . else (if $t.tag == $known then .done=true else .out += [$t] end) end
+               ) | .out
+               end' 2>/dev/null) && [ -n "$RESULT" ] && echo "$RESULT" && exit 0
+
+        echo "error: tag=true is not supported for this provider (use provider param to specify github, gitlab, gitea, or forgejo)" >&2
         exit 1
       fi
 
@@ -100,32 +155,46 @@ resource_type "git" {
         fi
 
         # GitHub PRs
-        if echo "$URL" | grep -q "github.com"; then
-          REPO=$(echo "$URL" | sed -E 's|https?://github\.com/||;s|\.git$||')
+        if [ "$PROVIDER" = "github" ]; then
           curl -sf -H "Authorization: token $TOKEN" \
-            "https://api.github.com/repos/$REPO/pulls?state=open&sort=updated&direction=desc&per_page=$PER_PAGE" \
+            "https://api.github.com/repos/$REPO_PATH/pulls?state=open&sort=updated&direction=desc&per_page=$PER_PAGE" \
             | jq -c '[.[] | {"ref": .head.sha, "pr": (.number | tostring)}]'
           exit 0
         fi
 
         # GitLab MRs
-        if echo "$URL" | grep -q "gitlab.com"; then
-          PROJECT=$(echo "$URL" | sed -E 's|https?://gitlab\.com/||;s|\.git$||' | sed 's|/|%2F|g')
+        if [ "$PROVIDER" = "gitlab" ]; then
           curl -sf -H "PRIVATE-TOKEN: $TOKEN" \
-            "https://gitlab.com/api/v4/projects/$PROJECT/merge_requests?state=opened&order_by=updated_at&sort=desc&per_page=$PER_PAGE" \
+            "https://$HOST/api/v4/projects/$PROJECT/merge_requests?state=opened&order_by=updated_at&sort=desc&per_page=$PER_PAGE" \
             | jq -c '[.[] | {"ref": .sha, "pr": (.iid | tostring)}]'
           exit 0
         fi
 
-        echo "error: pr=true is only supported for github.com and gitlab.com" >&2
+        # Gitea/Forgejo PRs
+        if [ "$PROVIDER" = "gitea" ]; then
+          curl -sf -H "Authorization: token $TOKEN" \
+            "https://$HOST/api/v1/repos/$REPO_PATH/pulls?state=open&sort=recentupdate&limit=$PER_PAGE" \
+            | jq -c '[.[] | {"ref": .head.sha, "pr": (.number | tostring)}]'
+          exit 0
+        fi
+
+        # Fallback: try GitLab API, then Gitea API
+        RESULT=$(curl -sf -H "PRIVATE-TOKEN: $TOKEN" \
+          "https://$HOST/api/v4/projects/$PROJECT/merge_requests?state=opened&order_by=updated_at&sort=desc&per_page=$PER_PAGE" 2>/dev/null \
+          | jq -c '[.[] | {"ref": .sha, "pr": (.iid | tostring)}]' 2>/dev/null) && [ -n "$RESULT" ] && echo "$RESULT" && exit 0
+
+        RESULT=$(curl -sf -H "Authorization: token $TOKEN" \
+          "https://$HOST/api/v1/repos/$REPO_PATH/pulls?state=open&sort=recentupdate&limit=$PER_PAGE" 2>/dev/null \
+          | jq -c '[.[] | {"ref": .head.sha, "pr": (.number | tostring)}]' 2>/dev/null) && [ -n "$RESULT" ] && echo "$RESULT" && exit 0
+
+        echo "error: pr=true is not supported for this provider (use provider param to specify github, gitlab, gitea, or forgejo)" >&2
         exit 1
       fi
 
-      # GitHub API
-      if [ -n "$TOKEN" ] && echo "$URL" | grep -q "github.com"; then
-        REPO=$(echo "$URL" | sed -E 's|https?://github\.com/||;s|\.git$||')
+      # Commit mode: GitHub API
+      if [ -n "$TOKEN" ] && [ "$PROVIDER" = "github" ]; then
         REF=$(curl -sf -H "Authorization: token $TOKEN" \
-          "https://api.github.com/repos/$REPO/commits?sha=$BRANCH&per_page=1" \
+          "https://api.github.com/repos/$REPO_PATH/commits?sha=$BRANCH&per_page=1" \
           | jq -r '.[0].sha')
         if [ -n "$REF" ] && [ "$REF" != "null" ]; then
           echo "[{\"ref\":\"$REF\"}]"
@@ -133,12 +202,43 @@ resource_type "git" {
         fi
       fi
 
-      # GitLab API
-      if [ -n "$TOKEN" ] && echo "$URL" | grep -q "gitlab.com"; then
-        PROJECT=$(echo "$URL" | sed -E 's|https?://gitlab\.com/||;s|\.git$||' | sed 's|/|%2F|g')
+      # Commit mode: GitLab API
+      if [ -n "$TOKEN" ] && [ "$PROVIDER" = "gitlab" ]; then
         REF=$(curl -sf -H "PRIVATE-TOKEN: $TOKEN" \
-          "https://gitlab.com/api/v4/projects/$PROJECT/repository/commits?ref_name=$BRANCH&per_page=1" \
+          "https://$HOST/api/v4/projects/$PROJECT/repository/commits?ref_name=$BRANCH&per_page=1" \
           | jq -r '.[0].id')
+        if [ -n "$REF" ] && [ "$REF" != "null" ]; then
+          echo "[{\"ref\":\"$REF\"}]"
+          exit 0
+        fi
+      fi
+
+      # Commit mode: Gitea API
+      if [ -n "$TOKEN" ] && [ "$PROVIDER" = "gitea" ]; then
+        REF=$(curl -sf -H "Authorization: token $TOKEN" \
+          "https://$HOST/api/v1/repos/$REPO_PATH/commits?sha=$BRANCH&limit=1" \
+          | jq -r '.[0].sha')
+        if [ -n "$REF" ] && [ "$REF" != "null" ]; then
+          echo "[{\"ref\":\"$REF\"}]"
+          exit 0
+        fi
+      fi
+
+      # Commit mode: fallback chain for unknown providers
+      if [ -n "$TOKEN" ] && [ -z "$PROVIDER" ]; then
+        # Try GitLab API
+        REF=$(curl -sf -H "PRIVATE-TOKEN: $TOKEN" \
+          "https://$HOST/api/v4/projects/$PROJECT/repository/commits?ref_name=$BRANCH&per_page=1" 2>/dev/null \
+          | jq -r '.[0].id' 2>/dev/null)
+        if [ -n "$REF" ] && [ "$REF" != "null" ]; then
+          echo "[{\"ref\":\"$REF\"}]"
+          exit 0
+        fi
+
+        # Try Gitea API
+        REF=$(curl -sf -H "Authorization: token $TOKEN" \
+          "https://$HOST/api/v1/repos/$REPO_PATH/commits?sha=$BRANCH&limit=1" 2>/dev/null \
+          | jq -r '.[0].sha' 2>/dev/null)
         if [ -n "$REF" ] && [ "$REF" != "null" ]; then
           echo "[{\"ref\":\"$REF\"}]"
           exit 0
@@ -169,6 +269,16 @@ resource_type "git" {
       PR="$param_pr"
       TAG="$param_tag"
 
+      # Determine provider for PR ref format
+      PROVIDER="$param_provider"
+      if [ "$PROVIDER" = "forgejo" ]; then PROVIDER="gitea"; fi
+      if [ -z "$PROVIDER" ]; then
+        if echo "$URL" | grep -q "github.com"; then PROVIDER="github"
+        elif echo "$URL" | grep -q "gitlab.com"; then PROVIDER="gitlab"
+        else PROVIDER="gitea"
+        fi
+      fi
+
       # Inject token into HTTPS URL if provided
       if [ -n "$TOKEN" ]; then
         URL=$(echo "$URL" | sed -E "s|https://|https://oauth2:$TOKEN@|")
@@ -188,7 +298,11 @@ resource_type "git" {
         # PR mode: fetch the PR head ref
         git clone $REFERENCE_ARGS "$URL" "$param_name"
         cd "$param_name"
-        git fetch origin "pull/$version_pr/head:pr-$version_pr"
+        if [ "$PROVIDER" = "gitlab" ]; then
+          git fetch origin "merge-requests/$version_pr/head:pr-$version_pr"
+        else
+          git fetch origin "pull/$version_pr/head:pr-$version_pr"
+        fi
         git checkout "pr-$version_pr"
       elif [ -n "$BRANCH" ]; then
         git clone $REFERENCE_ARGS -b "$BRANCH" "$URL" "$param_name"


### PR DESCRIPTION
## Summary

- Add optional `provider` param (`github`, `gitlab`, `gitea`, `forgejo`) to the built-in git resource type, enabling tag/PR/commit checks on self-hosted Forgejo, Gitea, and GitLab instances
- Auto-detect provider from URL domain (`github.com`, `gitlab.com`); for unknown domains, fall back through GitLab → Gitea APIs → `git ls-remote`
- Update pull script to use correct PR ref format per provider (`merge-requests/N/head` for GitLab, `pull/N/head` for others)
- Add 15 new tests covering Gitea tag/PR/commit modes, provider param validation, forgejo alias, self-hosted GitLab, fallback chain, and pull ref formats
- Update documentation with `provider` param, Gitea/Forgejo token setup, and usage examples

Closes #463