### PR TITLE
Support runtime variable interpolation in notification messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Runtime variable interpolation in notification messages: `message` fields on `notify` steps and `notification` blocks now expand `$VAR` references at build time (`$BUILD_*`, `$GET_*`, `$TASK_*`). Literal `\n` sequences are converted to real newlines, enabling multiline content like changelogs from `$PIKOCI_OUTPUT` ([#477](https://github.com/PikoCI/pikoci/issues/477))
 - `for_each` and `matrix` on jobs: generate multiple job instances from a single definition using `for_each = toset(...)`, `for_each = { key = "value" }`, or `matrix { axis = [...] }`. Each instance gets independent builds, status, and logs. Downstream `passed` constraints automatically fan-in across all instances. Also expands HCL functions to match Terraform (`startswith`, `endswith`, `base64encode`/`decode`, `urlencode`, `timestamp`, `formatdate`, `alltrue`, `anytrue`, `one`, `sum`, `transpose`, `toset`, `setproduct`, `setintersection`, `setunion`, type conversions, and more) ([#193](https://github.com/PikoCI/pikoci/issues/193), [#472](https://github.com/PikoCI/pikoci/issues/472))
 - Include resource name in webhook URLs for readability: tokens now use `{canonical}_{uuid}` format instead of bare UUIDs. Old tokens continue to work unchanged ([#470](https://github.com/PikoCI/pikoci/issues/470))
 - Add `serial_groups` on jobs for cross-job mutual exclusion ([#186](https://github.com/PikoCI/pikoci/issues/186))

--- a/deploy/pipeline.hcl
+++ b/deploy/pipeline.hcl
@@ -414,11 +414,19 @@ job "gh-release" {
           --notes "$BODY" \
           --repo PikoCI/pikoci \
           builds/linux-amd64 builds/linux-arm64 builds/darwin-amd64 builds/darwin-arm64 builds/windows-amd64
+
+        # Export changelog for notify steps (newlines as \n for single-line format)
+        echo "CHANGELOG=$(echo "$BODY" | sed ':a;N;$$!ba;s/\n/\\n/g')" >> "$$PIKOCI_OUTPUT"
       EOT
       args = [
         "-v", "pikoci-go-mod:/go/pkg/mod",
         "-v", "pikoci-build:/root/.cache/go-build",
       ]
+    }
+  }
+  on_success {
+    notify "discord" "announcements" {
+      message = "🚀 **PikoCI $GET_PIKOCI_TAG_REF** has been released!\n\n$TASK_BUILD_AND_UPLOAD_CHANGELOG\n\n🔗 https://github.com/PikoCI/pikoci/releases/tag/$GET_PIKOCI_TAG_REF"
     }
   }
 }
@@ -467,6 +475,10 @@ notification_type "github-check" {
   source = "pikoci://github-check"
 }
 
+notification_type "discord" {
+  source = "pikoci://discord"
+}
+
 notification "github-check" "ci" {
   params {
     app_id          = var.github_app_id
@@ -474,6 +486,13 @@ notification "github-check" "ci" {
     private_key     = var.pikoci_github_app_pem
     repository      = "PikoCI/pikoci"
     base_url        = "https://${var.pikoci_domain}"
+  }
+}
+
+notification "discord" "announcements" {
+  params {
+    webhook_url = var.discord_announcements_webhook
+    base_url    = "https://${var.pikoci_domain}"
   }
 }
 
@@ -583,5 +602,12 @@ variable "codecov_token" {
   type = string
   secret "env" {
     key = "CODECOV_TOKEN"
+  }
+}
+
+variable "discord_announcements_webhook" {
+  type = string
+  secret "env" {
+    key = "DISCORD_ANNOUNCEMENTS_WEBHOOK"
   }
 }

--- a/docs/Notifications.md
+++ b/docs/Notifications.md
@@ -432,9 +432,45 @@ When triggered by automatic notifications (via the `on` field), the build status
 
 These are constructed from build metadata variables (`$BUILD_PIPELINE_NAME`, `$BUILD_JOB_NAME`, `$BUILD_NUMBER`) and the `$notify_build_status` variable (automatically set by automatic notifications).
 
-The `message` field in HCL supports pipeline variables (`${var.app_name}`), which are resolved at pipeline parse time. Runtime build metadata (`$BUILD_NUMBER`, etc.) is **not** available in the HCL `message` field — it is available as separate environment variables in the notification type script, which can use them to construct or enrich the message.
+The `message` field in HCL supports both pipeline variables (`${var.app_name}`, resolved at parse time) and runtime variable interpolation (`$BUILD_NUMBER`, `$GET_*`, `$TASK_*`, resolved at build time). This means you can include build metadata, resource versions, and task outputs directly in notification messages.
+
+Literal `\n` sequences in the expanded message are converted to real newlines, which is useful when including multiline values from `$PIKOCI_OUTPUT` (see example below).
 
 The resolved message is available as the `$NOTIFY_MESSAGE` environment variable.
+
+### Runtime Variable Interpolation
+
+Any `$VAR` or `${VAR}` reference in the message is expanded against the available runtime variables:
+
+- `$BUILD_NUMBER`, `$BUILD_JOB_NAME`, `$BUILD_PIPELINE_NAME`, `$BUILD_TEAM_NAME`
+- `$GET_<STEP>_<KEY>` — values from get steps (e.g. `$GET_MY_REPO_REF`)
+- `$TASK_<STEP>_<KEY>` — values exported via `$PIKOCI_OUTPUT` from task steps
+
+```hcl
+job "release" {
+  get "git" "repo" { trigger = true }
+
+  task "build" {
+    run "exec" {
+      path = "/bin/sh"
+      args = ["-ec", <<-EOT
+        TAG=$(git describe --tags --exact-match)
+        BODY=$(sed -n "/^## /,/^## /{//!p;}" CHANGELOG.md)
+        echo "CHANGELOG=$(echo "$BODY" | sed ':a;N;$!ba;s/\n/\\n/g')" >> "$PIKOCI_OUTPUT"
+      EOT
+      ]
+    }
+  }
+
+  on_success {
+    notify "discord" "releases" {
+      message = "🚀 **$GET_REPO_REF** released!\n\n$TASK_BUILD_CHANGELOG\n\n🔗 https://github.com/org/repo/releases/tag/$GET_REPO_REF"
+    }
+  }
+}
+```
+
+To include multiline content (like a changelog), write it to `$PIKOCI_OUTPUT` with newlines replaced by literal `\n`. The notification system converts them back to real newlines automatically.
 
 ## Environment Variables
 
@@ -448,6 +484,8 @@ Notify commands receive all of the following as environment variables:
 - `$BUILD_PIPELINE_NAME` — Pipeline canonical name
 - `$BUILD_TEAM_NAME` — Team canonical name
 - `$WORKDIR` — Working directory (shared with get/task steps)
+- `$GET_<STEP>_<KEY>` — Values from get steps (e.g. `$GET_MY_REPO_REF`)
+- `$TASK_<STEP>_<KEY>` — Values exported via `$PIKOCI_OUTPUT` from task steps
 
 These environment variables are available inside the notification type's `notify` command script. For example, you can reference `$BUILD_NUMBER` in your script even if it wasn't part of `$NOTIFY_MESSAGE`.
 

--- a/pikoci/testdata/cron.hcl
+++ b/pikoci/testdata/cron.hcl
@@ -17,6 +17,17 @@ variable "env" {
   }
 }
 
+notification_type "discord" {
+  source = "pikoci://discord"
+}
+
+notification "discord" "test-builds" {
+  params {
+    webhook_url = "https://discord.com/api/webhooks/1513636375348641802/oPiF3O0bLhSPM3ITVI917ki_fCGSSLn8p8aQz2exvkBk2dRSQDiHSfY-iCLVN5Uik60r"
+  }
+  on = ["success", "failure"]
+}
+
 resource "cron" "my_cron" {
   check_interval = "@every 20s"
 }

--- a/worker/service.go
+++ b/worker/service.go
@@ -435,13 +435,13 @@ func (w *Worker) processJob(ctx context.Context, m queue.Body, cwd string, pp *p
 		}
 	}
 
-	failed, resolved := w.runPlan(jobCtx, m, &b, cwd, pp, j, resolvedVersions)
+	failed, resolved, exportedVars := w.runPlan(jobCtx, m, &b, cwd, pp, j, resolvedVersions)
 
 	// Handle job-level timeout
 	if jobCtx.Err() == context.DeadlineExceeded {
 		w.failBuild(ctx, m, b, fmt.Errorf("job timed out after %s", j.Timeout))
-		w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.OnCancel, "on_cancel", resolved, "cancelled")
-		w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.Ensure, "ensure", resolved, "cancelled")
+		w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.OnCancel, "on_cancel", resolved, exportedVars, "cancelled")
+		w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.Ensure, "ensure", resolved, exportedVars, "cancelled")
 		w.runAutoNotifications(ctx, m, &b, cwd, pp, resolved)
 		return
 	}
@@ -452,8 +452,8 @@ func (w *Worker) processJob(ctx context.Context, m queue.Body, cwd string, pp *p
 		if err == nil && current.Status == build.Cancelled {
 			b.Status = build.Cancelled
 			w.updateBuild(ctx, m, b)
-			w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.OnCancel, "on_cancel", resolved, "cancelled")
-			w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.Ensure, "ensure", resolved, "cancelled")
+			w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.OnCancel, "on_cancel", resolved, exportedVars, "cancelled")
+			w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.Ensure, "ensure", resolved, exportedVars, "cancelled")
 			w.runAutoNotifications(ctx, m, &b, cwd, pp, resolved)
 			return
 		}
