### PR TITLE
Switch production from embedded workers to separate workers with NATS

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -32,14 +32,14 @@ set -euo pipefail
 #   1. Validates that deploy/pikoci.env exists
 #   2. Detects the server's CPU architecture (amd64 or arm64)
 #   3. Obtains the PikoCI binary (download release or build from source)
-#   4. Stops the running PikoCI systemd service (if any)
+#   4. Stops the running PikoCI and worker systemd services (if any)
 #   5. Copies the binary to /usr/local/bin/pikoci on the server
 #   6. Creates server directories, system user, and sets ownership:
 #      - /opt/pikoci      — Docker Compose configs and supporting services
 #      - /etc/pikoci       — PikoCI environment/config (restricted permissions)
 #      - /var/lib/pikoci   — PikoCI data directory (owned by pikoci user)
 #   7. Copies config files to the server:
-#      - pikoci.service    → /etc/systemd/system/
+#      - pikoci.service, pikoci-worker@.service → /etc/systemd/system/
 #      - docker-compose.yml, Caddyfile, prometheus.yml → /opt/pikoci/
 #   8. Copies the env file to two locations:
 #      - /etc/pikoci/pikoci.env  — read by systemd (chmod 600)
@@ -48,16 +48,17 @@ set -euo pipefail
 #                                  Docker Compose variable interpolation in
 #                                  docker-compose.yml (avoids bcrypt $ warnings)
 #   9. Installs Docker on the server if not already present
-#  10. Reloads systemd and restarts the PikoCI service
-#  11. Runs docker compose up -d for supporting services
+#  10. Runs docker compose up -d for supporting services (NATS must start first)
+#  11. Reloads systemd and restarts PikoCI server + worker services
 #
 # SERVER LAYOUT:
 #   /usr/local/bin/pikoci              — PikoCI binary
-#   /etc/systemd/system/pikoci.service — systemd unit
+#   /etc/systemd/system/pikoci.service — systemd unit (server)
+#   /etc/systemd/system/pikoci-worker@.service — systemd template (workers)
 #   /etc/pikoci/pikoci.env             — env vars for PikoCI (secrets)
 #   /var/lib/pikoci/                   — PikoCI data (SQLite DB, XDG data)
 #   /opt/pikoci/                       — Docker Compose stack
-#   /opt/pikoci/docker-compose.yml     — Caddy, Prometheus, Grafana, Node Exporter
+#   /opt/pikoci/docker-compose.yml     — Caddy, Prometheus, Grafana, Node Exporter, NATS
 #   /opt/pikoci/Caddyfile              — reverse proxy config
 #   /opt/pikoci/prometheus.yml         — Prometheus scrape targets
 #   /opt/pikoci/pikoci.env             — env vars for Docker Compose containers
@@ -131,7 +132,8 @@ fi
 # --- Stop running service ---
 # Must stop before copying to avoid "text file busy" errors.
 
-echo "==> Stopping PikoCI service..."
+echo "==> Stopping PikoCI services..."
+ssh "$SSH_HOST" 'systemctl stop pikoci-worker@worker-1 pikoci-worker@worker-2 2>/dev/null || true'
 ssh "$SSH_HOST" 'systemctl stop pikoci 2>/dev/null || true'
 
 # --- Copy binary ---
@@ -146,6 +148,7 @@ ssh "$SSH_HOST" 'chown pikoci:pikoci /usr/local/bin/pikoci'
 echo "==> Syncing deploy configs..."
 ssh "$SSH_HOST" 'mkdir -p /opt/pikoci /etc/pikoci /var/lib/pikoci /var/www/pikoci.com /var/www/docs.pikoci.com && id -u pikoci &>/dev/null || useradd --system --no-create-home pikoci && chown pikoci:pikoci /var/lib/pikoci /var/www/pikoci.com /var/www/docs.pikoci.com && usermod -aG docker pikoci 2>/dev/null || true'
 scp "$DEPLOY_DIR/pikoci.service" "$SSH_HOST":/etc/systemd/system/pikoci.service
+scp "$DEPLOY_DIR/pikoci-worker@.service" "$SSH_HOST":/etc/systemd/system/pikoci-worker@.service
 scp "$DEPLOY_DIR/docker-compose.yml" "$SSH_HOST":/opt/pikoci/docker-compose.yml
 scp "$DEPLOY_DIR/Caddyfile" "$SSH_HOST":/opt/pikoci/Caddyfile
 scp "$DEPLOY_DIR/prometheus.yml" "$SSH_HOST":/opt/pikoci/prometheus.yml
