### PR TITLE
Fix stuck builds by re-queuing on transient DB errors

### DIFF
--- a/worker/service.go
+++ b/worker/service.go
@@ -337,22 +337,22 @@ func (w *Worker) processJob(ctx context.Context, m queue.Body, cwd string, pp *p
 
 	nb, err := w.pikoci.StartPendingBuild(ctx, m.TeamCanonical, m.PipelineCanonical, m.JobName, m.BuildID)
 	if err != nil {
-		if errors.Is(err, pikoci.ErrConcurrencyLimit) || errors.Is(err, pikoci.ErrJobPaused) || errors.Is(err, pikoci.ErrSerialGroupLimit) {
-			w.logger.Info("concurrency/serial group limit or job paused, re-queuing",
-				"pipeline", m.PipelineCanonical, "job", m.JobName, "build_id", m.BuildID)
-			mb, _ := json.Marshal(m)
-			if err := w.jobTopic.Send(ctx, &pubsub.Message{Body: mb}); err != nil {
-				w.logger.Error("failed to re-queue", "error", err)
-			}
-			time.Sleep(2 * time.Second)
-			return
-		}
 		if errors.Is(err, pikoci.ErrBuildNotPending) {
 			w.logger.Info("build no longer pending, skipping", "build_id", m.BuildID)
 			return
 		}
-		w.logger.Error("failed to start pending build",
-			"pipeline", m.PipelineCanonical, "job", m.JobName, "build_id", m.BuildID, "error", err)
+		if errors.Is(err, pikoci.ErrConcurrencyLimit) || errors.Is(err, pikoci.ErrJobPaused) || errors.Is(err, pikoci.ErrSerialGroupLimit) {
+			w.logger.Info("concurrency/serial group limit or job paused, re-queuing",
+				"pipeline", m.PipelineCanonical, "job", m.JobName, "build_id", m.BuildID)
+		} else {
+			w.logger.Error("failed to start pending build, re-queuing",
+				"pipeline", m.PipelineCanonical, "job", m.JobName, "build_id", m.BuildID, "error", err)
+		}
+		mb, _ := json.Marshal(m)
+		if err := w.jobTopic.Send(ctx, &pubsub.Message{Body: mb}); err != nil {
+			w.logger.Error("failed to re-queue", "error", err)
+		}
+		time.Sleep(2 * time.Second)
 		return
 	}
 

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -3898,6 +3898,37 @@ func TestProcessJob_SerialGroupLimit_Requeues(t *testing.T) {
 	w.processJob(ctx, m, cwd, pp)
 }
 
+func TestProcessJob_GenericError_Requeues(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, topic := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "test-job",
+		BuildID:           10,
+	}
+	pp := testPipeline()
+	cwd := t.TempDir()
+
+	svc.EXPECT().StartPendingBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, m.BuildID).
+		Return(nil, fmt.Errorf("database table is locked"))
+
+	// Should re-queue the message
+	topic.EXPECT().Send(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, msg *pubsub.Message) error {
+		var body queue.Body
+		err := json.Unmarshal(msg.Body, &body)
+		require.NoError(t, err)
+		assert.Equal(t, m.BuildID, body.BuildID)
+		assert.Equal(t, m.JobName, body.JobName)
+		return nil
+	})
+
+	expectPendingBuild(svc, 10)
+	w.processJob(ctx, m, cwd, pp)
+}
+
 func TestRunGetStepLocal_Success(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	w, svc, _ := newTestWorker(ctrl)


### PR DESCRIPTION
## Summary

- Re-queue **all** `StartPendingBuild` errors in `processJob` instead of only the three known sentinel errors, preventing builds from getting stuck in `pending` forever on transient failures (e.g. SQLite `database table is locked`)
- `ErrBuildNotPending` remains the only error that skips re-queuing
- Known expected errors (`ErrConcurrencyLimit`, `ErrJobPaused`, `ErrSerialGroupLimit`) log at INFO; unexpected errors log at ERROR

Fixes #473