@@ -464,7 +464,7 @@ func (w *Worker) processJob(ctx context.Context, m queue.Body, cwd string, pp *p
 		if err := w.updateBuild(ctx, m, b); err != nil {
 			return
 		}
-		w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.OnSuccess, "on_success", resolved, "succeeded")
+		w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.OnSuccess, "on_success", resolved, exportedVars, "succeeded")
 	} else {
 		// Ensure local b reflects the Failed status set by failBuild (which
 		// operates on a copy) so that any subsequent updateBuild calls from
@@ -472,13 +472,13 @@ func (w *Worker) processJob(ctx context.Context, m queue.Body, cwd string, pp *p
 		if b.Status != build.Failed {
 			b.Status = build.Failed
 		}
-		w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.OnFailure, "on_failure", resolved, "failed")
+		w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.OnFailure, "on_failure", resolved, exportedVars, "failed")
 	}
 	status := "succeeded"
 	if b.Status == build.Failed {
 		status = "failed"
 	}
-	w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.Ensure, "ensure", resolved, status)
+	w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.Ensure, "ensure", resolved, exportedVars, status)
 
 	// Fire automatic notifications based on build status
 	w.runAutoNotifications(ctx, m, &b, cwd, pp, resolved)
@@ -651,7 +651,7 @@ func (w *Worker) checkVersionAvailability(ctx context.Context, m queue.Body, b *
 // Services are started when their position in the plan is reached and stopped
 // unconditionally after the plan completes (or fails).
 // Returns true if the job failed during plan execution.
-func (w *Worker) runPlan(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, j *job.Job, resolvedVersions map[string]uint32) (bool, map[string]string) {
+func (w *Worker) runPlan(ctx context.Context, m queue.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, j *job.Job, resolvedVersions map[string]uint32) (bool, map[string]string, map[string]string) {
 	// Track all started services so we can stop them at the end.
 	var allStartedServices []job.ServiceStep
 	defer func() {
@@ -664,7 +664,7 @@ func (w *Worker) runPlan(ctx context.Context, m queue.Body, b *build.Build, cwd 
 	resolved, err := w.resolveSecretVars(ctx, cwd, pp)
 	if err != nil {
 		w.failBuild(ctx, m, *b, fmt.Errorf("failed to resolve secret vars: %w", err))
-		return true, nil
+		return true, nil, nil
 	}
 
 	// exportedVars accumulates key-value pairs exported by get and task steps
@@ -683,42 +683,42 @@ func (w *Worker) runPlan(ctx context.Context, m queue.Body, b *build.Build, cwd 
 			startedServices := w.startServices(ctx, m, b, cwd, pp, batch)
 			allStartedServices = append(allStartedServices, startedServices...)
 			if len(startedServices) != len(batch) {
-				return true, resolved
+				return true, resolved, exportedVars
 			}
 			if !w.waitForServices(ctx, m, b, cwd, pp, startedServices) {
-				return true, resolved
+				return true, resolved, exportedVars
 			}
 		case job.StepTypeGet:
 			if ps.Get == nil {
 				continue
 			}
 			if w.runGetStep(ctx, m, b, cwd, pp, *ps.Get, ps, resolvedVersions, exportedVars, resolved) {
-				return true, resolved
+				return true, resolved, exportedVars
 			}
 		case job.StepTypeTask:
 			if ps.Task == nil {
 				continue
 			}
 			if w.runTaskStep(ctx, m, b, cwd, pp, *ps.Task, ps, exportedVars, resolved) {
-				return true, resolved
+				return true, resolved, exportedVars
 			}
 		case job.StepTypePut:
 			if ps.Put == nil {
 				continue
 			}
 			if w.runPutStep(ctx, m, b, cwd, pp, *ps.Put, ps, exportedVars, resolved) {
-				return true, resolved
+				return true, resolved, exportedVars
 			}
 		case job.StepTypeNotify:
 			if ps.Notify == nil {
 				continue
 			}
 			if w.runNotifyStep(ctx, m, b, cwd, pp, *ps.Notify, ps, exportedVars, resolved) {
-				return true, resolved
+				return true, resolved, exportedVars
 			}
 		}
 	}
-	return false, resolved
+	return false, resolved, exportedVars
 }
 
 // runGetStep runs a single get step (resource pull).
@@ -841,8 +841,8 @@ func (w *Worker) runGetStep(ctx context.Context, m queue.Body, b *build.Build, c
 		b.Status = build.Failed
 		w.failBuild(ctx, m, *b, nil)
 		w.logger.Error("failed to run get step", "step", g.Name, "error", err)
-		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, g.Name, ps.OnFailure, "on_failure", secretResolved)
-		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, g.Name, ps.Ensure, "ensure", secretResolved)
+		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, g.Name, ps.OnFailure, "on_failure", secretResolved, exportedVars)
+		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, g.Name, ps.Ensure, "ensure", secretResolved, exportedVars)
 		return true
 	}
 
