### PR TITLE
Fix new trigger jobs replaying entire version backlog (#492)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- New jobs with `trigger = true` no longer replay the entire version backlog. Jobs now record a `baseline_version_id` at creation time, and the scheduler only considers versions newer than that baseline ([#492](https://github.com/PikoCI/pikoci/issues/492))
+
 ### Added
 
 - Release pipeline with .deb/.rpm packages: binaries are now named `pikoci-<os>-<arch>` (with `.exe` for Windows), Linux packages (.deb and .rpm) are generated via nfpm for amd64/arm64, and a SHA256SUMS file is included in GitHub Releases. The release job is split into discrete tasks (install-tools, build-binaries, package-deb-rpm, create-release) with tool caching ([#346](https://github.com/PikoCI/pikoci/issues/346))

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -219,6 +219,49 @@ if ! ssh "$SSH_HOST" 'command -v docker &>/dev/null'; then
     ssh "$SSH_HOST" 'curl -fsSL https://get.docker.com | sh'
 fi
 
+# --- Configure log rotation ---
+
+echo "==> Configuring log rotation..."
+ssh "$SSH_HOST" 'mkdir -p /etc/systemd/journald.conf.d && cat > /etc/systemd/journald.conf.d/retention.conf << JEOF
+[Journal]
+MaxRetentionSec=1day
+SystemMaxUse=200M
+JEOF
+systemctl restart systemd-journald'
+
+# Docker log rotation (only if not already configured)
+ssh "$SSH_HOST" 'if [ ! -f /etc/docker/daemon.json ]; then
+    cat > /etc/docker/daemon.json << DEOF
+{
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "10m",
+    "max-file": "3"
+  }
+}
+DEOF
+    systemctl restart docker
+fi'
+
+# --- Disk cleanup cron ---
+
+echo "==> Installing disk cleanup cron..."
+ssh "$SSH_HOST" 'cat > /opt/pikoci/disk-cleanup.sh << "DCEOF"
+#!/bin/bash
+THRESHOLD=80
+USAGE=$(df / --output=pcent | tail -1 | tr -d " %")
+if [ "$USAGE" -ge "$THRESHOLD" ]; then
+    logger -t disk-cleanup "Disk at ${USAGE}%, running cleanup (threshold: ${THRESHOLD}%)"
+    docker volume prune -f > /dev/null 2>&1
+    journalctl --vacuum-time=1d > /dev/null 2>&1
+    logger -t disk-cleanup "Cleanup done, now at $(df / --output=pcent | tail -1 | tr -d " %")%"
+fi
+DCEOF
+chmod +x /opt/pikoci/disk-cleanup.sh'
+
+# Run daily at 3am, only install if not already present
+ssh "$SSH_HOST" 'crontab -l 2>/dev/null | grep -q disk-cleanup || (crontab -l 2>/dev/null; echo "0 3 * * * /opt/pikoci/disk-cleanup.sh") | crontab -'
+
 # --- Restart services ---
 
 echo "==> Updating Docker Compose services..."

--- a/pikoci/build/repository.go
+++ b/pikoci/build/repository.go
@@ -26,7 +26,7 @@ type Repository interface {
 	// FindGetVersions returns a map of step names to version IDs for all get steps in a build.
 	FindGetVersions(ctx context.Context, buildID uint32) (map[string]uint32, error)
 	// FindReadyDownstreamVersion finds a version that has passed through all upstream jobs and is ready for the downstream job.
-	FindReadyDownstreamVersion(ctx context.Context, tc, pn string, upstreamJobs []string, downstreamJob string, stepName string, upstreamCount int) (uint32, bool, error)
+	FindReadyDownstreamVersion(ctx context.Context, tc, pn string, upstreamJobs []string, downstreamJob string, stepName string, upstreamCount int, baselineVersionID *uint32) (uint32, bool, error)
 	// LastBuildAtByPipeline returns the most recent build timestamp for each pipeline in a team.
 	LastBuildAtByPipeline(ctx context.Context, tc string) (map[uint32]time.Time, error)
 	// CountRunning returns the number of currently running builds for a given job.

--- a/pikoci/job/job.go
+++ b/pikoci/job/job.go
@@ -54,6 +54,8 @@ type Job struct {
 	ForEachGroup string `json:"for_each_group,omitempty"`
 	ForEachKey   string `json:"for_each_key,omitempty"`
 
+	BaselineVersionID *uint32 `json:"baseline_version_id,omitempty"`
+
 	OnSuccess []HookStep `json:"on_success,omitempty"`
 	OnFailure []HookStep `json:"on_failure,omitempty"`
 	OnCancel  []HookStep `json:"on_cancel,omitempty"`

--- a/pikoci/mock/build_repository.go
+++ b/pikoci/mock/build_repository.go
@@ -194,9 +194,9 @@ func (mr *BuildRepositoryMockRecorder) FindOldestPending(ctx, tc, pn, jn any) *g
 }
 
 // FindReadyDownstreamVersion mocks base method.
-func (m *BuildRepository) FindReadyDownstreamVersion(ctx context.Context, tc, pn string, upstreamJobs []string, downstreamJob, stepName string, upstreamCount int) (uint32, bool, error) {
+func (m *BuildRepository) FindReadyDownstreamVersion(ctx context.Context, tc, pn string, upstreamJobs []string, downstreamJob, stepName string, upstreamCount int, baselineVersionID *uint32) (uint32, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindReadyDownstreamVersion", ctx, tc, pn, upstreamJobs, downstreamJob, stepName, upstreamCount)
+	ret := m.ctrl.Call(m, "FindReadyDownstreamVersion", ctx, tc, pn, upstreamJobs, downstreamJob, stepName, upstreamCount, baselineVersionID)
 	ret0, _ := ret[0].(uint32)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
@@ -204,9 +204,9 @@ func (m *BuildRepository) FindReadyDownstreamVersion(ctx context.Context, tc, pn
 }
 
 // FindReadyDownstreamVersion indicates an expected call of FindReadyDownstreamVersion.
-func (mr *BuildRepositoryMockRecorder) FindReadyDownstreamVersion(ctx, tc, pn, upstreamJobs, downstreamJob, stepName, upstreamCount any) *gomock.Call {
+func (mr *BuildRepositoryMockRecorder) FindReadyDownstreamVersion(ctx, tc, pn, upstreamJobs, downstreamJob, stepName, upstreamCount, baselineVersionID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindReadyDownstreamVersion", reflect.TypeOf((*BuildRepository)(nil).FindReadyDownstreamVersion), ctx, tc, pn, upstreamJobs, downstreamJob, stepName, upstreamCount)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindReadyDownstreamVersion", reflect.TypeOf((*BuildRepository)(nil).FindReadyDownstreamVersion), ctx, tc, pn, upstreamJobs, downstreamJob, stepName, upstreamCount, baselineVersionID)
 }
 
 // InsertGetVersion mocks base method.

--- a/pikoci/mysql/build.go
+++ b/pikoci/mysql/build.go
@@ -359,7 +359,7 @@ func (r *BuildRepository) InsertGetVersion(ctx context.Context, tc, pn, jn strin
 // jobs succeeded with but the downstream job has no build for yet (regardless
 // of build status). Any existing build (pending, started, succeeded, failed,
 // cancelled) for the version on the downstream job prevents re-triggering.
-func (r *BuildRepository) FindReadyDownstreamVersion(ctx context.Context, tc, pn string, upstreamJobs []string, downstreamJob string, stepName string, upstreamCount int) (uint32, bool, error) {
+func (r *BuildRepository) FindReadyDownstreamVersion(ctx context.Context, tc, pn string, upstreamJobs []string, downstreamJob string, stepName string, upstreamCount int, baselineVersionID *uint32) (uint32, bool, error) {
 	// Build the IN clause placeholders
 	placeholders := make([]string, len(upstreamJobs))
 	args := make([]interface{}, 0, len(upstreamJobs)+5)
@@ -374,6 +374,11 @@ func (r *BuildRepository) FindReadyDownstreamVersion(ctx context.Context, tc, pn
 	// HAVING count
 	args = append(args, upstreamCount)
 
+	baselineClause := ""
+	if baselineVersionID != nil {
+		baselineClause = fmt.Sprintf("AND bgv.version_id > %d", *baselineVersionID)
+	}
+
 	query := `
 		SELECT bgv.version_id
 		FROM build_get_versions bgv
@@ -384,6 +389,7 @@ func (r *BuildRepository) FindReadyDownstreamVersion(ctx context.Context, tc, pn
 		WHERE t.canonical = ? AND p.canonical = ? AND b.status = 'succeeded'
 		  AND j.name IN (` + strings.Join(placeholders, ", ") + `)
 		  AND bgv.step_name = ?
+		  ` + baselineClause + `
 		  AND NOT EXISTS (
 			  SELECT 1 FROM builds b2
 			  JOIN jobs j2 ON b2.job_id = j2.id

--- a/pikoci/mysql/build_test.go
+++ b/pikoci/mysql/build_test.go
@@ -2,11 +2,13 @@ package mysql_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/pikoci/pikoci/pikoci/job"
 	"github.com/pikoci/pikoci/pikoci/mysql"
 )
 
@@ -203,7 +205,7 @@ func TestFindReadyDownstreamVersion_BasicCase(t *testing.T) {
 	br := mysql.NewBuildRepository(db, mysql.Mem)
 
 	vID, ready, err := br.FindReadyDownstreamVersion(ctx, "main", "bgv-basic",
-		[]string{"lint", "test"}, "deploy", "repo", 2)
+		[]string{"lint", "test"}, "deploy", "repo", 2, nil)
 	require.NoError(t, err)
 	assert.True(t, ready)
 	assert.Equal(t, uint32(10), vID)
@@ -238,7 +240,7 @@ func TestFindReadyDownstreamVersion_NotAllUpstreamsReady(t *testing.T) {
 	br := mysql.NewBuildRepository(db, mysql.Mem)
 
 	_, ready, err := br.FindReadyDownstreamVersion(ctx, "main", "bgv-partial",
-		[]string{"lint", "test"}, "deploy", "repo", 2)
+		[]string{"lint", "test"}, "deploy", "repo", 2, nil)
 	require.NoError(t, err)
 	assert.False(t, ready)
 }
@@ -276,7 +278,7 @@ func TestFindReadyDownstreamVersion_AlreadyBuiltByDownstream(t *testing.T) {
 	br := mysql.NewBuildRepository(db, mysql.Mem)
 
 	_, ready, err := br.FindReadyDownstreamVersion(ctx, "main", "bgv-already",
-		[]string{"lint"}, "deploy", "repo", 1)
+		[]string{"lint"}, "deploy", "repo", 1, nil)
 	require.NoError(t, err)
 	assert.False(t, ready)
 }
@@ -306,7 +308,7 @@ func TestFindReadyDownstreamVersion_FailedUpstreamIgnored(t *testing.T) {
 	br := mysql.NewBuildRepository(db, mysql.Mem)
 
 	_, ready, err := br.FindReadyDownstreamVersion(ctx, "main", "bgv-failed",
-		[]string{"lint"}, "deploy", "repo", 1)
+		[]string{"lint"}, "deploy", "repo", 1, nil)
 	require.NoError(t, err)
 	assert.False(t, ready)
 }
@@ -347,7 +349,7 @@ func TestFindReadyDownstreamVersion_MismatchedVersions(t *testing.T) {
 
 	// Should NOT be ready — lint has v10, test has v12, no common version
 	_, ready, err := br.FindReadyDownstreamVersion(ctx, "main", "bgv-mismatch",
-		[]string{"lint", "test"}, "deploy", "repo", 2)
+		[]string{"lint", "test"}, "deploy", "repo", 2, nil)
 	require.NoError(t, err)
 	assert.False(t, ready)
 }
@@ -384,10 +386,277 @@ func TestFindReadyDownstreamVersion_PicksHighestVersion(t *testing.T) {
 	br := mysql.NewBuildRepository(db, mysql.Mem)
 
 	vID, ready, err := br.FindReadyDownstreamVersion(ctx, "main", "bgv-highest",
-		[]string{"lint"}, "deploy", "repo", 1)
+		[]string{"lint"}, "deploy", "repo", 1, nil)
 	require.NoError(t, err)
 	assert.True(t, ready)
 	assert.Equal(t, uint32(10), vID)
+}
+
+func TestFindReadyDownstreamVersion_BaselineFiltersOldVersions(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	res, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'bgv-baseline', 'bgv-baseline')`)
+	require.NoError(t, err)
+	ppID, _ := res.LastInsertId()
+
+	res, err = db.ExecContext(ctx, `INSERT INTO jobs (pipeline_id, name) VALUES (?, 'lint')`, ppID)
+	require.NoError(t, err)
+	lintJobID, _ := res.LastInsertId()
+
+	_, err = db.ExecContext(ctx, `INSERT INTO jobs (pipeline_id, name) VALUES (?, 'deploy')`, ppID)
+	require.NoError(t, err)
+
+	// Lint succeeded with version 5 (before baseline)
+	res, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, build_number) VALUES (?, 'succeeded', '1')`, lintJobID)
+	require.NoError(t, err)
+	b1, _ := res.LastInsertId()
+	_, err = db.ExecContext(ctx, `INSERT INTO build_get_versions (build_id, step_name, version_id) VALUES (?, 'repo', 5)`, b1)
+	require.NoError(t, err)
+
+	// Lint succeeded with version 10 (after baseline)
+	res, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, build_number) VALUES (?, 'succeeded', '2')`, lintJobID)
+	require.NoError(t, err)
+	b2, _ := res.LastInsertId()
+	_, err = db.ExecContext(ctx, `INSERT INTO build_get_versions (build_id, step_name, version_id) VALUES (?, 'repo', 10)`, b2)
+	require.NoError(t, err)
+
+	br := mysql.NewBuildRepository(db, mysql.Mem)
+
+	// With baseline=7, only version 10 should be considered (>7), not version 5
+	baseline := uint32(7)
+	vID, ready, err := br.FindReadyDownstreamVersion(ctx, "main", "bgv-baseline",
+		[]string{"lint"}, "deploy", "repo", 1, &baseline)
+	require.NoError(t, err)
+	assert.True(t, ready)
+	assert.Equal(t, uint32(10), vID)
+
+	// With baseline=10, no versions should match (nothing > 10)
+	baseline2 := uint32(10)
+	_, ready, err = br.FindReadyDownstreamVersion(ctx, "main", "bgv-baseline",
+		[]string{"lint"}, "deploy", "repo", 1, &baseline2)
+	require.NoError(t, err)
+	assert.False(t, ready)
+
+	// With nil baseline, both versions are candidates — picks highest (10)
+	vID, ready, err = br.FindReadyDownstreamVersion(ctx, "main", "bgv-baseline",
+		[]string{"lint"}, "deploy", "repo", 1, nil)
+	require.NoError(t, err)
+	assert.True(t, ready)
+	assert.Equal(t, uint32(10), vID)
+}
+
+func TestFindReadyDownstreamVersion_RenamedJobSkipsOldVersions(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	// Setup: pipeline with upstream "gen" and downstream "deploy-staging"
+	res, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'bgv-rename', 'bgv-rename')`)
+	require.NoError(t, err)
+	ppID, _ := res.LastInsertId()
+
+	// Create a resource so resource_versions has entries
+	res, err = db.ExecContext(ctx, `INSERT INTO resources (pipeline_id, name, canonical, type) VALUES (?, 'output', 'artifact.output', 'artifact')`, ppID)
+	require.NoError(t, err)
+	resourceID, _ := res.LastInsertId()
+
+	// Insert old resource versions — capture actual IDs
+	versionIDs := make([]int64, 3)
+	for i := 0; i < 3; i++ {
+		res, err = db.ExecContext(ctx, `INSERT INTO resource_versions (resource_id, version) VALUES (?, ?)`,
+			resourceID, fmt.Sprintf(`{"v":"%d"}`, i+1))
+		require.NoError(t, err)
+		versionIDs[i], _ = res.LastInsertId()
+	}
+
+	// Create upstream "gen" job with old succeeded builds
+	res, err = db.ExecContext(ctx, `INSERT INTO jobs (pipeline_id, name) VALUES (?, 'gen')`, ppID)
+	require.NoError(t, err)
+	genJobID, _ := res.LastInsertId()
+
+	// gen succeeded with each version
+	for i := 0; i < 3; i++ {
+		res, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, build_number) VALUES (?, 'succeeded', ?)`, genJobID, i+1)
+		require.NoError(t, err)
+		buildID, _ := res.LastInsertId()
+		_, err = db.ExecContext(ctx, `INSERT INTO build_get_versions (build_id, step_name, version_id) VALUES (?, 'output', ?)`, buildID, versionIDs[i])
+		require.NoError(t, err)
+	}
+
+	// Simulate renaming: create a new job using JobRepository.Create
+	// which should set baseline_version_id = MAX(resource_versions.id)
+	jr := mysql.NewJobRepository(db)
+	jobID, err := jr.Create(ctx, "main", "bgv-rename", job.Job{Name: "deploy-staging-v2"})
+	require.NoError(t, err)
+
+	// Verify baseline was set to the last version ID
+	newJob, err := jr.Find(ctx, "main", "bgv-rename", "deploy-staging-v2")
+	require.NoError(t, err)
+	require.NotNil(t, newJob.BaselineVersionID, "baseline_version_id should be set on new job")
+	assert.Equal(t, uint32(versionIDs[2]), *newJob.BaselineVersionID)
+
+	br := mysql.NewBuildRepository(db, mysql.Mem)
+
+	// With the baseline, all old versions should be filtered out
+	_, ready, err := br.FindReadyDownstreamVersion(ctx, "main", "bgv-rename",
+		[]string{"gen"}, "deploy-staging-v2", "output", 1, newJob.BaselineVersionID)
+	require.NoError(t, err)
+	assert.False(t, ready, "old versions should be filtered by baseline")
+
+	// Without baseline (nil), latest version would be returned
+	vID, ready, err := br.FindReadyDownstreamVersion(ctx, "main", "bgv-rename",
+		[]string{"gen"}, "deploy-staging-v2", "output", 1, nil)
+	require.NoError(t, err)
+	assert.True(t, ready, "without baseline, old versions should be visible")
+	assert.Equal(t, uint32(versionIDs[2]), vID)
+
+	// Now add a NEW version after the baseline
+	res, err = db.ExecContext(ctx, `INSERT INTO resource_versions (resource_id, version) VALUES (?, '{"v":"4"}')`, resourceID)
+	require.NoError(t, err)
+	newVersionID, _ := res.LastInsertId()
+	res, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, build_number) VALUES (?, 'succeeded', '4')`, genJobID)
+	require.NoError(t, err)
+	b4ID, _ := res.LastInsertId()
+	_, err = db.ExecContext(ctx, `INSERT INTO build_get_versions (build_id, step_name, version_id) VALUES (?, 'output', ?)`, b4ID, newVersionID)
+	require.NoError(t, err)
+
+	// With the baseline, only the new version should be returned
+	vID, ready, err = br.FindReadyDownstreamVersion(ctx, "main", "bgv-rename",
+		[]string{"gen"}, "deploy-staging-v2", "output", 1, newJob.BaselineVersionID)
+	require.NoError(t, err)
+	assert.True(t, ready, "version after baseline should be visible")
+	assert.Equal(t, uint32(newVersionID), vID)
+
+	_ = jobID
+}
+
+// TestFindReadyDownstreamVersion_CronPipelineRenameScenario mirrors the cron.hcl pipeline:
+// gen (GET cron + PUT artifact) → deploy-staging (GET artifact, passed=["gen"])
+// and also a monitor job (GET cron, passed=["gen"]).
+// When deploy-staging or monitor is renamed, old versions must not replay.
+func TestFindReadyDownstreamVersion_CronPipelineRenameScenario(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	// Setup pipeline
+	res, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'cron-rename', 'cron-rename')`)
+	require.NoError(t, err)
+	ppID, _ := res.LastInsertId()
+
+	// Create cron resource + versions (simulating cron ticks)
+	res, err = db.ExecContext(ctx, `INSERT INTO resources (pipeline_id, name, canonical, type) VALUES (?, 'my_cron', 'cron.my_cron', 'cron')`, ppID)
+	require.NoError(t, err)
+	cronResID, _ := res.LastInsertId()
+
+	// Cron ticks create resource versions — capture actual IDs
+	cronVersionIDs := make([]int64, 3)
+	for i := 0; i < 3; i++ {
+		res, err = db.ExecContext(ctx, `INSERT INTO resource_versions (resource_id, version) VALUES (?, ?)`,
+			cronResID, fmt.Sprintf(`{"date":"tick-%d"}`, i+1))
+		require.NoError(t, err)
+		cronVersionIDs[i], _ = res.LastInsertId()
+	}
+
+	// Create artifact resource + versions (created by gen's PUT step)
+	res, err = db.ExecContext(ctx, `INSERT INTO resources (pipeline_id, name, canonical, type) VALUES (?, 'cron_output', 'artifact.cron_output', 'artifact')`, ppID)
+	require.NoError(t, err)
+	artifactResID, _ := res.LastInsertId()
+
+	artifactVersionIDs := make([]int64, 3)
+	for i := 0; i < 3; i++ {
+		res, err = db.ExecContext(ctx, `INSERT INTO resource_versions (resource_id, version) VALUES (?, ?)`,
+			artifactResID, fmt.Sprintf(`{"v":"%d"}`, i+1))
+		require.NoError(t, err)
+		artifactVersionIDs[i], _ = res.LastInsertId()
+	}
+
+	// Create upstream "gen" job
+	res, err = db.ExecContext(ctx, `INSERT INTO jobs (pipeline_id, name) VALUES (?, 'gen')`, ppID)
+	require.NoError(t, err)
+	genJobID, _ := res.LastInsertId()
+
+	// Gen succeeded 3 times. Each build has:
+	// - GET cron (step_name="my_cron", version_id = cron version)
+	// - PUT artifact (step_name="cron_output", version_id = artifact version)
+	for i := 0; i < 3; i++ {
+		res, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, build_number) VALUES (?, 'succeeded', ?)`, genJobID, fmt.Sprintf("%d", i+1))
+		require.NoError(t, err)
+		buildID, _ := res.LastInsertId()
+		_, err = db.ExecContext(ctx, `INSERT INTO build_get_versions (build_id, step_name, version_id) VALUES (?, 'my_cron', ?)`, buildID, cronVersionIDs[i])
+		require.NoError(t, err)
+		_, err = db.ExecContext(ctx, `INSERT INTO build_get_versions (build_id, step_name, version_id) VALUES (?, 'cron_output', ?)`, buildID, artifactVersionIDs[i])
+		require.NoError(t, err)
+	}
+
+	// Create the original deploy-staging (will be "renamed")
+	_, err = db.ExecContext(ctx, `INSERT INTO jobs (pipeline_id, name) VALUES (?, 'deploy-staging')`, ppID)
+	require.NoError(t, err)
+
+	br := mysql.NewBuildRepository(db, mysql.Mem)
+	jr := mysql.NewJobRepository(db)
+
+	// --- Test 1: Rename deploy-staging → deploy-staging-v2 (linked via artifact) ---
+	newJobID, err := jr.Create(ctx, "main", "cron-rename", job.Job{Name: "deploy-staging-v2"})
+	require.NoError(t, err)
+	require.NotZero(t, newJobID)
+
+	newJob, err := jr.Find(ctx, "main", "cron-rename", "deploy-staging-v2")
+	require.NoError(t, err)
+	require.NotNil(t, newJob.BaselineVersionID)
+	// Baseline should be the last artifact version (the highest resource_versions.id)
+	assert.Equal(t, uint32(artifactVersionIDs[2]), *newJob.BaselineVersionID, "baseline should be MAX(resource_versions.id)")
+
+	// With baseline, all existing artifact versions should be filtered
+	_, ready, err := br.FindReadyDownstreamVersion(ctx, "main", "cron-rename",
+		[]string{"gen"}, "deploy-staging-v2", "cron_output", 1, newJob.BaselineVersionID)
+	require.NoError(t, err)
+	assert.False(t, ready, "artifact versions should be filtered by baseline")
+
+	// --- Test 2: Add a monitor job linked to gen via cron (not artifact) ---
+	monitorJobID, err := jr.Create(ctx, "main", "cron-rename", job.Job{Name: "monitor"})
+	require.NoError(t, err)
+	require.NotZero(t, monitorJobID)
+
+	monitorJob, err := jr.Find(ctx, "main", "cron-rename", "monitor")
+	require.NoError(t, err)
+	require.NotNil(t, monitorJob.BaselineVersionID)
+
+	// With baseline, all existing cron versions should be filtered
+	_, ready, err = br.FindReadyDownstreamVersion(ctx, "main", "cron-rename",
+		[]string{"gen"}, "monitor", "my_cron", 1, monitorJob.BaselineVersionID)
+	require.NoError(t, err)
+	assert.False(t, ready, "cron versions should be filtered by baseline")
+
+	// --- Test 3: New cron tick + gen run AFTER baseline → should trigger both ---
+	res, err = db.ExecContext(ctx, `INSERT INTO resource_versions (resource_id, version) VALUES (?, '{"date":"tick-4"}')`, cronResID)
+	require.NoError(t, err)
+	newCronVersionID, _ := res.LastInsertId()
+
+	res, err = db.ExecContext(ctx, `INSERT INTO resource_versions (resource_id, version) VALUES (?, '{"v":"4"}')`, artifactResID)
+	require.NoError(t, err)
+	newArtifactVersionID, _ := res.LastInsertId()
+
+	res, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, build_number) VALUES (?, 'succeeded', '4')`, genJobID)
+	require.NoError(t, err)
+	b4ID, _ := res.LastInsertId()
+	_, err = db.ExecContext(ctx, `INSERT INTO build_get_versions (build_id, step_name, version_id) VALUES (?, 'my_cron', ?)`, b4ID, newCronVersionID)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO build_get_versions (build_id, step_name, version_id) VALUES (?, 'cron_output', ?)`, b4ID, newArtifactVersionID)
+	require.NoError(t, err)
+
+	// deploy-staging-v2 via artifact: new version > baseline → should trigger
+	vID, ready, err := br.FindReadyDownstreamVersion(ctx, "main", "cron-rename",
+		[]string{"gen"}, "deploy-staging-v2", "cron_output", 1, newJob.BaselineVersionID)
+	require.NoError(t, err)
+	assert.True(t, ready, "new artifact version after baseline should trigger")
+	assert.Equal(t, uint32(newArtifactVersionID), vID)
+
+	// monitor via cron: new version > baseline → should trigger
+	vID, ready, err = br.FindReadyDownstreamVersion(ctx, "main", "cron-rename",
+		[]string{"gen"}, "monitor", "my_cron", 1, monitorJob.BaselineVersionID)
+	require.NoError(t, err)
+	assert.True(t, ready, "new cron version after baseline should trigger")
+	assert.Equal(t, uint32(newCronVersionID), vID)
 }
 
 func TestCountRunningInSerialGroups(t *testing.T) {

--- a/pikoci/mysql/job.go
+++ b/pikoci/mysql/job.go
@@ -34,8 +34,9 @@ type dbJob struct {
 	Concurrency  sql.NullInt64
 	Paused       sql.NullBool
 	Timeout      sql.NullInt64
-	ForEachGroup sql.NullString
-	ForEachKey   sql.NullString
+	ForEachGroup      sql.NullString
+	ForEachKey        sql.NullString
+	BaselineVersionID sql.NullInt64
 }
 
 func newDBJob(p job.Job) dbJob {
@@ -81,6 +82,11 @@ func (dbp *dbJob) toDomainEntity() *job.Job {
 		j.Timeout = time.Duration(dbp.Timeout.Int64)
 	}
 
+	if dbp.BaselineVersionID.Valid {
+		v := uint32(dbp.BaselineVersionID.Int64)
+		j.BaselineVersionID = &v
+	}
+
 	_ = json.Unmarshal([]byte(dbp.Plan.String), &j.Plan)
 	_ = json.Unmarshal([]byte(dbp.OnSuccess.String), &j.OnSuccess)
 	_ = json.Unmarshal([]byte(dbp.OnFailure.String), &j.OnFailure)
@@ -93,7 +99,7 @@ func (dbp *dbJob) toDomainEntity() *job.Job {
 func (r *JobRepository) Create(ctx context.Context, tc, pn string, j job.Job) (uint32, error) {
 	dbj := newDBJob(j)
 	res, err := r.querier.ExecContext(ctx, `