@@ -217,10 +220,10 @@ fi
 
 # --- Restart services ---
 
-echo "==> Restarting PikoCI service..."
-ssh "$SSH_HOST" 'systemctl daemon-reload && systemctl restart pikoci'
-
 echo "==> Updating Docker Compose services..."
 ssh "$SSH_HOST" 'cd /opt/pikoci && docker compose up -d'
+
+echo "==> Restarting PikoCI services..."
+ssh "$SSH_HOST" 'systemctl daemon-reload && systemctl restart pikoci && systemctl enable --now pikoci-worker@worker-1 pikoci-worker@worker-2'
 
 echo "==> Deploy complete."

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -40,6 +40,21 @@ services:
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
       - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
 
+  nats:
+    image: nats:2
+    restart: unless-stopped
+    ports:
+      - "4222:4222"
+      - "8222:8222"
+    command: ["--http_port", "8222"]
+
+  nats-exporter:
+    image: natsio/prometheus-nats-exporter:latest
+    restart: unless-stopped
+    command: ["-varz", "-connz", "-subz", "http://nats:8222"]
+    depends_on:
+      - nats
+
   node-exporter:
     image: prom/node-exporter:latest
     restart: unless-stopped

--- a/deploy/grafana/dashboards/pikoci.json
+++ b/deploy/grafana/dashboards/pikoci.json
@@ -8,9 +8,341 @@
   "links": [],
   "panels": [
     {
+      "title": "Workers (Healthy)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 3, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "steps": [
+              { "value": 0, "color": "red" },
+              { "value": 1, "color": "green" }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "pikoci_workers{status=\"healthy\"}",
+          "legendFormat": "healthy",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Workers (Stale)",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 3, "x": 3, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "steps": [
+              { "value": 0, "color": "green" },
+              { "value": 1, "color": "red" }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "pikoci_workers{status=\"stale\"}",
+          "legendFormat": "stale",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "NATS Connections",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 3, "x": 6, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "gnatsd_varz_connections",
+          "legendFormat": "connections",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Uptime",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 3, "x": 9, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "time() - process_start_time_seconds",
+          "legendFormat": "uptime",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Total HTTP Requests",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 3, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(http_requests_total)",
+          "legendFormat": "total",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Current Goroutines",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 3, "x": 15, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "go_goroutines",
+          "legendFormat": "goroutines",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "NATS Slow Consumers",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 3, "x": 18, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "steps": [
+              { "value": 0, "color": "green" },
+              { "value": 1, "color": "red" }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "gnatsd_varz_slow_consumers",
+          "legendFormat": "slow consumers",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "NATS Subscriptions",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 3, "x": 21, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "gnatsd_varz_subscriptions",
+          "legendFormat": "subscriptions",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "HTTP Request Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total[5m])) by (code)",
+          "legendFormat": "{{code}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "HTTP Request Duration (p50 / p90 / p99)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.90, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "title": "NATS Messages In/Out Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "rate(gnatsd_varz_in_msgs[5m])",
+          "legendFormat": "messages in",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(gnatsd_varz_out_msgs[5m])",
+          "legendFormat": "messages out",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "title": "NATS Bytes In/Out",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "rate(gnatsd_varz_in_bytes[5m])",
+          "legendFormat": "bytes in",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(gnatsd_varz_out_bytes[5m])",
+          "legendFormat": "bytes out",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "title": "HTTP Requests by Method",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 50
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total[5m])) by (method)",
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Error Rate (4xx + 5xx)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20
+          },
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "red"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{code=~\"4..|5..\"}[5m]))",
+          "legendFormat": "errors",
+          "refId": "A"
+        }
+      ]
+    },
+    {
       "title": "CPU Usage",
       "type": "gauge",
-      "gridPos": { "h": 6, "w": 4, "x": 0, "y": 0 },
+      "gridPos": { "h": 6, "w": 4, "x": 0, "y": 28 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
@@ -38,7 +370,7 @@
     {
       "title": "Memory Usage",
       "type": "gauge",
-      "gridPos": { "h": 6, "w": 4, "x": 4, "y": 0 },
+      "gridPos": { "h": 6, "w": 4, "x": 4, "y": 28 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
@@ -66,7 +398,7 @@
     {
       "title": "Disk Usage",
       "type": "gauge",
-      "gridPos": { "h": 6, "w": 4, "x": 8, "y": 0 },
+      "gridPos": { "h": 6, "w": 4, "x": 8, "y": 28 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
@@ -94,7 +426,7 @@
     {
       "title": "Total CPU Cores",
       "type": "stat",
-      "gridPos": { "h": 6, "w": 4, "x": 12, "y": 0 },
+      "gridPos": { "h": 6, "w": 4, "x": 12, "y": 28 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
@@ -113,7 +445,7 @@
     {
       "title": "Total Memory",
       "type": "stat",
-      "gridPos": { "h": 6, "w": 4, "x": 16, "y": 0 },
+      "gridPos": { "h": 6, "w": 4, "x": 16, "y": 28 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
@@ -132,7 +464,7 @@
     {
       "title": "Total Disk",
       "type": "stat",
-      "gridPos": { "h": 6, "w": 4, "x": 20, "y": 0 },
+      "gridPos": { "h": 6, "w": 4, "x": 20, "y": 28 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
@@ -151,7 +483,7 @@
     {
       "title": "System CPU Usage %",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 6 },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 34 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
@@ -186,7 +518,7 @@
     {
       "title": "System Memory Usage",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 6 },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 34 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
@@ -214,7 +546,7 @@
     {
       "title": "System Disk Usage",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 6 },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 34 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
@@ -240,87 +572,13 @@
       ]
     },
     {
-      "title": "System Load Average",
-      "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 14 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "targets": [
-        { "expr": "node_load1", "legendFormat": "1m", "refId": "A" },
-        { "expr": "node_load5", "legendFormat": "5m", "refId": "B" },
-        { "expr": "node_load15", "legendFormat": "15m", "refId": "C" }
-      ]
-    },
-    {
-      "title": "Uptime",
-      "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 14 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "expr": "time() - process_start_time_seconds",
-          "legendFormat": "uptime",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "title": "Total HTTP Requests",
-      "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 14 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "expr": "sum(http_requests_total)",
-          "legendFormat": "total",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "title": "Current Goroutines",
-      "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 14 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "expr": "go_goroutines",
-          "legendFormat": "goroutines",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "title": "HTTP Request Rate",
+      "title": "Process CPU Usage",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 18 },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 42 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
-          "unit": "reqps",
+          "unit": "percentunit",
           "custom": {
             "drawStyle": "line",
             "fillOpacity": 10
@@ -330,20 +588,20 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(http_requests_total[5m])) by (code)",
-          "legendFormat": "{{code}}",
+          "expr": "rate(process_cpu_seconds_total[5m])",
+          "legendFormat": "CPU",
           "refId": "A"
         }
       ]
     },
     {
-      "title": "HTTP Request Duration (p50 / p90 / p99)",
+      "title": "Process Resident Memory",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 18 },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 42 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
-          "unit": "s",
+          "unit": "bytes",
           "custom": {
             "drawStyle": "line",
             "fillOpacity": 10
@@ -353,76 +611,49 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
-          "legendFormat": "p50",
+          "expr": "process_resident_memory_bytes",
+          "legendFormat": "RSS",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.90, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
-          "legendFormat": "p90",
+          "expr": "process_virtual_memory_bytes",
+          "legendFormat": "virtual",
           "refId": "B"
-        },
-        {
-          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
-          "legendFormat": "p99",
-          "refId": "C"
         }
       ]
     },
     {
-      "title": "HTTP Requests by Method",
+      "title": "Open File Descriptors",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 26 },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 42 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
-          "unit": "reqps",
-          "custom": {
-            "drawStyle": "bars",
-            "fillOpacity": 50
-          }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "expr": "sum(rate(http_requests_total[5m])) by (method)",
-          "legendFormat": "{{method}}",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "title": "Error Rate (4xx + 5xx)",
-      "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 26 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "reqps",
+          "unit": "short",
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 20
-          },
-          "color": {
-            "mode": "fixed",
-            "fixedColor": "red"
+            "fillOpacity": 10
           }
         },
         "overrides": []
       },
       "targets": [
         {
-          "expr": "sum(rate(http_requests_total{code=~\"4..|5..\"}[5m]))",
-          "legendFormat": "errors",
+          "expr": "process_open_fds",
+          "legendFormat": "open FDs",
           "refId": "A"
+        },
+        {
+          "expr": "process_max_fds",
+          "legendFormat": "max FDs",
+          "refId": "B"
         }
       ]
     },
     {
       "title": "Goroutines",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 34 },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 50 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