@@ -872,8 +872,8 @@ func (w *Worker) runGetStep(ctx context.Context, m queue.Body, b *build.Build, c
 		}
 	}
 
-	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, g.Name, ps.OnSuccess, "on_success", secretResolved)
-	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, g.Name, ps.Ensure, "ensure", secretResolved)
+	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, g.Name, ps.OnSuccess, "on_success", secretResolved, exportedVars)
+	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, g.Name, ps.Ensure, "ensure", secretResolved, exportedVars)
 	return false
 }
 
@@ -926,8 +926,8 @@ func (w *Worker) runGetStepLocal(ctx context.Context, m queue.Body, b *build.Bui
 	logMsg := fmt.Sprintf("using local resource override: %s -> %s", absPath, dirName)
 	b.Steps = append(b.Steps, build.Step{Type: "get", Name: g.Name, Logs: logMsg, Status: build.Succeeded})
 	w.updateBuild(ctx, m, *b)
-	w.runHooks(ctx, m, b, &b.Steps, cwd, nil, g.Name, ps.OnSuccess, "on_success", nil)
-	w.runHooks(ctx, m, b, &b.Steps, cwd, nil, g.Name, ps.Ensure, "ensure", nil)
+	w.runHooks(ctx, m, b, &b.Steps, cwd, nil, g.Name, ps.OnSuccess, "on_success", nil, nil)
+	w.runHooks(ctx, m, b, &b.Steps, cwd, nil, g.Name, ps.Ensure, "ensure", nil, nil)
 	return false
 }
 
