### PR TITLE
Include resource name in webhook URLs (#470)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Include resource name in webhook URLs for readability: tokens now use `{canonical}_{uuid}` format instead of bare UUIDs. Old tokens continue to work unchanged ([#470](https://github.com/PikoCI/pikoci/issues/470))
 - Add `serial_groups` on jobs for cross-job mutual exclusion ([#186](https://github.com/PikoCI/pikoci/issues/186))
 - Step metadata export: get steps auto-forward version metadata to subsequent steps as `GET_<STEPNAME>_<KEY>` env vars, and task steps can write `KEY=VALUE` lines to `$PIKOCI_OUTPUT` to export custom values as `TASK_<STEPNAME>_<KEY>` env vars ([#459](https://github.com/PikoCI/pikoci/issues/459))
 - Loading indicators on action buttons: all mutating buttons (trigger, cancel, retry, delete, pause, unpause, pin, etc.) now show a spinner and loading text while the request is in flight, preventing double-clicks and providing visual feedback ([#453](https://github.com/PikoCI/pikoci/issues/453))

--- a/pikoci/mysql/migrate/migrate.go
+++ b/pikoci/mysql/migrate/migrate.go
@@ -6,6 +6,7 @@ package migrate
 import (
 	"database/sql"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/lopezator/migrator"
@@ -48,6 +49,14 @@ func Migrate(db *sql.DB, system string, opts ...migrator.Option) error {
 // sqliteUUIDExpr is the SQLite expression used to generate UUID v4 values.
 const sqliteUUIDExpr = `lower(hex(randomblob(4))) || '-' || lower(hex(randomblob(2))) || '-4' || substr(lower(hex(randomblob(2))),2) || '-' || substr('89ab',abs(random()) % 4 + 1, 1) || substr(lower(hex(randomblob(2))),2) || '-' || lower(hex(randomblob(6)))`
 
+// modifyColumnRe matches ALTER TABLE ... MODIFY COLUMN statements that SQLite
+// does not support (SQLite doesn't enforce VARCHAR length constraints anyway).
+var modifyColumnRe = regexp.MustCompile(`(?i)ALTER\s+TABLE\s+\S+\s+MODIFY\s+COLUMN\s+[^;]+;?`)
+
+// modifyColumnRePostgres captures table, column and type from MODIFY COLUMN
+// so it can be rewritten to PostgreSQL's ALTER COLUMN ... TYPE syntax.
+var modifyColumnRePostgres = regexp.MustCompile(`(?i)ALTER\s+TABLE\s+(\S+)\s+MODIFY\s+COLUMN\s+(\S+)\s+(\S+)[^;]*;?`)
+
 func replaceSQLiteUUID(sql, replacement string) string {
 	return strings.ReplaceAll(sql, sqliteUUIDExpr, replacement)
 }
@@ -59,6 +68,8 @@ func adaptSQL(sql, system string) string {
 		sql = strings.ReplaceAll(sql, "id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,", "id INTEGER PRIMARY KEY,")
 		// SQLite doesn't support CASCADE on DROP TABLE
 		sql = strings.ReplaceAll(sql, "DROP TABLE IF EXISTS pipelines CASCADE;", "DROP TABLE IF EXISTS pipelines;")
+		// SQLite doesn't support MODIFY COLUMN (and doesn't enforce VARCHAR length)
+		sql = modifyColumnRe.ReplaceAllString(sql, "")
 	case mysql.PostgreSQL:
 		sql = strings.ReplaceAll(sql, "SET sql_mode = 'NO_AUTO_VALUE_ON_ZERO';", "")
 		sql = strings.ReplaceAll(sql, "id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,", "id SERIAL PRIMARY KEY,")
@@ -67,6 +78,8 @@ func adaptSQL(sql, system string) string {
 		// Replace backtick-quoted identifiers with double-quote-quoted ones
 		sql = strings.ReplaceAll(sql, "`type`", `"type"`)
 		sql = strings.ReplaceAll(sql, "`check`", `"check"`)
+		// PostgreSQL uses ALTER COLUMN ... TYPE instead of MODIFY COLUMN
+		sql = modifyColumnRePostgres.ReplaceAllString(sql, "ALTER TABLE $1 ALTER COLUMN $2 TYPE $3;")
 		// PostgreSQL doesn't support RENAME COLUMN with the same syntax in older versions,
 		// but ALTER TABLE ... RENAME COLUMN is standard and works in PG 9.6+
 		// Replace SQLite UUID expression with PostgreSQL's gen_random_uuid()

--- a/pikoci/mysql/migrate/migrate_test.go
+++ b/pikoci/mysql/migrate/migrate_test.go
@@ -52,3 +52,28 @@ func TestAdaptSQL(t *testing.T) {
 		assert.Contains(t, result, "INT UNSIGNED")
 	})
 }
+
+func TestAdaptSQL_ModifyColumn(t *testing.T) {
+	input := `ALTER TABLE resources MODIFY COLUMN webhook_token VARCHAR(255) DEFAULT '';`
+
+	t.Run("sqlite strips MODIFY COLUMN", func(t *testing.T) {
+		result := adaptSQL(input, mysql.SQLite)
+		assert.Empty(t, result)
+	})
+
+	t.Run("mem strips MODIFY COLUMN", func(t *testing.T) {
+		result := adaptSQL(input, mysql.Mem)
+		assert.Empty(t, result)
+	})
+
+	t.Run("postgresql rewrites to ALTER COLUMN TYPE", func(t *testing.T) {
+		result := adaptSQL(input, mysql.PostgreSQL)
+		assert.Contains(t, result, "ALTER TABLE resources ALTER COLUMN webhook_token TYPE VARCHAR(255);")
+		assert.NotContains(t, result, "MODIFY")
+	})
+
+	t.Run("mysql keeps MODIFY COLUMN as-is", func(t *testing.T) {
+		result := adaptSQL(input, mysql.MySQL)
+		assert.Contains(t, result, "MODIFY COLUMN")
+	})
+}

--- a/pikoci/mysql/migrate/migrations/V30WebhookTokenLength.go
+++ b/pikoci/mysql/migrate/migrations/V30WebhookTokenLength.go
@@ -1,0 +1,8 @@
+package migrations
+
+// V30WebhookTokenLength widens the webhook_token column to accommodate the
+// resource name prefix added to new tokens (format: name_uuid).
+var V30WebhookTokenLength = Migration{
+	Name: "WebhookTokenLength",
+	SQL:  `ALTER TABLE resources MODIFY COLUMN webhook_token VARCHAR(255) DEFAULT '';`,
+}

--- a/pikoci/mysql/migrate/migrations/migrations.go
+++ b/pikoci/mysql/migrate/migrations/migrations.go
@@ -16,7 +16,7 @@ type Migration struct {
 // Migrations is the ordered list of all schema migrations. It is defined as
 // a fixed-size array so that the compiler catches ordering conflicts when
 // multiple developers add migrations concurrently.
-var Migrations = [30]Migration{
+var Migrations = [31]Migration{
 	V0Initial,
 	V1ResourceCheckInterval,
 	V2JobsAndBuilds,
@@ -47,4 +47,5 @@ var Migrations = [30]Migration{
 	V27ResourcePin,
 	V28JobTimeout,
 	V29SerialGroups,
+	V30WebhookTokenLength,
 }

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/awalterschulze/gographviz"
-	"github.com/google/uuid"
+
 	"github.com/pikoci/pikoci/pikoci/build"
 	"github.com/pikoci/pikoci/pikoci/job"
 	"github.com/pikoci/pikoci/pikoci/notification"
@@ -91,7 +91,10 @@ func (q *PikoCI) CreatePipeline(ctx context.Context, tc, pn string, rpp []byte, 
 				return fmt.Errorf("failed to compute next check for resource %q: %w", r.Name, err)
 			}
 			r.NextCheck = nextCheck
-			r.WebhookToken = uuid.New().String()
+			r.WebhookToken, err = newWebhookToken(r.Canonical)
+			if err != nil {
+				return fmt.Errorf("failed to generate webhook token for resource %q: %w", r.Name, err)
+			}
 			_, err = uow.Resources().Create(ctx, tc, pCan, r)
 			if err != nil {
 				return fmt.Errorf("failed to create Resource %q: %w", r.Name, err)
@@ -293,7 +296,10 @@ func (q *PikoCI) UpdatePipeline(ctx context.Context, tc, pCan string, rpp []byte
 					return fmt.Errorf("failed to compute next check for resource %q: %w", r.Canonical, err)
 				}
 				r.NextCheck = nextCheck
-				r.WebhookToken = uuid.New().String()
+				r.WebhookToken, err = newWebhookToken(r.Canonical)
+				if err != nil {
+					return fmt.Errorf("failed to generate webhook token for resource %q: %w", r.Canonical, err)
+				}
 				_, err = uow.Resources().Create(ctx, tc, pCan, r)
 				if err != nil {
 					return fmt.Errorf("failed to create Resource %q: %w", r.Canonical, err)

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -3064,7 +3064,13 @@ job "test" {
 	s.Jobs.EXPECT().Update(ctx, tc, pCan, "test", gomock.Any()).Return(nil)
 	// timer is updated, new-res is created, old-res is deleted
 	s.Resources.EXPECT().Update(ctx, tc, pCan, "cron.timer", gomock.Any()).Return(nil)
-	s.Resources.EXPECT().Create(ctx, tc, pCan, gomock.Any()).Return(uint32(3), nil)
+	s.Resources.EXPECT().Create(ctx, tc, pCan, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _, _ string, r resource.Resource) (uint32, error) {
+			assert.True(t, strings.HasPrefix(r.WebhookToken, r.Canonical+"_"),
+				"webhook token should start with canonical prefix, got %q", r.WebhookToken)
+			return uint32(3), nil
+		},
+	)
 	s.Resources.EXPECT().Delete(ctx, tc, pCan, "cron.old-res").Return(nil)
 
 	pp, err := s.S.UpdatePipeline(ctx, tc, pCan, hclConfig, nil)

--- a/pikoci/resources.go
+++ b/pikoci/resources.go
@@ -295,13 +295,31 @@ func (q *PikoCI) RegenerateWebhookToken(ctx context.Context, tc, pc, rCan string
 		return "", fmt.Errorf("failed to find Resource: %w", err)
 	}
 
-	r.WebhookToken = uuid.New().String()
+	r.WebhookToken, err = newWebhookToken(r.Canonical)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate webhook token: %w", err)
+	}
 	err = q.UpdatePipelineResource(ctx, tc, pc, rCan, *r)
 	if err != nil {
 		return "", fmt.Errorf("failed to update Resource: %w", err)
 	}
 
 	return r.WebhookToken, nil
+}
+
+// newWebhookToken generates a webhook token that embeds the resource canonical
+// for readability: "canonical_uuid". The result is capped at 255 chars (DB limit).
+func newWebhookToken(name string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("webhook token name must not be empty")
+	}
+	id := uuid.New().String()
+	const maxLen = 255
+	maxName := maxLen - len(id) - 1 // 218
+	if len(name) > maxName {
+		name = name[:maxName]
+	}
+	return name + "_" + id, nil
 }
 
 // validateResourceVersion checks that the given versionID belongs to the

--- a/pikoci/resources_test.go
+++ b/pikoci/resources_test.go
@@ -3,6 +3,7 @@ package pikoci_test
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -364,6 +365,7 @@ func TestRegenerateWebhookToken(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, token)
 	assert.NotEqual(t, "old-token", token)
+	assert.True(t, strings.HasPrefix(token, "git.repo_"), "token should start with resource name prefix")
 }
 
 func TestRegenerateWebhookToken_InvalidCanonical(t *testing.T) {

--- a/pikoci/service_test.go
+++ b/pikoci/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,7 @@ import (
 	"github.com/pikoci/pikoci/pikoci/job"
 	"github.com/pikoci/pikoci/pikoci/pipeline"
 	"github.com/pikoci/pikoci/pikoci/queue"
+	"github.com/pikoci/pikoci/pikoci/resource"
 	"go.uber.org/mock/gomock"
 	"gocloud.dev/pubsub"
 )
@@ -31,7 +33,13 @@ func TestCreatePipeline(t *testing.T) {
 
 	s.Pipelines.EXPECT().Create(ctx, tc, gomock.Any()).Return(uint32(1), nil)
 	s.Jobs.EXPECT().Create(ctx, tc, ppc, gomock.Any()).Return(uint32(1), nil).Times(3)
-	s.Resources.EXPECT().Create(ctx, tc, ppc, gomock.Any()).Return(uint32(1), nil).Times(1)
+	s.Resources.EXPECT().Create(ctx, tc, ppc, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _, _ string, r resource.Resource) (uint32, error) {
+			assert.True(t, strings.HasPrefix(r.WebhookToken, r.Canonical+"_"),
+				"webhook token should start with canonical prefix, got %q", r.WebhookToken)
+			return uint32(1), nil
+		},
+	).Times(1)
 	// GetPipeline uses Find which now does a single JOIN query
 	s.Pipelines.EXPECT().Find(ctx, tc, ppc).Return(&pipeline.Pipeline{Name: ppc}, nil)
 

--- a/pikoci/transport/http/handlers_coverage_test.go
+++ b/pikoci/transport/http/handlers_coverage_test.go
@@ -1773,10 +1773,10 @@ func TestRegenerateWebhookToken_Error(t *testing.T) {
 
 func TestWebhookTrigger_Success(t *testing.T) {
 	e := newTestEnv(t)
-	e.svc.EXPECT().WebhookTrigger(gomock.Any(), "abc123").Return(nil)
+	e.svc.EXPECT().WebhookTrigger(gomock.Any(), "my-repo_abc123").Return(nil)
 
 	// Webhook endpoint uses POST without auth
-	req, err := http.NewRequest(http.MethodPost, e.server.URL+"/webhooks/abc123", nil)
+	req, err := http.NewRequest(http.MethodPost, e.server.URL+"/webhooks/my-repo_abc123", nil)
 	require.NoError(t, err)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)

--- a/pikoci/webhook_token_test.go
+++ b/pikoci/webhook_token_test.go
@@ -1,0 +1,37 @@
+package pikoci
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewWebhookToken(t *testing.T) {
+	t.Run("normal name", func(t *testing.T) {
+		token, err := newWebhookToken("my-repo")
+		require.NoError(t, err)
+		assert.True(t, strings.HasPrefix(token, "my-repo_"))
+		assert.LessOrEqual(t, len(token), 255)
+		// UUID is 36 chars, plus underscore and name
+		assert.Equal(t, len("my-repo")+1+36, len(token))
+	})
+
+	t.Run("empty name returns error", func(t *testing.T) {
+		_, err := newWebhookToken("")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must not be empty")
+	})
+
+	t.Run("very long name is truncated", func(t *testing.T) {
+		longName := strings.Repeat("a", 300)
+		token, err := newWebhookToken(longName)
+		require.NoError(t, err)
+		assert.Equal(t, 255, len(token))
+		// UUID (36 chars) should be intact at the end
+		parts := strings.SplitN(token, "_", 2)
+		assert.Equal(t, 218, len(parts[0]))
+		assert.Equal(t, 36, len(parts[1]))
+	})
+}


### PR DESCRIPTION
## Summary

- Webhook tokens now use `{canonical}_{uuid}` format (e.g., `git.my-repo_550e8400-...`) instead of bare UUIDs, making webhook URLs self-describing when viewed in external services like GitHub
- DB migration widens `webhook_token` column from `VARCHAR(36)` to `VARCHAR(255)` with SQLite and PostgreSQL compatibility
- Old UUID-only tokens continue to work unchanged (DB lookup is by exact match)

Closes #470