### PR TITLE
feat: support referencing specific for_each job instances (#512)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support referencing specific `for_each` job instances in `passed`, notification `jobs`, and notification `exclude` (e.g., `passed = ["test--a"]`). Also fixes a bug where notification `jobs`/`exclude` with group names never matched `for_each` instance builds at runtime ([#512](https://github.com/PikoCI/pikoci/issues/512))
 - Cross-reference validation in `ReadPipeline()`: pipeline saves now catch invalid references to non-existent jobs, resources, runners, notifications, resource types, notification types, and secret types. All errors are reported at once. Also surfaces graph rendering errors in the pipeline editor and show views ([#497](https://github.com/PikoCI/pikoci/issues/497))
 - `pipeline validate` CLI command: validate pipeline HCL files for syntax and structural errors without a running server. Supports `--var key=value` and `--vars vars.json` flags. Useful for CI/CD checks, pre-commit hooks, and headless environments ([#155](https://github.com/PikoCI/pikoci/issues/155))
 - Release pipeline with .deb/.rpm packages: binaries are now named `pikoci-<os>-<arch>` (with `.exe` for Windows), Linux packages (.deb and .rpm) are generated via nfpm for amd64/arm64, and a SHA256SUMS file is included in GitHub Releases. The release job is split into discrete tasks (install-tools, build-binaries, package-deb-rpm, create-release) with tool caching ([#346](https://github.com/PikoCI/pikoci/issues/346))

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -268,3 +268,91 @@ job "build" {
 	assert.Contains(t, err.Error(), "references unknown notification_type")
 	assert.Contains(t, err.Error(), "references unknown runner")
 }
+
+func TestReadPipeline_PassedSpecificForEachInstance_Valid(t *testing.T) {
+	hcl := `
+resource "git" "my-repo" {}
+job "test" {
+  for_each = toset(["a", "b"])
+  get "git" "my-repo" {}
+  task "echo" {
+    run "exec" { path = "echo" }
+  }
+}
+job "deploy" {
+  get "git" "my-repo" {
+    passed = ["test--a"]
+  }
+  task "echo" {
+    run "exec" { path = "echo" }
+  }
+}
+`
+	_, err := pikoci.ReadPipeline(context.Background(), []byte(hcl), nil)
+	assert.NoError(t, err)
+}
+
+func TestReadPipeline_PassedSpecificForEachInstance_Invalid(t *testing.T) {
+	hcl := `
+resource "git" "my-repo" {}
+job "test" {
+  for_each = toset(["a", "b"])
+  get "git" "my-repo" {}
+  task "echo" {
+    run "exec" { path = "echo" }
+  }
+}
+job "deploy" {
+  get "git" "my-repo" {
+    passed = ["test--c"]
+  }
+  task "echo" {
+    run "exec" { path = "echo" }
+  }
+}
+`
+	_, err := pikoci.ReadPipeline(context.Background(), []byte(hcl), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown job "test--c" in passed`)
+}
+
+func TestReadPipeline_NotificationJobsSpecificForEachInstance_Valid(t *testing.T) {
+	hcl := `
+notification_type "slack" {
+  notify "exec" {}
+}
+notification "slack" "my-notif" {
+  on = ["success"]
+  jobs = ["test--a"]
+}
+job "test" {
+  for_each = toset(["a", "b"])
+  task "echo" {
+    run "exec" { path = "echo" }
+  }
+}
+`
+	_, err := pikoci.ReadPipeline(context.Background(), []byte(hcl), nil)
+	assert.NoError(t, err)
+}
+
+func TestReadPipeline_NotificationExcludeSpecificForEachInstance_Invalid(t *testing.T) {
+	hcl := `
+notification_type "slack" {
+  notify "exec" {}
+}
+notification "slack" "my-notif" {
+  on = ["success"]
+  exclude = ["test--c"]
+}
+job "test" {
+  for_each = toset(["a", "b"])
+  task "echo" {
+    run "exec" { path = "echo" }
+  }
+}
+`
+	_, err := pikoci.ReadPipeline(context.Background(), []byte(hcl), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown job "test--c"`)
+}

--- a/docs/Notifications.md
+++ b/docs/Notifications.md
@@ -149,6 +149,48 @@ notification "slack" "skip-lint" {
 }
 ```
 
+#### Scoping with for_each jobs
+
+Both `jobs` and `exclude` support `for_each` group names and specific instance names:
+
+- **Group name** (e.g., `"test"`) — matches **all** instances of the for_each job (`test--a`, `test--b`, etc.)
+- **Specific instance** (e.g., `"test--a"`) — matches only that particular instance
+
+```hcl
+job "test" {
+  for_each = toset(["unit", "integration"])
+  task "run" {
+    run "exec" {
+      path = "/bin/sh"
+      args = ["-c", "make test-${each.value}"]
+    }
+  }
+}
+
+# Notify for ALL test instances (group name)
+notification "slack" "all-tests" {
+  params { webhook_url = var.slack_webhook }
+  on = ["failure"]
+  jobs = ["test"]  # matches test--unit AND test--integration
+}
+
+# Notify only for integration test failures (specific instance)
+notification "slack" "integration-alert" {
+  params { webhook_url = var.slack_webhook }
+  on = ["failure"]
+  jobs = ["test--integration"]  # matches only test--integration
+}
+
+# Exclude unit tests from notifications (specific instance)
+notification "slack" "skip-unit" {
+  params { webhook_url = var.slack_webhook }
+  on = ["failure"]
+  exclude = ["test--unit"]  # skips test--unit, still fires for test--integration
+}
+```
+
+Job names in `jobs` and `exclude` are validated at pipeline load time — referencing a non-existent instance produces a validation error.
+
 ## github-check
 
 The `github-check` notification type reports build status back to GitHub as check runs. It uses a GitHub App for authentication.

--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -475,6 +475,34 @@ job "deploy" {
 }
 ```
 
+You can also reference a **specific instance** by its expanded name (`{jobname}--{key}`). This is useful when a downstream job only depends on one particular instance rather than the entire group:
+
+```hcl
+job "test" {
+  for_each = toset(["unit", "integration"])
+
+  get "git" "code" { trigger = true }
+  task "run" {
+    run "exec" {
+      path = "/bin/sh"
+      args = ["-c", "make test-${each.value}"]
+    }
+  }
+}
+
+job "quick-deploy" {
+  get "git" "code" {
+    trigger = true
+    passed  = ["test--unit"]  # only waits for the unit test instance
+  }
+  task "deploy" {
+    run "exec" { path = "./deploy.sh" }
+  }
+}
+```
+
+Both group names and specific instance names are validated at pipeline load time — referencing a non-existent instance (e.g., `"test--lint"` when only `"unit"` and `"integration"` exist) produces a validation error.
+
 #### Lifecycle on pipeline update
 
 - Adding a key creates a new job instance

--- a/pikoci/testdata/cron.hcl
+++ b/pikoci/testdata/cron.hcl
@@ -49,6 +49,32 @@ job "deploy-prod" {
   }
 }
 
+job "validate" {
+  for_each = toset(["lint", "vet"])
+  get "cron" "my_cron" {
+    trigger = true
+  }
+  task "run" {
+    run "exec" {
+      path = "/bin/sh"
+      args = ["-ec", "echo 'validate ${each.value}'"]
+    }
+  }
+}
+
+job "deploy-after-lint" {
+  get "cron" "my_cron" {
+    trigger = true
+    passed  = ["validate--lint"]
+  }
+  task "deploy" {
+    run "exec" {
+      path = "/bin/sh"
+      args = ["-ec", "echo 'deploying after lint only'"]
+    }
+  }
+}
+
 job "monitor" {
   get "cron" "my_cron" {
     trigger = true

--- a/worker/service.go
+++ b/worker/service.go
@@ -1706,10 +1706,11 @@ func (w *Worker) runAutoNotifications(ctx context.Context, m workitem.Body, b *b
 			continue
 		}
 
-		// Check job scope
+		// Check job scope (expand for_each group names to instance names)
 		if len(n.Jobs) > 0 {
+			expandedJobs := resolvePassedJobNames(n.Jobs, pp)
 			found := false
-			for _, jn := range n.Jobs {
+			for _, jn := range expandedJobs {
 				if jn == m.JobName {
 					found = true
 					break
@@ -1720,8 +1721,9 @@ func (w *Worker) runAutoNotifications(ctx context.Context, m workitem.Body, b *b
 			}
 		}
 		if len(n.Exclude) > 0 {
+			expandedExclude := resolvePassedJobNames(n.Exclude, pp)
 			excluded := false
-			for _, jn := range n.Exclude {
+			for _, jn := range expandedExclude {
 				if jn == m.JobName {
 					excluded = true
 					break

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -5783,6 +5783,456 @@ func TestRunAutoNotifications_ExcludeJob(t *testing.T) {
 	require.Len(t, capturedBuild.Steps, 1)
 }
 
+func TestRunAutoNotifications_JobScope_ForEachGroup(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := workitem.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "test--a",
+		BuildID:           10,
+		BuildNumber:       "400",
+	}
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:           1,
+				Name:         "test--a",
+				ForEachGroup: "test",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "echo",
+							Run:  utils.RunnerCommand{Runner: "exec", Args: []string{"done"}, Params: map[string]string{"path": "echo"}},
+						},
+					},
+				},
+			},
+			{
+				ID:           2,
+				Name:         "test--b",
+				ForEachGroup: "test",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "echo",
+							Run:  utils.RunnerCommand{Runner: "exec", Args: []string{"done"}, Params: map[string]string{"path": "echo"}},
+						},
+					},
+				},
+			},
+		},
+		Notifications: []notification.Notification{
+			{
+				ID:        1,
+				Type:      "echo-notifier",
+				Name:      "group-alert",
+				Canonical: "echo-notifier.group-alert",
+				On:        []string{"success"},
+				Jobs:      []string{"test"}, // group name should match for_each instances
+			},
+		},
+		NotificationTypes: []notiftype.NotificationType{
+			{
+				ID:   1,
+				Name: "echo-notifier",
+				Notify: &utils.RunnerCommand{
+					Runner: "exec",
+					Args:   []string{"notified"},
+					Params: map[string]string{"path": "echo"},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().GetPipelineJob(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName).
+		Return(&pp.Jobs[0], nil)
+
+	var capturedBuild build.Build
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "400", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, b build.Build) error {
+			capturedBuild = b
+			return nil
+		}).AnyTimes()
+
+	w.processJob(ctx, m, cwd, pp)
+
+	assert.Equal(t, build.Succeeded, capturedBuild.Status)
+	// Notification scoped to group "test" should fire for instance "test--a"
+	require.Len(t, capturedBuild.Steps, 2) // task + notification
+}
+
+func TestRunAutoNotifications_ExcludeJob_ForEachGroup(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := workitem.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "test--a",
+		BuildID:           10,
+		BuildNumber:       "401",
+	}
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:           1,
+				Name:         "test--a",
+				ForEachGroup: "test",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "echo",
+							Run:  utils.RunnerCommand{Runner: "exec", Args: []string{"done"}, Params: map[string]string{"path": "echo"}},
+						},
+					},
+				},
+			},
+			{
+				ID:           2,
+				Name:         "test--b",
+				ForEachGroup: "test",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "echo",
+							Run:  utils.RunnerCommand{Runner: "exec", Args: []string{"done"}, Params: map[string]string{"path": "echo"}},
+						},
+					},
+				},
+			},
+		},
+		Notifications: []notification.Notification{
+			{
+				ID:        1,
+				Type:      "echo-notifier",
+				Name:      "exclude-group-alert",
+				Canonical: "echo-notifier.exclude-group-alert",
+				On:        []string{"success"},
+				Exclude:   []string{"test"}, // group name should exclude for_each instances
+			},
+		},
+		NotificationTypes: []notiftype.NotificationType{
+			{
+				ID:   1,
+				Name: "echo-notifier",
+				Notify: &utils.RunnerCommand{
+					Runner: "exec",
+					Args:   []string{"should not appear"},
+					Params: map[string]string{"path": "echo"},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().GetPipelineJob(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName).
+		Return(&pp.Jobs[0], nil)
+
+	var capturedBuild build.Build
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "401", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, b build.Build) error {
+			capturedBuild = b
+			return nil
+		}).AnyTimes()
+
+	w.processJob(ctx, m, cwd, pp)
+
+	assert.Equal(t, build.Succeeded, capturedBuild.Status)
+	// Notification excluded group "test", so it should NOT fire for instance "test--a"
+	require.Len(t, capturedBuild.Steps, 1) // task only
+}
+
+func TestRunAutoNotifications_JobScope_SpecificInstance(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := workitem.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "test--a",
+		BuildID:           10,
+		BuildNumber:       "402",
+	}
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:           1,
+				Name:         "test--a",
+				ForEachGroup: "test",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "echo",
+							Run:  utils.RunnerCommand{Runner: "exec", Args: []string{"done"}, Params: map[string]string{"path": "echo"}},
+						},
+					},
+				},
+			},
+			{
+				ID:           2,
+				Name:         "test--b",
+				ForEachGroup: "test",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "echo",
+							Run:  utils.RunnerCommand{Runner: "exec", Args: []string{"done"}, Params: map[string]string{"path": "echo"}},
+						},
+					},
+				},
+			},
+		},
+		Notifications: []notification.Notification{
+			{
+				ID:        1,
+				Type:      "echo-notifier",
+				Name:      "instance-alert",
+				Canonical: "echo-notifier.instance-alert",
+				On:        []string{"success"},
+				Jobs:      []string{"test--a"}, // specific instance, not group
+			},
+		},
+		NotificationTypes: []notiftype.NotificationType{
+			{
+				ID:   1,
+				Name: "echo-notifier",
+				Notify: &utils.RunnerCommand{
+					Runner: "exec",
+					Args:   []string{"notified"},
+					Params: map[string]string{"path": "echo"},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().GetPipelineJob(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName).
+		Return(&pp.Jobs[0], nil)
+
+	var capturedBuild build.Build
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "402", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, b build.Build) error {
+			capturedBuild = b
+			return nil
+		}).AnyTimes()
+
+	w.processJob(ctx, m, cwd, pp)
+
+	assert.Equal(t, build.Succeeded, capturedBuild.Status)
+	// Notification scoped to specific instance "test--a" should fire
+	require.Len(t, capturedBuild.Steps, 2) // task + notification
+}
+
+func TestRunAutoNotifications_JobScope_SpecificInstance_NoMatchOther(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := workitem.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "test--b", // different instance than scoped
+		BuildID:           10,
+		BuildNumber:       "403",
+	}
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:           1,
+				Name:         "test--a",
+				ForEachGroup: "test",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "echo",
+							Run:  utils.RunnerCommand{Runner: "exec", Args: []string{"done"}, Params: map[string]string{"path": "echo"}},
+						},
+					},
+				},
+			},
+			{
+				ID:           2,
+				Name:         "test--b",
+				ForEachGroup: "test",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "echo",
+							Run:  utils.RunnerCommand{Runner: "exec", Args: []string{"done"}, Params: map[string]string{"path": "echo"}},
+						},
+					},
+				},
+			},
+		},
+		Notifications: []notification.Notification{
+			{
+				ID:        1,
+				Type:      "echo-notifier",
+				Name:      "instance-alert",
+				Canonical: "echo-notifier.instance-alert",
+				On:        []string{"success"},
+				Jobs:      []string{"test--a"}, // scoped to test--a only
+			},
+		},
+		NotificationTypes: []notiftype.NotificationType{
+			{
+				ID:   1,
+				Name: "echo-notifier",
+				Notify: &utils.RunnerCommand{
+					Runner: "exec",
+					Args:   []string{"should not appear"},
+					Params: map[string]string{"path": "echo"},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().GetPipelineJob(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName).
+		Return(&pp.Jobs[1], nil)
+
+	var capturedBuild build.Build
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "403", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, b build.Build) error {
+			capturedBuild = b
+			return nil
+		}).AnyTimes()
+
+	w.processJob(ctx, m, cwd, pp)
+
+	assert.Equal(t, build.Succeeded, capturedBuild.Status)
+	// Notification scoped to "test--a" should NOT fire for "test--b"
+	require.Len(t, capturedBuild.Steps, 1) // task only
+}
+
+func TestRunAutoNotifications_ExcludeJob_SpecificInstance(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := workitem.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "test--b",
+		BuildID:           10,
+		BuildNumber:       "404",
+	}
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:           1,
+				Name:         "test--a",
+				ForEachGroup: "test",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "echo",
+							Run:  utils.RunnerCommand{Runner: "exec", Args: []string{"done"}, Params: map[string]string{"path": "echo"}},
+						},
+					},
+				},
+			},
+			{
+				ID:           2,
+				Name:         "test--b",
+				ForEachGroup: "test",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "echo",
+							Run:  utils.RunnerCommand{Runner: "exec", Args: []string{"done"}, Params: map[string]string{"path": "echo"}},
+						},
+					},
+				},
+			},
+		},
+		Notifications: []notification.Notification{
+			{
+				ID:        1,
+				Type:      "echo-notifier",
+				Name:      "exclude-instance-alert",
+				Canonical: "echo-notifier.exclude-instance-alert",
+				On:        []string{"success"},
+				Exclude:   []string{"test--b"}, // exclude only test--b
+			},
+		},
+		NotificationTypes: []notiftype.NotificationType{
+			{
+				ID:   1,
+				Name: "echo-notifier",
+				Notify: &utils.RunnerCommand{
+					Runner: "exec",
+					Args:   []string{"should not appear"},
+					Params: map[string]string{"path": "echo"},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().GetPipelineJob(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName).
+		Return(&pp.Jobs[1], nil)
+
+	var capturedBuild build.Build
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "404", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, b build.Build) error {
+			capturedBuild = b
+			return nil
+		}).AnyTimes()
+
+	w.processJob(ctx, m, cwd, pp)
+
+	assert.Equal(t, build.Succeeded, capturedBuild.Status)
+	// Notification excluded specific instance "test--b", so it should NOT fire
+	require.Len(t, capturedBuild.Steps, 1) // task only
+}
+
 func TestRunAutoNotifications_NoOnField_Skips(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	w, svc := newTestWorker(ctrl)


### PR DESCRIPTION
## Summary

- Fix bug where notification `jobs`/`exclude` did direct string comparison, so group names never matched `for_each` instance builds at runtime. Expand group names via `resolvePassedJobNames` before comparison.
- Allow specific `for_each` instance references (e.g., `passed = ["test--a"]`, `jobs = ["test--a"]`) in `passed`, notification `jobs`, and notification `exclude`.
- Add documentation for specific instance references in `docs/Pipeline.md` and `docs/Notifications.md`.

Closes #512