### PR TITLE
feat: show full version+commit in worker list and flag outdated workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Worker list now shows full version with commit hash (e.g., `v0.5.0 (abc1234)`) and flags outdated workers with a warning icon and banner when their version+commit doesn't match the server ([#522](https://github.com/PikoCI/pikoci/issues/522))
+
 ### Fixed
 
 - `$PIKOCI_OUTPUT` now works in Docker runner tasks. The host path is remapped to the container workdir (detected via `-w`/`--workdir`) and injected as an `-e` flag during `$env` expansion ([#519](https://github.com/PikoCI/pikoci/issues/519))

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -216,7 +216,7 @@ func runLocal(ctx context.Context, logger *slog.Logger, pipelineConfig, jobName 
 
 	// Create worker with overrides
 	workerLogger := logger.With("service", "worker")
-	w := worker.New(svc, workerLogger, "local-run", "", 1, nil, false)
+	w := worker.New(svc, workerLogger, "local-run", "", "", 1, nil, false)
 	w.ResourceOverrides = workerResourceOverrides
 	w.LocalMode = true
 

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -180,7 +180,7 @@ func runWorker(ctx context.Context, s pikoci.Service, c int, llvl string, name s
 		}
 		nlogger := logger.With("num", i+1, "name", workerName)
 		nlogger.Info(fmt.Sprintf("Starting Worker %d", i+1))
-		w := worker.New(s, nlogger, workerName, Version, c, tags, exclusiveTags)
+		w := worker.New(s, nlogger, workerName, Version, Commit, c, tags, exclusiveTags)
 		workers = append(workers, w)
 
 		go func() {
@@ -209,7 +209,7 @@ func runGRPCWorker(ctx context.Context, s pikoci.Service, grpcClient workerv1.Wo
 		}
 		nlogger := logger.With("num", i+1, "name", workerName)
 		nlogger.Info(fmt.Sprintf("Starting gRPC Worker %d", i+1))
-		w := worker.NewGRPC(s, grpcClient, nlogger, workerName, Version, c, workerToken, grpcAddr, tags, exclusiveTags)
+		w := worker.NewGRPC(s, grpcClient, nlogger, workerName, Version, Commit, c, workerToken, grpcAddr, tags, exclusiveTags)
 		workers = append(workers, w)
 
 		go func() {

--- a/integration/backends/concurrent_builds_test.go
+++ b/integration/backends/concurrent_builds_test.go
@@ -77,7 +77,7 @@ func TestConcurrentBuildCreation(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			w := worker.New(svc, logger.With("worker", i+1), fmt.Sprintf("test-worker-%d", i+1), "test", 3, nil, false)
+			w := worker.New(svc, logger.With("worker", i+1), fmt.Sprintf("test-worker-%d", i+1), "test", "", 3, nil, false)
 			w.Run(ctx)
 		}()
 	}

--- a/integration/backends/export_test.go
+++ b/integration/backends/export_test.go
@@ -70,7 +70,7 @@ func TestExportE2E(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		w := worker.New(svc, logger.With("worker", 1), "test-worker-1", "test", 1, nil, false)
+		w := worker.New(svc, logger.With("worker", 1), "test-worker-1", "test", "", 1, nil, false)
 		w.Run(ctx)
 	}()
 

--- a/integration/backends/grpc_worker_test.go
+++ b/integration/backends/grpc_worker_test.go
@@ -128,7 +128,7 @@ func TestGRPCWorkerFullFlow(t *testing.T) {
 	grpcClient := workerv1.NewWorkerServiceClient(grpcConn)
 
 	// --- Start standalone worker via gRPC ---
-	w := worker.NewGRPC(httpClient, grpcClient, logger.With("worker", "test-worker-1"), "test-worker-1", "test", 1, workerToken, addr, nil, false)
+	w := worker.NewGRPC(httpClient, grpcClient, logger.With("worker", "test-worker-1"), "test-worker-1", "test", "", 1, workerToken, addr, nil, false)
 	go w.Run(ctx)
 
 	// Wait for worker to register

--- a/integration/backends/secrets_test.go
+++ b/integration/backends/secrets_test.go
@@ -70,7 +70,7 @@ func TestSecretsE2E(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		w := worker.New(svc, logger.With("component", "worker"), "test-worker", "test", 1, nil, false)
+		w := worker.New(svc, logger.With("component", "worker"), "test-worker", "test", "", 1, nil, false)
 		w.Run(ctx)
 	}()
 

--- a/integration/backends/services_test.go
+++ b/integration/backends/services_test.go
@@ -66,7 +66,7 @@ func TestServicesE2E(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		w := worker.New(svc, logger.With("component", "worker"), "test-worker", "test", 1, nil, false)
+		w := worker.New(svc, logger.With("component", "worker"), "test-worker", "test", "", 1, nil, false)
 		w.Run(ctx)
 	}()
 

--- a/integration/backends/tags_test.go
+++ b/integration/backends/tags_test.go
@@ -100,7 +100,7 @@ job "gpu-job" {
 	// Start an UNTAGGED worker — should NOT pick up the gpu-tagged job
 	var wg sync.WaitGroup
 	wg.Add(1)
-	untaggedWorker := worker.New(svc, logger.With("worker", "untagged"), "untagged-worker", "test", 1, nil, false)
+	untaggedWorker := worker.New(svc, logger.With("worker", "untagged"), "untagged-worker", "test", "", 1, nil, false)
 	go func() { defer wg.Done(); untaggedWorker.Run(ctx) }()
 
 	// Directly trigger the job to create a pending build
@@ -116,7 +116,7 @@ job "gpu-job" {
 
 	// Now start a GPU-tagged worker — should pick up the build
 	wg.Add(1)
-	gpuWorker := worker.New(svc, logger.With("worker", "gpu"), "gpu-worker", "test", 1, []string{"gpu"}, false)
+	gpuWorker := worker.New(svc, logger.With("worker", "gpu"), "gpu-worker", "test", "", 1, []string{"gpu"}, false)
 	go func() { defer wg.Done(); gpuWorker.Run(ctx) }()
 
 	require.Eventually(t, func() bool {
@@ -186,7 +186,7 @@ job "gpu-job" {
 	// Start an exclusive gpu worker — should only handle gpu-tagged jobs
 	var wg sync.WaitGroup
 	wg.Add(1)
-	exclWorker := worker.New(svc, logger.With("worker", "exclusive-gpu"), "exclusive-gpu-worker", "test", 1, []string{"gpu"}, true)
+	exclWorker := worker.New(svc, logger.With("worker", "exclusive-gpu"), "exclusive-gpu-worker", "test", "", 1, []string{"gpu"}, true)
 	go func() { defer wg.Done(); exclWorker.Run(ctx) }()
 
 	// Directly trigger both jobs to create pending builds

--- a/integration/backends/vault_test.go
+++ b/integration/backends/vault_test.go
@@ -151,7 +151,7 @@ func TestSecretsVaultE2E(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		w := worker.New(svc, logger.With("component", "worker"), "test-worker", "test", 1, nil, false)
+		w := worker.New(svc, logger.With("component", "worker"), "test-worker", "test", "", 1, nil, false)
 		w.Run(ctx)
 	}()
 

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -92,7 +92,7 @@ func runWorker(ctx context.Context, s pikoci.Service, c int, llvl string) error 
 		wg.Add(1)
 		nlogger := logger.With("num", i+1)
 		nlogger.Info(fmt.Sprintf("Starting Worker %d", i+1))
-		w := worker.New(s, nlogger, fmt.Sprintf("test-worker-%d", i+1), "test", c, nil, false)
+		w := worker.New(s, nlogger, fmt.Sprintf("test-worker-%d", i+1), "test", "", c, nil, false)
 
 		go func() {
 			err := w.Run(ctx)

--- a/pikoci/mysql/migrate/migrate.go
+++ b/pikoci/mysql/migrate/migrate.go
@@ -78,6 +78,7 @@ func adaptSQL(sql, system string) string {
 		// Replace backtick-quoted identifiers with double-quote-quoted ones
 		sql = strings.ReplaceAll(sql, "`type`", `"type"`)
 		sql = strings.ReplaceAll(sql, "`check`", `"check"`)
+		sql = strings.ReplaceAll(sql, "`commit`", `"commit"`)
 		// PostgreSQL uses ALTER COLUMN ... TYPE instead of MODIFY COLUMN
 		sql = modifyColumnRePostgres.ReplaceAllString(sql, "ALTER TABLE $1 ALTER COLUMN $2 TYPE $3;")
 		// PostgreSQL doesn't support RENAME COLUMN with the same syntax in older versions,

--- a/pikoci/mysql/migrate/migrations/V37WorkerCommit.go
+++ b/pikoci/mysql/migrate/migrations/V37WorkerCommit.go
@@ -1,0 +1,6 @@
+package migrations
+
+var V37WorkerCommit = Migration{
+	Name: "WorkerCommit",
+	SQL:  "ALTER TABLE workers ADD COLUMN `commit` VARCHAR(50) NOT NULL DEFAULT '';",
+}

--- a/pikoci/mysql/migrate/migrations/migrations.go
+++ b/pikoci/mysql/migrate/migrations/migrations.go
@@ -16,7 +16,7 @@ type Migration struct {
 // Migrations is the ordered list of all schema migrations. It is defined as
 // a fixed-size array so that the compiler catches ordering conflicts when
 // multiple developers add migrations concurrently.
-var Migrations = [37]Migration{
+var Migrations = [38]Migration{
 	V0Initial,
 	V1ResourceCheckInterval,
 	V2JobsAndBuilds,
@@ -54,4 +54,5 @@ var Migrations = [37]Migration{
 	V34WorkerTags,
 	V35BaselineVersionID,
 	V36RunnerOverride,
+	V37WorkerCommit,
 }

--- a/pikoci/mysql/worker.go
+++ b/pikoci/mysql/worker.go
@@ -25,41 +25,46 @@ func NewWorkerRepository(db sqlr.Querier, system string) *WorkerRepository {
 
 func (r *WorkerRepository) Upsert(ctx context.Context, w wkr.Worker) error {
 	tagsStr := strings.Join(w.Tags, ",")
+	// "commit" is a reserved word in SQLite, so we quote it with backticks
+	// (works in MySQL and SQLite; adapted to double-quotes for PostgreSQL
+	// by the migrate package).
 	var q string
 	switch r.system {
 	case MySQL:
-		q = `INSERT INTO workers (name, hostname, os, arch, go_version, version, concurrency, tags, exclusive_tags, started_at, last_ping_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-			ON DUPLICATE KEY UPDATE
-				hostname = VALUES(hostname),
-				os = VALUES(os),
-				arch = VALUES(arch),
-				go_version = VALUES(go_version),
-				version = VALUES(version),
-				concurrency = VALUES(concurrency),
-				tags = VALUES(tags),
-				exclusive_tags = VALUES(exclusive_tags),
-				started_at = VALUES(started_at),
-				last_ping_at = VALUES(last_ping_at)`
+		q = "INSERT INTO workers (name, hostname, os, arch, go_version, version, `commit`, concurrency, tags, exclusive_tags, started_at, last_ping_at)" +
+			" VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)" +
+			" ON DUPLICATE KEY UPDATE" +
+			" hostname = VALUES(hostname)," +
+			" os = VALUES(os)," +
+			" arch = VALUES(arch)," +
+			" go_version = VALUES(go_version)," +
+			" version = VALUES(version)," +
+			" `commit` = VALUES(`commit`)," +
+			" concurrency = VALUES(concurrency)," +
+			" tags = VALUES(tags)," +
+			" exclusive_tags = VALUES(exclusive_tags)," +
+			" started_at = VALUES(started_at)," +
+			" last_ping_at = VALUES(last_ping_at)"
 	default:
 		// SQLite, mem, PostgreSQL
-		q = `INSERT INTO workers (name, hostname, os, arch, go_version, version, concurrency, tags, exclusive_tags, started_at, last_ping_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-			ON CONFLICT(name) DO UPDATE SET
-				hostname = excluded.hostname,
-				os = excluded.os,
-				arch = excluded.arch,
-				go_version = excluded.go_version,
-				version = excluded.version,
-				concurrency = excluded.concurrency,
-				tags = excluded.tags,
-				exclusive_tags = excluded.exclusive_tags,
-				started_at = excluded.started_at,
-				last_ping_at = excluded.last_ping_at`
+		q = "INSERT INTO workers (name, hostname, os, arch, go_version, version, `commit`, concurrency, tags, exclusive_tags, started_at, last_ping_at)" +
+			" VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)" +
+			" ON CONFLICT(name) DO UPDATE SET" +
+			" hostname = excluded.hostname," +
+			" os = excluded.os," +
+			" arch = excluded.arch," +
+			" go_version = excluded.go_version," +
+			" version = excluded.version," +
+			" `commit` = excluded.`commit`," +
+			" concurrency = excluded.concurrency," +
+			" tags = excluded.tags," +
+			" exclusive_tags = excluded.exclusive_tags," +
+			" started_at = excluded.started_at," +
+			" last_ping_at = excluded.last_ping_at"
 	}
 
 	_, err := r.querier.ExecContext(ctx, q,
-		w.Name, w.Hostname, w.OS, w.Arch, w.GoVersion, w.Version,
+		w.Name, w.Hostname, w.OS, w.Arch, w.GoVersion, w.Version, w.Commit,
 		w.Concurrency, tagsStr, w.ExclusiveTags, w.StartedAt, w.LastPingAt,
 	)
 	if err != nil {
@@ -69,11 +74,9 @@ func (r *WorkerRepository) Upsert(ctx context.Context, w wkr.Worker) error {
 }
 
 func (r *WorkerRepository) Filter(ctx context.Context) ([]*wkr.Worker, error) {
-	rows, err := r.querier.QueryContext(ctx, `
-		SELECT id, name, hostname, os, arch, go_version, version, concurrency, tags, exclusive_tags, started_at, last_ping_at
-		FROM workers
-		ORDER BY name ASC
-	`)
+	rows, err := r.querier.QueryContext(ctx,
+		"SELECT id, name, hostname, os, arch, go_version, version, `commit`, concurrency, tags, exclusive_tags, started_at, last_ping_at"+
+			" FROM workers ORDER BY name ASC")
 	if err != nil {
 		return nil, fmt.Errorf("failed to query workers: %w", err)
 	}
@@ -90,13 +93,14 @@ func (r *WorkerRepository) Filter(ctx context.Context) ([]*wkr.Worker, error) {
 			arch          sql.NullString
 			goVersion     sql.NullString
 			version       sql.NullString
+			commit        sql.NullString
 			concurrency   sql.NullInt64
 			tagsStr       sql.NullString
 			exclusiveTags sql.NullBool
 			startedAt     sql.NullTime
 			lastPingAt    sql.NullTime
 		)
-		if err := rows.Scan(&id, &name, &hostname, &os, &arch, &goVersion, &version, &concurrency, &tagsStr, &exclusiveTags, &startedAt, &lastPingAt); err != nil {
+		if err := rows.Scan(&id, &name, &hostname, &os, &arch, &goVersion, &version, &commit, &concurrency, &tagsStr, &exclusiveTags, &startedAt, &lastPingAt); err != nil {
 			return nil, fmt.Errorf("failed to scan worker: %w", err)
 		}
 		var tags []string
@@ -111,6 +115,7 @@ func (r *WorkerRepository) Filter(ctx context.Context) ([]*wkr.Worker, error) {
 			Arch:          arch.String,
 			GoVersion:     goVersion.String,
 			Version:       version.String,
+			Commit:        commit.String,
 			Concurrency:   int(concurrency.Int64),
 			Tags:          tags,
 			ExclusiveTags: exclusiveTags.Bool,

--- a/pikoci/mysql/worker_test.go
+++ b/pikoci/mysql/worker_test.go
@@ -1,0 +1,88 @@
+package mysql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/pikoci/pikoci/pikoci/mysql"
+	"github.com/pikoci/pikoci/pikoci/wkr"
+)
+
+func TestWorkerRepository_UpsertAndFilter_Commit(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	repo := mysql.NewWorkerRepository(db, mysql.Mem)
+
+	now := time.Now().Truncate(time.Second)
+	w := wkr.Worker{
+		Name:        "test-worker",
+		Hostname:    "host1",
+		OS:          "linux",
+		Arch:        "amd64",
+		GoVersion:   "go1.22",
+		Version:     "v0.5.0",
+		Commit:      "abc1234",
+		Concurrency: 2,
+		StartedAt:   now,
+		LastPingAt:  now,
+	}
+
+	err := repo.Upsert(ctx, w)
+	require.NoError(t, err)
+
+	workers, err := repo.Filter(ctx)
+	require.NoError(t, err)
+	require.Len(t, workers, 1)
+
+	assert.Equal(t, "test-worker", workers[0].Name)
+	assert.Equal(t, "v0.5.0", workers[0].Version)
+	assert.Equal(t, "abc1234", workers[0].Commit)
+
+	// Update commit via upsert
+	w.Commit = "def5678"
+	w.LastPingAt = now.Add(time.Second)
+	err = repo.Upsert(ctx, w)
+	require.NoError(t, err)
+
+	workers, err = repo.Filter(ctx)
+	require.NoError(t, err)
+	require.Len(t, workers, 1)
+	assert.Equal(t, "def5678", workers[0].Commit)
+}
+
+func TestWorkerRepository_UpsertAndFilter_EmptyCommit(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	repo := mysql.NewWorkerRepository(db, mysql.Mem)
+
+	now := time.Now().Truncate(time.Second)
+	w := wkr.Worker{
+		Name:       "empty-commit-worker",
+		Hostname:   "host2",
+		Version:    "v0.4.0",
+		Commit:     "",
+		StartedAt:  now,
+		LastPingAt: now,
+	}
+
+	err := repo.Upsert(ctx, w)
+	require.NoError(t, err)
+
+	workers, err := repo.Filter(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, workers)
+
+	// Find our worker
+	var found *wkr.Worker
+	for _, wk := range workers {
+		if wk.Name == "empty-commit-worker" {
+			found = wk
+			break
+		}
+	}
+	require.NotNil(t, found)
+	assert.Equal(t, "", found.Commit)
+}

--- a/pikoci/transport/http/assets/js/app/views/workers.js
+++ b/pikoci/transport/http/assets/js/app/views/workers.js
@@ -6,6 +6,19 @@ import { pikoTimeAgo } from '../namespace.js';
 export var WorkersListView = Backbone.View.extend({
   template: _.template($('#workers-list-view').html()),
   initialize: function() {
+    this.serverVersion = '';
+    this.serverCommit = '';
+    var self = this;
+    $.ajax({
+      url: '/version',
+      type: 'GET',
+      headers: {'Content-Type': 'application/json'},
+      dataType: 'json',
+    }).done(function(data) {
+      self.serverVersion = data.version;
+      self.serverCommit = data.commit;
+      self.render();
+    });
     this.listenTo(this.collection, "add", this.addWorker);
     this.listenTo(this.collection, "reset", this.render);
     this.collection.fetch();
@@ -13,13 +26,25 @@ export var WorkersListView = Backbone.View.extend({
   render: function() {
     this.$el.html(this.template());
     var that = this;
+    var hasOutdated = false;
     this.collection.each(function(m) {
+      var data = m.toJSON();
+      if (that.serverVersion && (data.version !== that.serverVersion || data.commit !== that.serverCommit)) {
+        hasOutdated = true;
+      }
       that.addWorker(m);
     });
+    if (hasOutdated) {
+      this.$('#worker-health-banner-container').html(
+        '<div class="piko-worker-banner mb-3">' +
+        '\u26A0 Some workers are running an outdated version. Restart them to pick up the latest release.' +
+        '</div>'
+      );
+    }
     return this;
   },
   addWorker: function(m) {
-    var view = new WorkersRowView({model: m, collection: this.collection});
+    var view = new WorkersRowView({model: m, collection: this.collection, serverVersion: this.serverVersion, serverCommit: this.serverCommit});
     this.$('#workers-table-body').append(view.render().el);
   },
 });
@@ -30,11 +55,21 @@ var WorkersRowView = Backbone.View.extend({
   events: {
     'click .delete-worker': 'deleteWorker',
   },
+  initialize: function(options) {
+    this.serverVersion = options.serverVersion || '';
+    this.serverCommit = options.serverCommit || '';
+  },
   render: function() {
     var data = this.model.toJSON();
     data.uptime = pikoTimeAgo(data.started_at);
     data.last_seen = pikoTimeAgo(data.last_ping_at);
+    data.server_version = this.serverVersion;
+    data.server_commit = this.serverCommit;
+    data.is_outdated = this.serverVersion && (data.version !== this.serverVersion || data.commit !== this.serverCommit);
     this.$el.html(this.template(data));
+    this.$('[data-bs-toggle="tooltip"]').each(function() {
+      new bootstrap.Tooltip(this);
+    });
     return this;
   },
   deleteWorker: function(e) {

--- a/pikoci/transport/http/client/client.go
+++ b/pikoci/transport/http/client/client.go
@@ -1040,6 +1040,7 @@ func (cl *Client) WorkerHeartbeat(ctx context.Context, w wkr.Worker) error {
 		Arch:          w.Arch,
 		GoVersion:     w.GoVersion,
 		Version:       w.Version,
+		Commit:        w.Commit,
 		Concurrency:   w.Concurrency,
 		Tags:          w.Tags,
 		ExclusiveTags: w.ExclusiveTags,

--- a/pikoci/transport/http/client/client_test.go
+++ b/pikoci/transport/http/client/client_test.go
@@ -2463,6 +2463,8 @@ func TestWorkerHeartbeat(t *testing.T) {
 		assert.Equal(t, "host1", hr.Hostname)
 		assert.Equal(t, "linux", hr.OS)
 		assert.Equal(t, "amd64", hr.Arch)
+		assert.Equal(t, "v0.4.0", hr.Version)
+		assert.Equal(t, "abc123", hr.Commit)
 		assert.Equal(t, 2, hr.Concurrency)
 		jsonHandler(w, thttp.WorkerHeartbeatResponse{})
 	}).Methods("POST")
@@ -2479,6 +2481,7 @@ func TestWorkerHeartbeat(t *testing.T) {
 		Arch:        "amd64",
 		GoVersion:   "go1.22",
 		Version:     "v0.4.0",
+		Commit:      "abc123",
 		Concurrency: 2,
 	})
 	require.NoError(t, err)

--- a/pikoci/transport/http/handler_test.go
+++ b/pikoci/transport/http/handler_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pikoci/pikoci/pikoci/mock"
 	"github.com/pikoci/pikoci/pikoci/pipeline"
 	"github.com/pikoci/pikoci/pikoci/user"
+	"github.com/pikoci/pikoci/pikoci/wkr"
 	"go.uber.org/mock/gomock"
 	_ "modernc.org/sqlite"
 )
@@ -758,9 +759,18 @@ func TestWorkerHeartbeat_WithWorkerToken(t *testing.T) {
 	workerJWT, err := token.SignedString(secret)
 	require.NoError(t, err)
 
-	s.EXPECT().WorkerHeartbeat(gomock.Any(), gomock.Any()).Return(nil)
+	s.EXPECT().WorkerHeartbeat(gomock.Any(), gomock.Any()).DoAndReturn(func(_ interface{}, w interface{}) error {
+		wk, ok := w.(wkr.Worker)
+		if !ok {
+			t.Fatal("expected wkr.Worker")
+		}
+		assert.Equal(t, "worker-1", wk.Name)
+		assert.Equal(t, "v1.0.0", wk.Version)
+		assert.Equal(t, "deadbeef", wk.Commit)
+		return nil
+	})
 
-	body := `{"name":"worker-1","hostname":"host1","os":"linux","arch":"amd64","concurrency":2,"queues":"jobs,checks"}`
+	body := `{"name":"worker-1","hostname":"host1","os":"linux","arch":"amd64","version":"v1.0.0","commit":"deadbeef","concurrency":2}`
 	req, err := http.NewRequest(http.MethodPost, server.URL+"/workers/heartbeat", strings.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Authorization", "Bearer "+workerJWT)

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -864,7 +864,14 @@
         <% } %>
       </td>
       <td><%- os %>/<%- arch %> (<%- go_version %>)</td>
-      <td><%- version %></td>
+      <td>
+        <%- version %><% if (commit && commit !== "unknown") { %> (<%- commit %>)<% } %>
+        <% if (is_outdated) { %>
+          <span class="text-warning ms-1" title="Worker version does not match server (server: <%= server_version %> (<%= server_commit %>))" data-bs-toggle="tooltip">
+            <i class="bi bi-exclamation-triangle-fill"></i>
+          </span>
+        <% } %>
+      </td>
       <td><%- uptime %></td>
       <td><%- last_seen %></td>
       <td>

--- a/pikoci/transport/http/workers.go
+++ b/pikoci/transport/http/workers.go
@@ -17,6 +17,7 @@ type WorkerHeartbeatRequest struct {
 	Arch          string   `json:"arch"`
 	GoVersion     string   `json:"go_version"`
 	Version       string   `json:"version"`
+	Commit        string   `json:"commit"`
 	Concurrency   int      `json:"concurrency"`
 	Tags          []string `json:"tags"`
 	ExclusiveTags bool     `json:"exclusive_tags"`
@@ -52,6 +53,7 @@ func workerHeartbeat(s pikoci.Service) http.HandlerFunc {
 			Arch:          req.Arch,
 			GoVersion:     req.GoVersion,
 			Version:       req.Version,
+			Commit:        req.Commit,
 			Concurrency:   req.Concurrency,
 			Tags:          req.Tags,
 			ExclusiveTags: req.ExclusiveTags,

--- a/pikoci/wkr/worker.go
+++ b/pikoci/wkr/worker.go
@@ -19,6 +19,7 @@ type Worker struct {
 	Arch        string    `json:"arch"`
 	GoVersion   string    `json:"go_version"`
 	Version     string    `json:"version"`
+	Commit      string    `json:"commit"`
 	Concurrency int       `json:"concurrency"`
 	Tags          []string  `json:"tags"`
 	ExclusiveTags bool      `json:"exclusive_tags"`

--- a/worker/service.go
+++ b/worker/service.go
@@ -86,6 +86,7 @@ type Worker struct {
 	StartedAt     time.Time
 	Concurrency   int
 	Version       string
+	Commit        string
 
 	// GRPCAddr is the address of the gRPC server. When set, the worker uses
 	// gRPC streaming instead of HTTP long polling. When empty (embedded worker),
@@ -125,7 +126,7 @@ func resourceCacheEnabled(rt restype.ResourceType, r resource.Resource) bool {
 // returned Worker is ready to be started with Run, which uses HTTP long-poll
 // to receive work items (embedded mode). The service must implement WorkPoller
 // (satisfied by *pikoci.PikoCI) for the embedded poll loop.
-func New(s pikoci.Service, l *slog.Logger, name, version string, concurrency int, tags []string, exclusiveTags bool) *Worker {
+func New(s pikoci.Service, l *slog.Logger, name, version, commit string, concurrency int, tags []string, exclusiveTags bool) *Worker {
 	w := &Worker{
 		pikoci:        s,
 		logger:        l,
@@ -135,6 +136,7 @@ func New(s pikoci.Service, l *slog.Logger, name, version string, concurrency int
 		StartedAt:     time.Now(),
 		Concurrency:   concurrency,
 		Version:       version,
+		Commit:        commit,
 	}
 	if wp, ok := s.(WorkPoller); ok {
 		w.workPoller = wp
@@ -143,7 +145,7 @@ func New(s pikoci.Service, l *slog.Logger, name, version string, concurrency int
 }
 
 // NewGRPC creates a Worker configured for gRPC streaming mode.
-func NewGRPC(s pikoci.Service, gc workerv1.WorkerServiceClient, l *slog.Logger, name, version string, concurrency int, workerToken, grpcAddr string, tags []string, exclusiveTags bool) *Worker {
+func NewGRPC(s pikoci.Service, gc workerv1.WorkerServiceClient, l *slog.Logger, name, version, commit string, concurrency int, workerToken, grpcAddr string, tags []string, exclusiveTags bool) *Worker {
 	return &Worker{
 		pikoci:        s,
 		grpcClient:    gc,
@@ -154,6 +156,7 @@ func NewGRPC(s pikoci.Service, gc workerv1.WorkerServiceClient, l *slog.Logger, 
 		StartedAt:     time.Now(),
 		Concurrency:   concurrency,
 		Version:       version,
+		Commit:        commit,
 		GRPCAddr:      grpcAddr,
 		WorkerToken:   workerToken,
 	}
@@ -194,6 +197,7 @@ func (w *Worker) sendHeartbeat(ctx context.Context) {
 		Arch:          runtime.GOARCH,
 		GoVersion:     runtime.Version(),
 		Version:       w.Version,
+		Commit:        w.Commit,
 		Concurrency:   w.Concurrency,
 		Tags:          w.Tags,
 		ExclusiveTags: w.ExclusiveTags,

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -7921,7 +7921,7 @@ func TestNew(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	svc := mock.NewService(ctrl)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	w := New(svc, logger, "test-worker", "test", 1, nil, false)
+	w := New(svc, logger, "test-worker", "test", "", 1, nil, false)
 	assert.NotNil(t, w)
 }
 


### PR DESCRIPTION
## Summary

- Adds `commit` column to workers table (V37 migration) and threads the field through the entire stack: model, heartbeat, HTTP client, worker service, and MySQL repository
- Worker list now shows `version (commit)` format and flags outdated workers (version+commit mismatch with server) via a ⚠️ icon with tooltip and an orange warning banner
- Frontend compares worker version+commit against the `/version` endpoint client-side

Closes #522
