### PR TITLE
fix: add missing hcl:"runner,block" tag to domain type structs (#507)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Persist `runner` override for `notification_type`, `resource_type`, and `secret_type`. The field was parsed from HCL but never saved to the database, silently dropping runner override configuration on reload ([#506](https://github.com/PikoCI/pikoci/issues/506))
+- Add missing `hcl:"runner,block"` tag to `Runner` field on `ResourceType`, `SecretType`, `NotificationType`, and `Service` domain types. Built-in HCL definitions decoded directly into these types would silently ignore `runner {}` blocks ([#507](https://github.com/PikoCI/pikoci/issues/507))
 - Pipeline updates no longer unpause paused jobs. The `paused` state is now exclusively managed by the dedicated pause/unpause actions, preventing HCL-parsed zero values from overwriting runtime state ([#495](https://github.com/PikoCI/pikoci/issues/495))
 - New jobs with `trigger = true` no longer replay the entire version backlog. Jobs now record a `baseline_version_id` at creation time, and the scheduler only considers versions newer than that baseline ([#492](https://github.com/PikoCI/pikoci/issues/492))
 

--- a/pikoci/builtin/builtin_test.go
+++ b/pikoci/builtin/builtin_test.go
@@ -3,9 +3,13 @@ package builtin_test
 import (
 	"testing"
 
+	"github.com/hashicorp/hcl/v2/hclsimple"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/pikoci/pikoci/pikoci/builtin"
+	"github.com/pikoci/pikoci/pikoci/notiftype"
+	"github.com/pikoci/pikoci/pikoci/restype"
+	"github.com/pikoci/pikoci/pikoci/sectype"
 )
 
 func TestResourceTypes(t *testing.T) {
@@ -161,6 +165,68 @@ func TestNotificationTypeHCL(t *testing.T) {
 	data, ok = builtin.NotificationTypeHCL("nonexistent")
 	assert.False(t, ok)
 	assert.Nil(t, data)
+}
+
+func TestRunnerBlockParsedOnDomainTypes(t *testing.T) {
+	t.Run("resource_type", func(t *testing.T) {
+		hcl := []byte(`
+resource_type "test" {
+  check "exec" {
+    path = "/bin/true"
+  }
+  runner "docker" {}
+}
+`)
+		var wrapper struct {
+			ResourceTypes []restype.ResourceType `hcl:"resource_type,block"`
+		}
+		err := hclsimple.Decode("test.hcl", hcl, nil, &wrapper)
+		require.NoError(t, err)
+		require.Len(t, wrapper.ResourceTypes, 1)
+		rt := wrapper.ResourceTypes[0]
+		require.NotNil(t, rt.Runner)
+		assert.Equal(t, "docker", rt.Runner.Runner)
+	})
+
+	t.Run("secret_type", func(t *testing.T) {
+		hcl := []byte(`
+secret_type "test" {
+  get "exec" {
+    path = "/bin/true"
+  }
+  runner "docker" {}
+}
+`)
+		var wrapper struct {
+			SecretTypes []sectype.SecretType `hcl:"secret_type,block"`
+		}
+		err := hclsimple.Decode("test.hcl", hcl, nil, &wrapper)
+		require.NoError(t, err)
+		require.Len(t, wrapper.SecretTypes, 1)
+		st := wrapper.SecretTypes[0]
+		require.NotNil(t, st.Runner)
+		assert.Equal(t, "docker", st.Runner.Runner)
+	})
+
+	t.Run("notification_type", func(t *testing.T) {
+		hcl := []byte(`
+notification_type "test" {
+  notify "exec" {
+    path = "/bin/true"
+  }
+  runner "docker" {}
+}
+`)
+		var wrapper struct {
+			NotificationTypes []notiftype.NotificationType `hcl:"notification_type,block"`
+		}
+		err := hclsimple.Decode("test.hcl", hcl, nil, &wrapper)
+		require.NoError(t, err)
+		require.Len(t, wrapper.NotificationTypes, 1)
+		nt := wrapper.NotificationTypes[0]
+		require.NotNil(t, nt.Runner)
+		assert.Equal(t, "docker", nt.Runner.Runner)
+	})
 }
 
 func TestServiceHCL(t *testing.T) {

--- a/pikoci/notiftype/notification_type.go
+++ b/pikoci/notiftype/notification_type.go
@@ -15,5 +15,5 @@ type NotificationType struct {
 	Notify *utils.RunnerCommand `json:"notify,omitempty" hcl:"notify,block"`
 	Params []string             `json:"params" hcl:"params,optional"`
 
-	Runner *utils.RunnerOverride `json:"runner,omitempty"`
+	Runner *utils.RunnerOverride `json:"runner,omitempty" hcl:"runner,block"`
 }

--- a/pikoci/restype/resource_type.go
+++ b/pikoci/restype/resource_type.go
@@ -18,6 +18,6 @@ type ResourceType struct {
 	Pull  *utils.RunnerCommand `json:"pull,omitempty" hcl:"pull,block"`
 	Push  *utils.RunnerCommand `json:"push,omitempty" hcl:"push,block"`
 
-	Runner *utils.RunnerOverride `json:"runner,omitempty"`
+	Runner *utils.RunnerOverride `json:"runner,omitempty" hcl:"runner,block"`
 	Cache  bool                  `json:"cache" hcl:"cache,optional"`
 }

--- a/pikoci/sectype/secret_type.go
+++ b/pikoci/sectype/secret_type.go
@@ -16,5 +16,5 @@ type SecretType struct {
 	Config map[string]string   `json:"config,omitempty"`
 	Get    utils.RunnerCommand `json:"get" hcl:"get,block"`
 
-	Runner *utils.RunnerOverride `json:"runner,omitempty"`
+	Runner *utils.RunnerOverride `json:"runner,omitempty" hcl:"runner,block"`
 }

--- a/pikoci/service/service.go
+++ b/pikoci/service/service.go
@@ -18,7 +18,7 @@ type Service struct {
 	ReadyCheck *ReadyCheck         `json:"ready_check,omitempty"`
 	Stop       utils.RunnerCommand `json:"stop"`
 
-	Runner *utils.RunnerOverride `json:"runner,omitempty"`
+	Runner *utils.RunnerOverride `json:"runner,omitempty" hcl:"runner,block"`
 }
 
 // ReadyCheck defines a health check that determines when a service is ready


### PR DESCRIPTION
## Summary

- Add missing `hcl:"runner,block"` struct tag to the `Runner` field on `ResourceType`, `SecretType`, `NotificationType`, and `Service` domain types
- The `builtin` package decodes embedded HCL directly into these structs via `hclsimple.Decode`, so any `runner {}` block would be silently ignored
- Add `TestRunnerBlockParsedOnDomainTypes` verifying HCL decoding works for all three type categories


Closes #507