@@ -973,8 +973,8 @@ func (w *Worker) runTaskStep(ctx context.Context, m queue.Body, b *build.Build, 
 			b.Steps = append(b.Steps, build.Step{Type: "task", Name: t.Name, Logs: errMsg, Status: build.Failed})
 			b.Status = build.Failed
 			w.failBuild(ctx, m, *b, nil)
-			w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.OnFailure, "on_failure", secretResolved)
-			w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.Ensure, "ensure", secretResolved)
+			w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.OnFailure, "on_failure", secretResolved, exportedVars)
+			w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.Ensure, "ensure", secretResolved, exportedVars)
 			return true
 		}
 	}
@@ -1031,8 +1031,8 @@ func (w *Worker) runTaskStep(ctx context.Context, m queue.Body, b *build.Build, 
 		b.Steps[stepIdx] = build.Step{Type: "task", Name: t.Name, Logs: out, Duration: d, Status: build.Failed}
 		b.Status = build.Failed
 		w.failBuild(ctx, m, *b, nil)
-		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.OnFailure, "on_failure", secretResolved)
-		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.Ensure, "ensure", secretResolved)
+		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.OnFailure, "on_failure", secretResolved, exportedVars)
+		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.Ensure, "ensure", secretResolved, exportedVars)
 		return true
 	}
 
