### PR TITLE
Better error reporting for param typos (#116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Worker health monitoring: workers send periodic heartbeats to the server, which tracks their status as healthy or stale (no heartbeat for over 90 seconds). Admin users see all workers in a new dashboard with status, queues, platform, version, and uptime. A warning banner appears when no healthy workers are detected. Admins can delete stale workers from the UI or via `DELETE /workers/{name}`. Includes a `pikoci_workers` Prometheus gauge with `status` label for alerting ([#482](https://github.com/PikoCI/pikoci/issues/482))
+- Better error reporting for param typos: pipeline schema validation now catches typos in block names (e.g. `tsk` → `task`) and attributes (e.g. `triggr` → `trigger`, `arg` → `args`) at save time with line-accurate errors and Levenshtein-based suggestions. At runtime, unrecognized resource/notification/service params show warnings in step logs with "did you mean?" hints, and failed commands list available environment variable names to help diagnose missing params ([#116](https://github.com/PikoCI/pikoci/issues/116))
 
 ## [0.4.0] - 2026-06-08
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.1
 require (
 	github.com/VividCortex/mysqlerr v1.0.0
 	github.com/adrg/xdg v0.5.3
+	github.com/agnivade/levenshtein v1.2.1
 	github.com/awalterschulze/gographviz v2.0.3+incompatible
 	github.com/cycloidio/sqlr v1.0.0
 	github.com/go-sql-driver/mysql v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
 github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
+github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
+github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
 github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38 h1:smF2tmSOzy2Mm+0dGI2AIUHY+w0BUc+4tn40djz7+6U=
 github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38/go.mod h1:r7bzyVFMNntcxPZXK3/+KdruV1H5KSlyVY0gc+NgInI=
 github.com/alecthomas/colour v0.1.0 h1:nOE9rJm6dsZ66RGWYSFrXw461ZIt9A6+nHgL7FRrDUk=
@@ -44,6 +46,8 @@ github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAu
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
+github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
+github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/awalterschulze/gographviz v2.0.3+incompatible h1:9sVEXJBJLwGX7EQVhLm2elIKCm7P2YHFC8v6096G09E=
@@ -89,6 +93,8 @@ github.com/cycloidio/sqlr v1.0.0/go.mod h1:s3kP+rzY2ZSdpm+CXpId/OZ3/100q8wnxyxCJ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54 h1:SG7nF6SRlWhcT7cNTs5R6Hk4V2lcmLz2NsG2VnInyNo=
+github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/dmarkham/enumer v1.6.1 h1:aSc9awYtZL07TUueWs40QcHtxTvHTAwG0EqrNsK45w4=
 github.com/dmarkham/enumer v1.6.1/go.mod h1:yixql+kDDQRYqcuBM2n9Vlt7NoT9ixgXhaXry8vmRg8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/pikoci/helper.go
+++ b/pikoci/helper.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/agnivade/levenshtein"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsimple"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -606,6 +607,255 @@ func makeToFunc(wantTy cty.Type) function.Function {
 	return stdlib.MakeToFunc(wantTy)
 }
 
+// Known block types at each level of the pipeline HCL schema.
+var (
+	pipelineTopBlocks = map[string]bool{
+		"job": true, "resource": true, "resource_type": true,
+		"notification_type": true, "notification": true,
+		"runner_type": true, "secret_type": true, "service_type": true,
+		"variable": true,
+	}
+	jobBlocks = map[string]bool{
+		"get": true, "task": true, "put": true, "notify": true, "service": true,
+		"on_success": true, "on_failure": true, "on_cancel": true, "ensure": true,
+		"matrix": true,
+	}
+	stepHookBlocks = map[string]bool{
+		"on_success": true, "on_failure": true, "on_cancel": true, "ensure": true,
+	}
+	// runnerCommandKnownAttrs are the structurally-parsed attributes of a
+	// RunnerCommand block (check, pull, push, start, stop, notify, get, run).
+	// Anything else ends up in the Params map via ",remain".
+	runnerCommandKnownAttrs = []string{"args"}
+	// readyCheckKnownAttrs are the structurally-parsed attributes of a
+	// ready_check block. Anything else ends up in the Params map via ",remain".
+	readyCheckKnownAttrs = []string{"args", "interval", "timeout"}
+	// Known attributes for each step/block type that uses hcl.Body Remain.
+	// Typos of these silently go into Remain and are ignored.
+	getStepKnownAttrs  = []string{"passed", "trigger", "timeout", "attempts"}
+	taskStepKnownAttrs = []string{"timeout", "attempts", "inputs", "outputs"}
+	putStepKnownAttrs  = []string{"timeout", "attempts"}
+	notifyStepKnownAttrs = []string{"message"}
+	jobKnownAttrs      = []string{"concurrency", "serial_groups", "timeout"}
+	// Known blocks inside task steps (run + hooks).
+	taskKnownBlocks = map[string]bool{
+		"run": true,
+		"on_success": true, "on_failure": true, "on_cancel": true, "ensure": true,
+	}
+)
+
+// validatePipelineSchema walks the raw HCL AST and returns errors for unknown
+// block types and attributes that look like typos of known fields.
+func validatePipelineSchema(raw []byte) error {
+	file, diags := hclsyntax.ParseConfig(raw, "pipeline.hcl", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil // syntax errors are reported elsewhere
+	}
+	body := file.Body.(*hclsyntax.Body)
+
+	var errs []string
+
+	for _, block := range body.Blocks {
+		if !pipelineTopBlocks[block.Type] {
+			errs = append(errs, suggestBlockTypo(block.Type, pipelineTopBlocks, "pipeline", block.TypeRange))
+			continue
+		}
+
+		switch block.Type {
+		case "job":
+			errs = append(errs, validateJobBlock(block)...)
+		case "resource_type":
+			errs = append(errs, validateRunnerCommandBlocks(block, blockLabel(block))...)
+		case "notification_type":
+			errs = append(errs, validateRunnerCommandBlocks(block, blockLabel(block))...)
+		case "secret_type":
+			errs = append(errs, validateRunnerCommandBlocks(block, blockLabel(block))...)
+		case "service_type":
+			errs = append(errs, validateServiceTypeBlock(block)...)
+		}
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+	return fmt.Errorf("pipeline schema warnings:\n  - %s", strings.Join(errs, "\n  - "))
+}
+
+// validateJobBlock checks for unknown block types and attribute typos within a job block.
+func validateJobBlock(block *hclsyntax.Block) []string {
+	var errs []string
+	jobName := blockLabel(block)
+	jobCtx := fmt.Sprintf("job %q", jobName)
+
+	errs = append(errs, validateAttrTypos(block, jobCtx, jobKnownAttrs)...)
+
+	for _, inner := range block.Body.Blocks {
+		if !jobBlocks[inner.Type] {
+			errs = append(errs, suggestBlockTypo(inner.Type, jobBlocks, jobCtx, inner.TypeRange))
+			continue
+		}
+
+		switch inner.Type {
+		case "task":
+			errs = append(errs, validateTaskBlock(inner, jobName)...)
+		case "get":
+			errs = append(errs, validateStepBlock(inner, jobName, getStepKnownAttrs)...)
+		case "put":
+			errs = append(errs, validateStepBlock(inner, jobName, putStepKnownAttrs)...)
+		case "notify":
+			errs = append(errs, validateStepBlock(inner, jobName, notifyStepKnownAttrs)...)
+		}
+	}
+	return errs
+}
+
+// validateTaskBlock checks the task step for unknown sub-blocks, attribute typos,
+// and run block attribute typos.
+func validateTaskBlock(block *hclsyntax.Block, jobName string) []string {
+	var errs []string
+	taskName := blockLabel(block)
+	ctx := fmt.Sprintf("task %q in job %q", taskName, jobName)
+
+	errs = append(errs, validateAttrTypos(block, ctx, taskStepKnownAttrs)...)
+
+	for _, inner := range block.Body.Blocks {
+		if inner.Type == "run" {
+			errs = append(errs, validateRunnerCommandAttrs(inner, ctx, runnerCommandKnownAttrs)...)
+		} else if !taskKnownBlocks[inner.Type] {
+			errs = append(errs, suggestBlockTypo(inner.Type, taskKnownBlocks, ctx, inner.TypeRange))
+		}
+	}
+	return errs
+}
+
+// validateStepBlock checks a get/put/notify step for attribute typos and unknown sub-blocks.
+func validateStepBlock(block *hclsyntax.Block, jobName string, knownAttrs []string) []string {
+	var errs []string
+	stepName := blockLabel(block)
+	ctx := fmt.Sprintf("%s %q in job %q", block.Type, stepName, jobName)
+
+	errs = append(errs, validateAttrTypos(block, ctx, knownAttrs)...)
+
+	for _, inner := range block.Body.Blocks {
+		if !stepHookBlocks[inner.Type] {
+			errs = append(errs, suggestBlockTypo(inner.Type, stepHookBlocks, ctx, inner.TypeRange))
+		}
+	}
+	return errs
+}
+
+// validateRunnerCommandBlocks finds check/pull/push/notify/get/start/stop blocks
+// inside a type definition and validates their attributes.
+func validateRunnerCommandBlocks(block *hclsyntax.Block, typeName string) []string {
+	var errs []string
+	for _, inner := range block.Body.Blocks {
+		ctx := fmt.Sprintf("%s block in %s %q", inner.Type, block.Type, typeName)
+		errs = append(errs, validateRunnerCommandAttrs(inner, ctx, runnerCommandKnownAttrs)...)
+	}
+	return errs
+}
+
+// validateServiceTypeBlock validates a service_type block including ready_check.
+func validateServiceTypeBlock(block *hclsyntax.Block) []string {
+	var errs []string
+	svcName := blockLabel(block)
+	for _, inner := range block.Body.Blocks {
+		if inner.Type == "ready_check" {
+			ctx := fmt.Sprintf("ready_check in service_type %q", svcName)
+			errs = append(errs, validateRunnerCommandAttrs(inner, ctx, readyCheckKnownAttrs)...)
+		} else {
+			ctx := fmt.Sprintf("%s block in service_type %q", inner.Type, svcName)
+			errs = append(errs, validateRunnerCommandAttrs(inner, ctx, runnerCommandKnownAttrs)...)
+		}
+	}
+	return errs
+}
+
+// hclPos formats an HCL source range as "pipeline.hcl:LINE,COL-COL:" to match
+// the format expected by the UI's error parser.
+func hclPos(r hcl.Range) string {
+	return fmt.Sprintf("pipeline.hcl:%d,%d-%d:", r.Start.Line, r.Start.Column, r.End.Column)
+}
+
+// validateAttrTypos checks attributes of a block with hcl.Body Remain for
+// possible typos of the block's known HCL attributes.
+func validateAttrTypos(block *hclsyntax.Block, ctx string, knownAttrs []string) []string {
+	var errs []string
+	for name, attr := range block.Body.Attributes {
+		// Skip if it exactly matches a known attr
+		isKnown := false
+		for _, known := range knownAttrs {
+			if name == known {
+				isKnown = true
+				break
+			}
+		}
+		if isKnown {
+			continue
+		}
+		// Check for close matches
+		for _, known := range knownAttrs {
+			if levenshtein.ComputeDistance(name, known) <= 2 {
+				errs = append(errs, fmt.Sprintf("%s %q in %s is not a known attribute (did you mean %q?)", hclPos(attr.SrcRange), name, ctx, known))
+				break
+			}
+		}
+	}
+	return errs
+}
+
+// validateRunnerCommandAttrs checks attributes of a runner command block for
+// possible typos of known fields.
+func validateRunnerCommandAttrs(block *hclsyntax.Block, ctx string, knownAttrs []string) []string {
+	var errs []string
+	for name, attr := range block.Body.Attributes {
+		isKnown := false
+		for _, known := range knownAttrs {
+			if name == known {
+				isKnown = true
+				break
+			}
+		}
+		if isKnown {
+			continue
+		}
+		for _, known := range knownAttrs {
+			if levenshtein.ComputeDistance(name, known) <= 2 {
+				errs = append(errs, fmt.Sprintf("%s %q in %s is not a known attribute (did you mean %q?)", hclPos(attr.SrcRange), name, ctx, known))
+				break
+			}
+		}
+	}
+	return errs
+}
+
+// suggestBlockTypo returns an error message for an unknown block type, with a
+// Levenshtein-based suggestion if one is close enough.
+func suggestBlockTypo(got string, allowed map[string]bool, ctx string, r hcl.Range) string {
+	best := ""
+	bestDist := 3
+	for name := range allowed {
+		d := levenshtein.ComputeDistance(got, name)
+		if d < bestDist {
+			bestDist = d
+			best = name
+		}
+	}
+	msg := fmt.Sprintf("%s unknown block %q in %s", hclPos(r), got, ctx)
+	if best != "" {
+		msg += fmt.Sprintf(" (did you mean %q?)", best)
+	}
+	return msg
+}
+
+// blockLabel returns the first label of an HCL block, or "<unnamed>" if none.
+func blockLabel(block *hclsyntax.Block) string {
+	if len(block.Labels) > 0 {
+		return block.Labels[0]
+	}
+	return "<unnamed>"
+}
+
 // readPipeline parses raw HCL pipeline configuration bytes into a Pipeline
 // struct. It handles variable resolution (string, number, bool, and secret
 // types), source resolution for resource types, runners, secret types, and
@@ -706,6 +956,12 @@ func (q *PikoCI) readPipeline(ctx context.Context, rpp []byte, vars map[string]i
 
 	// Strip for_each job blocks from the HCL for the main decode
 	decodeRPP, forEachBlockBytes := stripForEachJobBlocks(rpp, forEachExpansions)
+
+	// Run schema validation before decode so typos that cause cryptic HCL
+	// type errors (e.g. "arg = [...]" instead of "args") get a clear message.
+	if schemaErr := validatePipelineSchema(rpp); schemaErr != nil {
+		return nil, schemaErr
+	}
 
 	var hp hclPipeline
 	err = hclsimple.Decode("pipeline.hcl", decodeRPP, ectx, &hp)

--- a/pikoci/schema_validation_test.go
+++ b/pikoci/schema_validation_test.go
@@ -1,0 +1,481 @@
+package pikoci
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidatePipelineSchema_ValidPipeline(t *testing.T) {
+	hcl := []byte(`
+resource_type "git" {
+  check "exec" {
+    args = ["/opt/resource/check"]
+  }
+  pull "exec" {
+    args = ["/opt/resource/in"]
+  }
+  push "exec" {
+    args = ["/opt/resource/out"]
+  }
+}
+
+job "build" {
+  get "git" "my-repo" {}
+  task "compile" {
+    run "exec" {
+      args = ["make", "build"]
+    }
+  }
+  put "git" "my-repo" {
+    branch = "main"
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	assert.NoError(t, err)
+}
+
+func TestValidatePipelineSchema_UnknownTopLevelBlock(t *testing.T) {
+	hcl := []byte(`
+resouce_type "git" {
+  check "exec" {
+    args = ["/opt/resource/check"]
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown block "resouce_type"`)
+	assert.Contains(t, err.Error(), `did you mean "resource_type"`)
+}
+
+func TestValidatePipelineSchema_UnknownJobBlock(t *testing.T) {
+	hcl := []byte(`
+job "build" {
+  tsk "compile" {
+    run "exec" {
+      args = ["make"]
+    }
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown block "tsk"`)
+	assert.Contains(t, err.Error(), `did you mean "task"`)
+}
+
+func TestValidatePipelineSchema_UnknownHookBlock(t *testing.T) {
+	hcl := []byte(`
+job "build" {
+  task "compile" {
+    run "exec" {
+      args = ["make"]
+    }
+    on_succes "exec" {
+      args = ["echo", "done"]
+    }
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown block "on_succes"`)
+	assert.Contains(t, err.Error(), `did you mean "on_success"`)
+}
+
+func TestValidatePipelineSchema_RunBlockArgTypo(t *testing.T) {
+	hcl := []byte(`
+job "build" {
+  task "compile" {
+    run "exec" {
+      arg = ["make", "build"]
+    }
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"arg"`)
+	assert.Contains(t, err.Error(), `did you mean "args"`)
+}
+
+func TestValidatePipelineSchema_ResourceTypeArgTypo(t *testing.T) {
+	hcl := []byte(`
+resource_type "git" {
+  check "exec" {
+    arg = ["/opt/resource/check"]
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"arg"`)
+	assert.Contains(t, err.Error(), `did you mean "args"`)
+}
+
+func TestValidatePipelineSchema_ReadyCheckTypo(t *testing.T) {
+	hcl := []byte(`
+service_type "postgres" {
+  start "exec" {
+    args = ["pg_ctl", "start"]
+  }
+  ready_check "exec" {
+    args = ["pg_isready"]
+    inteval = "5s"
+  }
+  stop "exec" {
+    args = ["pg_ctl", "stop"]
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"inteval"`)
+	assert.Contains(t, err.Error(), `did you mean "interval"`)
+}
+
+func TestValidatePipelineSchema_ReadyCheckTimeoutTypo(t *testing.T) {
+	hcl := []byte(`
+service_type "postgres" {
+  start "exec" {
+    args = ["pg_ctl", "start"]
+  }
+  ready_check "exec" {
+    args = ["pg_isready"]
+    timout = "30s"
+  }
+  stop "exec" {
+    args = ["pg_ctl", "stop"]
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"timout"`)
+	assert.Contains(t, err.Error(), `did you mean "timeout"`)
+}
+
+func TestValidatePipelineSchema_CustomParamsNotFlagged(t *testing.T) {
+	hcl := []byte(`
+resource_type "git" {
+  check "exec" {
+    args = ["/opt/resource/check"]
+    url = "https://example.com"
+    token = "abc"
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	assert.NoError(t, err)
+}
+
+func TestValidatePipelineSchema_UnknownJobHookBlock(t *testing.T) {
+	hcl := []byte(`
+job "build" {
+  on_succes "exec" {
+    args = ["echo", "done"]
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown block "on_succes"`)
+	assert.Contains(t, err.Error(), `did you mean "on_success"`)
+}
+
+func TestValidatePipelineSchema_PutStepHookTypo(t *testing.T) {
+	hcl := []byte(`
+job "build" {
+  put "git" "my-repo" {
+    branch = "main"
+    on_faliure "exec" {
+      args = ["echo", "failed"]
+    }
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown block "on_faliure"`)
+	assert.Contains(t, err.Error(), `did you mean "on_failure"`)
+}
+
+func TestValidatePipelineSchema_NotificationTypeArgTypo(t *testing.T) {
+	hcl := []byte(`
+notification_type "slack" {
+  notify "exec" {
+    arg = ["/opt/notify/send"]
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"arg"`)
+	assert.Contains(t, err.Error(), `did you mean "args"`)
+}
+
+func TestValidatePipelineSchema_GetStepTriggerTypo(t *testing.T) {
+	hcl := []byte(`
+job "build" {
+  get "git" "my-repo" {
+    triggr = true
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"triggr"`)
+	assert.Contains(t, err.Error(), `did you mean "trigger"`)
+}
+
+func TestValidatePipelineSchema_GetStepPassedTypo(t *testing.T) {
+	hcl := []byte(`
+job "build" {
+  get "git" "my-repo" {
+    passd = ["unit"]
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"passd"`)
+	assert.Contains(t, err.Error(), `did you mean "passed"`)
+}
+
+func TestValidatePipelineSchema_GetStepTimeoutTypo(t *testing.T) {
+	hcl := []byte(`
+job "build" {
+  get "git" "my-repo" {
+    timout = "5m"
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"timout"`)
+	assert.Contains(t, err.Error(), `did you mean "timeout"`)
+}
+
+func TestValidatePipelineSchema_GetStepAttemptsTypo(t *testing.T) {
+	hcl := []byte(`
+job "build" {
+  get "git" "my-repo" {
+    atempts = 3
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"atempts"`)
+	assert.Contains(t, err.Error(), `did you mean "attempts"`)
+}
+
+func TestValidatePipelineSchema_TaskStepTimeoutTypo(t *testing.T) {
+	hcl := []byte(`
+job "build" {
+  task "compile" {
+    timout = "10m"
+    run "exec" {
+      args = ["make"]
+    }
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"timout"`)
+	assert.Contains(t, err.Error(), `did you mean "timeout"`)
+}
+
+func TestValidatePipelineSchema_TaskStepInputsTypo(t *testing.T) {
+	hcl := []byte(`
+job "build" {
+  task "compile" {
+    input = ["my-repo"]
+    run "exec" {
+      args = ["make"]
+    }
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"input"`)
+	assert.Contains(t, err.Error(), `did you mean "inputs"`)
+}
+
+func TestValidatePipelineSchema_TaskStepOutputsTypo(t *testing.T) {
+	hcl := []byte(`
+job "build" {
+  task "compile" {
+    output = ["artifact"]
+    run "exec" {
+      args = ["make"]
+    }
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"output"`)
+	assert.Contains(t, err.Error(), `did you mean "outputs"`)
+}
+
+func TestValidatePipelineSchema_PutStepTimeoutTypo(t *testing.T) {
+	hcl := []byte(`
+job "build" {
+  put "git" "my-repo" {
+    timout = "5m"
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"timout"`)
+	assert.Contains(t, err.Error(), `did you mean "timeout"`)
+}
+
+func TestValidatePipelineSchema_PutStepAttemptsTypo(t *testing.T) {
+	hcl := []byte(`
+job "build" {
+  put "git" "my-repo" {
+    atempts = 3
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"atempts"`)
+	assert.Contains(t, err.Error(), `did you mean "attempts"`)
+}
+
+func TestValidatePipelineSchema_NotifyStepMessageTypo(t *testing.T) {
+	hcl := []byte(`
+job "build" {
+  notify "slack" "deploy" {
+    mesage = "done"
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"mesage"`)
+	assert.Contains(t, err.Error(), `did you mean "message"`)
+}
+
+func TestValidatePipelineSchema_JobConcurrencyTypo(t *testing.T) {
+	hcl := []byte(`
+job "build" {
+  concurency = 2
+}
+`)
+	err := validatePipelineSchema(hcl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"concurency"`)
+	assert.Contains(t, err.Error(), `did you mean "concurrency"`)
+}
+
+func TestValidatePipelineSchema_JobSerialGroupsTypo(t *testing.T) {
+	hcl := []byte(`
+job "build" {
+  serial_group = ["deploy"]
+}
+`)
+	err := validatePipelineSchema(hcl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"serial_group"`)
+	assert.Contains(t, err.Error(), `did you mean "serial_groups"`)
+}
+
+func TestValidatePipelineSchema_JobTimeoutTypo(t *testing.T) {
+	hcl := []byte(`
+job "build" {
+  timout = "1h"
+}
+`)
+	err := validatePipelineSchema(hcl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"timout"`)
+	assert.Contains(t, err.Error(), `did you mean "timeout"`)
+}
+
+func TestValidatePipelineSchema_ErrorIncludesLineNumber(t *testing.T) {
+	hcl := []byte(`
+job "build" {
+  get "git" "my-repo" {
+    triggr = true
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	require.Error(t, err)
+	// "triggr" is on line 4, col 5-11
+	assert.Contains(t, err.Error(), "pipeline.hcl:4,")
+}
+
+func TestValidatePipelineSchema_BlockErrorIncludesLineNumber(t *testing.T) {
+	hcl := []byte(`
+job "build" {
+  task "compile" {
+    run "exec" {
+      args = ["make"]
+    }
+    on_succes "exec" {
+      args = ["echo", "done"]
+    }
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	require.Error(t, err)
+	// "on_succes" block is on line 7
+	assert.Contains(t, err.Error(), "pipeline.hcl:7,")
+}
+
+func TestValidatePipelineSchema_ValidGetStep(t *testing.T) {
+	hcl := []byte(`
+job "build" {
+  get "git" "my-repo" {
+    passed  = ["unit"]
+    trigger = true
+    timeout = "5m"
+    attempts = 3
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	assert.NoError(t, err)
+}
+
+func TestValidatePipelineSchema_ValidTaskStep(t *testing.T) {
+	hcl := []byte(`
+job "build" {
+  task "compile" {
+    timeout  = "10m"
+    attempts = 2
+    inputs   = ["my-repo"]
+    outputs  = ["artifact"]
+    run "exec" {
+      args = ["make"]
+    }
+  }
+}
+`)
+	err := validatePipelineSchema(hcl)
+	assert.NoError(t, err)
+}
+
+func TestValidatePipelineSchema_ValidJob(t *testing.T) {
+	hcl := []byte(`
+job "build" {
+  concurrency   = 2
+  serial_groups = ["deploy"]
+  timeout       = "1h"
+}
+`)
+	err := validatePipelineSchema(hcl)
+	assert.NoError(t, err)
+}

--- a/worker/service.go
+++ b/worker/service.go
@@ -16,12 +16,14 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/adrg/xdg"
+	"github.com/agnivade/levenshtein"
 	"github.com/google/uuid"
 	"github.com/pikoci/pikoci/pikoci"
 	"github.com/pikoci/pikoci/pikoci/build"
@@ -802,7 +804,7 @@ func (w *Worker) runGetStep(ctx context.Context, m queue.Body, b *build.Build, c
 		passedVersionID = resolvedVersions[rCan]
 	}
 
-	params, usedVersionID := w.buildPullParams(ctx, m, b, rt, r, g, passedVersionID)
+	params, usedVersionID, pullWarnings := w.buildPullParams(ctx, m, b, rt, r, g, passedVersionID)
 	if params == nil {
 		return true
 	}
@@ -847,7 +849,7 @@ func (w *Worker) runGetStep(ctx context.Context, m queue.Body, b *build.Build, c
 	b.Steps = append(b.Steps, build.Step{Type: "get", Name: g.Name, Status: build.Started})
 	w.updateBuild(ctx, m, *b)
 
-	var out string
+	out := formatParamWarnings(pullWarnings)
 	var d time.Duration
 	var err error
 
@@ -996,6 +998,8 @@ func (w *Worker) runTaskStep(ctx context.Context, m queue.Body, b *build.Build, 
 		t.Run.Params = make(map[string]string)
 	}
 
+	taskWarnings := validateTaskRunParams(t.Run.Params, w.logger, t.Name)
+
 	replaceSecretPlaceholders(t.Run.Params, secretResolved)
 	replaceSecretPlaceholdersInSlice(t.Run.Args, secretResolved)
 
@@ -1038,7 +1042,7 @@ func (w *Worker) runTaskStep(ctx context.Context, m queue.Body, b *build.Build, 
 	b.Steps = append(b.Steps, build.Step{Type: "task", Name: t.Name, Status: build.Started})
 	w.updateBuild(ctx, m, *b)
 
-	var out string
+	out := formatParamWarnings(taskWarnings)
 	var d time.Duration
 	var err error
 
@@ -1155,10 +1159,9 @@ func (w *Worker) runPutStep(ctx context.Context, m queue.Body, b *build.Build, c
 		params[k] = v
 	}
 	// Add resource-level params
-	for k, v := range r.GetParams() {
-		if slices.Contains(rt.Params, k) {
-			params["param_"+k] = v
-		}
+	accepted, putWarnings := validateParams(r.GetParams(), rt.Params, "param_", w.logger, "resource_type", rt.Name)
+	for k, v := range accepted {
+		params[k] = v
 	}
 	// Add put-step-level params with put_ prefix
 	for k, v := range p.Params {
@@ -1205,7 +1208,7 @@ func (w *Worker) runPutStep(ctx context.Context, m queue.Body, b *build.Build, c
 	b.Steps = append(b.Steps, build.Step{Type: "put", Name: p.Name, Status: build.Started})
 	w.updateBuild(ctx, m, *b)
 
-	var out string
+	out := formatParamWarnings(putWarnings)
 	var d time.Duration
 	var err error
 
@@ -1356,10 +1359,9 @@ func (w *Worker) runNotifyStep(ctx context.Context, m queue.Body, b *build.Build
 		params[k] = v
 	}
 	// Notification-level params (param_ prefix)
-	for k, v := range notif.GetParams() {
-		if slices.Contains(nt.Params, k) {
-			params["param_"+k] = v
-		}
+	accepted, notifyWarnings := validateParams(notif.GetParams(), nt.Params, "param_", w.logger, "notification_type", nt.Name)
+	for k, v := range accepted {
+		params[k] = v
 	}
 	// Step-level params (notify_ prefix)
 	for k, v := range n.Params {
@@ -1413,7 +1415,7 @@ func (w *Worker) runNotifyStep(ctx context.Context, m queue.Body, b *build.Build
 	b.Steps = append(b.Steps, build.Step{Type: "notify", Name: n.Name, Status: build.Started})
 	w.updateBuild(ctx, m, *b)
 
-	var out string
+	out := formatParamWarnings(notifyWarnings)
 	var d time.Duration
 	var err error
 
@@ -1547,9 +1549,10 @@ func (w *Worker) runAutoNotifications(ctx context.Context, m queue.Body, b *buil
 }
 
 // buildPullParams assembles the environment parameters needed to pull a resource version.
-// Returns (nil, 0) if an error occurred (error is already handled via failBuild).
+// Returns (nil, 0, nil) if an error occurred (error is already handled via failBuild).
 // The second return value is the version ID actually used.
-func (w *Worker) buildPullParams(ctx context.Context, m queue.Body, b *build.Build, rt restype.ResourceType, r resource.Resource, g job.GetStep, resolvedVersionID uint32) (map[string]string, uint32) {
+// The third return value contains warnings about unrecognized params.
+func (w *Worker) buildPullParams(ctx context.Context, m queue.Body, b *build.Build, rt restype.ResourceType, r resource.Resource, g job.GetStep, resolvedVersionID uint32) (map[string]string, uint32, []string) {
 	var params map[string]string
 	if rt.Pull != nil && rt.Pull.Params != nil {
 		params = make(map[string]string)
@@ -1563,7 +1566,7 @@ func (w *Worker) buildPullParams(ctx context.Context, m queue.Body, b *build.Bui
 	dbvers, _, err := w.pikoci.ListResourceVersions(ctx, m.TeamCanonical, m.PipelineCanonical, r.Canonical, nil, nil, 0)
 	if err != nil {
 		w.failBuild(ctx, m, *b, fmt.Errorf("failed to list resource versions: %w", err))
-		return nil, 0
+		return nil, 0, nil
 	}
 
 	// Version priority: resolvedVersionID (from passed constraints) > m.VersionID (from queue) > latest
@@ -1585,12 +1588,12 @@ func (w *Worker) buildPullParams(ctx context.Context, m queue.Body, b *build.Bui
 		}
 		if !found {
 			w.failBuild(ctx, m, *b, fmt.Errorf("no version found for resource %q", r.Canonical))
-			return nil, 0
+			return nil, 0, nil
 		}
 	} else {
 		if len(dbvers) == 0 {
 			w.failBuild(ctx, m, *b, fmt.Errorf("no versions for resource %q", r.Canonical))
-			return nil, 0
+			return nil, 0, nil
 		}
 		slices.Reverse(dbvers)
 		versionID = dbvers[0].ID
@@ -1599,13 +1602,12 @@ func (w *Worker) buildPullParams(ctx context.Context, m queue.Body, b *build.Bui
 		}
 	}
 
-	for k, v := range r.GetParams() {
-		if slices.Contains(rt.Params, k) {
-			params["param_"+k] = v
-		}
+	accepted, pullWarnings := validateParams(r.GetParams(), rt.Params, "param_", w.logger, "resource_type", rt.Name)
+	for k, v := range accepted {
+		params[k] = v
 	}
 
-	return params, versionID
+	return params, versionID, pullWarnings
 }
 
 // runHooks runs a list of hooks (on_success, on_failure, on_cancel, ensure) and appends
@@ -1734,10 +1736,9 @@ func (w *Worker) processResourceCheck(ctx context.Context, m queue.Body, cwd str
 			flattenVersionValue(params, "version_"+k, v)
 		}
 	}
-	for k, v := range r.GetParams() {
-		if slices.Contains(rt.Params, k) {
-			params["param_"+k] = v
-		}
+	accepted, checkWarnings := validateParams(r.GetParams(), rt.Params, "param_", w.logger, "resource_type", rt.Name)
+	for k, v := range accepted {
+		params[k] = v
 	}
 
 	resolved, err := w.resolveSecretVars(ctx, cwd, pp)
@@ -1770,9 +1771,10 @@ func (w *Worker) processResourceCheck(ctx context.Context, m queue.Body, cwd str
 	replaceSecretPlaceholders(rc.Params, resolved)
 	replaceSecretPlaceholdersInSlice(rc.Args, resolved)
 
+	checkWarnStr := formatParamWarnings(checkWarnings)
 	out, _, err := w.runRunner(ctx, ru, cwd, rc)
 	if err != nil {
-		r.Logs = out
+		r.Logs = checkWarnStr + out
 		if nerr := w.pikoci.UpdatePipelineResource(ctx, m.TeamCanonical, m.PipelineCanonical, r.Canonical, r); nerr != nil {
 			w.logger.Error("failed update resource", "resource", r.Canonical, "pipeline", m.PipelineCanonical, "error", nerr)
 		}
@@ -1780,8 +1782,8 @@ func (w *Worker) processResourceCheck(ctx context.Context, m queue.Body, cwd str
 		return
 	}
 
-	if r.Logs != "" {
-		r.Logs = ""
+	if r.Logs != checkWarnStr || checkWarnStr != "" {
+		r.Logs = checkWarnStr
 		if err := w.pikoci.UpdatePipelineResource(ctx, m.TeamCanonical, m.PipelineCanonical, r.Canonical, r); err != nil {
 			w.logger.Error("failed update resource", "resource", r.Canonical, "pipeline", m.PipelineCanonical, "error", err)
 			return
@@ -2207,6 +2209,18 @@ func (w *Worker) runRunner(ctx context.Context, ru runner.Runner, cwd string, rc
 	out += sw.String()
 	if err != nil {
 		out += "\n" + err.Error()
+		// List available env var names (not values) to help diagnose typos.
+		names := make([]string, 0, len(envs))
+		for k := range envs {
+			if !isRunnerInternalParam(k) {
+				names = append(names, k)
+			}
+		}
+		sort.Strings(names)
+		out += "\n\n--- Available environment variables ---\n"
+		for _, n := range names {
+			out += n + "\n"
+		}
 	}
 	w.logger.Debug("finished running command", "out", out)
 
@@ -2328,7 +2342,7 @@ func (w *Worker) startServices(ctx context.Context, m queue.Body, b *build.Build
 			return started
 		}
 
-		params := w.serviceParams(b, m, svc.Start.Params, ss.Params)
+		params, svcWarnings := w.serviceParams(b, m, svc.Start.Params, ss.Params, svc.Params, svc.Name)
 		for k, v := range params {
 			rc.Params[k] = v
 		}
@@ -2341,12 +2355,14 @@ func (w *Worker) startServices(ctx context.Context, m queue.Body, b *build.Build
 		b.Steps = append(b.Steps, build.Step{Type: "service", Name: ss.Name + ":start", Status: build.Started})
 		w.updateBuild(ctx, m, *b)
 
+		svcWarnStr := formatParamWarnings(svcWarnings)
 		onPartialLog := func(partial string) {
-			b.Steps[stepIdx].Logs = partial
+			b.Steps[stepIdx].Logs = svcWarnStr + partial
 			w.updateBuild(ctx, m, *b)
 		}
 
 		out, d, err := w.runRunner(ctx, ru, cwd, rc, onPartialLog)
+		out = svcWarnStr + out
 		if err != nil {
 			b.Steps[stepIdx] = build.Step{Type: "service", Name: ss.Name + ":start", Logs: out, Duration: d, Status: build.Failed}
 			b.Status = build.Failed
@@ -2425,6 +2441,77 @@ func isRunnerInternalParam(key string) bool {
 	return runnerInternalParams[key]
 }
 
+// validateParams filters userParams through allowedParams, returning accepted
+// params (with prefix prepended to each key) and warning strings for any
+// unrecognized params. For unrecognized params it uses Levenshtein distance to
+// suggest the closest match if distance <= 2.
+func validateParams(userParams map[string]string, allowedParams []string, prefix string, logger *slog.Logger, typeName, entityName string) (map[string]string, []string) {
+	accepted := make(map[string]string)
+	var warnings []string
+	for k, v := range userParams {
+		if slices.Contains(allowedParams, k) {
+			accepted[prefix+k] = v
+			continue
+		}
+		msg := fmt.Sprintf("WARNING: param %q is not declared by %s %q and was ignored", k, typeName, entityName)
+		best := ""
+		bestDist := 3
+		for _, p := range allowedParams {
+			d := levenshtein.ComputeDistance(k, p)
+			if d < bestDist {
+				bestDist = d
+				best = p
+			}
+		}
+		if best != "" {
+			msg += fmt.Sprintf(" (did you mean %q?)", best)
+		}
+		logger.Warn(msg)
+		warnings = append(warnings, msg)
+	}
+	return accepted, warnings
+}
+
+// formatParamWarnings joins warning strings into a single block suitable for
+// prepending to step log output.
+func formatParamWarnings(warnings []string) string {
+	if len(warnings) == 0 {
+		return ""
+	}
+	return strings.Join(warnings, "\n") + "\n"
+}
+
+// taskRunKnownFields are the HCL field names of RunnerCommand that are parsed
+// structurally. Anything else ends up in the Params map via ",remain". If a
+// Params key is a close Levenshtein match to one of these, the user likely made
+// a typo in their pipeline HCL.
+var taskRunKnownFields = []string{"args"}
+
+// validateTaskRunParams checks whether any keys in the user-supplied Params map
+// of a task's RunnerCommand look like typos of known HCL fields (e.g. "arg"
+// instead of "args"). Returns warning strings for any suspicious keys.
+func validateTaskRunParams(params map[string]string, logger *slog.Logger, stepName string) []string {
+	var warnings []string
+	for k := range params {
+		// Skip keys that are known runner-internal params — these are
+		// legitimate user-supplied values consumed by the runner template.
+		if isRunnerInternalParam(k) {
+			continue
+		}
+		for _, field := range taskRunKnownFields {
+			if k == field {
+				continue
+			}
+			if levenshtein.ComputeDistance(k, field) <= 2 {
+				msg := fmt.Sprintf("WARNING: %q in task %q is not a known field and was treated as a param (did you mean %q?)", k, stepName, field)
+				logger.Warn(msg)
+				warnings = append(warnings, msg)
+			}
+		}
+	}
+	return warnings
+}
+
 // sanitizeStepName converts a step name to a safe environment variable prefix
 // by uppercasing it and replacing non-alphanumeric characters with underscores.
 func sanitizeStepName(name string) string {
@@ -2486,7 +2573,7 @@ func parseOutputFile(path string, logger *slog.Logger) map[string]string {
 
 // serviceParams builds the environment parameters for a service command,
 // merging the command's own params with build info and per-job overrides.
-func (w *Worker) serviceParams(b *build.Build, m queue.Body, cmdParams map[string]string, overrides map[string]string) map[string]string {
+func (w *Worker) serviceParams(b *build.Build, m queue.Body, cmdParams map[string]string, overrides map[string]string, allowedParams []string, svcName string) (map[string]string, []string) {
 	params := make(map[string]string)
 	for k, v := range cmdParams {
 		params[k] = v
@@ -2494,10 +2581,11 @@ func (w *Worker) serviceParams(b *build.Build, m queue.Body, cmdParams map[strin
 	for k, v := range buildMetadataParams(b, m) {
 		params[k] = v
 	}
-	for k, v := range overrides {
-		params["param_"+k] = v
+	accepted, warnings := validateParams(overrides, allowedParams, "param_", w.logger, "service_type", svcName)
+	for k, v := range accepted {
+		params[k] = v
 	}
-	return params
+	return params, warnings
 }
 
 // waitForServices runs ready_check for all started services that have one.
@@ -2669,7 +2757,7 @@ func (w *Worker) stopServices(m queue.Body, b *build.Build, cwd string, pp *pipe
 			continue
 		}
 
-		params := w.serviceParams(b, m, svc.Stop.Params, ss.Params)
+		params, stopWarnings := w.serviceParams(b, m, svc.Stop.Params, ss.Params, svc.Params, svc.Name)
 		for k, v := range params {
 			rc.Params[k] = v
 		}
@@ -2682,12 +2770,14 @@ func (w *Worker) stopServices(m queue.Body, b *build.Build, cwd string, pp *pipe
 		b.Steps = append(b.Steps, build.Step{Type: "service", Name: ss.Name + ":stop", Status: build.Started})
 		w.updateBuild(stopCtx, m, *b)
 
+		stopWarnStr := formatParamWarnings(stopWarnings)
 		onPartialLog := func(partial string) {
-			b.Steps[stepIdx].Logs = partial
+			b.Steps[stepIdx].Logs = stopWarnStr + partial
 			w.updateBuild(stopCtx, m, *b)
 		}
 
 		out, d, err := w.runRunner(stopCtx, ru, cwd, rc, onPartialLog)
+		out = stopWarnStr + out
 		stepStatus := build.Succeeded
 		if err != nil {
 			stepStatus = build.Failed

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -1507,7 +1508,7 @@ func TestBuildPullParams_WithVersionID(t *testing.T) {
 			{ID: 5, Version: map[string]interface{}{"ref": "def"}},
 		}, false, nil).AnyTimes()
 
-	params, vid := w.buildPullParams(ctx, m, &b, rt, r, g, 0)
+	params, vid, _ := w.buildPullParams(ctx, m, &b, rt, r, g, 0)
 	require.NotNil(t, params)
 	assert.Equal(t, "def", params["version_ref"])
 	assert.Equal(t, "http://example.com", params["param_url"])
@@ -1542,7 +1543,7 @@ func TestBuildPullParams_NoVersionID_UsesLatest(t *testing.T) {
 			{ID: 2, Version: map[string]interface{}{"ref": "latest"}},
 		}, false, nil).AnyTimes()
 
-	params, vid := w.buildPullParams(ctx, m, &b, rt, r, g, 0)
+	params, vid, _ := w.buildPullParams(ctx, m, &b, rt, r, g, 0)
 	require.NotNil(t, params)
 	assert.Equal(t, "latest", params["version_ref"])
 	assert.Equal(t, uint32(2), vid)
@@ -1574,7 +1575,7 @@ func TestBuildPullParams_NoVersions_Fails(t *testing.T) {
 	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "72", gomock.Any()).
 		Return(nil)
 
-	params, _ := w.buildPullParams(ctx, m, &b, rt, r, g, 0)
+	params, _, _ := w.buildPullParams(ctx, m, &b, rt, r, g, 0)
 	assert.Nil(t, params)
 }
 
@@ -1605,7 +1606,7 @@ func TestBuildPullParams_ResolvedVersionTakesPriority(t *testing.T) {
 		}, false, nil).AnyTimes()
 
 	// resolvedVersionID=10 should take priority over m.VersionID=5
-	params, vid := w.buildPullParams(ctx, m, &b, rt, r, g, 10)
+	params, vid, _ := w.buildPullParams(ctx, m, &b, rt, r, g, 10)
 	require.NotNil(t, params)
 	assert.Equal(t, uint32(10), vid)
 	assert.Equal(t, "resolved-ver", params["version_ref"])
@@ -6763,7 +6764,7 @@ func TestServiceParams(t *testing.T) {
 	cmdParams := map[string]string{"image": "postgres:15"}
 	overrides := map[string]string{"port": "5433"}
 
-	params := w.serviceParams(b, m, cmdParams, overrides)
+	params, warnings := w.serviceParams(b, m, cmdParams, overrides, []string{"port"}, "postgres")
 
 	assert.Equal(t, "postgres:15", params["image"])
 	assert.Equal(t, "99", params["BUILD_NUMBER"])
@@ -6771,6 +6772,108 @@ func TestServiceParams(t *testing.T) {
 	assert.Equal(t, "test-pipeline", params["BUILD_PIPELINE_NAME"])
 	assert.Equal(t, "main", params["BUILD_TEAM_NAME"])
 	assert.Equal(t, "5433", params["param_port"])
+	assert.Empty(t, warnings)
+}
+
+func TestValidateParams(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	t.Run("valid params accepted", func(t *testing.T) {
+		accepted, warnings := validateParams(
+			map[string]string{"token": "abc", "url": "http://x"},
+			[]string{"token", "url"},
+			"param_", logger, "resource_type", "git",
+		)
+		assert.Equal(t, map[string]string{"param_token": "abc", "param_url": "http://x"}, accepted)
+		assert.Empty(t, warnings)
+	})
+
+	t.Run("invalid param with suggestion", func(t *testing.T) {
+		accepted, warnings := validateParams(
+			map[string]string{"toke": "abc"},
+			[]string{"token", "url"},
+			"param_", logger, "resource_type", "git",
+		)
+		assert.Empty(t, accepted)
+		require.Len(t, warnings, 1)
+		assert.Contains(t, warnings[0], `param "toke" is not declared by resource_type "git"`)
+		assert.Contains(t, warnings[0], `did you mean "token"`)
+	})
+
+	t.Run("invalid param without suggestion", func(t *testing.T) {
+		accepted, warnings := validateParams(
+			map[string]string{"completely_wrong": "abc"},
+			[]string{"token", "url"},
+			"param_", logger, "resource_type", "git",
+		)
+		assert.Empty(t, accepted)
+		require.Len(t, warnings, 1)
+		assert.Contains(t, warnings[0], `param "completely_wrong" is not declared by resource_type "git"`)
+		assert.NotContains(t, warnings[0], "did you mean")
+	})
+
+	t.Run("empty params", func(t *testing.T) {
+		accepted, warnings := validateParams(
+			map[string]string{},
+			[]string{"token"},
+			"param_", logger, "resource_type", "git",
+		)
+		assert.Empty(t, accepted)
+		assert.Empty(t, warnings)
+	})
+
+	t.Run("empty allowed params", func(t *testing.T) {
+		accepted, warnings := validateParams(
+			map[string]string{"token": "abc"},
+			[]string{},
+			"param_", logger, "resource_type", "git",
+		)
+		assert.Empty(t, accepted)
+		require.Len(t, warnings, 1)
+		assert.Contains(t, warnings[0], `param "token" is not declared`)
+	})
+}
+
+func TestFormatParamWarnings(t *testing.T) {
+	t.Run("no warnings", func(t *testing.T) {
+		assert.Equal(t, "", formatParamWarnings(nil))
+	})
+
+	t.Run("single warning", func(t *testing.T) {
+		result := formatParamWarnings([]string{"WARNING: something"})
+		assert.Equal(t, "WARNING: something\n", result)
+	})
+
+	t.Run("multiple warnings", func(t *testing.T) {
+		result := formatParamWarnings([]string{"WARNING: a", "WARNING: b"})
+		assert.Equal(t, "WARNING: a\nWARNING: b\n", result)
+	})
+}
+
+func TestValidateTaskRunParams(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	t.Run("typo of args", func(t *testing.T) {
+		warnings := validateTaskRunParams(map[string]string{"arg": "echo hello"}, logger, "my-step")
+		require.Len(t, warnings, 1)
+		assert.Contains(t, warnings[0], `"arg"`)
+		assert.Contains(t, warnings[0], `did you mean "args"`)
+	})
+
+	t.Run("known runner param not warned", func(t *testing.T) {
+		warnings := validateTaskRunParams(map[string]string{"cmd": "echo hello"}, logger, "my-step")
+		assert.Empty(t, warnings)
+	})
+
+	t.Run("unrelated param not warned", func(t *testing.T) {
+		warnings := validateTaskRunParams(map[string]string{"my_custom_var": "value"}, logger, "my-step")
+		assert.Empty(t, warnings)
+	})
+
+	t.Run("empty params", func(t *testing.T) {
+		warnings := validateTaskRunParams(map[string]string{}, logger, "my-step")
+		assert.Empty(t, warnings)
+	})
 }
 
 // --- processMessage tests ---


### PR DESCRIPTION
## Summary

- **Parse-time schema validation**: catches typos in HCL block names and attributes at pipeline save time with line-accurate errors and Levenshtein "did you mean?" suggestions
- **Runtime param warnings**: unrecognized resource/notification/service params show warnings in step logs instead of being silently dropped
- **Env var listing on failure**: failed commands now list available environment variable names to help diagnose missing/typo'd params

Closes #116