### PR TITLE
fix: format in_parallel sub_step durations as HH:MM:SS (#526)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `in_parallel` sub-step durations now display as formatted time (`HH:MM:SS`) instead of raw nanoseconds ([#526](https://github.com/PikoCI/pikoci/issues/526))
+
 ## [0.5.1] - 2026-06-16
 
 ### Added

--- a/pikoci/testdata/cron.hcl
+++ b/pikoci/testdata/cron.hcl
@@ -12,10 +12,18 @@ job "gen" {
   get "cron" "my_cron" {
     trigger = true
   }
-  task "create-file" {
-    run "exec" {
-      path = "/bin/sh"
-      args = ["-ec", "mkdir -p output && echo \"cron triggered at: $(date)\" > output/timestamp.txt && cat output/timestamp.txt"]
+  in_parallel {
+    task "create-file" {
+      run "exec" {
+        path = "/bin/sh"
+        args = ["-ec", "mkdir -p output && echo \"cron triggered at: $(date)\" > output/timestamp.txt && cat output/timestamp.txt"]
+      }
+    }
+    task "create-summary" {
+      run "exec" {
+        path = "/bin/sh"
+        args = ["-ec", "mkdir -p output && echo \"summary generated\" > output/summary.txt && cat output/summary.txt"]
+      }
     }
   }
   put "artifact" "cron_output" {

--- a/pikoci/transport/http/assets/js/app/models.js
+++ b/pikoci/transport/http/assets/js/app/models.js
@@ -159,6 +159,9 @@ export var Build = Backbone.Model.extend({
     }
     _.each(data.steps, function(s, i) {
       data.steps[i].duration = durationToString(s.duration);
+      _.each(s.sub_steps || [], function(child, j) {
+        data.steps[i].sub_steps[j].duration = durationToString(child.duration);
+      });
     });
     _.each(data.job, function(j, i) {
       data.job[i].duration = durationToString(j.duration);


### PR DESCRIPTION
## Summary

- Format `in_parallel` sub-step durations using `durationToString()` in `Build.parse()` so they display as `HH:MM:SS` instead of raw nanoseconds
- Add `in_parallel` block to `testdata/cron.hcl` for testing coverage

Fixes #526