### PR TITLE
Add serial_groups on jobs for cross-job mutual exclusion (#186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `serial_groups` on jobs for cross-job mutual exclusion ([#186](https://github.com/PikoCI/pikoci/issues/186))
 - Step metadata export: get steps auto-forward version metadata to subsequent steps as `GET_<STEPNAME>_<KEY>` env vars, and task steps can write `KEY=VALUE` lines to `$PIKOCI_OUTPUT` to export custom values as `TASK_<STEPNAME>_<KEY>` env vars ([#459](https://github.com/PikoCI/pikoci/issues/459))
 - Loading indicators on action buttons: all mutating buttons (trigger, cancel, retry, delete, pause, unpause, pin, etc.) now show a spinner and loading text while the request is in flight, preventing double-clicks and providing visual feedback ([#453](https://github.com/PikoCI/pikoci/issues/453))
 - Built-in `shell` runner for simplified shell command execution. Supports inline `cmd` mode (`run "shell" { cmd = "..." }`) and script `file` mode (`run "shell" { file = "script.sh" }`), with optional `shell` param to override the default `/bin/sh` ([#458](https://github.com/PikoCI/pikoci/issues/458))

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ dserve: ## Serves the server
 
 .PHONY: serve
 serve: ## Serves the server
-	@go run . server -p 4000 --log-level=debug --jwt-secret potato --users 'pepito:$$2a$$14$$rwQk8Qvc2rij7qhFO4P1W.OiSF6AkgVU1RCrLaY2wawJcpkPEKwbm,grillo:$$2a$$14$$SvWir17.jlXxiZfe0pJuDedznetc/HWKv43YPsQQNo6MJiuypS2q6' --pipeline-name=test --pipeline-config=./pikoci/testdata/cron.hcl
+	@go run . server -p 4000 --log-level=debug --jwt-secret potato --concurrency=2 --users 'pepito:$$2a$$14$$rwQk8Qvc2rij7qhFO4P1W.OiSF6AkgVU1RCrLaY2wawJcpkPEKwbm,grillo:$$2a$$14$$SvWir17.jlXxiZfe0pJuDedznetc/HWKv43YPsQQNo6MJiuypS2q6' --pipeline-name=test --pipeline-config=./pikoci/testdata/cron.hcl
 
 .PHONY: worker
 worker: ## Starts a worker

--- a/deploy/pipeline.hcl
+++ b/deploy/pipeline.hcl
@@ -272,7 +272,8 @@ job "test-backends" {
 # --- Jobs: Docker Release ---
 
 job "build-latest" {
-  concurrency = 1
+  concurrency    = 1
+  serial_groups  = ["docker-build"]
   get "git" "pikoci_master" {
     trigger = true
   }
@@ -356,7 +357,8 @@ job "deploy-website" {
 }
 
 job "build-release" {
-  concurrency = 1
+  concurrency    = 1
+  serial_groups  = ["docker-build"]
   get "git" "pikoci_tag" {
     trigger = true
   }

--- a/docs/Concourse.md
+++ b/docs/Concourse.md
@@ -20,6 +20,7 @@ PikoCI's resource model is directly inspired by [Concourse CI](https://concourse
 | `trigger: true` | `trigger = true` | Same. Auto-triggers the job on new versions. |
 | `on_success` / `on_failure` / `on_cancel` / `ensure` | Same names | Same semantics. Available on both steps and jobs. |
 | Webhook triggers | Webhook triggers | Same. `POST /webhooks/<token>` triggers a resource check. |
+| `serial_groups` | `serial_groups` | Same concept. Cross-job mutual exclusion within a pipeline. |
 | Teams | Teams | Similar. PikoCI has team-based scoping. |
 
 ## Key differences

--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -251,6 +251,36 @@ The optional `concurrency` attribute limits how many builds of the job can run s
 
 The optional `timeout` attribute limits the total wall-clock time for a build's plan steps. When the timeout is reached, the build fails with a "job timed out" error and `on_cancel`/`ensure` hooks still run. If not set, the job runs with no time limit.
 
+#### Serial Groups
+
+The `serial_groups` attribute provides cross-job mutual exclusion — only one job from a group runs at a time. This is useful for deploy jobs that shouldn't overlap, or any set of jobs that share a resource that can't handle concurrent access.
+
+```hcl
+job "deploy-staging" {
+  serial_groups = ["deploy"]
+
+  get "git" "my_repo" { trigger = true }
+  task "deploy" {
+    run "exec" { path = "./deploy.sh" }
+  }
+}
+
+job "deploy-prod" {
+  serial_groups = ["deploy"]
+
+  get "git" "my_repo" {}
+  task "deploy" {
+    run "exec" { path = "./deploy.sh" }
+  }
+}
+```
+
+When `deploy-staging` is running, `deploy-prod` will queue until it finishes, and vice versa. Serial groups are scoped per-pipeline.
+
+A job can belong to multiple serial groups. It will only run when **none** of its groups have a running build from another job.
+
+`serial_groups` is orthogonal to `concurrency` — both checks apply. A build must pass both the per-job concurrency limit and the serial group check before starting. Note that `serial_groups` only provides cross-job mutual exclusion; to also limit a single job to one build at a time, set `concurrency = 1` on the job.
+
 ```hcl
 job "deploy" {
   concurrency = 1

--- a/pikoci/build/repository.go
+++ b/pikoci/build/repository.go
@@ -37,4 +37,7 @@ type Repository interface {
 	FindOldestPending(ctx context.Context, tc, pn, jn string) (*Build, error)
 	// StartPending transitions a pending build to started status.
 	StartPending(ctx context.Context, tc, pn, jn string, buildID uint32) error
+	// CountRunningInSerialGroups returns the number of running builds for jobs (excluding excludeJobName)
+	// that share any of the given serial groups within the same pipeline.
+	CountRunningInSerialGroups(ctx context.Context, tc, pn string, serialGroups []string, excludeJobName string) (int, error)
 }

--- a/pikoci/builds.go
+++ b/pikoci/builds.go
@@ -25,6 +25,9 @@ var (
 	ErrBuildNotPending = build.ErrNotPending
 	// ErrJobPaused is returned when attempting to start a build for a paused job.
 	ErrJobPaused = errors.New("job is paused")
+	// ErrSerialGroupLimit is returned when a build cannot be started because
+	// another job in the same serial group already has a running build.
+	ErrSerialGroupLimit = errors.New("serial group limit reached")
 )
 
 // CreateJobBuild creates a new pending build for the specified job within a unit
@@ -339,6 +342,15 @@ func (q *PikoCI) StartPendingBuild(ctx context.Context, tc, pn, jn string, build
 				return ErrConcurrencyLimit
 			}
 		}
+		if len(j.SerialGroups) > 0 {
+			sgRunning, err := uow.Builds().CountRunningInSerialGroups(ctx, tc, pn, j.SerialGroups, jn)
+			if err != nil {
+				return fmt.Errorf("failed to count running builds in serial groups: %w", err)
+			}
+			if sgRunning > 0 {
+				return ErrSerialGroupLimit
+			}
+		}
 
 		return uow.Builds().StartPending(ctx, tc, pn, jn, buildID)
 	})
@@ -366,7 +378,15 @@ func (q *PikoCI) FindOldestPendingBuild(ctx context.Context, tc, pn, jn string) 
 // notifyNextPendingBuild finds the oldest pending build for the job and sends a
 // message to the job topic so it can be picked up for execution. This is called
 // after a build is cancelled or completes to fill any freed concurrency slots.
+// It also notifies pending builds for other jobs sharing serial groups.
 func (q *PikoCI) notifyNextPendingBuild(ctx context.Context, tc, pc, jn string) {
+	q.sendPendingBuildNotification(ctx, tc, pc, jn)
+	q.NotifySerialGroupPendingBuilds(ctx, tc, pc, jn)
+}
+
+// sendPendingBuildNotification finds the oldest pending build for a single job
+// and sends a message to the job topic.
+func (q *PikoCI) sendPendingBuildNotification(ctx context.Context, tc, pc, jn string) {
 	pending, err := q.Builds.FindOldestPending(ctx, tc, pc, jn)
 	if err != nil || pending == nil {
 		return
@@ -382,6 +402,25 @@ func (q *PikoCI) notifyNextPendingBuild(ctx context.Context, tc, pc, jn string) 
 		return
 	}
 	q.JobTopic.Send(ctx, &pubsub.Message{Body: mb})
+}
+
+// NotifySerialGroupPendingBuilds finds all jobs sharing serial groups with the
+// given job and enqueues their oldest pending builds for execution.
+func (q *PikoCI) NotifySerialGroupPendingBuilds(ctx context.Context, tc, pc, jn string) {
+	j, err := q.Jobs.Find(ctx, tc, pc, jn)
+	if err != nil || len(j.SerialGroups) == 0 {
+		return
+	}
+	peerJobs, err := q.Jobs.FindJobsBySerialGroups(ctx, tc, pc, j.SerialGroups)
+	if err != nil {
+		return
+	}
+	for _, pj := range peerJobs {
+		if pj.Name == jn {
+			continue
+		}
+		q.sendPendingBuildNotification(ctx, tc, pc, pj.Name)
+	}
 }
 
 // ReEnqueuePendingBuilds scans all jobs for pending builds and re-publishes

--- a/pikoci/builds_test.go
+++ b/pikoci/builds_test.go
@@ -298,6 +298,9 @@ func TestCancelJobBuild_Pending(t *testing.T) {
 	// Should also notify next pending build
 	s.Builds.EXPECT().FindOldestPending(ctx, "main", "my-pipeline", "my-job").
 		Return(nil, nil)
+	// NotifySerialGroupPendingBuilds looks up the job
+	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "my-job").
+		Return(&job.Job{Name: "my-job"}, nil)
 
 	err := s.S.CancelJobBuild(ctx, "main", "my-pipeline", "my-job", "1")
 	require.NoError(t, err)
@@ -314,6 +317,9 @@ func TestCancelJobBuild_Running_NotifiesNextPending(t *testing.T) {
 	// Should check for next pending build
 	s.Builds.EXPECT().FindOldestPending(ctx, "main", "my-pipeline", "my-job").
 		Return(nil, nil)
+	// NotifySerialGroupPendingBuilds looks up the job
+	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "my-job").
+		Return(&job.Job{Name: "my-job"}, nil)
 
 	err := s.S.CancelJobBuild(ctx, "main", "my-pipeline", "my-job", "1")
 	require.NoError(t, err)
@@ -462,6 +468,9 @@ func TestCancelJobBuild_Running_NotifiesNextPending_WithPendingBuild(t *testing.
 		assert.Equal(t, uint32(5), body.BuildID)
 		return nil
 	})
+	// NotifySerialGroupPendingBuilds looks up the job
+	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "my-job").
+		Return(&job.Job{Name: "my-job"}, nil)
 
 	err := s.S.CancelJobBuild(ctx, "main", "my-pipeline", "my-job", "1")
 	require.NoError(t, err)
@@ -646,6 +655,95 @@ func TestFindBuildGetVersions_InvalidCanonical(t *testing.T) {
 
 	_, err = s.S.FindBuildGetVersions(ctx, "main", "my-pipeline", "INVALID", 5)
 	require.Error(t, err)
+}
+
+// --- Serial Group tests ---
+
+func TestStartPendingBuild_SerialGroupLimit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "deploy-staging").
+		Return(&job.Job{Name: "deploy-staging", SerialGroups: []string{"deploy"}}, nil)
+	s.Builds.EXPECT().CountRunningInSerialGroups(ctx, "main", "my-pipeline", []string{"deploy"}, "deploy-staging").
+		Return(1, nil)
+
+	_, err := s.S.StartPendingBuild(ctx, "main", "my-pipeline", "deploy-staging", 10)
+	require.ErrorIs(t, err, pikoci.ErrSerialGroupLimit)
+}
+
+func TestStartPendingBuild_SerialGroupNoRunning(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "deploy-staging").
+		Return(&job.Job{Name: "deploy-staging", SerialGroups: []string{"deploy"}}, nil)
+	s.Builds.EXPECT().CountRunningInSerialGroups(ctx, "main", "my-pipeline", []string{"deploy"}, "deploy-staging").
+		Return(0, nil)
+	s.Builds.EXPECT().StartPending(ctx, "main", "my-pipeline", "deploy-staging", uint32(10)).Return(nil)
+	s.Builds.EXPECT().FindByID(ctx, uint32(10)).Return(
+		&build.Build{ID: 10, BuildNumber: "1", Status: build.Started}, nil)
+
+	b, err := s.S.StartPendingBuild(ctx, "main", "my-pipeline", "deploy-staging", 10)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(10), b.ID)
+}
+
+func TestStartPendingBuild_SerialGroupAndConcurrency(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	// Concurrency allows but serial group blocks
+	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "deploy-staging").
+		Return(&job.Job{Name: "deploy-staging", Concurrency: 2, SerialGroups: []string{"deploy"}}, nil)
+	s.Builds.EXPECT().CountRunning(ctx, "main", "my-pipeline", "deploy-staging").Return(0, nil)
+	s.Builds.EXPECT().CountRunningInSerialGroups(ctx, "main", "my-pipeline", []string{"deploy"}, "deploy-staging").
+		Return(1, nil)
+
+	_, err := s.S.StartPendingBuild(ctx, "main", "my-pipeline", "deploy-staging", 10)
+	require.ErrorIs(t, err, pikoci.ErrSerialGroupLimit)
+}
+
+func TestNotifySerialGroupPendingBuilds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "deploy-staging").
+		Return(&job.Job{Name: "deploy-staging", SerialGroups: []string{"deploy"}}, nil)
+	s.Jobs.EXPECT().FindJobsBySerialGroups(ctx, "main", "my-pipeline", []string{"deploy"}).
+		Return([]*job.Job{
+			{Name: "deploy-staging"},
+			{Name: "deploy-prod"},
+		}, nil)
+	// Should find pending build for deploy-prod (skip deploy-staging since it's the caller)
+	s.Builds.EXPECT().FindOldestPending(ctx, "main", "my-pipeline", "deploy-prod").
+		Return(&build.Build{ID: 42, Status: build.Pending}, nil)
+	s.Topic.EXPECT().Send(ctx, gomock.Any()).DoAndReturn(func(_ context.Context, msg *pubsub.Message) error {
+		var body queue.Body
+		err := json.Unmarshal(msg.Body, &body)
+		require.NoError(t, err)
+		assert.Equal(t, "deploy-prod", body.JobName)
+		assert.Equal(t, uint32(42), body.BuildID)
+		return nil
+	})
+
+	s.P.NotifySerialGroupPendingBuilds(ctx, "main", "my-pipeline", "deploy-staging")
+}
+
+func TestNotifySerialGroupPendingBuilds_NoSerialGroups(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "my-job").
+		Return(&job.Job{Name: "my-job"}, nil)
+	// No further calls expected — job has no serial groups
+
+	s.P.NotifySerialGroupPendingBuilds(ctx, "main", "my-pipeline", "my-job")
 }
 
 func TestCreateRetryJobBuild_InvalidCanonical(t *testing.T) {

--- a/pikoci/helper.go
+++ b/pikoci/helper.go
@@ -68,14 +68,15 @@ type hclPutStep struct {
 
 // hclJob is the intermediate HCL-decoded job with separate get/task/put/notify arrays.
 type hclJob struct {
-	Name        string           `hcl:"name,label"`
-	Concurrency int              `hcl:"concurrency,optional"`
-	Timeout     string           `hcl:"timeout,optional"`
-	Get         []hclGetStep     `hcl:"get,block"`
-	Task        []hclTaskStep    `hcl:"task,block"`
-	Put         []hclPutStep     `hcl:"put,block"`
-	Notify      []hclNotifyStep  `hcl:"notify,block"`
-	Service     []hclServiceRef  `hcl:"service,block"`
+	Name         string           `hcl:"name,label"`
+	Concurrency  int              `hcl:"concurrency,optional"`
+	SerialGroups []string         `hcl:"serial_groups,optional"`
+	Timeout      string           `hcl:"timeout,optional"`
+	Get          []hclGetStep     `hcl:"get,block"`
+	Task         []hclTaskStep    `hcl:"task,block"`
+	Put          []hclPutStep     `hcl:"put,block"`
+	Notify       []hclNotifyStep  `hcl:"notify,block"`
+	Service      []hclServiceRef  `hcl:"service,block"`
 
 	Remain hcl.Body `hcl:",remain"` // absorbs hook blocks; parsed by parseHooks from AST
 }
@@ -667,6 +668,11 @@ func (q *PikoCI) readPipeline(ctx context.Context, rpp []byte, vars map[string]i
 		if hj.Concurrency < 0 {
 			return nil, fmt.Errorf("job %q: concurrency must be >= 0", hj.Name)
 		}
+		for _, sg := range hj.SerialGroups {
+			if !utils.ValidateCanonical(sg) {
+				return nil, fmt.Errorf("job %q: invalid serial_group name %q (must be lowercase alphanumeric with hyphens)", hj.Name, sg)
+			}
+		}
 		var jobTimeout time.Duration
 		if hj.Timeout != "" {
 			jobTimeout, err = time.ParseDuration(hj.Timeout)
@@ -676,14 +682,15 @@ func (q *PikoCI) readPipeline(ctx context.Context, rpp []byte, vars map[string]i
 		}
 		jh := jobHooksMap[hj.Name]
 		j := job.Job{
-			Name:        hj.Name,
-			Concurrency: hj.Concurrency,
-			Timeout:     jobTimeout,
-			Plan:        jobPlans[hj.Name],
-			OnSuccess:   jh.OnSuccess,
-			OnFailure:   jh.OnFailure,
-			OnCancel:    jh.OnCancel,
-			Ensure:      jh.Ensure,
+			Name:         hj.Name,
+			Concurrency:  hj.Concurrency,
+			SerialGroups: hj.SerialGroups,
+			Timeout:      jobTimeout,
+			Plan:         jobPlans[hj.Name],
+			OnSuccess:    jh.OnSuccess,
+			OnFailure:    jh.OnFailure,
+			OnCancel:     jh.OnCancel,
+			Ensure:       jh.Ensure,
 		}
 		pp.Jobs = append(pp.Jobs, j)
 	}

--- a/pikoci/job/job.go
+++ b/pikoci/job/job.go
@@ -40,12 +40,13 @@ type HookStep struct {
 // ordered steps and optional lifecycle hooks that run on success, failure,
 // cancellation, or unconditionally (ensure).
 type Job struct {
-	ID          uint32     `json:"id"`
-	Name        string     `json:"name" hcl:"name,label"`
-	Concurrency int        `json:"concurrency,omitempty"`
-	Paused      bool          `json:"paused"`
-	Timeout     time.Duration `json:"timeout,omitempty"`
-	Plan        []PlanStep    `json:"plan"`
+	ID           uint32     `json:"id"`
+	Name         string     `json:"name" hcl:"name,label"`
+	Concurrency  int        `json:"concurrency,omitempty"`
+	SerialGroups []string      `json:"serial_groups,omitempty"`
+	Paused       bool          `json:"paused"`
+	Timeout      time.Duration `json:"timeout,omitempty"`
+	Plan         []PlanStep    `json:"plan"`
 
 	OnSuccess []HookStep `json:"on_success,omitempty"`
 	OnFailure []HookStep `json:"on_failure,omitempty"`

--- a/pikoci/job/repository.go
+++ b/pikoci/job/repository.go
@@ -22,4 +22,6 @@ type Repository interface {
 	PauseAll(ctx context.Context, tc, pn string) error
 	// UnpauseAll clears the paused flag for all jobs in a pipeline.
 	UnpauseAll(ctx context.Context, tc, pn string) error
+	// FindJobsBySerialGroups returns all jobs in the pipeline that share any of the given serial groups.
+	FindJobsBySerialGroups(ctx context.Context, tc, pn string, serialGroups []string) ([]*Job, error)
 }

--- a/pikoci/mock/build_repository.go
+++ b/pikoci/mock/build_repository.go
@@ -57,6 +57,21 @@ func (mr *BuildRepositoryMockRecorder) CountRunning(ctx, tc, pn, jn any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountRunning", reflect.TypeOf((*BuildRepository)(nil).CountRunning), ctx, tc, pn, jn)
 }
 
+// CountRunningInSerialGroups mocks base method.
+func (m *BuildRepository) CountRunningInSerialGroups(ctx context.Context, tc, pn string, serialGroups []string, excludeJobName string) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountRunningInSerialGroups", ctx, tc, pn, serialGroups, excludeJobName)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountRunningInSerialGroups indicates an expected call of CountRunningInSerialGroups.
+func (mr *BuildRepositoryMockRecorder) CountRunningInSerialGroups(ctx, tc, pn, serialGroups, excludeJobName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountRunningInSerialGroups", reflect.TypeOf((*BuildRepository)(nil).CountRunningInSerialGroups), ctx, tc, pn, serialGroups, excludeJobName)
+}
+
 // Create mocks base method.
 func (m *BuildRepository) Create(ctx context.Context, tc, pn, jn string, b build.Build) (uint32, string, error) {
 	m.ctrl.T.Helper()

--- a/pikoci/mock/job_repository.go
+++ b/pikoci/mock/job_repository.go
@@ -100,6 +100,21 @@ func (mr *JobRepositoryMockRecorder) Find(ctx, tc, pn, jn any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Find", reflect.TypeOf((*JobRepository)(nil).Find), ctx, tc, pn, jn)
 }
 
+// FindJobsBySerialGroups mocks base method.
+func (m *JobRepository) FindJobsBySerialGroups(ctx context.Context, tc, pn string, serialGroups []string) ([]*job.Job, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindJobsBySerialGroups", ctx, tc, pn, serialGroups)
+	ret0, _ := ret[0].([]*job.Job)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindJobsBySerialGroups indicates an expected call of FindJobsBySerialGroups.
+func (mr *JobRepositoryMockRecorder) FindJobsBySerialGroups(ctx, tc, pn, serialGroups any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindJobsBySerialGroups", reflect.TypeOf((*JobRepository)(nil).FindJobsBySerialGroups), ctx, tc, pn, serialGroups)
+}
+
 // PauseAll mocks base method.
 func (m *JobRepository) PauseAll(ctx context.Context, tc, pn string) error {
 	m.ctrl.T.Helper()

--- a/pikoci/mock/service.go
+++ b/pikoci/mock/service.go
@@ -613,6 +613,18 @@ func (mr *ServiceMockRecorder) ListUsers(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUsers", reflect.TypeOf((*Service)(nil).ListUsers), ctx)
 }
 
+// NotifySerialGroupPendingBuilds mocks base method.
+func (m *Service) NotifySerialGroupPendingBuilds(ctx context.Context, tc, pn, jn string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "NotifySerialGroupPendingBuilds", ctx, tc, pn, jn)
+}
+
+// NotifySerialGroupPendingBuilds indicates an expected call of NotifySerialGroupPendingBuilds.
+func (mr *ServiceMockRecorder) NotifySerialGroupPendingBuilds(ctx, tc, pn, jn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifySerialGroupPendingBuilds", reflect.TypeOf((*Service)(nil).NotifySerialGroupPendingBuilds), ctx, tc, pn, jn)
+}
+
 // PauseJob mocks base method.
 func (m *Service) PauseJob(ctx context.Context, tc, pCan, jn string) error {
 	m.ctrl.T.Helper()

--- a/pikoci/mysql/build.go
+++ b/pikoci/mysql/build.go
@@ -478,6 +478,38 @@ func (r *BuildRepository) CountRunning(ctx context.Context, tc, pn, jn string) (
 	return count, nil
 }
 
+func (r *BuildRepository) CountRunningInSerialGroups(ctx context.Context, tc, pn string, serialGroups []string, excludeJobName string) (int, error) {
+	if len(serialGroups) == 0 {
+		return 0, nil
+	}
+	placeholders := make([]string, len(serialGroups))
+	args := make([]interface{}, 0, len(serialGroups)+3)
+	args = append(args, tc, pn)
+	for i, sg := range serialGroups {
+		placeholders[i] = "?"
+		args = append(args, sg)
+	}
+	args = append(args, excludeJobName)
+	query := fmt.Sprintf(`
+		SELECT COUNT(DISTINCT b.id)
+		FROM builds AS b
+		JOIN jobs AS j ON b.job_id = j.id
+		JOIN pipelines AS p ON j.pipeline_id = p.id
+		JOIN teams AS t ON p.team_id = t.id
+		JOIN job_serial_groups AS sg ON j.id = sg.job_id
+		WHERE t.canonical = ? AND p.canonical = ?
+		  AND sg.serial_group IN (%s)
+		  AND b.status = 'started'
+		  AND j.name != ?
+	`, strings.Join(placeholders, ","))
+	var count int
+	err := r.querier.QueryRowContext(ctx, query, args...).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count running builds in serial groups: %w", err)
+	}
+	return count, nil
+}
+
 func (r *BuildRepository) FindByID(ctx context.Context, buildID uint32) (*build.Build, error) {
 	row := r.querier.QueryRowContext(ctx, `
 		SELECT b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical

--- a/pikoci/mysql/build_test.go
+++ b/pikoci/mysql/build_test.go
@@ -389,3 +389,53 @@ func TestFindReadyDownstreamVersion_PicksHighestVersion(t *testing.T) {
 	assert.True(t, ready)
 	assert.Equal(t, uint32(10), vID)
 }
+
+func TestCountRunningInSerialGroups(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	res, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'sg-pipe', 'sg-pipe')`)
+	require.NoError(t, err)
+	ppID, _ := res.LastInsertId()
+
+	res, err = db.ExecContext(ctx, `INSERT INTO jobs (pipeline_id, name) VALUES (?, 'deploy-staging')`, ppID)
+	require.NoError(t, err)
+	stagingID, _ := res.LastInsertId()
+
+	res, err = db.ExecContext(ctx, `INSERT INTO jobs (pipeline_id, name) VALUES (?, 'deploy-prod')`, ppID)
+	require.NoError(t, err)
+	prodID, _ := res.LastInsertId()
+
+	// Both jobs share serial group "deploy"
+	_, err = db.ExecContext(ctx, `INSERT INTO job_serial_groups (job_id, serial_group) VALUES (?, 'deploy')`, stagingID)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO job_serial_groups (job_id, serial_group) VALUES (?, 'deploy')`, prodID)
+	require.NoError(t, err)
+
+	// deploy-staging has a running build
+	_, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, build_number) VALUES (?, 'started', '1')`, stagingID)
+	require.NoError(t, err)
+
+	br := mysql.NewBuildRepository(db, mysql.Mem)
+
+	// From deploy-prod's perspective, there's 1 running build in the serial group
+	count, err := br.CountRunningInSerialGroups(ctx, "main", "sg-pipe", []string{"deploy"}, "deploy-prod")
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	// From deploy-staging's perspective, its own build is excluded
+	count, err = br.CountRunningInSerialGroups(ctx, "main", "sg-pipe", []string{"deploy"}, "deploy-staging")
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+func TestCountRunningInSerialGroups_Empty(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	br := mysql.NewBuildRepository(db, mysql.Mem)
+
+	count, err := br.CountRunningInSerialGroups(ctx, "main", "pipe", []string{}, "job")
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}

--- a/pikoci/mysql/job.go
+++ b/pikoci/mysql/job.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cycloidio/sqlr"
@@ -98,6 +99,10 @@ func (r *JobRepository) Create(ctx context.Context, tc, pn string, j job.Job) (u
 		return 0, fmt.Errorf("failed to get last inserted id: %w", err)
 	}
 
+	if err := r.replaceSerialGroups(ctx, id, j.SerialGroups); err != nil {
+		return 0, fmt.Errorf("failed to insert serial groups: %w", err)
+	}
+
 	return id, nil
 }
 
@@ -126,6 +131,22 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 		return fmt.Errorf("failed to update job: %w", err)
 	}
 
+	// Look up the job ID to replace serial groups.
+	var jobID uint32
+	err = r.querier.QueryRowContext(ctx, `
+		SELECT j.id FROM jobs AS j
+		JOIN pipelines AS p ON j.pipeline_id = p.id
+		JOIN teams AS t ON p.team_id = t.id
+		WHERE t.canonical = ? AND p.canonical = ? AND j.name = ?
+	`, tc, pn, j.Name).Scan(&jobID)
+	if err != nil {
+		return fmt.Errorf("failed to find job id for serial groups: %w", err)
+	}
+
+	if err := r.replaceSerialGroups(ctx, jobID, j.SerialGroups); err != nil {
+		return fmt.Errorf("failed to update serial groups: %w", err)
+	}
+
 	return nil
 }
 
@@ -144,6 +165,12 @@ func (r *JobRepository) Find(ctx context.Context, tc, pn, jn string) (*job.Job, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to scan Job: %w", err)
 	}
+
+	sgs, err := r.loadSerialGroups(ctx, j.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load serial groups: %w", err)
+	}
+	j.SerialGroups = sgs
 
 	return j, nil
 }
@@ -165,6 +192,14 @@ func (r *JobRepository) Filter(ctx context.Context, tc, pn string) ([]*job.Job, 
 	jobs, err := scanJobs(rows)
 	if err != nil {
 		return nil, fmt.Errorf("failed to filter jobs: %w", err)
+	}
+
+	for _, j := range jobs {
+		sgs, err := r.loadSerialGroups(ctx, j.ID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load serial groups for job %q: %w", j.Name, err)
+		}
+		j.SerialGroups = sgs
 	}
 
 	return jobs, nil
@@ -306,3 +341,76 @@ func scanJobs(rows *sql.Rows) ([]*job.Job, error) {
 	}
 	return js, nil
 }
+
+func (r *JobRepository) replaceSerialGroups(ctx context.Context, jobID uint32, groups []string) error {
+	_, err := r.querier.ExecContext(ctx, `DELETE FROM job_serial_groups WHERE job_id = ?`, jobID)
+	if err != nil {
+		return fmt.Errorf("failed to delete old serial groups: %w", err)
+	}
+	for _, sg := range groups {
+		_, err := r.querier.ExecContext(ctx, `INSERT INTO job_serial_groups (job_id, serial_group) VALUES (?, ?)`, jobID, sg)
+		if err != nil {
+			return fmt.Errorf("failed to insert serial group %q: %w", sg, err)
+		}
+	}
+	return nil
+}
+
+func (r *JobRepository) loadSerialGroups(ctx context.Context, jobID uint32) ([]string, error) {
+	rows, err := r.querier.QueryContext(ctx, `SELECT serial_group FROM job_serial_groups WHERE job_id = ? ORDER BY serial_group`, jobID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query serial groups: %w", err)
+	}
+	defer rows.Close()
+
+	var groups []string
+	for rows.Next() {
+		var sg string
+		if err := rows.Scan(&sg); err != nil {
+			return nil, fmt.Errorf("failed to scan serial group: %w", err)
+		}
+		groups = append(groups, sg)
+	}
+	return groups, rows.Err()
+}
+
+func (r *JobRepository) FindJobsBySerialGroups(ctx context.Context, tc, pn string, serialGroups []string) ([]*job.Job, error) {
+	if len(serialGroups) == 0 {
+		return nil, nil
+	}
+	placeholders := make([]string, len(serialGroups))
+	args := make([]interface{}, 0, len(serialGroups)+2)
+	args = append(args, tc, pn)
+	for i, sg := range serialGroups {
+		placeholders[i] = "?"
+		args = append(args, sg)
+	}
+	query := fmt.Sprintf(`
+		SELECT DISTINCT j.id, j.name, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout
+		FROM jobs AS j
+		JOIN pipelines AS p ON j.pipeline_id = p.id
+		JOIN teams AS t ON p.team_id = t.id
+		JOIN job_serial_groups AS sg ON j.id = sg.job_id
+		WHERE t.canonical = ? AND p.canonical = ? AND sg.serial_group IN (%s)
+	`, strings.Join(placeholders, ","))
+	rows, err := r.querier.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find jobs by serial groups: %w", err)
+	}
+
+	jobs, err := scanJobs(rows)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan jobs by serial groups: %w", err)
+	}
+
+	for _, j := range jobs {
+		sgs, err := r.loadSerialGroups(ctx, j.ID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load serial groups for job %q: %w", j.Name, err)
+		}
+		j.SerialGroups = sgs
+	}
+
+	return jobs, nil
+}
+

--- a/pikoci/mysql/migrate/migrations/V29SerialGroups.go
+++ b/pikoci/mysql/migrate/migrations/V29SerialGroups.go
@@ -1,0 +1,13 @@
+package migrations
+
+// V29SerialGroups creates the job_serial_groups join table for cross-job mutual exclusion.
+var V29SerialGroups = Migration{
+	Name: "SerialGroups",
+	SQL: `CREATE TABLE job_serial_groups (
+	job_id INTEGER NOT NULL,
+	serial_group VARCHAR(255) NOT NULL,
+	PRIMARY KEY (job_id, serial_group),
+	FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE
+);
+CREATE INDEX idx_job_serial_groups_group ON job_serial_groups (serial_group);`,
+}

--- a/pikoci/mysql/migrate/migrations/V29SerialGroups.go
+++ b/pikoci/mysql/migrate/migrations/V29SerialGroups.go
@@ -4,7 +4,7 @@ package migrations
 var V29SerialGroups = Migration{
 	Name: "SerialGroups",
 	SQL: `CREATE TABLE job_serial_groups (
-	job_id INTEGER NOT NULL,
+	job_id INT UNSIGNED NOT NULL,
 	serial_group VARCHAR(255) NOT NULL,
 	PRIMARY KEY (job_id, serial_group),
 	FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE

--- a/pikoci/mysql/migrate/migrations/migrations.go
+++ b/pikoci/mysql/migrate/migrations/migrations.go
@@ -16,7 +16,7 @@ type Migration struct {
 // Migrations is the ordered list of all schema migrations. It is defined as
 // a fixed-size array so that the compiler catches ordering conflicts when
 // multiple developers add migrations concurrently.
-var Migrations = [29]Migration{
+var Migrations = [30]Migration{
 	V0Initial,
 	V1ResourceCheckInterval,
 	V2JobsAndBuilds,
@@ -46,4 +46,5 @@ var Migrations = [29]Migration{
 	V26PausePipelineJob,
 	V27ResourcePin,
 	V28JobTimeout,
+	V29SerialGroups,
 }

--- a/pikoci/mysql/pipeline_test.go
+++ b/pikoci/mysql/pipeline_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/pikoci/pikoci/pikoci/job"
 	"github.com/pikoci/pikoci/pikoci/mysql"
 	"github.com/pikoci/pikoci/pikoci/mysql/migrate"
 )
@@ -169,4 +170,120 @@ func TestDeletePipeline_CascadesRunners(t *testing.T) {
 	err = db.QueryRowContext(ctx, `SELECT COUNT(*) FROM runners WHERE pipeline_id = ?`, ppID).Scan(&count)
 	require.NoError(t, err)
 	assert.Equal(t, 0, count, "runners should be cascade-deleted when pipeline is deleted")
+}
+
+func TestJobCreate_PersistsSerialGroups(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'sg-create', 'sg-create')`)
+	require.NoError(t, err)
+
+	jr := mysql.NewJobRepository(db)
+	j := job.Job{Name: "deploy-staging", SerialGroups: []string{"deploy", "infra"}}
+	id, err := jr.Create(ctx, "main", "sg-create", j)
+	require.NoError(t, err)
+	assert.NotZero(t, id)
+
+	found, err := jr.Find(ctx, "main", "sg-create", "deploy-staging")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"deploy", "infra"}, found.SerialGroups)
+}
+
+func TestJobUpdate_ReplacesSerialGroups(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'sg-update', 'sg-update')`)
+	require.NoError(t, err)
+
+	jr := mysql.NewJobRepository(db)
+	j := job.Job{Name: "deploy", SerialGroups: []string{"deploy"}}
+	_, err = jr.Create(ctx, "main", "sg-update", j)
+	require.NoError(t, err)
+
+	j.SerialGroups = []string{"infra"}
+	err = jr.Update(ctx, "main", "sg-update", "deploy", j)
+	require.NoError(t, err)
+
+	found, err := jr.Find(ctx, "main", "sg-update", "deploy")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"infra"}, found.SerialGroups)
+}
+
+func TestFindJobsBySerialGroups(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'sg-find', 'sg-find')`)
+	require.NoError(t, err)
+
+	jr := mysql.NewJobRepository(db)
+
+	_, err = jr.Create(ctx, "main", "sg-find", job.Job{Name: "staging", SerialGroups: []string{"deploy"}})
+	require.NoError(t, err)
+	_, err = jr.Create(ctx, "main", "sg-find", job.Job{Name: "prod", SerialGroups: []string{"deploy"}})
+	require.NoError(t, err)
+	_, err = jr.Create(ctx, "main", "sg-find", job.Job{Name: "unrelated"})
+	require.NoError(t, err)
+
+	jobs, err := jr.FindJobsBySerialGroups(ctx, "main", "sg-find", []string{"deploy"})
+	require.NoError(t, err)
+	assert.Len(t, jobs, 2)
+
+	names := []string{jobs[0].Name, jobs[1].Name}
+	assert.Contains(t, names, "staging")
+	assert.Contains(t, names, "prod")
+}
+
+func TestFindJobsBySerialGroups_Empty(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	jr := mysql.NewJobRepository(db)
+	jobs, err := jr.FindJobsBySerialGroups(ctx, "main", "pipe", []string{})
+	require.NoError(t, err)
+	assert.Nil(t, jobs)
+}
+
+func TestJobFilter_IncludesSerialGroups(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'sg-filter', 'sg-filter')`)
+	require.NoError(t, err)
+
+	jr := mysql.NewJobRepository(db)
+	_, err = jr.Create(ctx, "main", "sg-filter", job.Job{Name: "staging", SerialGroups: []string{"deploy"}})
+	require.NoError(t, err)
+
+	jobs, err := jr.Filter(ctx, "main", "sg-filter")
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	assert.Equal(t, []string{"deploy"}, jobs[0].SerialGroups)
+}
+
+func TestDeletePipeline_CascadesSerialGroups(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	res, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'sg-cascade', 'sg-cascade')`)
+	require.NoError(t, err)
+	ppID, _ := res.LastInsertId()
+
+	res, err = db.ExecContext(ctx, `INSERT INTO jobs (pipeline_id, name) VALUES (?, 'deploy')`, ppID)
+	require.NoError(t, err)
+	jobID, _ := res.LastInsertId()
+
+	_, err = db.ExecContext(ctx, `INSERT INTO job_serial_groups (job_id, serial_group) VALUES (?, 'deploy')`, jobID)
+	require.NoError(t, err)
+
+	pr := mysql.NewPipelineRepository(db)
+	err = pr.Delete(ctx, "main", "sg-cascade")
+	require.NoError(t, err)
+
+	var count int
+	err = db.QueryRowContext(ctx, `SELECT COUNT(*) FROM job_serial_groups WHERE job_id = ?`, jobID).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "serial groups should be cascade-deleted when pipeline is deleted")
 }

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -547,11 +547,15 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 	graph.SetStrict(true)
 	graph.AddAttr(pn, string(gographviz.RankDir), "LR")
 
-	// Collect resources referenced by get steps
+	// Collect resources referenced by get steps without passed constraints.
+	// Resources only accessed via get-with-passed don't need a standalone node
+	// because the passed-edge logic creates its own intermediate resource nodes.
 	referencedResources := make(map[string]bool)
 	for _, j := range pp.Jobs {
 		for _, g := range j.GetSteps() {
-			referencedResources[g.ResourceCanonical()] = true
+			if len(g.Passed) == 0 {
+				referencedResources[g.ResourceCanonical()] = true
+			}
 		}
 	}
 

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -1567,6 +1567,18 @@ func TestGetPipelineImage_PassedReusesPutOutputNode(t *testing.T) {
 	assert.Contains(t, dot, `"build-artifact.output-out"--"deploy"`, "passed edge should reuse put output node")
 	// There should NOT be a separate passed node for the same resource
 	assert.NotContains(t, dot, `"build-output-deploy"`, "should not create a separate passed node when put output exists")
+	// The resource should NOT appear as an orphaned standalone node since it's
+	// only accessed via get-with-passed (the put output node handles it)
+	lines := strings.Split(dot, "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.Contains(trimmed, "->") || strings.Contains(trimmed, "-out") {
+			continue
+		}
+		if strings.Contains(trimmed, `"artifact.output"`) && strings.Contains(trimmed, "shape") {
+			t.Errorf("resource only accessed via get-with-passed should not appear as standalone node: %s", trimmed)
+		}
+	}
 }
 
 func TestGetPipelineImage_JobStatusColors(t *testing.T) {

--- a/pikoci/service.go
+++ b/pikoci/service.go
@@ -157,6 +157,9 @@ type Service interface {
 	StartPendingBuild(ctx context.Context, tc, pn, jn string, buildID uint32) (*build.Build, error)
 	// FindOldestPendingBuild returns the oldest pending build for the specified job.
 	FindOldestPendingBuild(ctx context.Context, tc, pn, jn string) (*build.Build, error)
+	// NotifySerialGroupPendingBuilds finds all jobs sharing serial groups with the
+	// given job and enqueues their oldest pending builds for execution.
+	NotifySerialGroupPendingBuilds(ctx context.Context, tc, pn, jn string)
 
 	// GetPipelineResource retrieves a resource by its canonical name within a pipeline.
 	GetPipelineResource(ctx context.Context, tc, pn, rCan string) (*resource.Resource, error)

--- a/pikoci/service_test.go
+++ b/pikoci/service_test.go
@@ -67,6 +67,64 @@ func TestTriggerPipelineJob(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestCreatePipeline_SerialGroups(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+	tc := "team-canonical"
+	ppc := "serial-pipeline"
+
+	b, err := os.ReadFile("testdata/serial_groups.hcl")
+	require.NoError(t, err)
+
+	var capturedJobs []job.Job
+	s.Pipelines.EXPECT().Create(ctx, tc, gomock.Any()).Return(uint32(1), nil)
+	s.Jobs.EXPECT().Create(ctx, tc, ppc, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _, _ string, j job.Job) (uint32, error) {
+			capturedJobs = append(capturedJobs, j)
+			return uint32(len(capturedJobs)), nil
+		}).Times(2)
+	s.Resources.EXPECT().Create(ctx, tc, ppc, gomock.Any()).Return(uint32(1), nil).Times(1)
+	s.Pipelines.EXPECT().Find(ctx, tc, ppc).Return(&pipeline.Pipeline{Name: ppc}, nil)
+
+	pp, err := s.S.CreatePipeline(ctx, tc, ppc, b, nil)
+	require.NoError(t, err)
+	require.NotNil(t, pp)
+
+	require.Len(t, capturedJobs, 2)
+	assert.Equal(t, []string{"deploy"}, capturedJobs[0].SerialGroups)
+	assert.Equal(t, []string{"deploy"}, capturedJobs[1].SerialGroups)
+}
+
+func TestCreatePipeline_SerialGroups_InvalidName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hcl := []byte(`
+resource "git" "repo" {
+  params {
+    url = "https://example.com/repo.git"
+  }
+}
+job "bad-job" {
+  serial_groups = ["INVALID NAME"]
+  get "git" "repo" {
+    trigger = true
+  }
+  task "build" {
+    run "exec" {
+      path = "echo"
+    }
+  }
+}
+`)
+
+	_, err := s.S.CreatePipeline(ctx, "team", "pipe", hcl, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid serial_group name")
+}
+
 func TestGetPipelineJob(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := newService(ctrl)

--- a/pikoci/testdata/cron.hcl
+++ b/pikoci/testdata/cron.hcl
@@ -42,27 +42,32 @@ job "gen" {
   }
 }
 
-job "by-passed" {
+job "deploy-staging" {
+  serial_groups = ["deploy"]
+
   get "artifact" "cron_output" {
     trigger = true
     passed  = ["gen"]
   }
-  task "print-file" {
+  task "deploy" {
     run "exec" {
       path = "/bin/sh"
-      args = ["-ec", "echo '--- by-passed job ---' && cat cron-output/timestamp.txt"]
+      args = ["-ec", "echo '--- deploy-staging ---' && cat cron-output/timestamp.txt && echo 'deploying to staging...' && sleep 10 && echo 'done'"]
     }
   }
 }
 
-job "by-check" {
+job "deploy-prod" {
+  serial_groups = ["deploy"]
+
   get "artifact" "cron_output" {
     trigger = true
+    passed  = ["gen"]
   }
-  task "print-file" {
+  task "deploy" {
     run "exec" {
       path = "/bin/sh"
-      args = ["-ec", "echo '--- by-check job ---' && cat cron-output/timestamp.txt"]
+      args = ["-ec", "echo '--- deploy-prod ---' && cat cron-output/timestamp.txt && echo 'deploying to prod...' && sleep 10 && echo 'done'"]
     }
   }
 }

--- a/pikoci/testdata/serial_groups.hcl
+++ b/pikoci/testdata/serial_groups.hcl
@@ -1,0 +1,31 @@
+resource "git" "repo" {
+  params {
+    url = "https://example.com/repo.git"
+  }
+}
+
+job "deploy-staging" {
+  serial_groups = ["deploy"]
+
+  get "git" "repo" {
+    trigger = true
+  }
+  task "deploy" {
+    run "exec" {
+      path = "./deploy.sh"
+    }
+  }
+}
+
+job "deploy-prod" {
+  serial_groups = ["deploy"]
+
+  get "git" "repo" {
+    passed = ["deploy-staging"]
+  }
+  task "deploy" {
+    run "exec" {
+      path = "./deploy.sh"
+    }
+  }
+}

--- a/pikoci/transport/http/authorization.go
+++ b/pikoci/transport/http/authorization.go
@@ -52,9 +52,10 @@ var (
 		GetJobBuild:          member,
 		CancelJobBuild:         member,
 		RetryJobBuild:          member,
-		StartPendingBuild:      admin,
-		FindOldestPendingBuild: admin,
-		InsertBuildGetVersion:  admin,
+		StartPendingBuild:              admin,
+		FindOldestPendingBuild:         admin,
+		NotifySerialGroupPendingBuilds: admin,
+		InsertBuildGetVersion:          admin,
 		FindBuildGetVersions:   admin,
 
 		GetPipelineResource:     member,

--- a/pikoci/transport/http/builds.go
+++ b/pikoci/transport/http/builds.go
@@ -80,6 +80,18 @@ func findOldestPendingBuild(s pikoci.Service) http.HandlerFunc {
 	}
 }
 
+func notifySerialGroupPendingBuilds(s pikoci.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var ctx = r.Context()
+		vars := mux.Vars(r)
+		tc := vars["team_canonical"]
+		pc := vars["pipeline_canonical"]
+		jn := vars["job_name"]
+		s.NotifySerialGroupPendingBuilds(ctx, tc, pc, jn)
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
 type UpdateJobBuildRequest struct {
 	TeamCanonical     string      `json:"team_canonical"`
 	PipelineCanonical string      `json:"pipeline_canonical"`

--- a/pikoci/transport/http/client/client.go
+++ b/pikoci/transport/http/client/client.go
@@ -821,6 +821,12 @@ func (cl *Client) FindOldestPendingBuild(ctx context.Context, tc, pn, jn string)
 	return resp.Build, nil
 }
 
+// NotifySerialGroupPendingBuilds asks the server to notify pending builds for
+// all jobs sharing serial groups with the given job.
+func (cl *Client) NotifySerialGroupPendingBuilds(ctx context.Context, tc, pn, jn string) {
+	_ = cl.Request(ctx, http.MethodPost, fmt.Sprintf("%s/teams/%s/pipelines/%s/jobs/%s/notify-serial-groups", cl.url, tc, pn, jn), nil, nil)
+}
+
 // ListJobBuilds always fetches all builds (limit=0) for CLI backward compat.
 // The before/after/limit params satisfy the Service interface but are not sent.
 func (cl *Client) ListJobBuilds(ctx context.Context, tc, pn, jn string, before *uint32, after *uint32, limit uint32) ([]*build.Build, bool, error) {

--- a/pikoci/transport/http/client/client_test.go
+++ b/pikoci/transport/http/client/client_test.go
@@ -681,6 +681,23 @@ func TestFindOldestPendingBuild_None(t *testing.T) {
 	assert.Nil(t, b)
 }
 
+func TestNotifySerialGroupPendingBuilds(t *testing.T) {
+	called := false
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/{pn}/jobs/{jn}/notify-serial-groups", func(w http.ResponseWriter, req *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	}).Methods("POST")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	c.NotifySerialGroupPendingBuilds(context.Background(), "team", "pipe", "job1")
+	assert.True(t, called, "should have called the endpoint")
+}
+
 func TestCreateResourceVersion(t *testing.T) {
 	r := mux.NewRouter()
 	r.HandleFunc("/teams/{tc}/pipelines/{pn}/resources/{rCan}/versions", func(w http.ResponseWriter, req *http.Request) {

--- a/pikoci/transport/http/handler.go
+++ b/pikoci/transport/http/handler.go
@@ -248,6 +248,7 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, 
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/builds/{build_number}/retry").Name(RetryJobBuild.String()).Handler(retryJobBuild(s))
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/builds/start-pending").Name(StartPendingBuild.String()).Handler(startPendingBuild(s))
 	api.Methods(http.MethodGet).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/builds/oldest-pending").Name(FindOldestPendingBuild.String()).Handler(findOldestPendingBuild(s))
+	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/notify-serial-groups").Name(NotifySerialGroupPendingBuilds.String()).Handler(notifySerialGroupPendingBuilds(s))
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/retry-builds").Name(CreateRetryJobBuild.String()).Handler(createRetryJobBuild(s))
 	api.Methods(http.MethodGet).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/builds-get-versions/{build_id}").Name(FindBuildGetVersions.String()).Handler(findBuildGetVersions(s))
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/builds/{build_id}/get-versions").Name(InsertBuildGetVersion.String()).Handler(insertBuildGetVersion(s))

--- a/pikoci/transport/http/handlers_coverage_test.go
+++ b/pikoci/transport/http/handlers_coverage_test.go
@@ -2201,6 +2201,17 @@ func TestGetPipelineResource_PublicFallback(t *testing.T) {
 	assert.Equal(t, "my-res", got.Resource.Name)
 }
 
+func TestNotifySerialGroupPendingBuilds_Success(t *testing.T) {
+	e := newTestEnv(t)
+	e.expectAdminAuth()
+	e.svc.EXPECT().NotifySerialGroupPendingBuilds(gomock.Any(), "main", "my-pipe", "build")
+
+	resp := doRequest(t, http.MethodPost, e.server.URL+"/teams/main/pipelines/my-pipe/jobs/build/notify-serial-groups", e.adminJWT(t), "")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
 func TestListResourceVersions_PublicFallback(t *testing.T) {
 	e := newTestEnv(t)
 	pp := &pipeline.Pipeline{Name: "public-pipe", Canonical: "public-pipe", Public: true}

--- a/pikoci/transport/http/route_names.go
+++ b/pikoci/transport/http/route_names.go
@@ -90,6 +90,8 @@ const (
 	StartPendingBuild
 	// FindOldestPendingBuild is the route for finding the oldest pending build for a job.
 	FindOldestPendingBuild
+	// NotifySerialGroupPendingBuilds is the route for notifying pending builds in serial groups.
+	NotifySerialGroupPendingBuilds
 
 	// GetPipelineResource is the route for retrieving a single pipeline resource.
 	GetPipelineResource

--- a/pikoci/transport/http/route_names_string.go
+++ b/pikoci/transport/http/route_names_string.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _RouteNameName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_version"
+const _RouteNameName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_version"
 
-var _RouteNameIndex = [...]uint16{0, 10, 23, 34, 44, 52, 63, 74, 89, 103, 114, 124, 132, 143, 154, 172, 190, 208, 223, 238, 250, 265, 279, 297, 318, 338, 354, 370, 392, 408, 424, 439, 463, 486, 499, 515, 530, 549, 574, 595, 619, 644, 667, 689, 709, 731, 755, 770, 794, 808, 827, 842, 856, 872, 881, 892, 903}
+var _RouteNameIndex = [...]uint16{0, 10, 23, 34, 44, 52, 63, 74, 89, 103, 114, 124, 132, 143, 154, 172, 190, 208, 223, 238, 250, 265, 279, 297, 318, 338, 354, 370, 392, 408, 424, 439, 463, 486, 499, 515, 530, 549, 574, 608, 629, 653, 678, 701, 723, 743, 765, 789, 804, 828, 842, 861, 876, 890, 906, 915, 926, 937}
 
-const _RouteNameLowerName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_version"
+const _RouteNameLowerName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_version"
 
 func (i RouteName) String() string {
 	if i < 0 || i >= RouteName(len(_RouteNameIndex)-1) {
@@ -62,27 +62,28 @@ func _RouteNameNoOp() {
 	_ = x[RetryJobBuild-(35)]
 	_ = x[StartPendingBuild-(36)]
 	_ = x[FindOldestPendingBuild-(37)]
-	_ = x[GetPipelineResource-(38)]
-	_ = x[UpdatePipelineResource-(39)]
-	_ = x[TriggerPipelineResource-(40)]
-	_ = x[CreateResourceVersion-(41)]
-	_ = x[ListResourceVersions-(42)]
-	_ = x[PinResourceVersion-(43)]
-	_ = x[UnpinResourceVersion-(44)]
-	_ = x[TriggerResourceVersion-(45)]
-	_ = x[WebhookTrigger-(46)]
-	_ = x[RegenerateWebhookToken-(47)]
-	_ = x[CreateTrigger-(48)]
-	_ = x[ListTriggersAfter-(49)]
-	_ = x[ExportDatabase-(50)]
-	_ = x[PausePipeline-(51)]
-	_ = x[UnpausePipeline-(52)]
-	_ = x[PauseJob-(53)]
-	_ = x[UnpauseJob-(54)]
-	_ = x[GetVersion-(55)]
+	_ = x[NotifySerialGroupPendingBuilds-(38)]
+	_ = x[GetPipelineResource-(39)]
+	_ = x[UpdatePipelineResource-(40)]
+	_ = x[TriggerPipelineResource-(41)]
+	_ = x[CreateResourceVersion-(42)]
+	_ = x[ListResourceVersions-(43)]
+	_ = x[PinResourceVersion-(44)]
+	_ = x[UnpinResourceVersion-(45)]
+	_ = x[TriggerResourceVersion-(46)]
+	_ = x[WebhookTrigger-(47)]
+	_ = x[RegenerateWebhookToken-(48)]
+	_ = x[CreateTrigger-(49)]
+	_ = x[ListTriggersAfter-(50)]
+	_ = x[ExportDatabase-(51)]
+	_ = x[PausePipeline-(52)]
+	_ = x[UnpausePipeline-(53)]
+	_ = x[PauseJob-(54)]
+	_ = x[UnpauseJob-(55)]
+	_ = x[GetVersion-(56)]
 }
 
-var _RouteNameValues = []RouteName{UserLogin, RefreshToken, CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser, ChangePassword, UpdateProfile, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, GetPipelineJob, CreateJobBuild, CreateRetryJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, InsertBuildGetVersion, FindBuildGetVersions, GetJobBuild, CancelJobBuild, RetryJobBuild, StartPendingBuild, FindOldestPendingBuild, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions, PinResourceVersion, UnpinResourceVersion, TriggerResourceVersion, WebhookTrigger, RegenerateWebhookToken, CreateTrigger, ListTriggersAfter, ExportDatabase, PausePipeline, UnpausePipeline, PauseJob, UnpauseJob, GetVersion}
+var _RouteNameValues = []RouteName{UserLogin, RefreshToken, CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser, ChangePassword, UpdateProfile, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, GetPipelineJob, CreateJobBuild, CreateRetryJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, InsertBuildGetVersion, FindBuildGetVersions, GetJobBuild, CancelJobBuild, RetryJobBuild, StartPendingBuild, FindOldestPendingBuild, NotifySerialGroupPendingBuilds, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions, PinResourceVersion, UnpinResourceVersion, TriggerResourceVersion, WebhookTrigger, RegenerateWebhookToken, CreateTrigger, ListTriggersAfter, ExportDatabase, PausePipeline, UnpausePipeline, PauseJob, UnpauseJob, GetVersion}
 
 var _RouteNameNameToValueMap = map[string]RouteName{
 	_RouteNameName[0:10]:         UserLogin,
@@ -161,42 +162,44 @@ var _RouteNameNameToValueMap = map[string]RouteName{
 	_RouteNameLowerName[530:549]: StartPendingBuild,
 	_RouteNameName[549:574]:      FindOldestPendingBuild,
 	_RouteNameLowerName[549:574]: FindOldestPendingBuild,
-	_RouteNameName[574:595]:      GetPipelineResource,
-	_RouteNameLowerName[574:595]: GetPipelineResource,
-	_RouteNameName[595:619]:      UpdatePipelineResource,
-	_RouteNameLowerName[595:619]: UpdatePipelineResource,
-	_RouteNameName[619:644]:      TriggerPipelineResource,
-	_RouteNameLowerName[619:644]: TriggerPipelineResource,
-	_RouteNameName[644:667]:      CreateResourceVersion,
-	_RouteNameLowerName[644:667]: CreateResourceVersion,
-	_RouteNameName[667:689]:      ListResourceVersions,
-	_RouteNameLowerName[667:689]: ListResourceVersions,
-	_RouteNameName[689:709]:      PinResourceVersion,
-	_RouteNameLowerName[689:709]: PinResourceVersion,
-	_RouteNameName[709:731]:      UnpinResourceVersion,
-	_RouteNameLowerName[709:731]: UnpinResourceVersion,
-	_RouteNameName[731:755]:      TriggerResourceVersion,
-	_RouteNameLowerName[731:755]: TriggerResourceVersion,
-	_RouteNameName[755:770]:      WebhookTrigger,
-	_RouteNameLowerName[755:770]: WebhookTrigger,
-	_RouteNameName[770:794]:      RegenerateWebhookToken,
-	_RouteNameLowerName[770:794]: RegenerateWebhookToken,
-	_RouteNameName[794:808]:      CreateTrigger,
-	_RouteNameLowerName[794:808]: CreateTrigger,
-	_RouteNameName[808:827]:      ListTriggersAfter,
-	_RouteNameLowerName[808:827]: ListTriggersAfter,
-	_RouteNameName[827:842]:      ExportDatabase,
-	_RouteNameLowerName[827:842]: ExportDatabase,
-	_RouteNameName[842:856]:      PausePipeline,
-	_RouteNameLowerName[842:856]: PausePipeline,
-	_RouteNameName[856:872]:      UnpausePipeline,
-	_RouteNameLowerName[856:872]: UnpausePipeline,
-	_RouteNameName[872:881]:      PauseJob,
-	_RouteNameLowerName[872:881]: PauseJob,
-	_RouteNameName[881:892]:      UnpauseJob,
-	_RouteNameLowerName[881:892]: UnpauseJob,
-	_RouteNameName[892:903]:      GetVersion,
-	_RouteNameLowerName[892:903]: GetVersion,
+	_RouteNameName[574:608]:      NotifySerialGroupPendingBuilds,
+	_RouteNameLowerName[574:608]: NotifySerialGroupPendingBuilds,
+	_RouteNameName[608:629]:      GetPipelineResource,
+	_RouteNameLowerName[608:629]: GetPipelineResource,
+	_RouteNameName[629:653]:      UpdatePipelineResource,
+	_RouteNameLowerName[629:653]: UpdatePipelineResource,
+	_RouteNameName[653:678]:      TriggerPipelineResource,
+	_RouteNameLowerName[653:678]: TriggerPipelineResource,
+	_RouteNameName[678:701]:      CreateResourceVersion,
+	_RouteNameLowerName[678:701]: CreateResourceVersion,
+	_RouteNameName[701:723]:      ListResourceVersions,
+	_RouteNameLowerName[701:723]: ListResourceVersions,
+	_RouteNameName[723:743]:      PinResourceVersion,
+	_RouteNameLowerName[723:743]: PinResourceVersion,
+	_RouteNameName[743:765]:      UnpinResourceVersion,
+	_RouteNameLowerName[743:765]: UnpinResourceVersion,
+	_RouteNameName[765:789]:      TriggerResourceVersion,
+	_RouteNameLowerName[765:789]: TriggerResourceVersion,
+	_RouteNameName[789:804]:      WebhookTrigger,
+	_RouteNameLowerName[789:804]: WebhookTrigger,
+	_RouteNameName[804:828]:      RegenerateWebhookToken,
+	_RouteNameLowerName[804:828]: RegenerateWebhookToken,
+	_RouteNameName[828:842]:      CreateTrigger,
+	_RouteNameLowerName[828:842]: CreateTrigger,
+	_RouteNameName[842:861]:      ListTriggersAfter,
+	_RouteNameLowerName[842:861]: ListTriggersAfter,
+	_RouteNameName[861:876]:      ExportDatabase,
+	_RouteNameLowerName[861:876]: ExportDatabase,
+	_RouteNameName[876:890]:      PausePipeline,
+	_RouteNameLowerName[876:890]: PausePipeline,
+	_RouteNameName[890:906]:      UnpausePipeline,
+	_RouteNameLowerName[890:906]: UnpausePipeline,
+	_RouteNameName[906:915]:      PauseJob,
+	_RouteNameLowerName[906:915]: PauseJob,
+	_RouteNameName[915:926]:      UnpauseJob,
+	_RouteNameLowerName[915:926]: UnpauseJob,
+	_RouteNameName[926:937]:      GetVersion,
+	_RouteNameLowerName[926:937]: GetVersion,
 }
 
 var _RouteNameNames = []string{
@@ -238,24 +241,25 @@ var _RouteNameNames = []string{
 	_RouteNameName[515:530],
 	_RouteNameName[530:549],
 	_RouteNameName[549:574],
-	_RouteNameName[574:595],
-	_RouteNameName[595:619],
-	_RouteNameName[619:644],
-	_RouteNameName[644:667],
-	_RouteNameName[667:689],
-	_RouteNameName[689:709],
-	_RouteNameName[709:731],
-	_RouteNameName[731:755],
-	_RouteNameName[755:770],
-	_RouteNameName[770:794],
-	_RouteNameName[794:808],
-	_RouteNameName[808:827],
-	_RouteNameName[827:842],
-	_RouteNameName[842:856],
-	_RouteNameName[856:872],
-	_RouteNameName[872:881],
-	_RouteNameName[881:892],
-	_RouteNameName[892:903],
+	_RouteNameName[574:608],
+	_RouteNameName[608:629],
+	_RouteNameName[629:653],
+	_RouteNameName[653:678],
+	_RouteNameName[678:701],
+	_RouteNameName[701:723],
+	_RouteNameName[723:743],
+	_RouteNameName[743:765],
+	_RouteNameName[765:789],
+	_RouteNameName[789:804],
+	_RouteNameName[804:828],
+	_RouteNameName[828:842],
+	_RouteNameName[842:861],
+	_RouteNameName[861:876],
+	_RouteNameName[876:890],
+	_RouteNameName[890:906],
+	_RouteNameName[906:915],
+	_RouteNameName[915:926],
+	_RouteNameName[926:937],
 }
 
 // RouteNameString retrieves an enum value from the enum constants string name.

--- a/worker/service.go
+++ b/worker/service.go
@@ -337,8 +337,8 @@ func (w *Worker) processJob(ctx context.Context, m queue.Body, cwd string, pp *p
 
 	nb, err := w.pikoci.StartPendingBuild(ctx, m.TeamCanonical, m.PipelineCanonical, m.JobName, m.BuildID)
 	if err != nil {
-		if errors.Is(err, pikoci.ErrConcurrencyLimit) || errors.Is(err, pikoci.ErrJobPaused) {
-			w.logger.Info("concurrency limit or job paused, re-queuing",
+		if errors.Is(err, pikoci.ErrConcurrencyLimit) || errors.Is(err, pikoci.ErrJobPaused) || errors.Is(err, pikoci.ErrSerialGroupLimit) {
+			w.logger.Info("concurrency/serial group limit or job paused, re-queuing",
 				"pipeline", m.PipelineCanonical, "job", m.JobName, "build_id", m.BuildID)
 			mb, _ := json.Marshal(m)
 			if err := w.jobTopic.Send(ctx, &pubsub.Message{Body: mb}); err != nil {
@@ -485,6 +485,10 @@ func (w *Worker) processJob(ctx context.Context, m queue.Body, cwd string, pp *p
 }
 
 func (w *Worker) notifyNextPendingBuild(ctx context.Context, m queue.Body) {
+	// Always notify pending builds for jobs sharing serial groups,
+	// even if this job has no pending builds of its own.
+	w.pikoci.NotifySerialGroupPendingBuilds(ctx, m.TeamCanonical, m.PipelineCanonical, m.JobName)
+
 	pending, err := w.pikoci.FindOldestPendingBuild(ctx, m.TeamCanonical, m.PipelineCanonical, m.JobName)
 	if err != nil {
 		w.logger.Warn("failed to find next pending build", "error", err)

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -40,6 +40,9 @@ func newTestWorker(ctrl *gomock.Controller) (*Worker, *mock.Service, *mock.Topic
 	// InsertBuildGetVersion is called after every successful get step; allow it globally.
 	svc.EXPECT().InsertBuildGetVersion(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
+	// NotifySerialGroupPendingBuilds is called by notifyNextPendingBuild; allow it globally.
+	svc.EXPECT().NotifySerialGroupPendingBuilds(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
 	// GetJobBuild is polled by the cancellation goroutine; return Started by default.
 	svc.EXPECT().GetJobBuild(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&build.Build{Status: build.Started}, nil).AnyTimes()
@@ -285,6 +288,7 @@ func TestInsertBuildGetVersion_CalledWithCorrectArgs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	// Don't use newTestWorker — we need precise control over InsertBuildGetVersion.
 	svc := mock.NewService(ctrl)
+	svc.EXPECT().NotifySerialGroupPendingBuilds(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	topic := mock.NewTopic(ctrl)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	svc.EXPECT().GetJobBuild(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -3332,6 +3336,7 @@ func TestProcessJob_Cancellation(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	// Build a worker with custom GetJobBuild behavior (don't use newTestWorker's default).
 	svc := mock.NewService(ctrl)
+	svc.EXPECT().NotifySerialGroupPendingBuilds(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	topic := mock.NewTopic(ctrl)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	svc.EXPECT().InsertBuildGetVersion(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
@@ -3564,6 +3569,7 @@ func TestProcessJob_Retry_FailsOnVersionLookupError(t *testing.T) {
 func TestProcessJob_Cancellation_RunsOnCancelNotOnFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	svc := mock.NewService(ctrl)
+	svc.EXPECT().NotifySerialGroupPendingBuilds(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	topic := mock.NewTopic(ctrl)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	svc.EXPECT().InsertBuildGetVersion(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
@@ -3692,6 +3698,7 @@ func TestProcessJob_Cancellation_RunsOnCancelNotOnFailure(t *testing.T) {
 func TestProcessJob_Cancellation_NoUpdateLoopAfterCancel(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	svc := mock.NewService(ctrl)
+	svc.EXPECT().NotifySerialGroupPendingBuilds(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	topic := mock.NewTopic(ctrl)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	svc.EXPECT().InsertBuildGetVersion(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
@@ -3845,6 +3852,37 @@ func TestProcessJob_ConcurrencyLimit_Requeues(t *testing.T) {
 
 	svc.EXPECT().StartPendingBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, m.BuildID).
 		Return(nil, pikoci.ErrConcurrencyLimit)
+
+	// Should re-queue the message
+	topic.EXPECT().Send(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, msg *pubsub.Message) error {
+		var body queue.Body
+		err := json.Unmarshal(msg.Body, &body)
+		require.NoError(t, err)
+		assert.Equal(t, m.BuildID, body.BuildID)
+		assert.Equal(t, m.JobName, body.JobName)
+		return nil
+	})
+
+	expectPendingBuild(svc, 10)
+	w.processJob(ctx, m, cwd, pp)
+}
+
+func TestProcessJob_SerialGroupLimit_Requeues(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, topic := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "deploy-staging",
+		BuildID:           10,
+	}
+	pp := testPipeline()
+	cwd := t.TempDir()
+
+	svc.EXPECT().StartPendingBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, m.BuildID).
+		Return(nil, pikoci.ErrSerialGroupLimit)
 
 	// Should re-queue the message
 	topic.EXPECT().Send(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, msg *pubsub.Message) error {


### PR DESCRIPTION
## Summary

- Add `serial_groups` attribute on jobs for per-pipeline cross-job mutual exclusion — only one job from a group runs at a time
- New `job_serial_groups` join table (V29 migration) with enforcement in `StartPendingBuild` and cross-job notification when builds complete
- Fix pipeline graph rendering: resources only accessed via get-with-passed no longer appear as orphaned nodes
- Add `docker-build` serial group to `build-latest` and `build-release` in the CI pipeline


Closes #186