@@ -445,7 +676,7 @@
     {
       "title": "Go Memory Usage",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 34 },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 50 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
@@ -478,7 +709,7 @@
     {
       "title": "GC Pause Duration",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 34 },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 50 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
@@ -499,82 +730,20 @@
       ]
     },
     {
-      "title": "Process CPU Usage",
-      "type": "timeseries",
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 42 },
+      "title": "System Load Average",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 24, "x": 0, "y": 58 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
-          "unit": "percentunit",
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 10
-          }
+          "unit": "short"
         },
         "overrides": []
       },
       "targets": [
-        {
-          "expr": "rate(process_cpu_seconds_total[5m])",
-          "legendFormat": "CPU",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "title": "Open File Descriptors",
-      "type": "timeseries",
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 42 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 10
-          }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "expr": "process_open_fds",
-          "legendFormat": "open FDs",
-          "refId": "A"
-        },
-        {
-          "expr": "process_max_fds",
-          "legendFormat": "max FDs",
-          "refId": "B"
-        }
-      ]
-    },
-    {
-      "title": "Process Resident Memory",
-      "type": "timeseries",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 42 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "bytes",
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 10
-          }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "expr": "process_resident_memory_bytes",
-          "legendFormat": "RSS",
-          "refId": "A"
-        },
-        {
-          "expr": "process_virtual_memory_bytes",
-          "legendFormat": "virtual",
-          "refId": "B"
-        }
+        { "expr": "node_load1", "legendFormat": "1m", "refId": "A" },
+        { "expr": "node_load5", "legendFormat": "5m", "refId": "B" },
+        { "expr": "node_load15", "legendFormat": "15m", "refId": "C" }
       ]
     }
   ],

