### PR TITLE
refactor: consolidate duplicated clickLink into shared helper (#447)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Refactored
+
+- Consolidate duplicated `clickLink` method from seven Backbone views into a single shared helper in `namespace.js`. Uses `event.target.closest('a')` for safe anchor resolution and adds a null guard for clicks on non-anchor areas ([#447](https://github.com/PikoCI/pikoci/issues/447))
+
 ### Fixed
 
 - Persist `runner` override for `notification_type`, `resource_type`, and `secret_type`. The field was parsed from HCL but never saved to the database, silently dropping runner override configuration on reload ([#506](https://github.com/PikoCI/pikoci/issues/506))

--- a/pikoci/transport/http/assets/js/app/namespace.js
+++ b/pikoci/transport/http/assets/js/app/namespace.js
@@ -114,6 +114,14 @@ export function withLoading(btn, ajaxFn) {
   return xhr;
 }
 
+export function clickLink(event) {
+  event.preventDefault();
+  var target = event.target.closest('a');
+  if (!target) return;
+  var url = new URL(target.href);
+  window.app.router.navigate(url.pathname, { trigger: true });
+}
+
 export var addSessionFunctions = function(data) {
   return _.extend(window.app.session.data(), data);
 };

--- a/pikoci/transport/http/assets/js/app/views/layout.js
+++ b/pikoci/transport/http/assets/js/app/views/layout.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import { session, apiNotice } from '../collections.js';
-import { syncThemeSwitch } from '../namespace.js';
+import { clickLink, syncThemeSwitch } from '../namespace.js';
 
 export var MainView = Backbone.View.extend({
   template: _.template($('#main-view').html()),
@@ -138,7 +138,7 @@ export var BreadcrumbView = Backbone.View.extend({
   tagName: "nav",
   template: _.template($('#breadcrumb-view').html()),
   events: {
-    'click a': 'clickLink',
+    'click a': clickLink,
   },
   initialize: function(opts) {
     opts = opts||{};
@@ -157,10 +157,5 @@ export var BreadcrumbView = Backbone.View.extend({
       showPipelines: this.showPipelines,
     }));
     return this;
-  },
-  clickLink: function(event) {
-    event.preventDefault();
-    var url = new URL(event.target.href);
-    window.app.router.navigate(url.pathname, { trigger: true });
   },
 });

--- a/pikoci/transport/http/assets/js/app/views/pipelines.js
+++ b/pikoci/transport/http/assets/js/app/views/pipelines.js
@@ -2,7 +2,7 @@
 
 import { session } from '../collections.js';
 import { PipelineImage } from '../models.js';
-import { addSessionFunctions, fetchInterval, pikoTimeAgo, withLoading } from '../namespace.js';
+import { addSessionFunctions, clickLink, fetchInterval, pikoTimeAgo, withLoading } from '../namespace.js';
 import { PipelineGraphView, PikoGraphZoom } from './editor.js';
 
 export var PipelinesView = Backbone.View.extend({
@@ -14,7 +14,7 @@ export var PipelinesView = Backbone.View.extend({
     this.collection.fetch();
   },
   events: {
-    'click #pipelines-new': 'clickLink',
+    'click #pipelines-new': clickLink,
     'click #live-status-toggle': 'toggleLive',
   },
   addPipeline: function(pp) {
@@ -61,11 +61,6 @@ export var PipelinesView = Backbone.View.extend({
     }
     this.cardViews = [];
     Backbone.View.prototype.remove.call(this);
-  },
-  clickLink: function(event) {
-    event.preventDefault();
-    var url = new URL(event.target.href);
-    window.app.router.navigate(url.pathname, { trigger: true });
   },
 });
 

--- a/pikoci/transport/http/assets/js/app/views/teams.js
+++ b/pikoci/transport/http/assets/js/app/views/teams.js
@@ -2,7 +2,7 @@
 
 import { session, teams, Users } from '../collections.js';
 import { Team } from '../models.js';
-import { addSessionFunctions, withLoading } from '../namespace.js';
+import { addSessionFunctions, clickLink, withLoading } from '../namespace.js';
 
 export var TeamsView = Backbone.View.extend({
   template: _.template($('#teams-view').html()),
@@ -13,7 +13,7 @@ export var TeamsView = Backbone.View.extend({
     teams.fetch();
   },
   events: {
-    'click #team-new': 'clickLink',
+    'click #team-new': clickLink,
   },
   addTeam: function(t) {
     var view = new TeamRowView({model: t});
@@ -28,11 +28,6 @@ export var TeamsView = Backbone.View.extend({
     });
     return this;
   },
-  clickLink: function(event) {
-    event.preventDefault();
-    var url = new URL(event.target.href);
-    window.app.router.navigate(url.pathname, { trigger: true });
-  },
 });
 
 var TeamRowView = Backbone.View.extend({
@@ -40,19 +35,14 @@ var TeamRowView = Backbone.View.extend({
   tagName: "div",
   className: "piko-team-row",
   events: {
-    'click': 'clickLink',
-    'click #pipelines':   'clickLink',
-    'click #manage':      'clickLink',
+    'click': clickLink,
+    'click #pipelines':   clickLink,
+    'click #manage':      clickLink,
     'click #delete':      'clickDelete',
   },
   render: function () {
     this.$el.html(this.template(addSessionFunctions(this.model.toJSON())));
     return this;
-  },
-  clickLink: function(event) {
-    event.preventDefault();
-    var url = new URL(event.target.href);
-    window.app.router.navigate(url.pathname, { trigger: true });
   },
   clickDelete: function(event) {
     event.preventDefault();
@@ -101,7 +91,7 @@ export var TeamShowView = Backbone.View.extend({
   events: {
     'submit form': 'clickUpdate',
     'click #new-member': 'clickNewMember',
-    'click a.btn-primary': 'clickLink',
+    'click a.btn-primary': clickLink,
   },
   render: function () {
     this.$el.html(this.template(addSessionFunctions(this.model.toJSON())));
@@ -121,11 +111,6 @@ export var TeamShowView = Backbone.View.extend({
   renderMember: function(m) {
     var view = new TeamShowMemberRowView({team: this.model, model: m});
     this.$el.find('tbody').append(view.render().el);
-  },
-  clickLink: function(event) {
-    event.preventDefault();
-    var url = new URL(event.currentTarget.href);
-    window.app.router.navigate(url.pathname, { trigger: true });
   },
   clickUpdate: function(event){
     event.preventDefault();

--- a/pikoci/transport/http/assets/js/app/views/users.js
+++ b/pikoci/transport/http/assets/js/app/views/users.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import { session, userSessionKey } from '../collections.js';
-import { withLoading } from '../namespace.js';
+import { clickLink, withLoading } from '../namespace.js';
 
 export var UsersListView = Backbone.View.extend({
   template: _.template($('#users-list-view').html()),
@@ -11,7 +11,7 @@ export var UsersListView = Backbone.View.extend({
     this.collection.fetch();
   },
   events: {
-    'click a': 'clickLink',
+    'click a': clickLink,
   },
   render: function() {
     this.$el.html(this.template());
@@ -25,28 +25,17 @@ export var UsersListView = Backbone.View.extend({
     var view = new UsersRowView({model: m});
     this.$('#users-table-body').append(view.render().el);
   },
-  clickLink: function(event) {
-    event.preventDefault();
-    var target = event.target.closest('a');
-    var url = new URL(target.href);
-    window.app.router.navigate(url.pathname, { trigger: true });
-  },
 });
 
 var UsersRowView = Backbone.View.extend({
   template: _.template($('#users-row-view').html()),
   tagName: "tr",
   events: {
-    'click a': 'clickLink',
+    'click a': clickLink,
   },
   render: function() {
     this.$el.html(this.template(this.model.toJSON()));
     return this;
-  },
-  clickLink: function(event) {
-    event.preventDefault();
-    var url = new URL(event.target.href);
-    window.app.router.navigate(url.pathname, { trigger: true });
   },
 });
 


### PR DESCRIPTION
## Summary

- Extract duplicated `clickLink` method from 7 Backbone views into a shared `clickLink` helper in `namespace.js`
- Use `event.target.closest('a')` for safe anchor resolution (works when click target is a child element inside `<a>`)
- Add null guard for clicks on non-anchor areas (fixes pre-existing bug in `TeamRowView`)

Closes #447