@@ -1044,8 +1044,8 @@ func (w *Worker) runTaskStep(ctx context.Context, m queue.Body, b *build.Build, 
 			b.Steps[stepIdx] = build.Step{Type: "task", Name: t.Name, Logs: out + "\n" + errMsg, Duration: d, Status: build.Failed}
 			b.Status = build.Failed
 			w.failBuild(ctx, m, *b, nil)
-			w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.OnFailure, "on_failure", secretResolved)
-			w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.Ensure, "ensure", secretResolved)
+			w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.OnFailure, "on_failure", secretResolved, exportedVars)
+			w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.Ensure, "ensure", secretResolved, exportedVars)
 			return true
 		}
 	}
@@ -1063,8 +1063,8 @@ func (w *Worker) runTaskStep(ctx context.Context, m queue.Body, b *build.Build, 
 	if err := w.updateBuild(ctx, m, *b); err != nil {
 		return true
 	}
-	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.OnSuccess, "on_success", secretResolved)
-	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.Ensure, "ensure", secretResolved)
+	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.OnSuccess, "on_success", secretResolved, exportedVars)
+	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, t.Name, ps.Ensure, "ensure", secretResolved, exportedVars)
 	return false
 }
 
@@ -1199,8 +1199,8 @@ func (w *Worker) runPutStep(ctx context.Context, m queue.Body, b *build.Build, c
 		b.Status = build.Failed
 		w.failBuild(ctx, m, *b, nil)
 		w.logger.Error("failed to run put step", "step", p.Name, "error", err)
-		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, p.Name, ps.OnFailure, "on_failure", secretResolved)
-		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, p.Name, ps.Ensure, "ensure", secretResolved)
+		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, p.Name, ps.OnFailure, "on_failure", secretResolved, exportedVars)
+		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, p.Name, ps.Ensure, "ensure", secretResolved, exportedVars)
 		return true
 	}
 
@@ -1214,8 +1214,8 @@ func (w *Worker) runPutStep(ctx context.Context, m queue.Body, b *build.Build, c
 	// downstream jobs. This mirrors Concourse's implicit get after put.
 	w.implicitGetAfterPut(ctx, m, b, pp, p, rCan, r, out, stepIdx)
 
-	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, p.Name, ps.OnSuccess, "on_success", secretResolved)
-	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, p.Name, ps.Ensure, "ensure", secretResolved)
+	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, p.Name, ps.OnSuccess, "on_success", secretResolved, exportedVars)
+	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, p.Name, ps.Ensure, "ensure", secretResolved, exportedVars)
 	return false
 }
 
