### PR TITLE
fix: remap $PIKOCI_OUTPUT for Docker runner tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `$PIKOCI_OUTPUT` now works in Docker runner tasks. The host path is remapped to the container workdir (detected via `-w`/`--workdir`) and injected as an `-e` flag during `$env` expansion ([#519](https://github.com/PikoCI/pikoci/issues/519))
+
 ## [0.5.0] - 2026-06-15
 
 ### Refactored

--- a/deploy/pipeline.hcl
+++ b/deploy/pipeline.hcl
@@ -519,11 +519,14 @@ job "publish-release" {
         # Extract changelog
         BODY=$(sed -n "/^## \[$VERSION\]/,/^## \[/{/^## \[$VERSION\]/d;/^## \[/d;p;}" CHANGELOG.md)
 
-        # Create release and upload all artifacts
-        # Use --clobber to allow retries when a previous attempt partially uploaded
+        # Create release (or reuse existing from a partial retry)
         GH_TOKEN="${var.github_token}" gh release create $TAG \
           --title "$TAG" \
           --notes "$BODY" \
+          --repo PikoCI/pikoci 2>/dev/null || true
+
+        # Upload artifacts (--clobber overwrites assets from partial retries)
+        GH_TOKEN="${var.github_token}" gh release upload $TAG \
           --repo PikoCI/pikoci \
           --clobber \
           builds/pikoci-* \

--- a/deploy/pipeline.hcl
+++ b/deploy/pipeline.hcl
@@ -485,7 +485,7 @@ job "publish-release" {
       cmd   = <<-EOT
         export PATH=/pikoci-tools:$PATH
         cd ${var.git_name}
-        TAG=$GET_PIKOCI_TAG_REF
+        TAG=$GET_PIKOCI_TAG_TAG
         VERSION=$${TAG#v}
 
         # Package for each Linux architecture
@@ -508,7 +508,7 @@ job "publish-release" {
       cmd   = <<-EOT
         export PATH=/pikoci-tools:$PATH
         cd ${var.git_name}
-        TAG=$GET_PIKOCI_TAG_REF
+        TAG=$GET_PIKOCI_TAG_TAG
         VERSION=$${TAG#v}
 
         # Generate SHA256SUMS
@@ -516,26 +516,33 @@ job "publish-release" {
         sha256sum pikoci-linux-* pikoci-darwin-* pikoci-windows-* *.deb *.rpm > SHA256SUMS
         cd ..
 
-        # Extract changelog
-        BODY=$(sed -n "/^## \[$VERSION\]/,/^## \[/{/^## \[$VERSION\]/d;/^## \[/d;p;}" CHANGELOG.md)
+        # Extract changelog for this version
+        CHANGELOG=$(awk '/^## \['"$VERSION"'\]/{found=1; next} found && /^## \[/{exit} found{print}' CHANGELOG.md | sed '/^$/d')
+        if [ -z "$CHANGELOG" ]; then
+          CHANGELOG="See https://github.com/PikoCI/pikoci/releases/tag/$TAG"
+        fi
 
-        # Create release (or reuse existing from a partial retry)
-        GH_TOKEN="${var.github_token}" gh release create $TAG \
-          --title "$TAG" \
-          --notes "$BODY" \
-          --repo PikoCI/pikoci 2>/dev/null || true
+        # Create release if it doesn't already exist (retries reuse the existing one)
+        if ! GH_TOKEN="${var.github_token}" gh release view $TAG --repo PikoCI/pikoci >/dev/null 2>&1; then
+          GH_TOKEN="${var.github_token}" gh release create $TAG \
+            --title "$TAG" \
+            --notes "$CHANGELOG" \
+            --repo PikoCI/pikoci
+        fi
 
         # Upload artifacts (--clobber overwrites assets from partial retries)
         GH_TOKEN="${var.github_token}" gh release upload $TAG \
           --repo PikoCI/pikoci \
           --clobber \
-          builds/pikoci-* \
+          builds/pikoci-linux-* \
+          builds/pikoci-darwin-* \
+          builds/pikoci-windows-* \
           builds/*.deb \
           builds/*.rpm \
           builds/SHA256SUMS
 
-        # Export changelog for Discord notification
-        echo "CHANGELOG=$(echo "$BODY" | sed ':a;N;$$!ba;s/\n/\\n/g')" >> "$$PIKOCI_OUTPUT"
+        # Export changelog for Discord notification (escape newlines for parseOutputFile)
+        echo "CHANGELOG=$(echo "$CHANGELOG" | sed ':a;N;$$!ba;s/\n/\\n/g')" >> "$PIKOCI_OUTPUT"
       EOT
       args = [
         "-v", "pikoci-tools:/pikoci-tools",
@@ -545,7 +552,7 @@ job "publish-release" {
 
   on_success {
     notify "discord" "announcements" {
-      message = "🚀 **PikoCI $GET_PIKOCI_TAG_REF** has been released!\n\n$TASK_CREATE_RELEASE_CHANGELOG\n\n🔗 https://github.com/PikoCI/pikoci/releases/tag/$GET_PIKOCI_TAG_REF"
+      message = "🚀 **PikoCI $GET_PIKOCI_TAG_TAG** has been released!\n\n$TASK_CREATE_RELEASE_CHANGELOG\n\n🔗 https://github.com/PikoCI/pikoci/releases/tag/$GET_PIKOCI_TAG_TAG"
     }
   }
 }

--- a/worker/service.go
+++ b/worker/service.go
@@ -2340,6 +2340,16 @@ func (w *Worker) runRunner(ctx context.Context, ru runner.Runner, cwd string, rc
 					args = append(args, "-e", k+"="+v)
 				}
 			}
+			// Inject PIKOCI_OUTPUT with the path remapped from host to
+			// container. Detect the container workdir by scanning for
+			// "-w <path>" in the already-resolved args.
+			if hostPath, ok := envs["PIKOCI_OUTPUT"]; ok {
+				containerPath := hostPath
+				if cw := findContainerWorkdir(args); cw != "" {
+					containerPath = cw + "/" + filepath.Base(hostPath)
+				}
+				args = append(args, "-e", "PIKOCI_OUTPUT="+containerPath)
+			}
 			continue
 		}
 		ea := os.Expand(a, envFn)
@@ -2643,6 +2653,20 @@ var runnerInternalParams = map[string]bool{
 // parameter that should be excluded from $env injection.
 func isRunnerInternalParam(key string) bool {
 	return runnerInternalParams[key]
+}
+
+// findContainerWorkdir scans resolved args for "-w <path>", "--workdir <path>",
+// or "--workdir=<path>" and returns the container workdir path. Returns "" if not found.
+func findContainerWorkdir(args []string) string {
+	for i := 0; i < len(args); i++ {
+		if (args[i] == "-w" || args[i] == "--workdir") && i+1 < len(args) {
+			return args[i+1]
+		}
+		if strings.HasPrefix(args[i], "--workdir=") {
+			return strings.TrimPrefix(args[i], "--workdir=")
+		}
+	}
+	return ""
 }
 
 // validateParams filters userParams through allowedParams, returning accepted

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -2633,6 +2633,179 @@ func TestIsRunnerInternalParam(t *testing.T) {
 	}
 }
 
+func TestFindContainerWorkdir(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "found",
+			args: []string{"run", "--rm", "-v", "/host:/workdir", "-w", "/workdir", "-e", "FOO=bar", "image"},
+			want: "/workdir",
+		},
+		{
+			name: "not found",
+			args: []string{"run", "--rm", "-v", "/host:/data", "image"},
+			want: "",
+		},
+		{
+			name: "w flag at end without value",
+			args: []string{"run", "-w"},
+			want: "",
+		},
+		{
+			name: "custom workdir",
+			args: []string{"run", "-w", "/app/src", "image"},
+			want: "/app/src",
+		},
+		{
+			name: "long form --workdir",
+			args: []string{"run", "--workdir", "/app", "image"},
+			want: "/app",
+		},
+		{
+			name: "long form --workdir=path",
+			args: []string{"run", "--workdir=/app/data", "image"},
+			want: "/app/data",
+		},
+		{
+			name: "workdir at end without value",
+			args: []string{"run", "--workdir"},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, findContainerWorkdir(tt.args))
+		})
+	}
+}
+
+func TestRunRunner_EnvPlaceholder_RemapsPIKOCIOutput(t *testing.T) {
+	// Verifies that $env injects PIKOCI_OUTPUT with remapped container path
+	// when -w is present in the runner args.
+	ctrl := gomock.NewController(t)
+	w, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	cwd := t.TempDir()
+
+	// Runner template with -w /workdir (like the built-in docker runner).
+	ru := runner.Runner{
+		Name: "docker",
+		Run:  utils.RunCommand{Path: "echo", Args: []string{"-w", "/workdir", "$env", "$args"}},
+	}
+
+	rc := utils.RunnerCommand{
+		Runner: "docker",
+		Args:   []string{"hello"},
+		Params: map[string]string{
+			"cmd":           "echo test",
+			"image":         "alpine",
+			"PIKOCI_OUTPUT": cwd + "/.pikoci-output-12345",
+			"GET_REPO_REF":  "abc123",
+		},
+	}
+
+	out, _, _ := w.runRunner(ctx, ru, cwd, rc)
+
+	// The output should contain the remapped PIKOCI_OUTPUT path
+	assert.Contains(t, out, "PIKOCI_OUTPUT=/workdir/.pikoci-output-12345",
+		"PIKOCI_OUTPUT should be remapped to container workdir")
+	// Regular env vars should also be present
+	assert.Contains(t, out, "GET_REPO_REF=abc123")
+}
+
+func TestRunRunner_EnvPlaceholder_DockerTemplate(t *testing.T) {
+	// Simulates the full built-in docker runner template to verify
+	// PIKOCI_OUTPUT remapping works with the real arg layout.
+	ctrl := gomock.NewController(t)
+	w, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	cwd := t.TempDir()
+
+	// Mirror the real docker.hcl template but use echo to inspect args.
+	ru := runner.Runner{
+		Name: "docker",
+		Run: utils.RunCommand{
+			Path: "echo",
+			Args: []string{
+				"run", "--rm",
+				"-v", "$WORKDIR:/workdir",
+				"-w", "/workdir",
+				"$env",
+				"$args",
+				"$image",
+				"/bin/sh", "-ec", "$cmd",
+			},
+		},
+	}
+
+	rc := utils.RunnerCommand{
+		Runner: "docker",
+		Args:   []string{"-v", "cache:/cache"},
+		Params: map[string]string{
+			"cmd":           "echo hello",
+			"image":         "golang:1.25",
+			"PIKOCI_OUTPUT": cwd + "/.pikoci-output-42",
+			"GET_REPO_REF":  "abc123",
+			"TASK_BUILD_VER": "2.0",
+		},
+	}
+
+	out, _, err := w.runRunner(ctx, ru, cwd, rc)
+	require.NoError(t, err)
+
+	// Verify volume mount expanded
+	assert.Contains(t, out, "-v "+cwd+":/workdir")
+	// Verify PIKOCI_OUTPUT remapped to container path
+	assert.Contains(t, out, "PIKOCI_OUTPUT=/workdir/.pikoci-output-42")
+	// Verify regular env vars injected
+	assert.Contains(t, out, "GET_REPO_REF=abc123")
+	assert.Contains(t, out, "TASK_BUILD_VER=2.0")
+	// Verify internal params NOT injected as -e flags
+	assert.NotContains(t, out, "-e cmd=")
+	assert.NotContains(t, out, "-e image=")
+	// Verify image and cmd expanded
+	assert.Contains(t, out, "golang:1.25")
+	assert.Contains(t, out, "echo hello")
+}
+
+func TestRunRunner_EnvPlaceholder_PIKOCIOutputNoWorkdir(t *testing.T) {
+	// When no -w flag is present, PIKOCI_OUTPUT should be injected with the
+	// original host path (no remapping).
+	ctrl := gomock.NewController(t)
+	w, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	cwd := t.TempDir()
+
+	ru := runner.Runner{
+		Name: "custom",
+		Run:  utils.RunCommand{Path: "echo", Args: []string{"$env", "$args"}},
+	}
+
+	hostPath := cwd + "/.pikoci-output-99999"
+	rc := utils.RunnerCommand{
+		Runner: "custom",
+		Args:   []string{"hello"},
+		Params: map[string]string{
+			"cmd":           "echo test",
+			"PIKOCI_OUTPUT": hostPath,
+			"GET_REPO_REF":  "abc123",
+		},
+	}
+
+	out, _, _ := w.runRunner(ctx, ru, cwd, rc)
+
+	// Without -w, the original host path should be used
+	assert.Contains(t, out, "PIKOCI_OUTPUT="+hostPath,
+		"PIKOCI_OUTPUT should use original host path when no -w flag")
+	assert.Contains(t, out, "GET_REPO_REF=abc123")
+}
+
 func TestProcessResourceCheck_RawSecretFormat(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	w, svc := newTestWorker(ctrl)


### PR DESCRIPTION
## Summary

Fixes #519.

- **Remap `PIKOCI_OUTPUT` in `$env` expansion**: During Docker runner arg expansion, detects `-w`/`--workdir`/`--workdir=<path>` in the resolved args and injects `-e PIKOCI_OUTPUT=<container-path>` with the filename remapped from the host `cwd` to the container workdir. When no `-w` flag is present, the original host path is used unchanged.
- **Add `findContainerWorkdir()` helper**: Scans an args slice for `-w`, `--workdir`, or `--workdir=<path>` and returns the container workdir.
- **Restore changelog in deploy pipeline**: The `create-release` Docker task now extracts the changelog from `CHANGELOG.md`, writes it to `$PIKOCI_OUTPUT` (with escaped newlines), and the Discord notification uses `$TASK_CREATE_RELEASE_CHANGELOG`.