-		INSERT INTO jobs(name, tags, plan, on_success, on_failure, on_cancel, ensure, concurrency, paused, timeout, for_each_group, for_each_key, pipeline_id)
+		INSERT INTO jobs(name, tags, plan, on_success, on_failure, on_cancel, ensure, concurrency, paused, timeout, for_each_group, for_each_key, pipeline_id, baseline_version_id)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 			-- pipeline_id
 			(
@@ -102,7 +108,9 @@ func (r *JobRepository) Create(ctx context.Context, tc, pn string, j job.Job) (u
 				JOIN teams AS t
 					ON p.team_id = t.id
 				WHERE t.canonical = ? AND p.canonical = ?
-			))`, dbj.Name, dbj.Tags, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Paused, dbj.Timeout, dbj.ForEachGroup, dbj.ForEachKey, tc, pn)
+			),
+			-- baseline_version_id
+			(SELECT MAX(id) FROM resource_versions))`, dbj.Name, dbj.Tags, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Paused, dbj.Timeout, dbj.ForEachGroup, dbj.ForEachKey, tc, pn)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -165,7 +173,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 
 func (r *JobRepository) Find(ctx context.Context, tc, pn, jn string) (*job.Job, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key
+		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -190,7 +198,7 @@ func (r *JobRepository) Find(ctx context.Context, tc, pn, jn string) (*job.Job, 
 
 func (r *JobRepository) Filter(ctx context.Context, tc, pn string) ([]*job.Job, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key
+		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -330,6 +338,7 @@ func scanJob(s sqlr.Scanner) (*job.Job, error) {
 		&j.Timeout,
 		&j.ForEachGroup,
 		&j.ForEachKey,
+		&j.BaselineVersionID,
 	)
 
 	if err != nil {
@@ -392,7 +401,7 @@ func (r *JobRepository) loadSerialGroups(ctx context.Context, jobID uint32) ([]s
 
 func (r *JobRepository) FilterByForEachGroup(ctx context.Context, tc, pn, group string) ([]*job.Job, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key
+		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -432,7 +441,7 @@ func (r *JobRepository) FindJobsBySerialGroups(ctx context.Context, tc, pn strin
 		args = append(args, sg)
 	}
 	query := fmt.Sprintf(`
-		SELECT DISTINCT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key
+		SELECT DISTINCT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id
 		FROM jobs AS j
 		JOIN pipelines AS p ON j.pipeline_id = p.id
 		JOIN teams AS t ON p.team_id = t.id

--- a/pikoci/mysql/migrate/migrations/V35BaselineVersionID.go
+++ b/pikoci/mysql/migrate/migrations/V35BaselineVersionID.go
@@ -1,0 +1,6 @@
+package migrations
+
+var V35BaselineVersionID = Migration{
+	Name: "BaselineVersionID",
+	SQL:  `ALTER TABLE jobs ADD COLUMN baseline_version_id INT UNSIGNED;`,
+}

--- a/pikoci/mysql/migrate/migrations/migrations.go
+++ b/pikoci/mysql/migrate/migrations/migrations.go
@@ -16,7 +16,7 @@ type Migration struct {
 // Migrations is the ordered list of all schema migrations. It is defined as
 // a fixed-size array so that the compiler catches ordering conflicts when
 // multiple developers add migrations concurrently.
-var Migrations = [35]Migration{
+var Migrations = [36]Migration{
 	V0Initial,
 	V1ResourceCheckInterval,
 	V2JobsAndBuilds,
@@ -52,4 +52,5 @@ var Migrations = [35]Migration{
 	V32Workers,
 	V33ClearQueuesColumn,
 	V34WorkerTags,
+	V35BaselineVersionID,
 }

--- a/pikoci/mysql/pipeline.go
+++ b/pikoci/mysql/pipeline.go
@@ -181,7 +181,7 @@ func (r *PipelineRepository) FilterAll(ctx context.Context) ([]*pipeline.WithTea
 		SELECT
 			t.id, t.name, t.canonical,
 			p.id, p.name, p.canonical, p.raw, p.public,
-			j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.paused, j.for_each_group, j.for_each_key,
+			j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.paused, j.for_each_group, j.for_each_key, j.baseline_version_id,
 			r.id, r.name, r.type, r.canonical, r.params, r.check_interval, r.logs, r.last_check, r.next_check, r.tags, r.pinned_version_id,
 			rt.id, rt.name, rt.`+"`check`"+`, rt.pull, rt.push, rt.params,
 			ru.id, ru.name, ru.run,
@@ -237,7 +237,7 @@ func scanPipelinesWithTeam(rows *sql.Rows) ([]*pipeline.WithTeam, error) {
 		err := rows.Scan(
 			&tt.ID, &tt.Name, &tt.Canonical,
 			&pp.ID, &pp.Name, &pp.Canonical, &pp.Raw, &pp.Public,
-			&j.ID, &j.Name, &j.Tags, &j.Plan, &j.OnSuccess, &j.OnFailure, &j.OnCancel, &j.Ensure, &j.Paused, &j.ForEachGroup, &j.ForEachKey,
+			&j.ID, &j.Name, &j.Tags, &j.Plan, &j.OnSuccess, &j.OnFailure, &j.OnCancel, &j.Ensure, &j.Paused, &j.ForEachGroup, &j.ForEachKey, &j.BaselineVersionID,
 			&r.ID, &r.Name, &r.Type, &r.Canonical, &r.Params, &r.CheckInterval, &r.Logs, &r.LastCheck, &r.NextCheck, &r.Tags, &r.PinnedVersionID,
 			&rt.ID, &rt.Name, &rt.Check, &rt.Pull, &rt.Push, &rt.Params,
 			&ru.ID, &ru.Name, &ru.Run,
@@ -351,7 +351,7 @@ func (r *PipelineRepository) Delete(ctx context.Context, tc, pCan string) error 
 const pipelineQuery = `
 	SELECT
 		p.id, p.name, p.canonical, p.raw, p.public,
-		j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.paused, j.for_each_group, j.for_each_key,
+		j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.paused, j.for_each_group, j.for_each_key, j.baseline_version_id,
 		r.id, r.name, r.type, r.canonical, r.params, r.check_interval, r.logs, r.last_check, r.next_check, r.webhook_token, r.tags, r.pinned_version_id,
 		rt.id, rt.name, rt.` + "`check`" + `, rt.pull, rt.push, rt.params,
 		ru.id, ru.name, ru.run,
@@ -395,7 +395,7 @@ func scanPipelines(rows *sql.Rows) ([]*pipeline.Pipeline, error) {
 
 		err := rows.Scan(
 			&pp.ID, &pp.Name, &pp.Canonical, &pp.Raw, &pp.Public,
-			&j.ID, &j.Name, &j.Tags, &j.Plan, &j.OnSuccess, &j.OnFailure, &j.OnCancel, &j.Ensure, &j.Paused, &j.ForEachGroup, &j.ForEachKey,
+			&j.ID, &j.Name, &j.Tags, &j.Plan, &j.OnSuccess, &j.OnFailure, &j.OnCancel, &j.Ensure, &j.Paused, &j.ForEachGroup, &j.ForEachKey, &j.BaselineVersionID,
 			&r.ID, &r.Name, &r.Type, &r.Canonical, &r.Params, &r.CheckInterval, &r.Logs, &r.LastCheck, &r.NextCheck, &r.WebhookToken, &r.Tags, &r.PinnedVersionID,
 			&rt.ID, &rt.Name, &rt.Check, &rt.Pull, &rt.Push, &rt.Params,
 			&ru.ID, &ru.Name, &ru.Run,

--- a/pikoci/mysql/pipeline_test.go
+++ b/pikoci/mysql/pipeline_test.go
@@ -391,6 +391,73 @@ func TestPipelineFilterAll_IncludesForEachFields(t *testing.T) {
 	assert.Equal(t, "", jobMap["regular"].ForEachGroup)
 }
 
+func TestFilterAll_IncludesBaselineVersionID(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'bl-all', 'bl-all')`)
+	require.NoError(t, err)
+
+	// Create a resource version so MAX(resource_versions.id) is non-null
+	res, err := db.ExecContext(ctx, `INSERT INTO resources (pipeline_id, name, canonical, type) VALUES (
+		(SELECT id FROM pipelines WHERE canonical = 'bl-all'), 'timer', 'cron.timer', 'cron')`)
+	require.NoError(t, err)
+	resID, _ := res.LastInsertId()
+	res, err = db.ExecContext(ctx, `INSERT INTO resource_versions (resource_id, version) VALUES (?, '{"v":"1"}')`, resID)
+	require.NoError(t, err)
+	expectedBaseline, _ := res.LastInsertId()
+
+	// Create job via repository — baseline_version_id should be set
+	jr := mysql.NewJobRepository(db)
+	_, err = jr.Create(ctx, "main", "bl-all", job.Job{Name: "deploy"})
+	require.NoError(t, err)
+
+	pr := mysql.NewPipelineRepository(db)
+	pps, err := pr.FilterAll(ctx)
+	require.NoError(t, err)
+
+	var found *pipeline.WithTeam
+	for _, pwt := range pps {
+		if pwt.Canonical == "bl-all" {
+			found = pwt
+			break
+		}
+	}
+	require.NotNil(t, found)
+	require.Len(t, found.Jobs, 1)
+	require.NotNil(t, found.Jobs[0].BaselineVersionID,
+		"FilterAll must load baseline_version_id for the scheduler")
+	assert.Equal(t, uint32(expectedBaseline), *found.Jobs[0].BaselineVersionID)
+}
+
+func TestFind_IncludesBaselineVersionID(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'bl-find', 'bl-find')`)
+	require.NoError(t, err)
+
+	res, err := db.ExecContext(ctx, `INSERT INTO resources (pipeline_id, name, canonical, type) VALUES (
+		(SELECT id FROM pipelines WHERE canonical = 'bl-find'), 'timer', 'cron.timer', 'cron')`)
+	require.NoError(t, err)
+	resID, _ := res.LastInsertId()
+	res, err = db.ExecContext(ctx, `INSERT INTO resource_versions (resource_id, version) VALUES (?, '{"v":"1"}')`, resID)
+	require.NoError(t, err)
+	expectedBaseline, _ := res.LastInsertId()
+
+	jr := mysql.NewJobRepository(db)
+	_, err = jr.Create(ctx, "main", "bl-find", job.Job{Name: "deploy"})
+	require.NoError(t, err)
+
+	pr := mysql.NewPipelineRepository(db)
+	pp, err := pr.Find(ctx, "main", "bl-find")
+	require.NoError(t, err)
+	require.Len(t, pp.Jobs, 1)
+	require.NotNil(t, pp.Jobs[0].BaselineVersionID,
+		"Find must load baseline_version_id for the scheduler")
+	assert.Equal(t, uint32(expectedBaseline), *pp.Jobs[0].BaselineVersionID)
+}
+
 func TestDeletePipeline_CascadesSerialGroups(t *testing.T) {
 	db := setupTestDB(t)
 	ctx := context.Background()

--- a/pikoci/scheduler/scheduler.go
+++ b/pikoci/scheduler/scheduler.go
@@ -117,6 +117,7 @@ func (s *Scheduler) evaluateJob(ctx context.Context, pwt *pipeline.WithTeam, j *
 		versionID, ready, err := s.builds.FindReadyDownstreamVersion(
 			ctx, pwt.Team.Canonical, pwt.Canonical,
 			expandedPassed, j.Name, g.Name, len(expandedPassed),
+			j.BaselineVersionID,
 		)
 		if err != nil {
 			s.logger.Error("failed to find ready downstream version",

--- a/pikoci/scheduler/scheduler_test.go
+++ b/pikoci/scheduler/scheduler_test.go
@@ -159,7 +159,7 @@ func TestTickJobs_TriggersWhenCommonVersionExists(t *testing.T) {
 
 	br.EXPECT().FindReadyDownstreamVersion(
 		gomock.Any(), "main", "my-pipeline",
-		[]string{"lint", "test-mock"}, "test-backends", "repo", 2,
+		[]string{"lint", "test-mock"}, "test-backends", "repo", 2, (*uint32)(nil),
 	).Return(uint32(42), true, nil)
 
 	// Pin check — resource is not pinned
@@ -211,7 +211,7 @@ func TestTickJobs_SkipsWhenNoCommonVersion(t *testing.T) {
 
 	br.EXPECT().FindReadyDownstreamVersion(
 		gomock.Any(), "main", "my-pipeline",
-		[]string{"upstream"}, "downstream", "repo", 1,
+		[]string{"upstream"}, "downstream", "repo", 1, (*uint32)(nil),
 	).Return(uint32(0), false, nil)
 
 	s.tick(context.Background())
@@ -251,7 +251,7 @@ func TestTickJobs_SkipsWhenPendingBuildExists(t *testing.T) {
 
 	br.EXPECT().FindReadyDownstreamVersion(
 		gomock.Any(), "main", "my-pipeline",
-		[]string{"lint"}, "deploy", "repo", 1,
+		[]string{"lint"}, "deploy", "repo", 1, (*uint32)(nil),
 	).Return(uint32(42), true, nil)
 
 	// Pin check — resource is not pinned
@@ -378,7 +378,7 @@ func TestTickJobs_MultipleGetSteps_AllMustBeReady(t *testing.T) {
 	// First get step IS ready
 	br.EXPECT().FindReadyDownstreamVersion(
 		gomock.Any(), "main", "my-pipeline",
-		[]string{"lint"}, "deploy", "repo", 1,
+		[]string{"lint"}, "deploy", "repo", 1, (*uint32)(nil),
 	).Return(uint32(42), true, nil)
 
 	// Pin check — resource is not pinned
@@ -388,7 +388,7 @@ func TestTickJobs_MultipleGetSteps_AllMustBeReady(t *testing.T) {
 	// Second get step is NOT ready
 	br.EXPECT().FindReadyDownstreamVersion(
 		gomock.Any(), "main", "my-pipeline",
-		[]string{"build"}, "deploy", "image", 1,
+		[]string{"build"}, "deploy", "image", 1, (*uint32)(nil),
 	).Return(uint32(0), false, nil)
 
 	s.tick(context.Background())
@@ -437,7 +437,7 @@ func TestTickJobs_MultipleGetSteps_BothReady_TriggersOnce(t *testing.T) {
 
 	br.EXPECT().FindReadyDownstreamVersion(
 		gomock.Any(), "main", "my-pipeline",
-		[]string{"lint"}, "deploy", "repo", 1,
+		[]string{"lint"}, "deploy", "repo", 1, (*uint32)(nil),
 	).Return(uint32(42), true, nil)
 
 	rr.EXPECT().Find(gomock.Any(), "main", "my-pipeline", "git.repo").
@@ -445,7 +445,7 @@ func TestTickJobs_MultipleGetSteps_BothReady_TriggersOnce(t *testing.T) {
 
 	br.EXPECT().FindReadyDownstreamVersion(
 		gomock.Any(), "main", "my-pipeline",
-		[]string{"build"}, "deploy", "image", 1,
+		[]string{"build"}, "deploy", "image", 1, (*uint32)(nil),
 	).Return(uint32(99), true, nil)
 
 	rr.EXPECT().Find(gomock.Any(), "main", "my-pipeline", "docker.image").
@@ -494,7 +494,7 @@ func TestTickJobs_SkipsWhenResourcePinnedToDifferentVersion(t *testing.T) {
 
 	br.EXPECT().FindReadyDownstreamVersion(
 		gomock.Any(), "main", "my-pipeline",
-		[]string{"lint"}, "deploy", "repo", 1,
+		[]string{"lint"}, "deploy", "repo", 1, (*uint32)(nil),
 	).Return(uint32(42), true, nil)
 
 	pinnedVersion := uint32(99)
@@ -538,7 +538,7 @@ func TestTickJobs_SkipsWhenPinCheckFails(t *testing.T) {
 
 	br.EXPECT().FindReadyDownstreamVersion(
 		gomock.Any(), "main", "my-pipeline",
-		[]string{"lint"}, "deploy", "repo", 1,
+		[]string{"lint"}, "deploy", "repo", 1, (*uint32)(nil),
 	).Return(uint32(42), true, nil)
 
 	rr.EXPECT().Find(gomock.Any(), "main", "my-pipeline", "git.repo").
@@ -581,7 +581,7 @@ func TestTickJobs_FindReadyError_SkipsJob(t *testing.T) {
 
 	br.EXPECT().FindReadyDownstreamVersion(
 		gomock.Any(), "main", "my-pipeline",
-		[]string{"upstream"}, "downstream", "repo", 1,
+		[]string{"upstream"}, "downstream", "repo", 1, (*uint32)(nil),
 	).Return(uint32(0), false, assert.AnError)
 
 	s.tick(context.Background())

--- a/pikoci/testdata/cron.hcl
+++ b/pikoci/testdata/cron.hcl
@@ -1,22 +1,3 @@
-secret_type "my-file" {
-  source = "pikoci://file"
-  path   = "pikoci/testdata/secrets.json"
-}
-
-variable "greeting" {
-  type = string
-  secret "my-file" {
-    key = "greeting"
-  }
-}
-
-variable "env" {
-  type = string
-  secret "my-file" {
-    key = "env"
-  }
-}
-
 resource "cron" "my_cron" {
   check_interval = "@every 20s"
 }
@@ -31,25 +12,10 @@ job "gen" {
   get "cron" "my_cron" {
     trigger = true
   }
-  in_parallel {
-    limit = 2
-    task "create-file" {
-      run "exec" {
-        path = "/bin/sh"
-        args = ["-ec", "for i in $(seq 1 10); do echo \"create-file: waiting $i/10...\"; sleep 1; done && mkdir -p output && echo \"cron triggered at: $(date)\" > output/timestamp.txt && cat output/timestamp.txt"]
-      }
-    }
-    task "show-date" {
-      run "exec" {
-        path = "/bin/sh"
-        args = ["-ec", "for i in $(seq 1 10); do echo \"show-date: waiting $i/10...\"; sleep 1; done && echo \"current date: $(date)\""]
-      }
-    }
-    task "quick-check" {
-      run "exec" {
-        path = "/bin/sh"
-        args = ["-ec", "for i in $(seq 1 5); do echo \"quick-check: step $i/5...\"; sleep 1; done && echo \"quick-check failed!\" && exit 1"]
-      }
+  task "create-file" {
+    run "exec" {
+      path = "/bin/sh"
+      args = ["-ec", "mkdir -p output && echo \"cron triggered at: $(date)\" > output/timestamp.txt && cat output/timestamp.txt"]
     }
   }
   put "artifact" "cron_output" {
@@ -58,8 +24,6 @@ job "gen" {
 }
 
 job "deploy-staging" {
-  serial_groups = ["deploy"]
-
   get "artifact" "cron_output" {
     trigger = true
     passed  = ["gen"]
@@ -67,14 +31,12 @@ job "deploy-staging" {
   task "deploy" {
     run "exec" {
       path = "/bin/sh"
-      args = ["-ec", "echo '--- deploy-staging ---' && cat cron-output/timestamp.txt && echo 'deploying to staging...' && sleep 10 && echo 'done'"]
+      args = ["-ec", "echo '--- deploy-staging ---' && cat cron-output/timestamp.txt && echo 'deploying to staging...' && sleep 5 && echo 'done'"]
     }
   }
 }
 
 job "deploy-prod" {
-  serial_groups = ["deploy"]
-
   get "artifact" "cron_output" {
     trigger = true
     passed  = ["gen"]
@@ -82,58 +44,20 @@ job "deploy-prod" {
   task "deploy" {
     run "exec" {
       path = "/bin/sh"
-      args = ["-ec", "echo '--- deploy-prod ---' && cat cron-output/timestamp.txt && echo 'deploying to prod...' && sleep 10 && echo 'done'"]
+      args = ["-ec", "echo '--- deploy-prod ---' && cat cron-output/timestamp.txt && echo 'deploying to prod...' && sleep 5 && echo 'done'"]
     }
   }
 }
 
-job "validate" {
-  for_each = toset(["format", "lint", "vet"])
-
-  get "artifact" "cron_output" {
+job "monitor" {
+  get "cron" "my_cron" {
     trigger = true
     passed  = ["gen"]
   }
-  task "run-check" {
+  task "check" {
     run "exec" {
       path = "/bin/sh"
-      args = ["-ec", "echo 'running ${each.value} check...' && cat cron-output/timestamp.txt && echo '${each.value}: ok'"]
-    }
-  }
-}
-
-job "notify" {
-  for_each = {
-    "slack"   = "#deploys"
-    "discord" = "#ci-alerts"
-  }
-
-  get "artifact" "cron_output" {
-    trigger = true
-    passed  = ["validate"]
-  }
-  task "send" {
-    run "exec" {
-      path = "/bin/sh"
-      args = ["-ec", "echo 'notifying ${each.key} channel ${each.value}...'"]
-    }
-  }
-}
-
-job "deploy-matrix" {
-  matrix {
-    env    = ["staging", "prod"]
-    region = ["us", "eu"]
-  }
-
-  get "artifact" "cron_output" {
-    trigger = true
-    passed  = ["notify"]
-  }
-  task "deploy" {
-    run "exec" {
-      path = "/bin/sh"
-      args = ["-ec", "echo 'deploying to ${each.value.env}/${each.value.region}...' && cat cron-output/timestamp.txt && echo 'done'"]
+      args = ["-ec", "echo '--- monitor ---' && echo 'cron version: $GET_MY_CRON_DATE' && echo 'done'"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add `baseline_version_id` column to jobs table, set to `MAX(resource_versions.id)` on creation
- Scheduler skips versions at or below this baseline, preventing new/renamed jobs with `trigger=true` from flooding old builds
- Add log rotation (journald, Docker, syslog) and daily disk cleanup cron to deploy script

Closes #492