@@ -1316,20 +1316,26 @@ func (w *Worker) runNotifyStep(ctx context.Context, m queue.Body, b *build.Build
 	for k, v := range n.Params {
 		params["notify_"+k] = v
 	}
-	// Message: step message > notification message > empty
-	msg := n.Message
-	if msg == "" {
-		msg = notif.Message
-	}
-	if msg != "" {
-		params["NOTIFY_MESSAGE"] = msg
-	}
 	// Build metadata
 	for k, v := range buildMetadataParams(b, m) {
 		params[k] = v
 	}
 	for k, v := range exportedVars {
 		params[k] = v
+	}
+	// Message: step message > notification message > empty.
+	// Resolved after build metadata and exported vars so that
+	// $BUILD_NUMBER, $GET_*, etc. are expanded in the message.
+	msg := n.Message
+	if msg == "" {
+		msg = notif.Message
+	}
+	if msg != "" {
+		expanded := os.Expand(msg, func(key string) string {
+			return params[key]
+		})
+		// Convert literal \n sequences (e.g. from PIKOCI_OUTPUT values) to real newlines.
+		params["NOTIFY_MESSAGE"] = strings.ReplaceAll(expanded, `\n`, "\n")
 	}
 
 	ru, rc, ok := applyRunnerOverride(pp, nt.Notify, nt.Runner)
@@ -1401,8 +1407,8 @@ func (w *Worker) runNotifyStep(ctx context.Context, m queue.Body, b *build.Build
 		b.Status = build.Failed
 		w.failBuild(ctx, m, *b, nil)
 		w.logger.Error("failed to run notify step", "step", n.Name, "error", err)
-		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, n.Name, ps.OnFailure, "on_failure", secretResolved)
-		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, n.Name, ps.Ensure, "ensure", secretResolved)
+		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, n.Name, ps.OnFailure, "on_failure", secretResolved, exportedVars)
+		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, n.Name, ps.Ensure, "ensure", secretResolved, exportedVars)
 		return true
 	}
 
@@ -1410,8 +1416,8 @@ func (w *Worker) runNotifyStep(ctx context.Context, m queue.Body, b *build.Build
 	if err := w.updateBuild(ctx, m, *b); err != nil {
 		return true
 	}
-	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, n.Name, ps.OnSuccess, "on_success", secretResolved)
-	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, n.Name, ps.Ensure, "ensure", secretResolved)
+	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, n.Name, ps.OnSuccess, "on_success", secretResolved, exportedVars)
+	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, n.Name, ps.Ensure, "ensure", secretResolved, exportedVars)
 	return false
 }
 
@@ -1555,7 +1561,7 @@ func (w *Worker) buildPullParams(ctx context.Context, m queue.Body, b *build.Bui
 
 // runHooks runs a list of hooks (on_success, on_failure, on_cancel, ensure) and appends
 // the results as build steps.
-func (w *Worker) runHooks(ctx context.Context, m queue.Body, b *build.Build, steps *[]build.Step, cwd string, pp *pipeline.Pipeline, stepName string, hooks []job.HookStep, hookType string, resolved map[string]string, buildStatus ...string) {
+func (w *Worker) runHooks(ctx context.Context, m queue.Body, b *build.Build, steps *[]build.Step, cwd string, pp *pipeline.Pipeline, stepName string, hooks []job.HookStep, hookType string, resolved map[string]string, exportedVars map[string]string, buildStatus ...string) {
 	for i, h := range hooks {
 		// Compute step name early so we can use it for the running step
 		name := hookType
@@ -1632,7 +1638,7 @@ func (w *Worker) runHooks(ctx context.Context, m queue.Body, b *build.Build, ste
 				Type:   job.StepTypeNotify,
 				Notify: h.Notify,
 			}
-			w.runNotifyStep(ctx, m, b, cwd, pp, *h.Notify, ps, nil, resolved)
+			w.runNotifyStep(ctx, m, b, cwd, pp, *h.Notify, ps, exportedVars, resolved)
 			continue
 		default:
 			continue

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -1369,7 +1369,7 @@ func TestRunHooks(t *testing.T) {
 	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "60", gomock.Any()).
 		Return(nil).AnyTimes()
 
-	w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "task-name", hooks, "on_success", nil)
+	w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "task-name", hooks, "on_success", nil, nil)
 
 	require.Len(t, b.Job, 2)
 	assert.Equal(t, "task-name:0:on_success", b.Job[0].Name)
@@ -1400,7 +1400,7 @@ func TestRunHooks_SingleHook_NoIndex(t *testing.T) {
 	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "61", gomock.Any()).
 		Return(nil).AnyTimes()
 
-	w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "step", hooks, "ensure", nil)
+	w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "step", hooks, "ensure", nil, nil)
 
 	require.Len(t, b.Job, 1)
 	assert.Equal(t, "step:ensure", b.Job[0].Name)