--- a/deploy/pikoci-worker@.service
+++ b/deploy/pikoci-worker@.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=PikoCI Worker %i
+After=network.target pikoci.service
+Wants=pikoci.service
+
+[Service]
+Type=simple
+User=pikoci
+Group=pikoci
+ExecStart=/usr/local/bin/pikoci worker --name %i
+EnvironmentFile=/etc/pikoci/pikoci.env
+Environment=HOME=/var/lib/pikoci
+WorkingDirectory=/var/lib/pikoci
+Restart=always
+RestartSec=5
+
+# Hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/lib/pikoci /tmp
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/pikoci.env.example
+++ b/deploy/pikoci.env.example
@@ -12,10 +12,19 @@ DB_SYSTEM=sqlite
 DB_NAME=/var/lib/pikoci/pikoci.db
 
 # Queue backend (mem, nats, rabbit, kafka)
-PUBSUB_SYSTEM=mem
+PUBSUB_SYSTEM=nats
 
 # Run embedded worker (set to false if running workers separately)
-RUN_WORKER=true
+RUN_WORKER=false
+
+# NATS server URL (required when PUBSUB_SYSTEM=nats)
+# NATS_SERVER_URL=nats://localhost:4222
+
+# Worker auth token (generate with: pikoci worker-token --jwt-secret <JWT_SECRET>)
+# WORKER_TOKEN=
+
+# PikoCI server URL for workers to connect to
+# PIKOCI_URL=http://localhost:8080
 
 # Number of concurrent workers (default 1)
 # CONCURRENCY=2

--- a/deploy/pipeline.hcl
+++ b/deploy/pipeline.hcl
@@ -320,7 +320,7 @@ job "deploy" {
     }
   }
   on_success "shell" {
-    cmd = "kill -QUIT $(pidof pikoci)"
+    cmd = "systemctl kill --signal=QUIT pikoci pikoci-worker@worker-1 pikoci-worker@worker-2"
   }
 }
 

--- a/deploy/prometheus.yml
+++ b/deploy/prometheus.yml
@@ -10,3 +10,7 @@ scrape_configs:
   - job_name: "node-exporter"
     static_configs:
       - targets: ["node-exporter:9100"]
+
+  - job_name: "nats"
+    static_configs:
+      - targets: ["nats-exporter:7777"]


### PR DESCRIPTION
## Summary

- Replace single-process embedded worker with distributed architecture: server + 2 separate worker processes communicating via NATS
- Add NATS and NATS Prometheus exporter to Docker Compose
- Create systemd template unit (`pikoci-worker@.service`) for worker instances
- Update `deploy.sh` to manage worker lifecycle, copy template, and ensure correct startup ordering (NATS → server → workers)
- Update CI deploy job to restart workers alongside server on deploy
- Add NATS metrics scraping to Prometheus
- Reorder Grafana dashboard by priority: service health at top, Go internals at bottom
- Update `pikoci.env.example` with new NATS/worker configuration keys
