### PR TITLE
feat: faster downstream job triggering with passed constraints (#496)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pipeline updates no longer unpause paused jobs. The `paused` state is now exclusively managed by the dedicated pause/unpause actions, preventing HCL-parsed zero values from overwriting runtime state ([#495](https://github.com/PikoCI/pikoci/issues/495))
 - New jobs with `trigger = true` no longer replay the entire version backlog. Jobs now record a `baseline_version_id` at creation time, and the scheduler only considers versions newer than that baseline ([#492](https://github.com/PikoCI/pikoci/issues/492))
 
+### Changed
+
+- Downstream jobs with `passed` constraints are now triggered immediately when upstream builds succeed, instead of waiting for the 10-second scheduler tick. The scheduler remains as a fallback ([#496](https://github.com/PikoCI/pikoci/issues/496))
+
 ### Added
 
 - Release pipeline with .deb/.rpm packages: binaries are now named `pikoci-<os>-<arch>` (with `.exe` for Windows), Linux packages (.deb and .rpm) are generated via nfpm for amd64/arm64, and a SHA256SUMS file is included in GitHub Releases. The release job is split into discrete tasks (install-tools, build-binaries, package-deb-rpm, create-release) with tool caching ([#346](https://github.com/PikoCI/pikoci/issues/346))

--- a/pikoci/builds.go
+++ b/pikoci/builds.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/pikoci/pikoci/pikoci/build"
+	"github.com/pikoci/pikoci/pikoci/job"
 	"github.com/pikoci/pikoci/pikoci/unitwork"
 	"github.com/pikoci/pikoci/pikoci/utils"
 )
@@ -400,5 +401,175 @@ func (q *PikoCI) NotifySerialGroupPendingBuilds(ctx context.Context, tc, pc, jn 
 // Duplicate messages simply result in redundant DB lookups with no side effects.
 func (q *PikoCI) ReEnqueuePendingBuilds(ctx context.Context) error {
 	q.Notifier.Notify()
+	return nil
+}
+
+// resolvePassedJobNames expands for_each group names in a passed list to all
+// instance names. If a name matches a for_each group, it is replaced by all
+// instance names in that group. Non-group names are kept as-is.
+func resolvePassedJobNames(passed []string, jobs []job.Job) []string {
+	groupInstances := make(map[string][]string)
+	for _, j := range jobs {
+		if j.ForEachGroup != "" {
+			groupInstances[j.ForEachGroup] = append(groupInstances[j.ForEachGroup], j.Name)
+		}
+	}
+
+	var expanded []string
+	for _, name := range passed {
+		if instances, ok := groupInstances[name]; ok {
+			expanded = append(expanded, instances...)
+		} else {
+			expanded = append(expanded, name)
+		}
+	}
+	return expanded
+}
+
+// jobReferencedInPassed checks whether completedJobName is referenced in a
+// passed list, either directly or as a for_each instance of a group name.
+func jobReferencedInPassed(completedJobName string, passed []string, allJobs []job.Job) bool {
+	for _, p := range passed {
+		if p == completedJobName {
+			return true
+		}
+	}
+	for _, pj := range allJobs {
+		if pj.Name == completedJobName && pj.ForEachGroup != "" {
+			for _, p := range passed {
+				if p == pj.ForEachGroup {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// EvaluateDownstreamJobs checks all jobs in the pipeline that have passed
+// constraints referencing completedJobName. For each that is ready (all
+// upstream jobs succeeded with a common version), it creates a pending build.
+func (q *PikoCI) EvaluateDownstreamJobs(ctx context.Context, tc, pn, completedJobName string) error {
+	pp, err := q.Pipelines.Find(ctx, tc, pn)
+	if err != nil {
+		return fmt.Errorf("failed to find pipeline %q: %w", pn, err)
+	}
+
+	for _, j := range pp.Jobs {
+		if j.Paused {
+			continue
+		}
+		if err := q.evaluateJobDownstream(ctx, tc, pn, completedJobName, &j, pp.Jobs); err != nil {
+			q.logger.Error("failed to evaluate downstream job",
+				"pipeline", pn, "job", j.Name, "completed", completedJobName, "error", err)
+		}
+	}
+	return nil
+}
+
+func (q *PikoCI) evaluateJobDownstream(ctx context.Context, tc, pn, completedJobName string, j *job.Job, allJobs []job.Job) error {
+	// Pre-check: does this job have ANY get step with passed+trigger that
+	// references completedJobName? If not, skip entirely.
+	relevant := false
+	for _, ps := range j.FlatPlanSteps() {
+		if ps.Type != job.StepTypeGet || ps.Get == nil {
+			continue
+		}
+		g := ps.Get
+		if len(g.Passed) == 0 || !g.Trigger {
+			continue
+		}
+		if jobReferencedInPassed(completedJobName, g.Passed, allJobs) {
+			relevant = true
+			break
+		}
+	}
+	if !relevant {
+		return nil
+	}
+
+	// Job is relevant. Now evaluate ALL get steps with passed+trigger —
+	// ALL must be ready for the job to trigger (same as original evaluateJob).
+	type candidate struct {
+		stepName  string
+		versionID uint32
+	}
+	var candidates []candidate
+
+	for _, ps := range j.FlatPlanSteps() {
+		if ps.Type != job.StepTypeGet || ps.Get == nil {
+			continue
+		}
+		g := ps.Get
+		if len(g.Passed) == 0 || !g.Trigger {
+			continue
+		}
+
+		expandedPassed := resolvePassedJobNames(g.Passed, allJobs)
+
+		versionID, ready, err := q.Builds.FindReadyDownstreamVersion(
+			ctx, tc, pn,
+			expandedPassed, j.Name, g.Name, len(expandedPassed),
+			j.BaselineVersionID,
+		)
+		if err != nil {
+			return fmt.Errorf("FindReadyDownstreamVersion: %w", err)
+		}
+		if !ready {
+			return nil
+		}
+
+		rCan := g.ResourceCanonical()
+		res, err := q.Resources.Find(ctx, tc, pn, rCan)
+		if err != nil {
+			return fmt.Errorf("resource pin check for %q: %w", rCan, err)
+		}
+		if res.PinnedVersionID != nil && versionID != *res.PinnedVersionID {
+			return nil
+		}
+
+		candidates = append(candidates, candidate{g.Name, versionID})
+	}
+
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	versionID := candidates[0].versionID
+
+	// Atomic check-and-create to prevent duplicate pending builds
+	// from concurrent callers (multiple workers or worker + scheduler).
+	var triggered bool
+	err := q.StartUoW(ctx, func(uow unitwork.UnitOfWork) error {
+		pending, err := uow.Builds().FindOldestPending(ctx, tc, pn, j.Name)
+		if err != nil {
+			return fmt.Errorf("FindOldestPending: %w", err)
+		}
+		if pending != nil {
+			return nil
+		}
+
+		id, buildNumber, err := uow.Builds().Create(ctx, tc, pn, j.Name, build.Build{
+			Status:    build.Pending,
+			VersionID: versionID,
+		})
+		if err != nil {
+			return fmt.Errorf("create pending build: %w", err)
+		}
+
+		q.logger.Info("triggered downstream job",
+			"pipeline", pn, "job", j.Name, "version_id", versionID,
+			"build_id", id, "build_number", buildNumber,
+			"completed_job", completedJobName)
+
+		triggered = true
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if triggered {
+		q.Notifier.Notify()
+	}
 	return nil
 }

--- a/pikoci/builds_test.go
+++ b/pikoci/builds_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/pikoci/pikoci/pikoci"
 	"github.com/pikoci/pikoci/pikoci/build"
 	"github.com/pikoci/pikoci/pikoci/job"
+	"github.com/pikoci/pikoci/pikoci/pipeline"
+	"github.com/pikoci/pikoci/pikoci/resource"
 	"go.uber.org/mock/gomock"
 )
 
@@ -669,4 +671,300 @@ func TestCreateRetryJobBuild_InvalidCanonical(t *testing.T) {
 
 	_, err = s.S.CreateRetryJobBuild(ctx, "main", "my-pipeline", "INVALID", "3", build.Build{})
 	require.Error(t, err)
+}
+
+// --- EvaluateDownstreamJobs tests ---
+
+// makePipelineLintDeploy returns a pipeline with "lint" and "deploy" jobs.
+// "deploy" has a get step on git.repo with passed=["lint"] and trigger=true.
+func makePipelineLintDeploy() *pipeline.Pipeline {
+	return &pipeline.Pipeline{
+		Name: "my-pipeline",
+		Jobs: []job.Job{
+			{Name: "lint"},
+			{
+				Name: "deploy",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeGet,
+						Get: &job.GetStep{
+							Type:    "git",
+							Name:    "repo",
+							Passed:  []string{"lint"},
+							Trigger: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestEvaluateDownstreamJobs_TriggersWhenReady(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	pp := makePipelineLintDeploy()
+	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
+
+	// FindReadyDownstreamVersion returns ready (version 42)
+	s.Builds.EXPECT().FindReadyDownstreamVersion(
+		ctx, "main", "my-pipeline",
+		[]string{"lint"}, "deploy", "repo", 1, (*uint32)(nil),
+	).Return(uint32(42), true, nil)
+
+	// Resources.Find returns resource with no pinned version
+	s.Resources.EXPECT().Find(ctx, "main", "my-pipeline", "git.repo").
+		Return(&resource.Resource{Type: "git", Name: "repo"}, nil)
+
+	// FindOldestPending returns nil (no pending build)
+	s.Builds.EXPECT().FindOldestPending(ctx, "main", "my-pipeline", "deploy").
+		Return(nil, nil)
+
+	// Create is called to create a new pending build
+	s.Builds.EXPECT().Create(ctx, "main", "my-pipeline", "deploy", gomock.Any()).
+		Return(uint32(10), "1", nil)
+
+	err := s.S.EvaluateDownstreamJobs(ctx, "main", "my-pipeline", "lint")
+	require.NoError(t, err)
+}
+
+func TestEvaluateDownstreamJobs_SkipsWhenNotReady(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	pp := makePipelineLintDeploy()
+	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
+
+	// FindReadyDownstreamVersion returns not ready
+	s.Builds.EXPECT().FindReadyDownstreamVersion(
+		ctx, "main", "my-pipeline",
+		[]string{"lint"}, "deploy", "repo", 1, (*uint32)(nil),
+	).Return(uint32(0), false, nil)
+
+	// Create must NOT be called — no expectation set; gomock will fail if it is
+
+	err := s.S.EvaluateDownstreamJobs(ctx, "main", "my-pipeline", "lint")
+	require.NoError(t, err)
+}
+
+func TestEvaluateDownstreamJobs_SkipsWhenPendingExists(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	pp := makePipelineLintDeploy()
+	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
+
+	s.Builds.EXPECT().FindReadyDownstreamVersion(
+		ctx, "main", "my-pipeline",
+		[]string{"lint"}, "deploy", "repo", 1, (*uint32)(nil),
+	).Return(uint32(42), true, nil)
+
+	s.Resources.EXPECT().Find(ctx, "main", "my-pipeline", "git.repo").
+		Return(&resource.Resource{Type: "git", Name: "repo"}, nil)
+
+	// FindOldestPending returns an existing pending build
+	s.Builds.EXPECT().FindOldestPending(ctx, "main", "my-pipeline", "deploy").
+		Return(&build.Build{ID: 5, BuildNumber: "1", Status: build.Pending}, nil)
+
+	// Create must NOT be called
+
+	err := s.S.EvaluateDownstreamJobs(ctx, "main", "my-pipeline", "lint")
+	require.NoError(t, err)
+}
+
+func TestEvaluateDownstreamJobs_SkipsWhenResourcePinned(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	pp := makePipelineLintDeploy()
+	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
+
+	// FindReadyDownstreamVersion returns version 42
+	s.Builds.EXPECT().FindReadyDownstreamVersion(
+		ctx, "main", "my-pipeline",
+		[]string{"lint"}, "deploy", "repo", 1, (*uint32)(nil),
+	).Return(uint32(42), true, nil)
+
+	// Resource has PinnedVersionID=99 which differs from 42
+	pinnedID := uint32(99)
+	s.Resources.EXPECT().Find(ctx, "main", "my-pipeline", "git.repo").
+		Return(&resource.Resource{Type: "git", Name: "repo", PinnedVersionID: &pinnedID}, nil)
+
+	// Create must NOT be called — resource pin mismatch
+
+	err := s.S.EvaluateDownstreamJobs(ctx, "main", "my-pipeline", "lint")
+	require.NoError(t, err)
+}
+
+func TestEvaluateDownstreamJobs_OnlyEvaluatesRelevantJobs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	// Pipeline: lint, test, deploy (passed: ["lint"]), release (passed: ["test"])
+	// Only deploy references "lint" so only deploy should be evaluated.
+	pp := &pipeline.Pipeline{
+		Name: "my-pipeline",
+		Jobs: []job.Job{
+			{Name: "lint"},
+			{Name: "test"},
+			{
+				Name: "deploy",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeGet,
+						Get: &job.GetStep{
+							Type:    "git",
+							Name:    "repo",
+							Passed:  []string{"lint"},
+							Trigger: true,
+						},
+					},
+				},
+			},
+			{
+				Name: "release",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeGet,
+						Get: &job.GetStep{
+							Type:    "git",
+							Name:    "repo",
+							Passed:  []string{"test"},
+							Trigger: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
+
+	// Only deploy should be evaluated — FindReadyDownstreamVersion called for deploy only
+	s.Builds.EXPECT().FindReadyDownstreamVersion(
+		ctx, "main", "my-pipeline",
+		[]string{"lint"}, "deploy", "repo", 1, (*uint32)(nil),
+	).Return(uint32(0), false, nil)
+
+	// release must NOT be evaluated (no expectation set for it)
+
+	err := s.S.EvaluateDownstreamJobs(ctx, "main", "my-pipeline", "lint")
+	require.NoError(t, err)
+}
+
+func TestEvaluateDownstreamJobs_MultiInputAllMustBeReady(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	// deploy has two get steps:
+	//   repo (passed: ["lint"], trigger: true)
+	//   image (passed: ["build-image"], trigger: true)
+	// Call with completedJobName="lint". First step ready, second not ready.
+	// Create must NOT be called because ALL steps must be ready.
+	pp := &pipeline.Pipeline{
+		Name: "my-pipeline",
+		Jobs: []job.Job{
+			{Name: "lint"},
+			{Name: "build-image"},
+			{
+				Name: "deploy",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeGet,
+						Get: &job.GetStep{
+							Type:    "git",
+							Name:    "repo",
+							Passed:  []string{"lint"},
+							Trigger: true,
+						},
+					},
+					{
+						Type: job.StepTypeGet,
+						Get: &job.GetStep{
+							Type:    "docker",
+							Name:    "image",
+							Passed:  []string{"build-image"},
+							Trigger: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
+
+	// First step (repo) is ready
+	s.Builds.EXPECT().FindReadyDownstreamVersion(
+		ctx, "main", "my-pipeline",
+		[]string{"lint"}, "deploy", "repo", 1, (*uint32)(nil),
+	).Return(uint32(42), true, nil)
+
+	s.Resources.EXPECT().Find(ctx, "main", "my-pipeline", "git.repo").
+		Return(&resource.Resource{Type: "git", Name: "repo"}, nil)
+
+	// Second step (image) is NOT ready
+	s.Builds.EXPECT().FindReadyDownstreamVersion(
+		ctx, "main", "my-pipeline",
+		[]string{"build-image"}, "deploy", "image", 1, (*uint32)(nil),
+	).Return(uint32(0), false, nil)
+
+	// Create must NOT be called — second step not ready
+
+	err := s.S.EvaluateDownstreamJobs(ctx, "main", "my-pipeline", "lint")
+	require.NoError(t, err)
+}
+
+func TestEvaluateDownstreamJobs_ForEachGroupExpansion(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.Background()
+
+	// "lint-go" and "lint-js" are for_each instances of group "lint".
+	// "deploy" has passed: ["lint"] which should match both instances.
+	// Completing "lint-go" should trigger evaluation of "deploy".
+	pp := &pipeline.Pipeline{
+		Canonical: "my-pipeline",
+		Jobs: []job.Job{
+			{Name: "lint-go", ForEachGroup: "lint"},
+			{Name: "lint-js", ForEachGroup: "lint"},
+			{
+				Name: "deploy",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeGet,
+						Get: &job.GetStep{
+							Type:    "git",
+							Name:    "repo",
+							Passed:  []string{"lint"},
+							Trigger: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s.Pipelines.EXPECT().Find(gomock.Any(), "main", "my-pipeline").Return(pp, nil)
+	// Passed ["lint"] expands to ["lint-go", "lint-js"] via resolvePassedJobNames
+	s.Builds.EXPECT().FindReadyDownstreamVersion(
+		gomock.Any(), "main", "my-pipeline",
+		[]string{"lint-go", "lint-js"}, "deploy", "repo", 2, (*uint32)(nil),
+	).Return(uint32(42), true, nil)
+	s.Resources.EXPECT().Find(gomock.Any(), "main", "my-pipeline", "git.repo").
+		Return(&resource.Resource{}, nil)
+	s.Builds.EXPECT().FindOldestPending(gomock.Any(), "main", "my-pipeline", "deploy").
+		Return(nil, nil)
+	s.Builds.EXPECT().Create(gomock.Any(), "main", "my-pipeline", "deploy", gomock.Any()).
+		Return(uint32(1), "1", nil)
+
+	err := s.S.EvaluateDownstreamJobs(ctx, "main", "my-pipeline", "lint-go")
+	require.NoError(t, err)
 }

--- a/pikoci/mock/service.go
+++ b/pikoci/mock/service.go
@@ -295,6 +295,20 @@ func (mr *ServiceMockRecorder) DeleteWorker(ctx, name any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorker", reflect.TypeOf((*Service)(nil).DeleteWorker), ctx, name)
 }
 
+// EvaluateDownstreamJobs mocks base method.
+func (m *Service) EvaluateDownstreamJobs(ctx context.Context, tc, pn, completedJobName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EvaluateDownstreamJobs", ctx, tc, pn, completedJobName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EvaluateDownstreamJobs indicates an expected call of EvaluateDownstreamJobs.
+func (mr *ServiceMockRecorder) EvaluateDownstreamJobs(ctx, tc, pn, completedJobName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvaluateDownstreamJobs", reflect.TypeOf((*Service)(nil).EvaluateDownstreamJobs), ctx, tc, pn, completedJobName)
+}
+
 // FindBuildGetVersions mocks base method.
 func (m *Service) FindBuildGetVersions(ctx context.Context, tc, pn, jn string, buildID uint32) (map[string]uint32, error) {
 	m.ctrl.T.Helper()

--- a/pikoci/scheduler/scheduler.go
+++ b/pikoci/scheduler/scheduler.go
@@ -5,37 +5,44 @@ package scheduler
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"time"
 
-	"github.com/pikoci/pikoci/pikoci/build"
-	"github.com/pikoci/pikoci/pikoci/job"
 	"github.com/pikoci/pikoci/pikoci/notifier"
 	"github.com/pikoci/pikoci/pikoci/pipeline"
 	"github.com/pikoci/pikoci/pikoci/resource"
 )
 
+// DownstreamEvaluator is the narrow interface the scheduler uses to evaluate
+// whether downstream jobs are ready to run.
+type DownstreamEvaluator interface {
+	EvaluateDownstreamJobs(ctx context.Context, tc, pn, completedJobName string) error
+}
+
 // Scheduler polls the database for due resources and ready downstream jobs.
 type Scheduler struct {
 	resources resource.Repository
 	pipelines pipeline.Repository
-	builds    build.Repository
+	evaluator DownstreamEvaluator
 	notifier  *notifier.WorkNotifier
 	logger    *slog.Logger
 	interval  time.Duration
 }
 
 // New creates a new Scheduler.
-func New(resources resource.Repository, pipelines pipeline.Repository, builds build.Repository, wn *notifier.WorkNotifier, logger *slog.Logger) *Scheduler {
+func New(resources resource.Repository, pipelines pipeline.Repository, wn *notifier.WorkNotifier, logger *slog.Logger) *Scheduler {
 	return &Scheduler{
 		resources: resources,
 		pipelines: pipelines,
-		builds:    builds,
 		notifier:  wn,
 		logger:    logger,
 		interval:  10 * time.Second,
 	}
+}
+
+// SetEvaluator sets the DownstreamEvaluator used by tickJobs.
+func (s *Scheduler) SetEvaluator(e DownstreamEvaluator) {
+	s.evaluator = e
 }
 
 // Start launches the polling goroutine that ticks every interval.
@@ -73,136 +80,23 @@ func (s *Scheduler) tickResources(ctx context.Context) {
 }
 
 func (s *Scheduler) tickJobs(ctx context.Context) {
+	if s.evaluator == nil {
+		return
+	}
 	pps, err := s.pipelines.FilterAll(ctx)
 	if err != nil {
 		s.logger.Error("failed to filter all pipelines", "error", err)
 		return
 	}
-
 	for _, pwt := range pps {
 		for _, j := range pwt.Jobs {
 			if j.Paused {
 				continue
 			}
-			s.evaluateJob(ctx, pwt, &j)
+			if err := s.evaluator.EvaluateDownstreamJobs(ctx, pwt.Team.Canonical, pwt.Canonical, j.Name); err != nil {
+				s.logger.Error("failed to evaluate downstream jobs",
+					"pipeline", pwt.Canonical, "job", j.Name, "error", err)
+			}
 		}
 	}
-}
-
-// evaluateJob checks whether a job with passed constraints is ready to run.
-// It checks ALL get steps with passed+trigger; if any is not ready, the job
-// is skipped. Once triggered, it breaks — a job is only queued once per tick.
-func (s *Scheduler) evaluateJob(ctx context.Context, pwt *pipeline.WithTeam, j *job.Job) {
-	// Collect all get steps that have passed+trigger constraints.
-	// ALL must be ready for the job to trigger.
-	type candidate struct {
-		stepName  string
-		passed    []string
-		versionID uint32
-	}
-	var candidates []candidate
-
-	for _, ps := range j.FlatPlanSteps() {
-		if ps.Type != job.StepTypeGet || ps.Get == nil {
-			continue
-		}
-		g := ps.Get
-		if len(g.Passed) == 0 || !g.Trigger {
-			continue
-		}
-
-		// Expand for_each group names to instance names
-		expandedPassed := resolvePassedJobNames(g.Passed, pwt.Jobs)
-
-		versionID, ready, err := s.builds.FindReadyDownstreamVersion(
-			ctx, pwt.Team.Canonical, pwt.Canonical,
-			expandedPassed, j.Name, g.Name, len(expandedPassed),
-			j.BaselineVersionID,
-		)
-		if err != nil {
-			s.logger.Error("failed to find ready downstream version",
-				"pipeline", pwt.Canonical, "job", j.Name, "error", err)
-			return
-		}
-		if !ready {
-			return
-		}
-
-		// Check if the resource is pinned to a different version
-		rCan := g.ResourceCanonical()
-		res, resErr := s.resources.Find(ctx, pwt.Team.Canonical, pwt.Canonical, rCan)
-		if resErr != nil {
-			s.logger.Error("failed to find resource for pin check, skipping job",
-				"pipeline", pwt.Canonical, "job", j.Name, "resource", rCan, "error", resErr)
-			return
-		}
-		if res.PinnedVersionID != nil && versionID != *res.PinnedVersionID {
-			return // resource is pinned to a different version, skip
-		}
-
-		candidates = append(candidates, candidate{g.Name, g.Passed, versionID})
-	}
-
-	if len(candidates) == 0 {
-		return
-	}
-
-	// If there's already a pending build for this job, skip — don't create
-	// another one. This prevents the scheduler from re-triggering the same
-	// unconsumed version every tick.
-	pending, err := s.builds.FindOldestPending(ctx, pwt.Team.Canonical, pwt.Canonical, j.Name)
-	if err != nil {
-		s.logger.Error("failed to check for pending builds",
-			"pipeline", pwt.Canonical, "job", j.Name, "error", err)
-		return
-	}
-	if pending != nil {
-		return
-	}
-
-	// Use the version from the first candidate.
-	versionID := candidates[0].versionID
-
-	s.logger.Info("Triggering downstream job",
-		"pipeline", pwt.Canonical, "job", j.Name, "version_id", versionID,
-		"candidates", fmt.Sprintf("%+v", candidates))
-
-	// Create a pending build
-	bb := build.Build{
-		Status:    build.Pending,
-		VersionID: versionID,
-	}
-	id, buildNumber, err := s.builds.Create(ctx, pwt.Team.Canonical, pwt.Canonical, j.Name, bb)
-	if err != nil {
-		s.logger.Error("failed to create pending build for downstream job",
-			"pipeline", pwt.Canonical, "job", j.Name, "error", err)
-		return
-	}
-
-	s.logger.Info("created pending build for downstream job",
-		"pipeline", pwt.Canonical, "job", j.Name, "build_id", id, "build_number", buildNumber)
-
-	s.notifier.Notify()
-}
-
-// resolvePassedJobNames expands for_each group names in a passed list to all
-// instance names. If a name matches a for_each group, it is replaced by all
-// instance names in that group. Non-group names are kept as-is.
-func resolvePassedJobNames(passed []string, jobs []job.Job) []string {
-	groupInstances := make(map[string][]string)
-	for _, j := range jobs {
-		if j.ForEachGroup != "" {
-			groupInstances[j.ForEachGroup] = append(groupInstances[j.ForEachGroup], j.Name)
-		}
-	}
-
-	var expanded []string
-	for _, name := range passed {
-		if instances, ok := groupInstances[name]; ok {
-			expanded = append(expanded, instances...)
-		} else {
-			expanded = append(expanded, name)
-		}
-	}
-	return expanded
 }

--- a/pikoci/scheduler/scheduler_test.go
+++ b/pikoci/scheduler/scheduler_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/pikoci/pikoci/pikoci/build"
 	"github.com/pikoci/pikoci/pikoci/job"
 	"github.com/pikoci/pikoci/pikoci/mock"
 	"github.com/pikoci/pikoci/pikoci/notifier"
@@ -17,14 +16,13 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func newTestScheduler(ctrl *gomock.Controller) (*Scheduler, *mock.ResourceRepository, *mock.PipelineRepository, *mock.BuildRepository) {
+func newTestScheduler(ctrl *gomock.Controller) (*Scheduler, *mock.ResourceRepository, *mock.PipelineRepository) {
 	rr := mock.NewResourceRepository(ctrl)
 	pr := mock.NewPipelineRepository(ctrl)
-	br := mock.NewBuildRepository(ctrl)
 	wn := notifier.New()
 	logger := slog.Default()
-	s := New(rr, pr, br, wn, logger)
-	return s, rr, pr, br
+	s := New(rr, pr, wn, logger)
+	return s, rr, pr
 }
 
 // expectEmptyTickJobs sets up expectations for tickJobs when no pipelines exist.
@@ -34,7 +32,9 @@ func expectEmptyTickJobs(pr *mock.PipelineRepository) {
 
 func TestTickResources_NoDueResources(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	s, rr, pr, _ := newTestScheduler(ctrl)
+	s, rr, pr := newTestScheduler(ctrl)
+	eval := &mockEvaluator{}
+	s.SetEvaluator(eval)
 
 	rr.EXPECT().FilterDueResources(gomock.Any()).Return(nil, nil)
 	expectEmptyTickJobs(pr)
@@ -44,7 +44,9 @@ func TestTickResources_NoDueResources(t *testing.T) {
 
 func TestTickResources_ProcessesDueResources(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	s, rr, pr, _ := newTestScheduler(ctrl)
+	s, rr, pr := newTestScheduler(ctrl)
+	eval := &mockEvaluator{}
+	s.SetEvaluator(eval)
 
 	due := []*resource.ResourceWithPipeline{
 		{
@@ -66,7 +68,9 @@ func TestTickResources_ProcessesDueResources(t *testing.T) {
 
 func TestTickResources_MultipleDueResources(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	s, rr, pr, _ := newTestScheduler(ctrl)
+	s, rr, pr := newTestScheduler(ctrl)
+	eval := &mockEvaluator{}
+	s.SetEvaluator(eval)
 
 	due := []*resource.ResourceWithPipeline{
 		{
@@ -89,7 +93,9 @@ func TestTickResources_MultipleDueResources(t *testing.T) {
 
 func TestTickResources_DefaultCheckInterval(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	s, rr, pr, _ := newTestScheduler(ctrl)
+	s, rr, pr := newTestScheduler(ctrl)
+	eval := &mockEvaluator{}
+	s.SetEvaluator(eval)
 
 	due := []*resource.ResourceWithPipeline{
 		{
@@ -107,7 +113,9 @@ func TestTickResources_DefaultCheckInterval(t *testing.T) {
 
 func TestStart_StopsOnContextCancel(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	s, rr, pr, _ := newTestScheduler(ctrl)
+	s, rr, pr := newTestScheduler(ctrl)
+	eval := &mockEvaluator{}
+	s.SetEvaluator(eval)
 	s.interval = 50 * time.Millisecond
 
 	rr.EXPECT().FilterDueResources(gomock.Any()).Return(nil, nil).AnyTimes()
@@ -121,468 +129,64 @@ func TestStart_StopsOnContextCancel(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 }
 
+// --- mockEvaluator ---
+
+type mockEvaluator struct {
+	calls []evaluateCall
+}
+
+type evaluateCall struct {
+	tc, pn, completedJobName string
+}
+
+func (m *mockEvaluator) EvaluateDownstreamJobs(_ context.Context, tc, pn, completedJobName string) error {
+	m.calls = append(m.calls, evaluateCall{tc, pn, completedJobName})
+	return nil
+}
+
 // --- tickJobs tests ---
 
-func TestTickJobs_TriggersWhenCommonVersionExists(t *testing.T) {
+func TestTickJobs_CallsEvaluatorForEachJob(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	s, rr, pr, br := newTestScheduler(ctrl)
+	s, rr, pr := newTestScheduler(ctrl)
+	eval := &mockEvaluator{}
+	s.SetEvaluator(eval)
 
 	rr.EXPECT().FilterDueResources(gomock.Any()).Return(nil, nil)
-
-	pps := []*pipeline.WithTeam{
-		{
-			Pipeline: pipeline.Pipeline{
-				Name: "my-pipeline", Canonical: "my-pipeline",
-				Jobs: []job.Job{
-					{Name: "lint"},
-					{Name: "test-mock"},
-					{
-						Name: "test-backends",
-						Plan: []job.PlanStep{
-							{
-								Type: job.StepTypeGet,
-								Get: &job.GetStep{
-									Type:    "git",
-									Name:    "repo",
-									Passed:  []string{"lint", "test-mock"},
-									Trigger: true,
-								},
-							},
-						},
-					},
-				},
-			},
-			Team: team.Team{Canonical: "main"},
-		},
-	}
+	pps := []*pipeline.WithTeam{{
+		Pipeline: pipeline.Pipeline{Canonical: "pp1", Jobs: []job.Job{{Name: "lint"}, {Name: "test"}}},
+		Team:     team.Team{Canonical: "main"},
+	}}
 	pr.EXPECT().FilterAll(gomock.Any()).Return(pps, nil)
-
-	br.EXPECT().FindReadyDownstreamVersion(
-		gomock.Any(), "main", "my-pipeline",
-		[]string{"lint", "test-mock"}, "test-backends", "repo", 2, (*uint32)(nil),
-	).Return(uint32(42), true, nil)
-
-	// Pin check — resource is not pinned
-	rr.EXPECT().Find(gomock.Any(), "main", "my-pipeline", "git.repo").
-		Return(&resource.Resource{}, nil)
-
-	// Check for existing pending build (none)
-	br.EXPECT().FindOldestPending(gomock.Any(), "main", "my-pipeline", "test-backends").
-		Return(nil, nil)
-
-	// Create a pending build
-	br.EXPECT().Create(gomock.Any(), "main", "my-pipeline", "test-backends", gomock.Any()).
-		Return(uint32(100), "1", nil)
-
 	s.tick(context.Background())
+
+	assert.Equal(t, 2, len(eval.calls))
+	assert.Equal(t, evaluateCall{"main", "pp1", "lint"}, eval.calls[0])
+	assert.Equal(t, evaluateCall{"main", "pp1", "test"}, eval.calls[1])
 }
 
-func TestTickJobs_SkipsWhenNoCommonVersion(t *testing.T) {
+func TestTickJobs_SkipsPausedJobs(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	s, rr, pr, br := newTestScheduler(ctrl)
+	s, rr, pr := newTestScheduler(ctrl)
+	eval := &mockEvaluator{}
+	s.SetEvaluator(eval)
 
 	rr.EXPECT().FilterDueResources(gomock.Any()).Return(nil, nil)
-
-	pps := []*pipeline.WithTeam{
-		{
-			Pipeline: pipeline.Pipeline{
-				Name: "my-pipeline", Canonical: "my-pipeline",
-				Jobs: []job.Job{
-					{
-						Name: "downstream",
-						Plan: []job.PlanStep{
-							{
-								Type: job.StepTypeGet,
-								Get: &job.GetStep{
-									Type:    "git",
-									Name:    "repo",
-									Passed:  []string{"upstream"},
-									Trigger: true,
-								},
-							},
-						},
-					},
-				},
-			},
-			Team: team.Team{Canonical: "main"},
-		},
-	}
+	pps := []*pipeline.WithTeam{{
+		Pipeline: pipeline.Pipeline{Canonical: "pp1", Jobs: []job.Job{{Name: "active"}, {Name: "paused-job", Paused: true}}},
+		Team:     team.Team{Canonical: "main"},
+	}}
 	pr.EXPECT().FilterAll(gomock.Any()).Return(pps, nil)
-
-	br.EXPECT().FindReadyDownstreamVersion(
-		gomock.Any(), "main", "my-pipeline",
-		[]string{"upstream"}, "downstream", "repo", 1, (*uint32)(nil),
-	).Return(uint32(0), false, nil)
-
 	s.tick(context.Background())
+
+	assert.Equal(t, 1, len(eval.calls))
+	assert.Equal(t, "active", eval.calls[0].completedJobName)
 }
 
-func TestTickJobs_SkipsWhenPendingBuildExists(t *testing.T) {
+func TestTickJobs_NilEvaluator(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	s, rr, pr, br := newTestScheduler(ctrl)
-
+	s, rr, _ := newTestScheduler(ctrl)
 	rr.EXPECT().FilterDueResources(gomock.Any()).Return(nil, nil)
-
-	pps := []*pipeline.WithTeam{
-		{
-			Pipeline: pipeline.Pipeline{
-				Name: "my-pipeline", Canonical: "my-pipeline",
-				Jobs: []job.Job{
-					{
-						Name: "deploy",
-						Plan: []job.PlanStep{
-							{
-								Type: job.StepTypeGet,
-								Get: &job.GetStep{
-									Type:    "git",
-									Name:    "repo",
-									Passed:  []string{"lint"},
-									Trigger: true,
-								},
-							},
-						},
-					},
-				},
-			},
-			Team: team.Team{Canonical: "main"},
-		},
-	}
-	pr.EXPECT().FilterAll(gomock.Any()).Return(pps, nil)
-
-	br.EXPECT().FindReadyDownstreamVersion(
-		gomock.Any(), "main", "my-pipeline",
-		[]string{"lint"}, "deploy", "repo", 1, (*uint32)(nil),
-	).Return(uint32(42), true, nil)
-
-	// Pin check — resource is not pinned
-	rr.EXPECT().Find(gomock.Any(), "main", "my-pipeline", "git.repo").
-		Return(&resource.Resource{}, nil)
-
-	// A pending build already exists — should skip creating another
-	br.EXPECT().FindOldestPending(gomock.Any(), "main", "my-pipeline", "deploy").
-		Return(&build.Build{ID: 99, BuildNumber: "1", Status: build.Pending}, nil)
-
-	s.tick(context.Background())
-}
-
-func TestTickJobs_SkipsWhenTriggerFalse(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	s, rr, pr, _ := newTestScheduler(ctrl)
-
-	rr.EXPECT().FilterDueResources(gomock.Any()).Return(nil, nil)
-
-	pps := []*pipeline.WithTeam{
-		{
-			Pipeline: pipeline.Pipeline{
-				Name: "my-pipeline", Canonical: "my-pipeline",
-				Jobs: []job.Job{
-					{
-						Name: "downstream",
-						Plan: []job.PlanStep{
-							{
-								Type: job.StepTypeGet,
-								Get: &job.GetStep{
-									Type:    "git",
-									Name:    "repo",
-									Passed:  []string{"upstream"},
-									Trigger: false,
-								},
-							},
-						},
-					},
-				},
-			},
-			Team: team.Team{Canonical: "main"},
-		},
-	}
-	pr.EXPECT().FilterAll(gomock.Any()).Return(pps, nil)
-
-	s.tick(context.Background())
-}
-
-func TestTickJobs_SkipsJobsWithoutPassedConstraints(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	s, rr, pr, _ := newTestScheduler(ctrl)
-
-	rr.EXPECT().FilterDueResources(gomock.Any()).Return(nil, nil)
-
-	pps := []*pipeline.WithTeam{
-		{
-			Pipeline: pipeline.Pipeline{
-				Name: "my-pipeline", Canonical: "my-pipeline",
-				Jobs: []job.Job{
-					{
-						Name: "simple-job",
-						Plan: []job.PlanStep{
-							{
-								Type: job.StepTypeGet,
-								Get: &job.GetStep{
-									Type:    "git",
-									Name:    "repo",
-									Trigger: true,
-								},
-							},
-						},
-					},
-				},
-			},
-			Team: team.Team{Canonical: "main"},
-		},
-	}
-	pr.EXPECT().FilterAll(gomock.Any()).Return(pps, nil)
-
-	s.tick(context.Background())
-}
-
-func TestTickJobs_MultipleGetSteps_AllMustBeReady(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	s, rr, pr, br := newTestScheduler(ctrl)
-
-	rr.EXPECT().FilterDueResources(gomock.Any()).Return(nil, nil)
-
-	pps := []*pipeline.WithTeam{
-		{
-			Pipeline: pipeline.Pipeline{
-				Name: "my-pipeline", Canonical: "my-pipeline",
-				Jobs: []job.Job{
-					{
-						Name: "deploy",
-						Plan: []job.PlanStep{
-							{
-								Type: job.StepTypeGet,
-								Get: &job.GetStep{
-									Type:    "git",
-									Name:    "repo",
-									Passed:  []string{"lint"},
-									Trigger: true,
-								},
-							},
-							{
-								Type: job.StepTypeGet,
-								Get: &job.GetStep{
-									Type:    "docker",
-									Name:    "image",
-									Passed:  []string{"build"},
-									Trigger: true,
-								},
-							},
-						},
-					},
-				},
-			},
-			Team: team.Team{Canonical: "main"},
-		},
-	}
-	pr.EXPECT().FilterAll(gomock.Any()).Return(pps, nil)
-
-	// First get step IS ready
-	br.EXPECT().FindReadyDownstreamVersion(
-		gomock.Any(), "main", "my-pipeline",
-		[]string{"lint"}, "deploy", "repo", 1, (*uint32)(nil),
-	).Return(uint32(42), true, nil)
-
-	// Pin check — resource is not pinned
-	rr.EXPECT().Find(gomock.Any(), "main", "my-pipeline", "git.repo").
-		Return(&resource.Resource{}, nil)
-
-	// Second get step is NOT ready
-	br.EXPECT().FindReadyDownstreamVersion(
-		gomock.Any(), "main", "my-pipeline",
-		[]string{"build"}, "deploy", "image", 1, (*uint32)(nil),
-	).Return(uint32(0), false, nil)
-
-	s.tick(context.Background())
-}
-
-func TestTickJobs_MultipleGetSteps_BothReady_TriggersOnce(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	s, rr, pr, br := newTestScheduler(ctrl)
-
-	rr.EXPECT().FilterDueResources(gomock.Any()).Return(nil, nil)
-
-	pps := []*pipeline.WithTeam{
-		{
-			Pipeline: pipeline.Pipeline{
-				Name: "my-pipeline", Canonical: "my-pipeline",
-				Jobs: []job.Job{
-					{
-						Name: "deploy",
-						Plan: []job.PlanStep{
-							{
-								Type: job.StepTypeGet,
-								Get: &job.GetStep{
-									Type:    "git",
-									Name:    "repo",
-									Passed:  []string{"lint"},
-									Trigger: true,
-								},
-							},
-							{
-								Type: job.StepTypeGet,
-								Get: &job.GetStep{
-									Type:    "docker",
-									Name:    "image",
-									Passed:  []string{"build"},
-									Trigger: true,
-								},
-							},
-						},
-					},
-				},
-			},
-			Team: team.Team{Canonical: "main"},
-		},
-	}
-	pr.EXPECT().FilterAll(gomock.Any()).Return(pps, nil)
-
-	br.EXPECT().FindReadyDownstreamVersion(
-		gomock.Any(), "main", "my-pipeline",
-		[]string{"lint"}, "deploy", "repo", 1, (*uint32)(nil),
-	).Return(uint32(42), true, nil)
-
-	rr.EXPECT().Find(gomock.Any(), "main", "my-pipeline", "git.repo").
-		Return(&resource.Resource{}, nil)
-
-	br.EXPECT().FindReadyDownstreamVersion(
-		gomock.Any(), "main", "my-pipeline",
-		[]string{"build"}, "deploy", "image", 1, (*uint32)(nil),
-	).Return(uint32(99), true, nil)
-
-	rr.EXPECT().Find(gomock.Any(), "main", "my-pipeline", "docker.image").
-		Return(&resource.Resource{}, nil)
-
-	br.EXPECT().FindOldestPending(gomock.Any(), "main", "my-pipeline", "deploy").
-		Return(nil, nil)
-
-	br.EXPECT().Create(gomock.Any(), "main", "my-pipeline", "deploy", gomock.Any()).
-		Return(uint32(100), "1", nil)
-
-	s.tick(context.Background())
-}
-
-func TestTickJobs_SkipsWhenResourcePinnedToDifferentVersion(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	s, rr, pr, br := newTestScheduler(ctrl)
-
-	rr.EXPECT().FilterDueResources(gomock.Any()).Return(nil, nil)
-
-	pps := []*pipeline.WithTeam{
-		{
-			Pipeline: pipeline.Pipeline{
-				Name: "my-pipeline", Canonical: "my-pipeline",
-				Jobs: []job.Job{
-					{
-						Name: "deploy",
-						Plan: []job.PlanStep{
-							{
-								Type: job.StepTypeGet,
-								Get: &job.GetStep{
-									Type:    "git",
-									Name:    "repo",
-									Passed:  []string{"lint"},
-									Trigger: true,
-								},
-							},
-						},
-					},
-				},
-			},
-			Team: team.Team{Canonical: "main"},
-		},
-	}
-	pr.EXPECT().FilterAll(gomock.Any()).Return(pps, nil)
-
-	br.EXPECT().FindReadyDownstreamVersion(
-		gomock.Any(), "main", "my-pipeline",
-		[]string{"lint"}, "deploy", "repo", 1, (*uint32)(nil),
-	).Return(uint32(42), true, nil)
-
-	pinnedVersion := uint32(99)
-	rr.EXPECT().Find(gomock.Any(), "main", "my-pipeline", "git.repo").
-		Return(&resource.Resource{PinnedVersionID: &pinnedVersion}, nil)
-
-	s.tick(context.Background())
-}
-
-func TestTickJobs_SkipsWhenPinCheckFails(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	s, rr, pr, br := newTestScheduler(ctrl)
-
-	rr.EXPECT().FilterDueResources(gomock.Any()).Return(nil, nil)
-
-	pps := []*pipeline.WithTeam{
-		{
-			Pipeline: pipeline.Pipeline{
-				Name: "my-pipeline", Canonical: "my-pipeline",
-				Jobs: []job.Job{
-					{
-						Name: "deploy",
-						Plan: []job.PlanStep{
-							{
-								Type: job.StepTypeGet,
-								Get: &job.GetStep{
-									Type:    "git",
-									Name:    "repo",
-									Passed:  []string{"lint"},
-									Trigger: true,
-								},
-							},
-						},
-					},
-				},
-			},
-			Team: team.Team{Canonical: "main"},
-		},
-	}
-	pr.EXPECT().FilterAll(gomock.Any()).Return(pps, nil)
-
-	br.EXPECT().FindReadyDownstreamVersion(
-		gomock.Any(), "main", "my-pipeline",
-		[]string{"lint"}, "deploy", "repo", 1, (*uint32)(nil),
-	).Return(uint32(42), true, nil)
-
-	rr.EXPECT().Find(gomock.Any(), "main", "my-pipeline", "git.repo").
-		Return(nil, assert.AnError)
-
-	s.tick(context.Background())
-}
-
-func TestTickJobs_FindReadyError_SkipsJob(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	s, rr, pr, br := newTestScheduler(ctrl)
-
-	rr.EXPECT().FilterDueResources(gomock.Any()).Return(nil, nil)
-
-	pps := []*pipeline.WithTeam{
-		{
-			Pipeline: pipeline.Pipeline{
-				Name: "my-pipeline", Canonical: "my-pipeline",
-				Jobs: []job.Job{
-					{
-						Name: "downstream",
-						Plan: []job.PlanStep{
-							{
-								Type: job.StepTypeGet,
-								Get: &job.GetStep{
-									Type:    "git",
-									Name:    "repo",
-									Passed:  []string{"upstream"},
-									Trigger: true,
-								},
-							},
-						},
-					},
-				},
-			},
-			Team: team.Team{Canonical: "main"},
-		},
-	}
-	pr.EXPECT().FilterAll(gomock.Any()).Return(pps, nil)
-
-	br.EXPECT().FindReadyDownstreamVersion(
-		gomock.Any(), "main", "my-pipeline",
-		[]string{"upstream"}, "downstream", "repo", 1, (*uint32)(nil),
-	).Return(uint32(0), false, assert.AnError)
-
+	// FilterAll should NOT be called — no expectation
 	s.tick(context.Background())
 }

--- a/pikoci/service.go
+++ b/pikoci/service.go
@@ -162,6 +162,11 @@ type Service interface {
 	// given job and enqueues their oldest pending builds for execution.
 	NotifySerialGroupPendingBuilds(ctx context.Context, tc, pn, jn string)
 
+	// EvaluateDownstreamJobs checks all jobs in the pipeline that have passed
+	// constraints referencing completedJobName. For each that is ready (all
+	// upstream jobs succeeded with a common version), it creates a pending build.
+	EvaluateDownstreamJobs(ctx context.Context, tc, pn, completedJobName string) error
+
 	// GetPipelineResource retrieves a resource by its canonical name within a pipeline.
 	GetPipelineResource(ctx context.Context, tc, pn, rCan string) (*resource.Resource, error)
 	// UpdatePipelineResource updates a resource's metadata within a pipeline.
@@ -262,7 +267,11 @@ type PikoCI struct {
 // initializes the internal scheduler for periodic resource checks and returns
 // the configured service ready for use.
 func New(ctx context.Context, ur user.Repository, tr team.Repository, pr pipeline.Repository, jr job.Repository, rr resource.Repository, rt restype.Repository, br build.Repository, rur runner.Repository, str sectype.Repository, tgr trigger.Repository, wr wkr.Repository, suow unitwork.StartUnitOfWork, js []byte, wn *notifier.WorkNotifier, l *slog.Logger) *PikoCI {
-	return &PikoCI{
+	if l == nil {
+		l = slog.Default()
+	}
+	sched := scheduler.New(rr, pr, wn, l)
+	p := &PikoCI{
 		Ctx:           ctx,
 		Notifier:      wn,
 		Users:         ur,
@@ -279,8 +288,10 @@ func New(ctx context.Context, ur user.Repository, tr team.Repository, pr pipelin
 		StartUoW:      suow,
 		JWTSecret:     js,
 		logger:        l,
-		scheduler:     scheduler.New(rr, pr, br, wn, l),
+		scheduler:     sched,
 	}
+	sched.SetEvaluator(p)
+	return p
 }
 
 // StartScheduler starts the background scheduler that polls for due resources.

--- a/pikoci/transport/http/authorization.go
+++ b/pikoci/transport/http/authorization.go
@@ -55,6 +55,7 @@ var (
 		StartPendingBuild:              admin,
 		FindOldestPendingBuild:         admin,
 		NotifySerialGroupPendingBuilds: admin,
+		EvaluateDownstreamJobs:         admin,
 		InsertBuildGetVersion:          admin,
 		FindBuildGetVersions:   admin,
 

--- a/pikoci/transport/http/builds.go
+++ b/pikoci/transport/http/builds.go
@@ -116,6 +116,21 @@ func notifySerialGroupPendingBuilds(s pikoci.Service) http.HandlerFunc {
 	}
 }
 
+func evaluateDownstreamJobs(s pikoci.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var ctx = r.Context()
+		vars := mux.Vars(r)
+		tc := vars["team_canonical"]
+		pc := vars["pipeline_canonical"]
+		jn := vars["job_name"]
+		if err := s.EvaluateDownstreamJobs(ctx, tc, pc, jn); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
 type UpdateJobBuildRequest struct {
 	TeamCanonical     string      `json:"team_canonical"`
 	PipelineCanonical string      `json:"pipeline_canonical"`

--- a/pikoci/transport/http/client/client.go
+++ b/pikoci/transport/http/client/client.go
@@ -829,6 +829,12 @@ func (cl *Client) NotifySerialGroupPendingBuilds(ctx context.Context, tc, pn, jn
 	_ = cl.Request(ctx, http.MethodPost, fmt.Sprintf("%s/teams/%s/pipelines/%s/jobs/%s/notify-serial-groups", cl.url, tc, pn, jn), nil, nil)
 }
 
+// EvaluateDownstreamJobs asks the server to evaluate downstream jobs with
+// passed constraints after a build succeeds.
+func (cl *Client) EvaluateDownstreamJobs(ctx context.Context, tc, pn, completedJobName string) error {
+	return cl.Request(ctx, http.MethodPost, fmt.Sprintf("%s/teams/%s/pipelines/%s/jobs/%s/evaluate-downstream", cl.url, tc, pn, completedJobName), nil, nil)
+}
+
 // ListJobBuilds always fetches all builds (limit=0) for CLI backward compat.
 // The before/after/limit params satisfy the Service interface but are not sent.
 func (cl *Client) ListJobBuilds(ctx context.Context, tc, pn, jn string, before *uint32, after *uint32, limit uint32) ([]*build.Build, bool, error) {

--- a/pikoci/transport/http/handler.go
+++ b/pikoci/transport/http/handler.go
@@ -250,6 +250,7 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, 
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/builds/start-pending").Name(StartPendingBuild.String()).Handler(startPendingBuild(s))
 	api.Methods(http.MethodGet).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/builds/oldest-pending").Name(FindOldestPendingBuild.String()).Handler(findOldestPendingBuild(s))
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/notify-serial-groups").Name(NotifySerialGroupPendingBuilds.String()).Handler(notifySerialGroupPendingBuilds(s))
+	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/evaluate-downstream").Name(EvaluateDownstreamJobs.String()).Handler(evaluateDownstreamJobs(s))
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/retry-builds").Name(CreateRetryJobBuild.String()).Handler(createRetryJobBuild(s))
 	api.Methods(http.MethodGet).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/builds-get-versions/{build_id}").Name(FindBuildGetVersions.String()).Handler(findBuildGetVersions(s))
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/builds/{build_id}/get-versions").Name(InsertBuildGetVersion.String()).Handler(insertBuildGetVersion(s))

--- a/pikoci/transport/http/route_names.go
+++ b/pikoci/transport/http/route_names.go
@@ -92,6 +92,8 @@ const (
 	FindOldestPendingBuild
 	// NotifySerialGroupPendingBuilds is the route for notifying pending builds in serial groups.
 	NotifySerialGroupPendingBuilds
+	// EvaluateDownstreamJobs is the route for evaluating downstream jobs after a build succeeds.
+	EvaluateDownstreamJobs
 
 	// GetPipelineResource is the route for retrieving a single pipeline resource.
 	GetPipelineResource

--- a/pikoci/transport/http/route_names_string.go
+++ b/pikoci/transport/http/route_names_string.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _RouteNameName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_worker"
+const _RouteNameName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobsget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_worker"
 
-var _RouteNameIndex = [...]uint16{0, 10, 23, 34, 44, 52, 63, 74, 89, 103, 114, 124, 132, 143, 154, 172, 190, 208, 223, 238, 250, 265, 279, 297, 318, 338, 354, 370, 392, 408, 424, 439, 463, 486, 499, 515, 530, 549, 574, 608, 629, 653, 678, 701, 723, 743, 765, 789, 804, 828, 842, 861, 876, 890, 906, 915, 926, 937, 953, 965, 979, 992}
+var _RouteNameIndex = [...]uint16{0, 10, 23, 34, 44, 52, 63, 74, 89, 103, 114, 124, 132, 143, 154, 172, 190, 208, 223, 238, 250, 265, 279, 297, 318, 338, 354, 370, 392, 408, 424, 439, 463, 486, 499, 515, 530, 549, 574, 608, 632, 653, 677, 702, 725, 747, 767, 789, 813, 828, 852, 866, 885, 900, 914, 930, 939, 950, 961, 977, 989, 1003, 1016}
 
-const _RouteNameLowerName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_worker"
+const _RouteNameLowerName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobsget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_worker"
 
 func (i RouteName) String() string {
 	if i < 0 || i >= RouteName(len(_RouteNameIndex)-1) {
@@ -63,155 +63,158 @@ func _RouteNameNoOp() {
 	_ = x[StartPendingBuild-(36)]
 	_ = x[FindOldestPendingBuild-(37)]
 	_ = x[NotifySerialGroupPendingBuilds-(38)]
-	_ = x[GetPipelineResource-(39)]
-	_ = x[UpdatePipelineResource-(40)]
-	_ = x[TriggerPipelineResource-(41)]
-	_ = x[CreateResourceVersion-(42)]
-	_ = x[ListResourceVersions-(43)]
-	_ = x[PinResourceVersion-(44)]
-	_ = x[UnpinResourceVersion-(45)]
-	_ = x[TriggerResourceVersion-(46)]
-	_ = x[WebhookTrigger-(47)]
-	_ = x[RegenerateWebhookToken-(48)]
-	_ = x[CreateTrigger-(49)]
-	_ = x[ListTriggersAfter-(50)]
-	_ = x[ExportDatabase-(51)]
-	_ = x[PausePipeline-(52)]
-	_ = x[UnpausePipeline-(53)]
-	_ = x[PauseJob-(54)]
-	_ = x[UnpauseJob-(55)]
-	_ = x[GetVersion-(56)]
-	_ = x[WorkerHeartbeat-(57)]
-	_ = x[ListWorkers-(58)]
-	_ = x[WorkersHealth-(59)]
-	_ = x[DeleteWorker-(60)]
+	_ = x[EvaluateDownstreamJobs-(39)]
+	_ = x[GetPipelineResource-(40)]
+	_ = x[UpdatePipelineResource-(41)]
+	_ = x[TriggerPipelineResource-(42)]
+	_ = x[CreateResourceVersion-(43)]
+	_ = x[ListResourceVersions-(44)]
+	_ = x[PinResourceVersion-(45)]
+	_ = x[UnpinResourceVersion-(46)]
+	_ = x[TriggerResourceVersion-(47)]
+	_ = x[WebhookTrigger-(48)]
+	_ = x[RegenerateWebhookToken-(49)]
+	_ = x[CreateTrigger-(50)]
+	_ = x[ListTriggersAfter-(51)]
+	_ = x[ExportDatabase-(52)]
+	_ = x[PausePipeline-(53)]
+	_ = x[UnpausePipeline-(54)]
+	_ = x[PauseJob-(55)]
+	_ = x[UnpauseJob-(56)]
+	_ = x[GetVersion-(57)]
+	_ = x[WorkerHeartbeat-(58)]
+	_ = x[ListWorkers-(59)]
+	_ = x[WorkersHealth-(60)]
+	_ = x[DeleteWorker-(61)]
 }
 
-var _RouteNameValues = []RouteName{UserLogin, RefreshToken, CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser, ChangePassword, UpdateProfile, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, GetPipelineJob, CreateJobBuild, CreateRetryJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, InsertBuildGetVersion, FindBuildGetVersions, GetJobBuild, CancelJobBuild, RetryJobBuild, StartPendingBuild, FindOldestPendingBuild, NotifySerialGroupPendingBuilds, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions, PinResourceVersion, UnpinResourceVersion, TriggerResourceVersion, WebhookTrigger, RegenerateWebhookToken, CreateTrigger, ListTriggersAfter, ExportDatabase, PausePipeline, UnpausePipeline, PauseJob, UnpauseJob, GetVersion, WorkerHeartbeat, ListWorkers, WorkersHealth, DeleteWorker}
+var _RouteNameValues = []RouteName{UserLogin, RefreshToken, CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser, ChangePassword, UpdateProfile, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, GetPipelineJob, CreateJobBuild, CreateRetryJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, InsertBuildGetVersion, FindBuildGetVersions, GetJobBuild, CancelJobBuild, RetryJobBuild, StartPendingBuild, FindOldestPendingBuild, NotifySerialGroupPendingBuilds, EvaluateDownstreamJobs, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions, PinResourceVersion, UnpinResourceVersion, TriggerResourceVersion, WebhookTrigger, RegenerateWebhookToken, CreateTrigger, ListTriggersAfter, ExportDatabase, PausePipeline, UnpausePipeline, PauseJob, UnpauseJob, GetVersion, WorkerHeartbeat, ListWorkers, WorkersHealth, DeleteWorker}
 
 var _RouteNameNameToValueMap = map[string]RouteName{
-	_RouteNameName[0:10]:         UserLogin,
-	_RouteNameLowerName[0:10]:    UserLogin,
-	_RouteNameName[10:23]:        RefreshToken,
-	_RouteNameLowerName[10:23]:   RefreshToken,
-	_RouteNameName[23:34]:        CreateUser,
-	_RouteNameLowerName[23:34]:   CreateUser,
-	_RouteNameName[34:44]:        ListUsers,
-	_RouteNameLowerName[34:44]:   ListUsers,
-	_RouteNameName[44:52]:        GetUser,
-	_RouteNameLowerName[44:52]:   GetUser,
-	_RouteNameName[52:63]:        UpdateUser,
-	_RouteNameLowerName[52:63]:   UpdateUser,
-	_RouteNameName[63:74]:        DeleteUser,
-	_RouteNameLowerName[63:74]:   DeleteUser,
-	_RouteNameName[74:89]:        ChangePassword,
-	_RouteNameLowerName[74:89]:   ChangePassword,
-	_RouteNameName[89:103]:       UpdateProfile,
-	_RouteNameLowerName[89:103]:  UpdateProfile,
-	_RouteNameName[103:114]:      CreateTeam,
-	_RouteNameLowerName[103:114]: CreateTeam,
-	_RouteNameName[114:124]:      ListTeams,
-	_RouteNameLowerName[114:124]: ListTeams,
-	_RouteNameName[124:132]:      GetTeam,
-	_RouteNameLowerName[124:132]: GetTeam,
-	_RouteNameName[132:143]:      UpdateTeam,
-	_RouteNameLowerName[132:143]: UpdateTeam,
-	_RouteNameName[143:154]:      DeleteTeam,
-	_RouteNameLowerName[143:154]: DeleteTeam,
-	_RouteNameName[154:172]:      CreateTeamMember,
-	_RouteNameLowerName[154:172]: CreateTeamMember,
-	_RouteNameName[172:190]:      UpdateTeamMember,
-	_RouteNameLowerName[172:190]: UpdateTeamMember,
-	_RouteNameName[190:208]:      DeleteTeamMember,
-	_RouteNameLowerName[190:208]: DeleteTeamMember,
-	_RouteNameName[208:223]:      CreatePipeline,
-	_RouteNameLowerName[208:223]: CreatePipeline,
-	_RouteNameName[223:238]:      UpdatePipeline,
-	_RouteNameLowerName[223:238]: UpdatePipeline,
-	_RouteNameName[238:250]:      GetPipeline,
-	_RouteNameLowerName[238:250]: GetPipeline,
-	_RouteNameName[250:265]:      DeletePipeline,
-	_RouteNameLowerName[250:265]: DeletePipeline,
-	_RouteNameName[265:279]:      ListPipelines,
-	_RouteNameLowerName[265:279]: ListPipelines,
-	_RouteNameName[279:297]:      GetPipelineImage,
-	_RouteNameLowerName[279:297]: GetPipelineImage,
-	_RouteNameName[297:318]:      CreatePipelineImage,
-	_RouteNameLowerName[297:318]: CreatePipelineImage,
-	_RouteNameName[318:338]:      TriggerPipelineJob,
-	_RouteNameLowerName[318:338]: TriggerPipelineJob,
-	_RouteNameName[338:354]:      GetPipelineJob,
-	_RouteNameLowerName[338:354]: GetPipelineJob,
-	_RouteNameName[354:370]:      CreateJobBuild,
-	_RouteNameLowerName[354:370]: CreateJobBuild,
-	_RouteNameName[370:392]:      CreateRetryJobBuild,
-	_RouteNameLowerName[370:392]: CreateRetryJobBuild,
-	_RouteNameName[392:408]:      UpdateJobBuild,
-	_RouteNameLowerName[392:408]: UpdateJobBuild,
-	_RouteNameName[408:424]:      DeleteJobBuild,
-	_RouteNameLowerName[408:424]: DeleteJobBuild,
-	_RouteNameName[424:439]:      ListJobBuilds,
-	_RouteNameLowerName[424:439]: ListJobBuilds,
-	_RouteNameName[439:463]:      InsertBuildGetVersion,
-	_RouteNameLowerName[439:463]: InsertBuildGetVersion,
-	_RouteNameName[463:486]:      FindBuildGetVersions,
-	_RouteNameLowerName[463:486]: FindBuildGetVersions,
-	_RouteNameName[486:499]:      GetJobBuild,
-	_RouteNameLowerName[486:499]: GetJobBuild,
-	_RouteNameName[499:515]:      CancelJobBuild,
-	_RouteNameLowerName[499:515]: CancelJobBuild,
-	_RouteNameName[515:530]:      RetryJobBuild,
-	_RouteNameLowerName[515:530]: RetryJobBuild,
-	_RouteNameName[530:549]:      StartPendingBuild,
-	_RouteNameLowerName[530:549]: StartPendingBuild,
-	_RouteNameName[549:574]:      FindOldestPendingBuild,
-	_RouteNameLowerName[549:574]: FindOldestPendingBuild,
-	_RouteNameName[574:608]:      NotifySerialGroupPendingBuilds,
-	_RouteNameLowerName[574:608]: NotifySerialGroupPendingBuilds,
-	_RouteNameName[608:629]:      GetPipelineResource,
-	_RouteNameLowerName[608:629]: GetPipelineResource,
-	_RouteNameName[629:653]:      UpdatePipelineResource,
-	_RouteNameLowerName[629:653]: UpdatePipelineResource,
-	_RouteNameName[653:678]:      TriggerPipelineResource,
-	_RouteNameLowerName[653:678]: TriggerPipelineResource,
-	_RouteNameName[678:701]:      CreateResourceVersion,
-	_RouteNameLowerName[678:701]: CreateResourceVersion,
-	_RouteNameName[701:723]:      ListResourceVersions,
-	_RouteNameLowerName[701:723]: ListResourceVersions,
-	_RouteNameName[723:743]:      PinResourceVersion,
-	_RouteNameLowerName[723:743]: PinResourceVersion,
-	_RouteNameName[743:765]:      UnpinResourceVersion,
-	_RouteNameLowerName[743:765]: UnpinResourceVersion,
-	_RouteNameName[765:789]:      TriggerResourceVersion,
-	_RouteNameLowerName[765:789]: TriggerResourceVersion,
-	_RouteNameName[789:804]:      WebhookTrigger,
-	_RouteNameLowerName[789:804]: WebhookTrigger,
-	_RouteNameName[804:828]:      RegenerateWebhookToken,
-	_RouteNameLowerName[804:828]: RegenerateWebhookToken,
-	_RouteNameName[828:842]:      CreateTrigger,
-	_RouteNameLowerName[828:842]: CreateTrigger,
-	_RouteNameName[842:861]:      ListTriggersAfter,
-	_RouteNameLowerName[842:861]: ListTriggersAfter,
-	_RouteNameName[861:876]:      ExportDatabase,
-	_RouteNameLowerName[861:876]: ExportDatabase,
-	_RouteNameName[876:890]:      PausePipeline,
-	_RouteNameLowerName[876:890]: PausePipeline,
-	_RouteNameName[890:906]:      UnpausePipeline,
-	_RouteNameLowerName[890:906]: UnpausePipeline,
-	_RouteNameName[906:915]:      PauseJob,
-	_RouteNameLowerName[906:915]: PauseJob,
-	_RouteNameName[915:926]:      UnpauseJob,
-	_RouteNameLowerName[915:926]: UnpauseJob,
-	_RouteNameName[926:937]:      GetVersion,
-	_RouteNameLowerName[926:937]: GetVersion,
-	_RouteNameName[937:953]:      WorkerHeartbeat,
-	_RouteNameLowerName[937:953]: WorkerHeartbeat,
-	_RouteNameName[953:965]:      ListWorkers,
-	_RouteNameLowerName[953:965]: ListWorkers,
-	_RouteNameName[965:979]:      WorkersHealth,
-	_RouteNameLowerName[965:979]: WorkersHealth,
-	_RouteNameName[979:992]:      DeleteWorker,
-	_RouteNameLowerName[979:992]: DeleteWorker,
+	_RouteNameName[0:10]:           UserLogin,
+	_RouteNameLowerName[0:10]:      UserLogin,
+	_RouteNameName[10:23]:          RefreshToken,
+	_RouteNameLowerName[10:23]:     RefreshToken,
+	_RouteNameName[23:34]:          CreateUser,
+	_RouteNameLowerName[23:34]:     CreateUser,
+	_RouteNameName[34:44]:          ListUsers,
+	_RouteNameLowerName[34:44]:     ListUsers,
+	_RouteNameName[44:52]:          GetUser,
+	_RouteNameLowerName[44:52]:     GetUser,
+	_RouteNameName[52:63]:          UpdateUser,
+	_RouteNameLowerName[52:63]:     UpdateUser,
+	_RouteNameName[63:74]:          DeleteUser,
+	_RouteNameLowerName[63:74]:     DeleteUser,
+	_RouteNameName[74:89]:          ChangePassword,
+	_RouteNameLowerName[74:89]:     ChangePassword,
+	_RouteNameName[89:103]:         UpdateProfile,
+	_RouteNameLowerName[89:103]:    UpdateProfile,
+	_RouteNameName[103:114]:        CreateTeam,
+	_RouteNameLowerName[103:114]:   CreateTeam,
+	_RouteNameName[114:124]:        ListTeams,
+	_RouteNameLowerName[114:124]:   ListTeams,
+	_RouteNameName[124:132]:        GetTeam,
+	_RouteNameLowerName[124:132]:   GetTeam,
+	_RouteNameName[132:143]:        UpdateTeam,
+	_RouteNameLowerName[132:143]:   UpdateTeam,
+	_RouteNameName[143:154]:        DeleteTeam,
+	_RouteNameLowerName[143:154]:   DeleteTeam,
+	_RouteNameName[154:172]:        CreateTeamMember,
+	_RouteNameLowerName[154:172]:   CreateTeamMember,
+	_RouteNameName[172:190]:        UpdateTeamMember,
+	_RouteNameLowerName[172:190]:   UpdateTeamMember,
+	_RouteNameName[190:208]:        DeleteTeamMember,
+	_RouteNameLowerName[190:208]:   DeleteTeamMember,
+	_RouteNameName[208:223]:        CreatePipeline,
+	_RouteNameLowerName[208:223]:   CreatePipeline,
+	_RouteNameName[223:238]:        UpdatePipeline,
+	_RouteNameLowerName[223:238]:   UpdatePipeline,
+	_RouteNameName[238:250]:        GetPipeline,
+	_RouteNameLowerName[238:250]:   GetPipeline,
+	_RouteNameName[250:265]:        DeletePipeline,
+	_RouteNameLowerName[250:265]:   DeletePipeline,
+	_RouteNameName[265:279]:        ListPipelines,
+	_RouteNameLowerName[265:279]:   ListPipelines,
+	_RouteNameName[279:297]:        GetPipelineImage,
+	_RouteNameLowerName[279:297]:   GetPipelineImage,
+	_RouteNameName[297:318]:        CreatePipelineImage,
+	_RouteNameLowerName[297:318]:   CreatePipelineImage,
+	_RouteNameName[318:338]:        TriggerPipelineJob,
+	_RouteNameLowerName[318:338]:   TriggerPipelineJob,
+	_RouteNameName[338:354]:        GetPipelineJob,
+	_RouteNameLowerName[338:354]:   GetPipelineJob,
+	_RouteNameName[354:370]:        CreateJobBuild,
+	_RouteNameLowerName[354:370]:   CreateJobBuild,
+	_RouteNameName[370:392]:        CreateRetryJobBuild,
+	_RouteNameLowerName[370:392]:   CreateRetryJobBuild,
+	_RouteNameName[392:408]:        UpdateJobBuild,
+	_RouteNameLowerName[392:408]:   UpdateJobBuild,
+	_RouteNameName[408:424]:        DeleteJobBuild,
+	_RouteNameLowerName[408:424]:   DeleteJobBuild,
+	_RouteNameName[424:439]:        ListJobBuilds,
+	_RouteNameLowerName[424:439]:   ListJobBuilds,
+	_RouteNameName[439:463]:        InsertBuildGetVersion,
+	_RouteNameLowerName[439:463]:   InsertBuildGetVersion,
+	_RouteNameName[463:486]:        FindBuildGetVersions,
+	_RouteNameLowerName[463:486]:   FindBuildGetVersions,
+	_RouteNameName[486:499]:        GetJobBuild,
+	_RouteNameLowerName[486:499]:   GetJobBuild,
+	_RouteNameName[499:515]:        CancelJobBuild,
+	_RouteNameLowerName[499:515]:   CancelJobBuild,
+	_RouteNameName[515:530]:        RetryJobBuild,
+	_RouteNameLowerName[515:530]:   RetryJobBuild,
+	_RouteNameName[530:549]:        StartPendingBuild,
+	_RouteNameLowerName[530:549]:   StartPendingBuild,
+	_RouteNameName[549:574]:        FindOldestPendingBuild,
+	_RouteNameLowerName[549:574]:   FindOldestPendingBuild,
+	_RouteNameName[574:608]:        NotifySerialGroupPendingBuilds,
+	_RouteNameLowerName[574:608]:   NotifySerialGroupPendingBuilds,
+	_RouteNameName[608:632]:        EvaluateDownstreamJobs,
+	_RouteNameLowerName[608:632]:   EvaluateDownstreamJobs,
+	_RouteNameName[632:653]:        GetPipelineResource,
+	_RouteNameLowerName[632:653]:   GetPipelineResource,
+	_RouteNameName[653:677]:        UpdatePipelineResource,
+	_RouteNameLowerName[653:677]:   UpdatePipelineResource,
+	_RouteNameName[677:702]:        TriggerPipelineResource,
+	_RouteNameLowerName[677:702]:   TriggerPipelineResource,
+	_RouteNameName[702:725]:        CreateResourceVersion,
+	_RouteNameLowerName[702:725]:   CreateResourceVersion,
+	_RouteNameName[725:747]:        ListResourceVersions,
+	_RouteNameLowerName[725:747]:   ListResourceVersions,
+	_RouteNameName[747:767]:        PinResourceVersion,
+	_RouteNameLowerName[747:767]:   PinResourceVersion,
+	_RouteNameName[767:789]:        UnpinResourceVersion,
+	_RouteNameLowerName[767:789]:   UnpinResourceVersion,
+	_RouteNameName[789:813]:        TriggerResourceVersion,
+	_RouteNameLowerName[789:813]:   TriggerResourceVersion,
+	_RouteNameName[813:828]:        WebhookTrigger,
+	_RouteNameLowerName[813:828]:   WebhookTrigger,
+	_RouteNameName[828:852]:        RegenerateWebhookToken,
+	_RouteNameLowerName[828:852]:   RegenerateWebhookToken,
+	_RouteNameName[852:866]:        CreateTrigger,
+	_RouteNameLowerName[852:866]:   CreateTrigger,
+	_RouteNameName[866:885]:        ListTriggersAfter,
+	_RouteNameLowerName[866:885]:   ListTriggersAfter,
+	_RouteNameName[885:900]:        ExportDatabase,
+	_RouteNameLowerName[885:900]:   ExportDatabase,
+	_RouteNameName[900:914]:        PausePipeline,
+	_RouteNameLowerName[900:914]:   PausePipeline,
+	_RouteNameName[914:930]:        UnpausePipeline,
+	_RouteNameLowerName[914:930]:   UnpausePipeline,
+	_RouteNameName[930:939]:        PauseJob,
+	_RouteNameLowerName[930:939]:   PauseJob,
+	_RouteNameName[939:950]:        UnpauseJob,
+	_RouteNameLowerName[939:950]:   UnpauseJob,
+	_RouteNameName[950:961]:        GetVersion,
+	_RouteNameLowerName[950:961]:   GetVersion,
+	_RouteNameName[961:977]:        WorkerHeartbeat,
+	_RouteNameLowerName[961:977]:   WorkerHeartbeat,
+	_RouteNameName[977:989]:        ListWorkers,
+	_RouteNameLowerName[977:989]:   ListWorkers,
+	_RouteNameName[989:1003]:       WorkersHealth,
+	_RouteNameLowerName[989:1003]:  WorkersHealth,
+	_RouteNameName[1003:1016]:      DeleteWorker,
+	_RouteNameLowerName[1003:1016]: DeleteWorker,
 }
 
 var _RouteNameNames = []string{
@@ -254,28 +257,29 @@ var _RouteNameNames = []string{
 	_RouteNameName[530:549],
 	_RouteNameName[549:574],
 	_RouteNameName[574:608],
-	_RouteNameName[608:629],
-	_RouteNameName[629:653],
-	_RouteNameName[653:678],
-	_RouteNameName[678:701],
-	_RouteNameName[701:723],
-	_RouteNameName[723:743],
-	_RouteNameName[743:765],
-	_RouteNameName[765:789],
-	_RouteNameName[789:804],
-	_RouteNameName[804:828],
-	_RouteNameName[828:842],
-	_RouteNameName[842:861],
-	_RouteNameName[861:876],
-	_RouteNameName[876:890],
-	_RouteNameName[890:906],
-	_RouteNameName[906:915],
-	_RouteNameName[915:926],
-	_RouteNameName[926:937],
-	_RouteNameName[937:953],
-	_RouteNameName[953:965],
-	_RouteNameName[965:979],
-	_RouteNameName[979:992],
+	_RouteNameName[608:632],
+	_RouteNameName[632:653],
+	_RouteNameName[653:677],
+	_RouteNameName[677:702],
+	_RouteNameName[702:725],
+	_RouteNameName[725:747],
+	_RouteNameName[747:767],
+	_RouteNameName[767:789],
+	_RouteNameName[789:813],
+	_RouteNameName[813:828],
+	_RouteNameName[828:852],
+	_RouteNameName[852:866],
+	_RouteNameName[866:885],
+	_RouteNameName[885:900],
+	_RouteNameName[900:914],
+	_RouteNameName[914:930],
+	_RouteNameName[930:939],
+	_RouteNameName[939:950],
+	_RouteNameName[950:961],
+	_RouteNameName[961:977],
+	_RouteNameName[977:989],
+	_RouteNameName[989:1003],
+	_RouteNameName[1003:1016],
 }
 
 // RouteNameString retrieves an enum value from the enum constants string name.

--- a/worker/service.go
+++ b/worker/service.go
@@ -513,6 +513,11 @@ func (w *Worker) processJob(ctx context.Context, m workitem.Body, cwd string, pp
 		if err := w.updateBuild(ctx, m, b); err != nil {
 			return
 		}
+		// Trigger downstream jobs with passed constraints immediately
+		if err := w.pikoci.EvaluateDownstreamJobs(ctx, m.TeamCanonical, m.PipelineCanonical, j.Name); err != nil {
+			w.logger.Error("failed to evaluate downstream jobs",
+				"pipeline", m.PipelineCanonical, "job", j.Name, "error", err)
+		}
 		w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.OnSuccess, "on_success", resolved, exportedVars, "succeeded")
 	} else {
 		// Ensure local b reflects the Failed status set by failBuild (which

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -55,6 +55,9 @@ func newTestWorker(ctrl *gomock.Controller) (*Worker, *mock.Service) {
 			return &build.Build{ID: createBuildCounter, BuildNumber: fmt.Sprintf("%d", createBuildCounter)}, nil
 		}).AnyTimes()
 
+	// EvaluateDownstreamJobs is called after a build succeeds; allow it globally.
+	svc.EXPECT().EvaluateDownstreamJobs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
 	w := &Worker{
 		pikoci: svc,
 		logger: logger,
@@ -260,6 +263,7 @@ func TestInsertBuildGetVersion_CalledWithCorrectArgs(t *testing.T) {
 	// Don't use newTestWorker — we need precise control over InsertBuildGetVersion.
 	svc := mock.NewService(ctrl)
 	svc.EXPECT().NotifySerialGroupPendingBuilds(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	svc.EXPECT().EvaluateDownstreamJobs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	svc.EXPECT().GetJobBuild(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, _, _, _ string, bn string) (*build.Build, error) {


### PR DESCRIPTION
## Summary

- Extract scheduler's `evaluateJob` logic into `EvaluateDownstreamJobs` service method
- Worker calls it immediately after a build succeeds for near-instant downstream triggering
- Scheduler remains as a 10s fallback
- `StartUoW` transaction prevents duplicate builds from concurrent workers
- `DownstreamEvaluator` interface with two-phase init avoids circular dependency
- HTTP endpoint `POST .../evaluate-downstream` for remote workers
- 7 unit tests covering ready, not-ready, pending-exists, pinned, relevance filter, multi-input, for_each group expansion

Closes #496