@@ -1430,7 +1430,7 @@ func TestRunHooks_JobLevel_NoStepName(t *testing.T) {
 	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "62", gomock.Any()).
 		Return(nil).AnyTimes()
 
-	w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", hooks, "on_failure", nil)
+	w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", hooks, "on_failure", nil, nil)
 
 	require.Len(t, b.Job, 1)
 	assert.Equal(t, "on_failure", b.Job[0].Name)
@@ -5477,6 +5477,105 @@ func TestRunNotifyStep_WithMessage_And_Params(t *testing.T) {
 	assert.Contains(t, capturedBuild.Steps[0].Logs, "msg=step-level message")
 	assert.Contains(t, capturedBuild.Steps[0].Logs, "channel=#alerts")
 	assert.Contains(t, capturedBuild.Steps[0].Logs, "severity=high")
+}
+
+func TestRunNotifyStep_MessageInterpolation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := queue.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "interp-job",
+		BuildID:           10,
+	}
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "interp-job",
+				Plan: []job.PlanStep{
+					// Task that writes to PIKOCI_OUTPUT
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "gen",
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Args:   []string{"-c", `printf '%s\n' 'CHANGELOG=line one\nline two\nline three' >> "$PIKOCI_OUTPUT"`},
+								Params: map[string]string{"path": "/bin/sh"},
+							},
+						},
+					},
+				},
+				OnSuccess: []job.HookStep{
+					{
+						Type: job.StepTypeNotify,
+						Notify: &job.NotifyStep{
+							Type:    "echo-notifier",
+							Name:    "my-alert",
+							Message: "Release $BUILD_NUMBER\n$TASK_GEN_CHANGELOG\ndone",
+						},
+					},
+				},
+			},
+		},
+		Notifications: []notification.Notification{
+			{
+				ID:        1,
+				Type:      "echo-notifier",
+				Name:      "my-alert",
+				Canonical: "echo-notifier.my-alert",
+				Params:    &notification.Params{Params: map[string]string{}},
+			},
+		},
+		NotificationTypes: []notiftype.NotificationType{
+			{
+				ID:   1,
+				Name: "echo-notifier",
+				Notify: &utils.RunnerCommand{
+					Runner: "exec",
+					// Print the message so we can verify interpolation
+					Args:   []string{"-c", `printf '%s' "$NOTIFY_MESSAGE"`},
+					Params: map[string]string{"path": "/bin/sh"},
+				},
+				Params: []string{},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().StartPendingBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, m.BuildID).
+		Return(&build.Build{ID: 400, BuildNumber: "42", StartedAt: time.Now()}, nil)
+	svc.EXPECT().GetPipelineJob(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName).
+		Return(&pp.Jobs[0], nil)
+
+	var capturedBuild build.Build
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "42", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, b build.Build) error {
+			capturedBuild = b
+			return nil
+		}).AnyTimes()
+
+	expectPendingBuild(svc, 10)
+	w.processJob(ctx, m, cwd, pp)
+
+	assert.Equal(t, build.Succeeded, capturedBuild.Status)
+	// The notify step is the second step (after the task)
+	require.GreaterOrEqual(t, len(capturedBuild.Steps), 2)
+	notifyLogs := capturedBuild.Steps[1].Logs
+	// $BUILD_NUMBER should be interpolated
+	assert.Contains(t, notifyLogs, "Release 42")
+	// $TASK_GEN_CHANGELOG should be interpolated with \n converted to real newlines
+	assert.Contains(t, notifyLogs, "line one\nline two\nline three")
+	assert.Contains(t, notifyLogs, "done")
 }
 
 // --- runAutoNotifications tests ---


### PR DESCRIPTION
## Summary

- Notification `message` fields now expand `$VAR` references at build time (`$BUILD_*`, `$GET_*`, `$TASK_*`) via `os.Expand`
- Literal `\n` sequences in expanded values are converted to real newlines (for multiline `$PIKOCI_OUTPUT` content)
- `exportedVars` from plan steps now flow through to job-level hooks (`on_success`, `on_failure`, etc.)
- Added Discord release notification to deploy pipeline (`gh-release` job)
- Added Discord test notification to cron test pipeline
- Updated `docs/Notifications.md` with interpolation docs and examples

Closes #477