### PR TITLE
feat: resource version row aggregate build status indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Resource version rows now show a colored status dot indicating the aggregate build status of all jobs that consumed that version ([#534](https://github.com/PikoCI/pikoci/issues/534))
+
 ### Fixed
 
 - `in_parallel` sub-step durations now display as formatted time (`HH:MM:SS`) instead of raw nanoseconds ([#526](https://github.com/PikoCI/pikoci/issues/526))

--- a/pikoci/build/repository.go
+++ b/pikoci/build/repository.go
@@ -40,4 +40,6 @@ type Repository interface {
 	// CountRunningInSerialGroups returns the number of running builds for jobs (excluding excludeJobName)
 	// that share any of the given serial groups within the same pipeline.
 	CountRunningInSerialGroups(ctx context.Context, tc, pn string, serialGroups []string, excludeJobName string) (int, error)
+	// AggregateStatusByVersionIDs returns the aggregate build status for each version ID.
+	AggregateStatusByVersionIDs(ctx context.Context, versionIDs []uint32) (map[uint32]string, error)
 }

--- a/pikoci/mock/build_repository.go
+++ b/pikoci/mock/build_repository.go
@@ -42,6 +42,21 @@ func (m *BuildRepository) EXPECT() *BuildRepositoryMockRecorder {
 	return m.recorder
 }
 
+// AggregateStatusByVersionIDs mocks base method.
+func (m *BuildRepository) AggregateStatusByVersionIDs(ctx context.Context, versionIDs []uint32) (map[uint32]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AggregateStatusByVersionIDs", ctx, versionIDs)
+	ret0, _ := ret[0].(map[uint32]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AggregateStatusByVersionIDs indicates an expected call of AggregateStatusByVersionIDs.
+func (mr *BuildRepositoryMockRecorder) AggregateStatusByVersionIDs(ctx, versionIDs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AggregateStatusByVersionIDs", reflect.TypeOf((*BuildRepository)(nil).AggregateStatusByVersionIDs), ctx, versionIDs)
+}
+
 // CountRunning mocks base method.
 func (m *BuildRepository) CountRunning(ctx context.Context, tc, pn, jn string) (int, error) {
 	m.ctrl.T.Helper()

--- a/pikoci/mysql/build.go
+++ b/pikoci/mysql/build.go
@@ -575,6 +575,57 @@ func (r *BuildRepository) StartPending(ctx context.Context, tc, pn, jn string, b
 	return nil
 }
 
+func (r *BuildRepository) AggregateStatusByVersionIDs(ctx context.Context, versionIDs []uint32) (map[uint32]string, error) {
+	if len(versionIDs) == 0 {
+		return nil, nil
+	}
+
+	placeholders := make([]string, len(versionIDs))
+	args := make([]interface{}, len(versionIDs))
+	for i, id := range versionIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	query := `
+		SELECT bgv.version_id,
+			CASE
+				WHEN SUM(CASE WHEN b.status = 'failed' THEN 1 ELSE 0 END) > 0 THEN 'failed'
+				WHEN SUM(CASE WHEN b.status = 'started' THEN 1 ELSE 0 END) > 0 THEN 'started'
+				WHEN SUM(CASE WHEN b.status = 'pending' THEN 1 ELSE 0 END) > 0 THEN 'pending'
+				WHEN SUM(CASE WHEN b.status = 'succeeded' THEN 1 ELSE 0 END) > 0 THEN 'succeeded'
+				ELSE ''
+			END AS agg_status
+		FROM build_get_versions bgv
+		JOIN builds b ON b.id = bgv.build_id
+		WHERE bgv.version_id IN (` + strings.Join(placeholders, ",") + `)
+		GROUP BY bgv.version_id
+	`
+
+	rows, err := r.querier.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query aggregate status by version IDs: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[uint32]string)
+	for rows.Next() {
+		var versionID uint32
+		var status string
+		if err := rows.Scan(&versionID, &status); err != nil {
+			return nil, fmt.Errorf("failed to scan aggregate status: %w", err)
+		}
+		if status != "" {
+			result[versionID] = status
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate aggregate status: %w", err)
+	}
+
+	return result, nil
+}
+
 func scanBuild(s sqlr.Scanner) (*build.Build, error) {
 	var b dbBuild
 

--- a/pikoci/mysql/build_test.go
+++ b/pikoci/mysql/build_test.go
@@ -659,6 +659,68 @@ func TestFindReadyDownstreamVersion_CronPipelineRenameScenario(t *testing.T) {
 	assert.Equal(t, uint32(newCronVersionID), vID)
 }
 
+func TestAggregateStatusByVersionIDs(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	res, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'agg-pipe', 'agg-pipe')`)
+	require.NoError(t, err)
+	ppID, _ := res.LastInsertId()
+
+	res, err = db.ExecContext(ctx, `INSERT INTO jobs (pipeline_id, name) VALUES (?, 'build')`, ppID)
+	require.NoError(t, err)
+	jobID, _ := res.LastInsertId()
+
+	// Build 1: succeeded, consumed version 10
+	res, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, build_number) VALUES (?, 'succeeded', '1')`, jobID)
+	require.NoError(t, err)
+	b1, _ := res.LastInsertId()
+	_, err = db.ExecContext(ctx, `INSERT INTO build_get_versions (build_id, step_name, version_id) VALUES (?, 'repo', 10)`, b1)
+	require.NoError(t, err)
+
+	// Build 2: failed, consumed version 10 (should make agg status "failed")
+	res, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, build_number) VALUES (?, 'failed', '2')`, jobID)
+	require.NoError(t, err)
+	b2, _ := res.LastInsertId()
+	_, err = db.ExecContext(ctx, `INSERT INTO build_get_versions (build_id, step_name, version_id) VALUES (?, 'repo', 10)`, b2)
+	require.NoError(t, err)
+
+	// Build 3: succeeded, consumed version 20
+	res, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, build_number) VALUES (?, 'succeeded', '3')`, jobID)
+	require.NoError(t, err)
+	b3, _ := res.LastInsertId()
+	_, err = db.ExecContext(ctx, `INSERT INTO build_get_versions (build_id, step_name, version_id) VALUES (?, 'repo', 20)`, b3)
+	require.NoError(t, err)
+
+	br := mysql.NewBuildRepository(db, mysql.Mem)
+
+	result, err := br.AggregateStatusByVersionIDs(ctx, []uint32{10, 20, 30})
+	require.NoError(t, err)
+
+	// Version 10: has succeeded + failed → "failed" wins
+	assert.Equal(t, "failed", result[10])
+	// Version 20: only succeeded → "succeeded"
+	assert.Equal(t, "succeeded", result[20])
+	// Version 30: no builds → not in map
+	_, exists := result[30]
+	assert.False(t, exists)
+}
+
+func TestAggregateStatusByVersionIDs_Empty(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	br := mysql.NewBuildRepository(db, mysql.Mem)
+
+	result, err := br.AggregateStatusByVersionIDs(ctx, []uint32{})
+	require.NoError(t, err)
+	assert.Nil(t, result)
+
+	result, err = br.AggregateStatusByVersionIDs(ctx, nil)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
 func TestCountRunningInSerialGroups(t *testing.T) {
 	db := setupTestDB(t)
 	ctx := context.Background()

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -2823,6 +2823,7 @@ func TestListPublicResourceVersions(t *testing.T) {
 		{ID: 2},
 		{ID: 1},
 	}, nil)
+	s.Builds.EXPECT().AggregateStatusByVersionIDs(ctx, []uint32{2, 1}).Return(nil, nil)
 
 	vers, hasMore, err := s.S.ListPublicResourceVersions(ctx, "main", "my-pipeline", "git.repo", nil, nil, 0)
 	require.NoError(t, err)

--- a/pikoci/resource/resource.go
+++ b/pikoci/resource/resource.go
@@ -48,4 +48,5 @@ type Params struct {
 type Version struct {
 	ID      uint32                 `json:"id"`
 	Version map[string]interface{} `json:"version"`
+	Status  string                 `json:"status,omitempty"`
 }

--- a/pikoci/resources.go
+++ b/pikoci/resources.go
@@ -66,6 +66,21 @@ func (q *PikoCI) ListResourceVersions(ctx context.Context, tc, pc, rCan string, 
 		slices.Reverse(rvers)
 	}
 
+	if len(rvers) > 0 {
+		versionIDs := make([]uint32, len(rvers))
+		for i, v := range rvers {
+			versionIDs[i] = v.ID
+		}
+		statuses, err := q.Builds.AggregateStatusByVersionIDs(ctx, versionIDs)
+		if err == nil {
+			for _, v := range rvers {
+				if s, ok := statuses[v.ID]; ok {
+					v.Status = s
+				}
+			}
+		}
+	}
+
 	return rvers, hasMore, nil
 }
 

--- a/pikoci/resources_test.go
+++ b/pikoci/resources_test.go
@@ -53,6 +53,7 @@ func TestListResourceVersions(t *testing.T) {
 		{ID: 2},
 		{ID: 1},
 	}, nil)
+	s.Builds.EXPECT().AggregateStatusByVersionIDs(ctx, []uint32{2, 1}).Return(nil, nil)
 
 	vers, hasMore, err := s.S.ListResourceVersions(ctx, "main", "my-pipeline", "git.repo", nil, nil, 0)
 	require.NoError(t, err)
@@ -73,6 +74,7 @@ func TestListResourceVersions_WithLimit(t *testing.T) {
 		{ID: 4},
 		{ID: 3},
 	}, nil)
+	s.Builds.EXPECT().AggregateStatusByVersionIDs(ctx, []uint32{5, 4}).Return(nil, nil)
 
 	vers, hasMore, err := s.S.ListResourceVersions(ctx, "main", "my-pipeline", "git.repo", nil, nil, 2)
 	require.NoError(t, err)
@@ -90,6 +92,7 @@ func TestListResourceVersions_After(t *testing.T) {
 		{ID: 4},
 		{ID: 5},
 	}, nil)
+	s.Builds.EXPECT().AggregateStatusByVersionIDs(ctx, []uint32{5, 4}).Return(nil, nil)
 
 	vers, hasMore, err := s.S.ListResourceVersions(ctx, "main", "my-pipeline", "git.repo", nil, &after, 0)
 	require.NoError(t, err)
@@ -98,6 +101,29 @@ func TestListResourceVersions_After(t *testing.T) {
 	// Reversed to newest-first
 	assert.Equal(t, uint32(5), vers[0].ID)
 	assert.Equal(t, uint32(4), vers[1].ID)
+}
+
+func TestListResourceVersions_WithStatus(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "git.repo", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*resource.Version{
+		{ID: 3},
+		{ID: 2},
+		{ID: 1},
+	}, nil)
+	s.Builds.EXPECT().AggregateStatusByVersionIDs(ctx, []uint32{3, 2, 1}).Return(map[uint32]string{
+		3: "started",
+		1: "succeeded",
+	}, nil)
+
+	vers, _, err := s.S.ListResourceVersions(ctx, "main", "my-pipeline", "git.repo", nil, nil, 0)
+	require.NoError(t, err)
+	require.Len(t, vers, 3)
+	assert.Equal(t, "started", vers[0].Status)
+	assert.Equal(t, "", vers[1].Status)
+	assert.Equal(t, "succeeded", vers[2].Status)
 }
 
 func TestGetPipelineResource(t *testing.T) {

--- a/pikoci/testdata/cron.hcl
+++ b/pikoci/testdata/cron.hcl
@@ -83,6 +83,19 @@ job "deploy-after-lint" {
   }
 }
 
+job "failing" {
+  get "cron" "my_cron" {
+    trigger = true
+    passed  = ["gen"]
+  }
+  task "fail" {
+    run "exec" {
+      path = "/bin/sh"
+      args = ["-ec", "echo 'about to fail' && sleep 10 && exit 1"]
+    }
+  }
+}
+
 job "monitor" {
   get "cron" "my_cron" {
     trigger = true

--- a/pikoci/transport/http/assets/css/pikoci.css
+++ b/pikoci/transport/http/assets/css/pikoci.css
@@ -590,6 +590,13 @@ textarea.form-control {
 /* ============================================================
    VERSION TABLE (Resource versions)
    ============================================================ */
+.piko-version-status-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  display: inline-block;
+  flex-shrink: 0;
+}
 .piko-version-kv {
   font-family: var(--font-mono);
   font-size: 0.82rem;

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -675,6 +675,9 @@
             <% if (pinned_version_id === id) { %>
               <span class="piko-badge piko-badge-pending">pinned</span>
             <% } %>
+            <% if (status) { %>
+              <span class="piko-version-status-dot" style="background:var(--status-<%= status %>);" title="<%= status %>"></span>
+            <% } %>
             <span class="piko-version-kv">
               <% _.mapObject(version, function(v, k) { %>
                 <%- k %>: <span><%- v %></span>


### PR DESCRIPTION
## Summary
- Add a colored status dot on each resource version row showing the aggregate build status (failed > started > pending > succeeded) of all jobs that consumed that version
- Backend: new `AggregateStatusByVersionIDs` query on `build_get_versions` + `builds`, wired into `ListResourceVersions` response
- Frontend: status dot with CSS variable colors and hover tooltip
- Add failing test job to cron testdata

Closes #534