### PR TITLE
fix: persist runner override for notification_type, resource_type, and secret_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Persist `runner` override for `notification_type`, `resource_type`, and `secret_type`. The field was parsed from HCL but never saved to the database, silently dropping runner override configuration on reload ([#506](https://github.com/PikoCI/pikoci/issues/506))
 - Pipeline updates no longer unpause paused jobs. The `paused` state is now exclusively managed by the dedicated pause/unpause actions, preventing HCL-parsed zero values from overwriting runtime state ([#495](https://github.com/PikoCI/pikoci/issues/495))
 - New jobs with `trigger = true` no longer replay the entire version backlog. Jobs now record a `baseline_version_id` at creation time, and the scheduler only considers versions newer than that baseline ([#492](https://github.com/PikoCI/pikoci/issues/492))
 

--- a/pikoci/mysql/migrate/migrations/V36RunnerOverride.go
+++ b/pikoci/mysql/migrate/migrations/V36RunnerOverride.go
@@ -1,0 +1,8 @@
+package migrations
+
+var V36RunnerOverride = Migration{
+	Name: "RunnerOverride",
+	SQL: `ALTER TABLE notification_types ADD COLUMN runner TEXT;
+ALTER TABLE resource_types ADD COLUMN runner TEXT;
+ALTER TABLE secret_types ADD COLUMN runner TEXT;`,
+}

--- a/pikoci/mysql/migrate/migrations/migrations.go
+++ b/pikoci/mysql/migrate/migrations/migrations.go
@@ -16,7 +16,7 @@ type Migration struct {
 // Migrations is the ordered list of all schema migrations. It is defined as
 // a fixed-size array so that the compiler catches ordering conflicts when
 // multiple developers add migrations concurrently.
-var Migrations = [36]Migration{
+var Migrations = [37]Migration{
 	V0Initial,
 	V1ResourceCheckInterval,
 	V2JobsAndBuilds,
@@ -53,4 +53,5 @@ var Migrations = [36]Migration{
 	V33ClearQueuesColumn,
 	V34WorkerTags,
 	V35BaselineVersionID,
+	V36RunnerOverride,
 }

--- a/pikoci/mysql/notification_type.go
+++ b/pikoci/mysql/notification_type.go
@@ -26,17 +26,23 @@ type dbNotificationType struct {
 	Source sql.NullString
 	Notify sql.NullString
 	Params sql.NullString
+	Runner sql.NullString
 }
 
 func newDBNotificationType(nt notiftype.NotificationType) dbNotificationType {
 	p, _ := json.Marshal(nt.Params)
 	n, _ := json.Marshal(nt.Notify)
-	return dbNotificationType{
+	dbnt := dbNotificationType{
 		Name:   toNullString(nt.Name),
 		Source: toNullString(nt.Source),
 		Notify: toNullString(string(n)),
 		Params: toNullString(string(p)),
 	}
+	if nt.Runner != nil {
+		r, _ := json.Marshal(nt.Runner)
+		dbnt.Runner = toNullString(string(r))
+	}
+	return dbnt
 }
 
 func (dbnt *dbNotificationType) toDomainEntity() *notiftype.NotificationType {
@@ -48,6 +54,9 @@ func (dbnt *dbNotificationType) toDomainEntity() *notiftype.NotificationType {
 
 	_ = json.Unmarshal([]byte(dbnt.Params.String), &nt.Params)
 	_ = json.Unmarshal([]byte(dbnt.Notify.String), &nt.Notify)
+	if dbnt.Runner.Valid {
+		_ = json.Unmarshal([]byte(dbnt.Runner.String), &nt.Runner)
+	}
 
 	return nt
 }
@@ -55,15 +64,15 @@ func (dbnt *dbNotificationType) toDomainEntity() *notiftype.NotificationType {
 func (r *NotificationTypeRepository) Create(ctx context.Context, tc, pn string, nt notiftype.NotificationType) (uint32, error) {
 	dbnt := newDBNotificationType(nt)
 	res, err := r.querier.ExecContext(ctx, `
-		INSERT INTO notification_types(name, source, notify, params, pipeline_id)
-		VALUES (?, ?, ?, ?,
+		INSERT INTO notification_types(name, source, notify, params, runner, pipeline_id)
+		VALUES (?, ?, ?, ?, ?,
 			(
 				SELECT p.id
 				FROM pipelines AS p
 				JOIN teams AS t
 					ON p.team_id = t.id
 				WHERE t.canonical = ? AND p.canonical = ?
-			))`, dbnt.Name, dbnt.Source, dbnt.Notify, dbnt.Params, tc, pn)
+			))`, dbnt.Name, dbnt.Source, dbnt.Notify, dbnt.Params, dbnt.Runner, tc, pn)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -80,7 +89,7 @@ func (r *NotificationTypeRepository) Update(ctx context.Context, tc, pn, tn stri
 	dbnt := newDBNotificationType(nt)
 	res, err := r.querier.ExecContext(ctx, `
 		UPDATE notification_types AS nt
-		SET name = ?, source = ?, notify = ?, params = ?
+		SET name = ?, source = ?, notify = ?, params = ?, runner = ?
 		FROM (
 			SELECT nt.id
 			FROM notification_types AS nt
@@ -91,7 +100,7 @@ func (r *NotificationTypeRepository) Update(ctx context.Context, tc, pn, tn stri
 			WHERE t.canonical = ? AND p.canonical = ? AND nt.name = ?
 		) AS ntt
 		WHERE ntt.id = nt.id
-	`, dbnt.Name, dbnt.Source, dbnt.Notify, dbnt.Params, tc, pn, tn)
+	`, dbnt.Name, dbnt.Source, dbnt.Notify, dbnt.Params, dbnt.Runner, tc, pn, tn)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -106,7 +115,7 @@ func (r *NotificationTypeRepository) Update(ctx context.Context, tc, pn, tn stri
 
 func (r *NotificationTypeRepository) Find(ctx context.Context, tc, pn, tn string) (*notiftype.NotificationType, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT nt.id, nt.name, nt.source, nt.notify, nt.params
+		SELECT nt.id, nt.name, nt.source, nt.notify, nt.params, nt.runner
 		FROM notification_types AS nt
 		JOIN pipelines AS p
 			ON nt.pipeline_id = p.id
@@ -125,7 +134,7 @@ func (r *NotificationTypeRepository) Find(ctx context.Context, tc, pn, tn string
 
 func (r *NotificationTypeRepository) Filter(ctx context.Context, tc, pn string) ([]*notiftype.NotificationType, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT nt.id, nt.name, nt.source, nt.notify, nt.params
+		SELECT nt.id, nt.name, nt.source, nt.notify, nt.params, nt.runner
 		FROM notification_types AS nt
 		JOIN pipelines AS p
 			ON nt.pipeline_id = p.id
@@ -180,6 +189,7 @@ func scanNotificationType(s sqlr.Scanner) (*notiftype.NotificationType, error) {
 		&nt.Source,
 		&nt.Notify,
 		&nt.Params,
+		&nt.Runner,
 	)
 
 	if err != nil {

--- a/pikoci/mysql/notification_type_test.go
+++ b/pikoci/mysql/notification_type_test.go
@@ -1,0 +1,91 @@
+package mysql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/pikoci/pikoci/pikoci/mysql"
+	"github.com/pikoci/pikoci/pikoci/notiftype"
+	"github.com/pikoci/pikoci/pikoci/utils"
+)
+
+func TestNotificationType_RunnerPersistence(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'nt-pipe', 'nt-pipe')`)
+	require.NoError(t, err)
+
+	repo := mysql.NewNotificationTypeRepository(db)
+
+	nt := notiftype.NotificationType{
+		Name:   "slack",
+		Source: "github.com/example/slack",
+		Notify: &utils.RunnerCommand{Runner: "exec", Args: []string{"notify"}},
+		Runner: &utils.RunnerOverride{Runner: "docker", Args: []string{"--privileged"}},
+	}
+
+	_, err = repo.Create(ctx, "main", "nt-pipe", nt)
+	require.NoError(t, err)
+
+	found, err := repo.Find(ctx, "main", "nt-pipe", "slack")
+	require.NoError(t, err)
+
+	require.NotNil(t, found.Runner, "Runner should be persisted")
+	assert.Equal(t, "docker", found.Runner.Runner)
+	assert.Equal(t, []string{"--privileged"}, found.Runner.Args)
+}
+
+func TestNotificationType_NilRunnerPersistence(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'nt-nil', 'nt-nil')`)
+	require.NoError(t, err)
+
+	repo := mysql.NewNotificationTypeRepository(db)
+
+	nt := notiftype.NotificationType{
+		Name:   "slack",
+		Source: "github.com/example/slack",
+		Notify: &utils.RunnerCommand{Runner: "exec", Args: []string{"notify"}},
+	}
+
+	_, err = repo.Create(ctx, "main", "nt-nil", nt)
+	require.NoError(t, err)
+
+	found, err := repo.Find(ctx, "main", "nt-nil", "slack")
+	require.NoError(t, err)
+	assert.Nil(t, found.Runner, "Runner should be nil when not set")
+}
+
+func TestNotificationType_UpdateRunner(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'nt-upd', 'nt-upd')`)
+	require.NoError(t, err)
+
+	repo := mysql.NewNotificationTypeRepository(db)
+
+	nt := notiftype.NotificationType{
+		Name:   "slack",
+		Source: "github.com/example/slack",
+		Notify: &utils.RunnerCommand{Runner: "exec", Args: []string{"notify"}},
+		Runner: &utils.RunnerOverride{Runner: "docker", Args: []string{"--privileged"}},
+	}
+
+	_, err = repo.Create(ctx, "main", "nt-upd", nt)
+	require.NoError(t, err)
+
+	// Update to remove Runner
+	nt.Runner = nil
+	err = repo.Update(ctx, "main", "nt-upd", "slack", nt)
+	require.NoError(t, err)
+
+	found, err := repo.Find(ctx, "main", "nt-upd", "slack")
+	require.NoError(t, err)
+	assert.Nil(t, found.Runner, "Runner should be nil after update removes it")
+}

--- a/pikoci/mysql/resource_type.go
+++ b/pikoci/mysql/resource_type.go
@@ -29,6 +29,7 @@ type dbResourceType struct {
 	Pull   sql.NullString
 	Push   sql.NullString
 	Cache  sql.NullBool
+	Runner sql.NullString
 }
 
 func newDBResourceType(rt restype.ResourceType) dbResourceType {
@@ -36,7 +37,7 @@ func newDBResourceType(rt restype.ResourceType) dbResourceType {
 	c, _ := json.Marshal(rt.Check)
 	pl, _ := json.Marshal(rt.Pull)
 	ps, _ := json.Marshal(rt.Push)
-	return dbResourceType{
+	dbrt := dbResourceType{
 		Name:   toNullString(rt.Name),
 		Source: toNullString(rt.Source),
 		Params: toNullString(string(i)),
@@ -45,6 +46,11 @@ func newDBResourceType(rt restype.ResourceType) dbResourceType {
 		Push:   toNullString(string(ps)),
 		Cache:  sql.NullBool{Bool: rt.Cache, Valid: true},
 	}
+	if rt.Runner != nil {
+		r, _ := json.Marshal(rt.Runner)
+		dbrt.Runner = toNullString(string(r))
+	}
+	return dbrt
 }
 
 func (dbrt *dbResourceType) toDomainEntity() *restype.ResourceType {
@@ -59,6 +65,9 @@ func (dbrt *dbResourceType) toDomainEntity() *restype.ResourceType {
 	_ = json.Unmarshal([]byte(dbrt.Check.String), &rt.Check)
 	_ = json.Unmarshal([]byte(dbrt.Pull.String), &rt.Pull)
 	_ = json.Unmarshal([]byte(dbrt.Push.String), &rt.Push)
+	if dbrt.Runner.Valid {
+		_ = json.Unmarshal([]byte(dbrt.Runner.String), &rt.Runner)
+	}
 
 	return rt
 }
@@ -66,8 +75,8 @@ func (dbrt *dbResourceType) toDomainEntity() *restype.ResourceType {
 func (r *ResourceTypeRepository) Create(ctx context.Context, tc, pn string, rt restype.ResourceType) (uint32, error) {
 	dbrt := newDBResourceType(rt)
 	res, err := r.querier.ExecContext(ctx, `
-		INSERT INTO resource_types(name, source, `+"`check`"+`, pull, push, params, cache, pipeline_id)
-		VALUES (?, ?, ?, ?, ?, ?, ?,
+		INSERT INTO resource_types(name, source, `+"`check`"+`, pull, push, params, cache, runner, pipeline_id)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?,
 			-- pipeline_id
 			(
 				SELECT p.id
@@ -75,7 +84,7 @@ func (r *ResourceTypeRepository) Create(ctx context.Context, tc, pn string, rt r
 				JOIN teams AS t
 					ON p.team_id = t.id
 				WHERE t.canonical = ? AND p.canonical = ?
-			))`, dbrt.Name, dbrt.Source, dbrt.Check, dbrt.Pull, dbrt.Push, dbrt.Params, dbrt.Cache, tc, pn)
+			))`, dbrt.Name, dbrt.Source, dbrt.Check, dbrt.Pull, dbrt.Push, dbrt.Params, dbrt.Cache, dbrt.Runner, tc, pn)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -92,7 +101,7 @@ func (r *ResourceTypeRepository) Update(ctx context.Context, tc, pn, rtn string,
 	dbrt := newDBResourceType(rt)
 	res, err := r.querier.ExecContext(ctx, `
 		UPDATE resource_types AS rt
-		SET name = ?, source = ?, `+"`check`"+` = ?, pull = ?, push = ?, params = ?, cache = ?
+		SET name = ?, source = ?, `+"`check`"+` = ?, pull = ?, push = ?, params = ?, cache = ?, runner = ?
 		FROM (
 			SELECT rt.id
 			FROM resource_types AS rt
@@ -103,7 +112,7 @@ func (r *ResourceTypeRepository) Update(ctx context.Context, tc, pn, rtn string,
 			WHERE t.canonical = ? AND p.canonical = ? AND rt.name = ?
 		) AS rtt
 		WHERE rtt.id = rt.id
-	`, dbrt.Name, dbrt.Source, dbrt.Check, dbrt.Pull, dbrt.Push, dbrt.Params, dbrt.Cache, tc, pn, rtn)
+	`, dbrt.Name, dbrt.Source, dbrt.Check, dbrt.Pull, dbrt.Push, dbrt.Params, dbrt.Cache, dbrt.Runner, tc, pn, rtn)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -118,7 +127,7 @@ func (r *ResourceTypeRepository) Update(ctx context.Context, tc, pn, rtn string,
 
 func (r *ResourceTypeRepository) Find(ctx context.Context, tc, pn, rtn string) (*restype.ResourceType, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT rt.id, rt.name, rt.source, `+"rt.`check`"+`, rt.pull, rt.push, rt.params, rt.cache
+		SELECT rt.id, rt.name, rt.source, `+"rt.`check`"+`, rt.pull, rt.push, rt.params, rt.cache, rt.runner
 		FROM resource_types AS rt
 		JOIN pipelines AS p
 			ON rt.pipeline_id = p.id
@@ -137,7 +146,7 @@ func (r *ResourceTypeRepository) Find(ctx context.Context, tc, pn, rtn string) (
 
 func (r *ResourceTypeRepository) Filter(ctx context.Context, tc, pn string) ([]*restype.ResourceType, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT rt.id, rt.name, rt.source, `+"rt.`check`"+`, rt.pull, rt.push, rt.params, rt.cache
+		SELECT rt.id, rt.name, rt.source, `+"rt.`check`"+`, rt.pull, rt.push, rt.params, rt.cache, rt.runner
 		FROM resource_types AS rt
 		JOIN pipelines AS p
 			ON rt.pipeline_id = p.id
@@ -195,6 +204,7 @@ func scanResourceType(s sqlr.Scanner) (*restype.ResourceType, error) {
 		&rt.Push,
 		&rt.Params,
 		&rt.Cache,
+		&rt.Runner,
 	)
 
 	if err != nil {

--- a/pikoci/mysql/resource_type_test.go
+++ b/pikoci/mysql/resource_type_test.go
@@ -1,0 +1,92 @@
+package mysql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/pikoci/pikoci/pikoci/mysql"
+	"github.com/pikoci/pikoci/pikoci/restype"
+	"github.com/pikoci/pikoci/pikoci/utils"
+)
+
+func TestResourceType_RunnerPersistence(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'rt-pipe', 'rt-pipe')`)
+	require.NoError(t, err)
+
+	repo := mysql.NewResourceTypeRepository(db)
+
+	rt := restype.ResourceType{
+		Name:   "git",
+		Source: "github.com/example/git",
+		Check:  &utils.RunnerCommand{Runner: "exec", Args: []string{"check"}},
+		Pull:   &utils.RunnerCommand{Runner: "exec", Args: []string{"pull"}},
+		Runner: &utils.RunnerOverride{Runner: "docker", Args: []string{"--privileged"}},
+	}
+
+	_, err = repo.Create(ctx, "main", "rt-pipe", rt)
+	require.NoError(t, err)
+
+	found, err := repo.Find(ctx, "main", "rt-pipe", "git")
+	require.NoError(t, err)
+
+	require.NotNil(t, found.Runner, "Runner should be persisted")
+	assert.Equal(t, "docker", found.Runner.Runner)
+	assert.Equal(t, []string{"--privileged"}, found.Runner.Args)
+}
+
+func TestResourceType_NilRunnerPersistence(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'rt-nil', 'rt-nil')`)
+	require.NoError(t, err)
+
+	repo := mysql.NewResourceTypeRepository(db)
+
+	rt := restype.ResourceType{
+		Name:   "git",
+		Source: "github.com/example/git",
+		Check:  &utils.RunnerCommand{Runner: "exec", Args: []string{"check"}},
+	}
+
+	_, err = repo.Create(ctx, "main", "rt-nil", rt)
+	require.NoError(t, err)
+
+	found, err := repo.Find(ctx, "main", "rt-nil", "git")
+	require.NoError(t, err)
+	assert.Nil(t, found.Runner, "Runner should be nil when not set")
+}
+
+func TestResourceType_UpdateRunner(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'rt-upd', 'rt-upd')`)
+	require.NoError(t, err)
+
+	repo := mysql.NewResourceTypeRepository(db)
+
+	rt := restype.ResourceType{
+		Name:   "git",
+		Source: "github.com/example/git",
+		Check:  &utils.RunnerCommand{Runner: "exec", Args: []string{"check"}},
+		Runner: &utils.RunnerOverride{Runner: "docker", Args: []string{"--privileged"}},
+	}
+
+	_, err = repo.Create(ctx, "main", "rt-upd", rt)
+	require.NoError(t, err)
+
+	// Update to remove Runner
+	rt.Runner = nil
+	err = repo.Update(ctx, "main", "rt-upd", "git", rt)
+	require.NoError(t, err)
+
+	found, err := repo.Find(ctx, "main", "rt-upd", "git")
+	require.NoError(t, err)
+	assert.Nil(t, found.Runner, "Runner should be nil after update removes it")
+}

--- a/pikoci/mysql/secret_type.go
+++ b/pikoci/mysql/secret_type.go
@@ -27,19 +27,25 @@ type dbSecretType struct {
 	Params sql.NullString
 	Config sql.NullString
 	Get    sql.NullString
+	Runner sql.NullString
 }
 
 func newDBSecretType(st sectype.SecretType) dbSecretType {
 	p, _ := json.Marshal(st.Params)
 	c, _ := json.Marshal(st.Config)
 	g, _ := json.Marshal(st.Get)
-	return dbSecretType{
+	dbst := dbSecretType{
 		Name:   toNullString(st.Name),
 		Source: toNullString(st.Source),
 		Params: toNullString(string(p)),
 		Config: toNullString(string(c)),
 		Get:    toNullString(string(g)),
 	}
+	if st.Runner != nil {
+		r, _ := json.Marshal(st.Runner)
+		dbst.Runner = toNullString(string(r))
+	}
+	return dbst
 }
 
 func (dbst *dbSecretType) toDomainEntity() *sectype.SecretType {
@@ -52,6 +58,9 @@ func (dbst *dbSecretType) toDomainEntity() *sectype.SecretType {
 	_ = json.Unmarshal([]byte(dbst.Params.String), &st.Params)
 	_ = json.Unmarshal([]byte(dbst.Config.String), &st.Config)
 	_ = json.Unmarshal([]byte(dbst.Get.String), &st.Get)
+	if dbst.Runner.Valid {
+		_ = json.Unmarshal([]byte(dbst.Runner.String), &st.Runner)
+	}
 
 	return st
 }
@@ -59,8 +68,8 @@ func (dbst *dbSecretType) toDomainEntity() *sectype.SecretType {
 func (r *SecretTypeRepository) Create(ctx context.Context, tc, pn string, st sectype.SecretType) (uint32, error) {
 	dbst := newDBSecretType(st)
 	res, err := r.querier.ExecContext(ctx, `
-		INSERT INTO secret_types(name, source, get, params, config, pipeline_id)
-		VALUES (?, ?, ?, ?, ?,
+		INSERT INTO secret_types(name, source, get, params, config, runner, pipeline_id)
+		VALUES (?, ?, ?, ?, ?, ?,
 			-- pipeline_id
 			(
 				SELECT p.id
@@ -68,7 +77,7 @@ func (r *SecretTypeRepository) Create(ctx context.Context, tc, pn string, st sec
 				JOIN teams AS t
 					ON p.team_id = t.id
 				WHERE t.canonical = ? AND p.canonical = ?
-			))`, dbst.Name, dbst.Source, dbst.Get, dbst.Params, dbst.Config, tc, pn)
+			))`, dbst.Name, dbst.Source, dbst.Get, dbst.Params, dbst.Config, dbst.Runner, tc, pn)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -85,7 +94,7 @@ func (r *SecretTypeRepository) Update(ctx context.Context, tc, pn, stn string, s
 	dbst := newDBSecretType(st)
 	res, err := r.querier.ExecContext(ctx, `
 		UPDATE secret_types
-		SET name = ?, source = ?, get = ?, params = ?, config = ?
+		SET name = ?, source = ?, get = ?, params = ?, config = ?, runner = ?
 		WHERE id = (
 			SELECT st.id
 			FROM (SELECT * FROM secret_types) AS st
@@ -95,7 +104,7 @@ func (r *SecretTypeRepository) Update(ctx context.Context, tc, pn, stn string, s
 				ON p.team_id = t.id
 			WHERE t.canonical = ? AND p.canonical = ? AND st.name = ?
 		)
-	`, dbst.Name, dbst.Source, dbst.Get, dbst.Params, dbst.Config, tc, pn, stn)
+	`, dbst.Name, dbst.Source, dbst.Get, dbst.Params, dbst.Config, dbst.Runner, tc, pn, stn)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -110,7 +119,7 @@ func (r *SecretTypeRepository) Update(ctx context.Context, tc, pn, stn string, s
 
 func (r *SecretTypeRepository) Find(ctx context.Context, tc, pn, stn string) (*sectype.SecretType, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT st.id, st.name, st.source, st.get, st.params, st.config
+		SELECT st.id, st.name, st.source, st.get, st.params, st.config, st.runner
 		FROM secret_types AS st
 		JOIN pipelines AS p
 			ON st.pipeline_id = p.id
@@ -129,7 +138,7 @@ func (r *SecretTypeRepository) Find(ctx context.Context, tc, pn, stn string) (*s
 
 func (r *SecretTypeRepository) Filter(ctx context.Context, tc, pn string) ([]*sectype.SecretType, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT st.id, st.name, st.source, st.get, st.params, st.config
+		SELECT st.id, st.name, st.source, st.get, st.params, st.config, st.runner
 		FROM secret_types AS st
 		JOIN pipelines AS p
 			ON st.pipeline_id = p.id
@@ -185,6 +194,7 @@ func scanSecretType(s sqlr.Scanner) (*sectype.SecretType, error) {
 		&st.Get,
 		&st.Params,
 		&st.Config,
+		&st.Runner,
 	)
 
 	if err != nil {

--- a/pikoci/mysql/secret_type_test.go
+++ b/pikoci/mysql/secret_type_test.go
@@ -1,0 +1,91 @@
+package mysql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/pikoci/pikoci/pikoci/mysql"
+	"github.com/pikoci/pikoci/pikoci/sectype"
+	"github.com/pikoci/pikoci/pikoci/utils"
+)
+
+func TestSecretType_RunnerPersistence(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'st-pipe', 'st-pipe')`)
+	require.NoError(t, err)
+
+	repo := mysql.NewSecretTypeRepository(db)
+
+	st := sectype.SecretType{
+		Name:   "vault",
+		Source: "github.com/example/vault",
+		Get:    utils.RunnerCommand{Runner: "exec", Args: []string{"get"}},
+		Runner: &utils.RunnerOverride{Runner: "docker", Args: []string{"--privileged"}},
+	}
+
+	_, err = repo.Create(ctx, "main", "st-pipe", st)
+	require.NoError(t, err)
+
+	found, err := repo.Find(ctx, "main", "st-pipe", "vault")
+	require.NoError(t, err)
+
+	require.NotNil(t, found.Runner, "Runner should be persisted")
+	assert.Equal(t, "docker", found.Runner.Runner)
+	assert.Equal(t, []string{"--privileged"}, found.Runner.Args)
+}
+
+func TestSecretType_NilRunnerPersistence(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'st-nil', 'st-nil')`)
+	require.NoError(t, err)
+
+	repo := mysql.NewSecretTypeRepository(db)
+
+	st := sectype.SecretType{
+		Name:   "vault",
+		Source: "github.com/example/vault",
+		Get:    utils.RunnerCommand{Runner: "exec", Args: []string{"get"}},
+	}
+
+	_, err = repo.Create(ctx, "main", "st-nil", st)
+	require.NoError(t, err)
+
+	found, err := repo.Find(ctx, "main", "st-nil", "vault")
+	require.NoError(t, err)
+	assert.Nil(t, found.Runner, "Runner should be nil when not set")
+}
+
+func TestSecretType_UpdateRunner(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'st-upd', 'st-upd')`)
+	require.NoError(t, err)
+
+	repo := mysql.NewSecretTypeRepository(db)
+
+	st := sectype.SecretType{
+		Name:   "vault",
+		Source: "github.com/example/vault",
+		Get:    utils.RunnerCommand{Runner: "exec", Args: []string{"get"}},
+		Runner: &utils.RunnerOverride{Runner: "docker", Args: []string{"--privileged"}},
+	}
+
+	_, err = repo.Create(ctx, "main", "st-upd", st)
+	require.NoError(t, err)
+
+	// Update to remove Runner
+	st.Runner = nil
+	err = repo.Update(ctx, "main", "st-upd", "vault", st)
+	require.NoError(t, err)
+
+	found, err := repo.Find(ctx, "main", "st-upd", "vault")
+	require.NoError(t, err)
+	assert.Nil(t, found.Runner, "Runner should be nil after update removes it")
+}


### PR DESCRIPTION
## Summary

- Add migration V36 adding `runner TEXT` column to `notification_types`, `resource_types`, and `secret_types` tables
- Update DB layer (INSERT, UPDATE, SELECT, Scan) for all three types to marshal/unmarshal the `Runner` field as JSON
- Add tests covering runner persistence, nil-runner round-trip, and update-to-remove scenarios

Closes #506