### PR TITLE
fix: pipeline update no longer unpauses paused jobs (#495)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Pipeline updates no longer unpause paused jobs. The `paused` state is now exclusively managed by the dedicated pause/unpause actions, preventing HCL-parsed zero values from overwriting runtime state ([#495](https://github.com/PikoCI/pikoci/issues/495))
 - New jobs with `trigger = true` no longer replay the entire version backlog. Jobs now record a `baseline_version_id` at creation time, and the scheduler only considers versions newer than that baseline ([#492](https://github.com/PikoCI/pikoci/issues/492))
 
 ### Added

--- a/pikoci/mysql/job.go
+++ b/pikoci/mysql/job.go
@@ -131,7 +131,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 	dbj := newDBJob(j)
 	res, err := r.querier.ExecContext(ctx, `
 		UPDATE jobs AS j
-		SET name = ?, tags = ?, plan = ?, on_success = ?, on_failure = ?, on_cancel = ?, ensure = ?, concurrency = ?, paused = ?, timeout = ?, for_each_group = ?, for_each_key = ?
+		SET name = ?, tags = ?, plan = ?, on_success = ?, on_failure = ?, on_cancel = ?, ensure = ?, concurrency = ?, timeout = ?, for_each_group = ?, for_each_key = ?
 		FROM (
 			SELECT j.id
 			FROM jobs AS j
@@ -142,7 +142,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 			WHERE t.canonical = ? AND p.canonical = ? AND j.name = ?
 		) AS jj
 		WHERE jj.id = j.id
-	`, dbj.Name, dbj.Tags, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Paused, dbj.Timeout, dbj.ForEachGroup, dbj.ForEachKey, tc, pn, jn)
+	`, dbj.Name, dbj.Tags, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Timeout, dbj.ForEachGroup, dbj.ForEachKey, tc, pn, jn)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}

--- a/pikoci/mysql/pipeline_test.go
+++ b/pikoci/mysql/pipeline_test.go
@@ -482,3 +482,38 @@ func TestDeletePipeline_CascadesSerialGroups(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, count, "serial groups should be cascade-deleted when pipeline is deleted")
 }
+
+func TestJobUpdate_PreservesPausedState(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	// Create a pipeline with a job
+	res, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'pause-test', 'pause-test')`)
+	require.NoError(t, err)
+	ppID, _ := res.LastInsertId()
+
+	_, err = db.ExecContext(ctx, `INSERT INTO jobs (pipeline_id, name) VALUES (?, 'my-job')`, ppID)
+	require.NoError(t, err)
+
+	jr := mysql.NewJobRepository(db)
+
+	// Pause the job
+	err = jr.SetPaused(ctx, "main", "pause-test", "my-job", true)
+	require.NoError(t, err)
+
+	// Verify it's paused
+	j, err := jr.Find(ctx, "main", "pause-test", "my-job")
+	require.NoError(t, err)
+	assert.True(t, j.Paused, "job should be paused after SetPaused(true)")
+
+	// Update the job with Paused=false (simulating pipeline update from HCL)
+	err = jr.Update(ctx, "main", "pause-test", "my-job", job.Job{
+		Name: "my-job",
+	})
+	require.NoError(t, err)
+
+	// Verify the job is still paused
+	j, err = jr.Find(ctx, "main", "pause-test", "my-job")
+	require.NoError(t, err)
+	assert.True(t, j.Paused, "job should remain paused after Update()")
+}


### PR DESCRIPTION
## Summary

- Remove `paused` from the `Jobs().Update()` SQL so pipeline updates don't overwrite runtime pause state with the HCL zero value (`false`)
- Paused state is now exclusively managed by `SetPaused`/`PauseAll`/`UnpauseAll`
- Add test verifying paused state is preserved through `Update()`

Closes #495