### PR TITLE
feat: add resources panel to pipeline show page (#536)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Resource version rows now show a colored status dot indicating the aggregate build status of all jobs that consumed that version ([#534](https://github.com/PikoCI/pikoci/issues/534))
+- Pipeline show page now has a "Resources" button that opens a slide-out panel listing all pipeline resources with name, type, latest version, build status, last check time, and a "Check Now" button ([#536](https://github.com/PikoCI/pikoci/issues/536))
 
 ### Fixed
 

--- a/pikoci/mock/service.go
+++ b/pikoci/mock/service.go
@@ -534,6 +534,21 @@ func (mr *ServiceMockRecorder) ListJobBuilds(ctx, tc, pn, jn, before, after, lim
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobBuilds", reflect.TypeOf((*Service)(nil).ListJobBuilds), ctx, tc, pn, jn, before, after, limit)
 }
 
+// ListPipelineResources mocks base method.
+func (m *Service) ListPipelineResources(ctx context.Context, tc, pn string) ([]*resource.Resource, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPipelineResources", ctx, tc, pn)
+	ret0, _ := ret[0].([]*resource.Resource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPipelineResources indicates an expected call of ListPipelineResources.
+func (mr *ServiceMockRecorder) ListPipelineResources(ctx, tc, pn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPipelineResources", reflect.TypeOf((*Service)(nil).ListPipelineResources), ctx, tc, pn)
+}
+
 // ListPipelines mocks base method.
 func (m *Service) ListPipelines(ctx context.Context, tc string) ([]*pipeline.Pipeline, error) {
 	m.ctrl.T.Helper()
@@ -563,6 +578,21 @@ func (m *Service) ListPublicJobBuilds(ctx context.Context, tc, pn, jn string, be
 func (mr *ServiceMockRecorder) ListPublicJobBuilds(ctx, tc, pn, jn, before, after, limit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPublicJobBuilds", reflect.TypeOf((*Service)(nil).ListPublicJobBuilds), ctx, tc, pn, jn, before, after, limit)
+}
+
+// ListPublicPipelineResources mocks base method.
+func (m *Service) ListPublicPipelineResources(ctx context.Context, tc, pn string) ([]*resource.Resource, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPublicPipelineResources", ctx, tc, pn)
+	ret0, _ := ret[0].([]*resource.Resource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPublicPipelineResources indicates an expected call of ListPublicPipelineResources.
+func (mr *ServiceMockRecorder) ListPublicPipelineResources(ctx, tc, pn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPublicPipelineResources", reflect.TypeOf((*Service)(nil).ListPublicPipelineResources), ctx, tc, pn)
 }
 
 // ListPublicResourceVersions mocks base method.

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -1237,6 +1237,27 @@ func (q *PikoCI) ListPublicJobBuilds(ctx context.Context, tc, pCan, jn string, b
 	return builds, hasMore, nil
 }
 
+// ListPublicPipelineResources returns all resources for a public pipeline with
+// sensitive fields sanitized.
+func (q *PikoCI) ListPublicPipelineResources(ctx context.Context, tc, pCan string) ([]*resource.Resource, error) {
+	_, err := q.Pipelines.FindPublic(ctx, tc, pCan)
+	if err != nil {
+		return nil, fmt.Errorf("pipeline not found or not public: %w", err)
+	}
+
+	rs, err := q.ListPipelineResources(ctx, tc, pCan)
+	if err != nil {
+		return nil, err
+	}
+
+	for i, r := range rs {
+		sr := sanitizeResourceForPublic(*r)
+		rs[i] = &sr
+	}
+
+	return rs, nil
+}
+
 // GetPublicPipelineResource retrieves a resource from a public pipeline with
 // sensitive fields sanitized.
 func (q *PikoCI) GetPublicPipelineResource(ctx context.Context, tc, pCan, rCan string) (*resource.Resource, error) {

--- a/pikoci/resource/resource.go
+++ b/pikoci/resource/resource.go
@@ -27,6 +27,8 @@ type Resource struct {
 	LastCheck    time.Time `json:"last_check"`
 	NextCheck    time.Time `json:"next_check"`
 	WebhookToken string    `json:"webhook_token"`
+
+	LatestVersion *Version `json:"latest_version,omitempty"`
 }
 
 // GetParams returns the resource's parameters as a string map, or nil if no

--- a/pikoci/resources.go
+++ b/pikoci/resources.go
@@ -84,6 +84,38 @@ func (q *PikoCI) ListResourceVersions(ctx context.Context, tc, pc, rCan string, 
 	return rvers, hasMore, nil
 }
 
+// ListPipelineResources returns all resources for the given pipeline,
+// enriched with the latest version and its aggregate build status.
+func (q *PikoCI) ListPipelineResources(ctx context.Context, tc, pc string) ([]*resource.Resource, error) {
+	if !utils.ValidateCanonical(tc) {
+		return nil, fmt.Errorf("invalid Team Canonical format %q", tc)
+	} else if !utils.ValidateCanonical(pc) {
+		return nil, fmt.Errorf("invalid Pipeline Canonical format %q", pc)
+	}
+
+	rs, err := q.Resources.Filter(ctx, tc, pc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list Pipeline Resources: %w", err)
+	}
+
+	for _, r := range rs {
+		vers, err := q.Resources.FilterVersions(ctx, tc, pc, r.Canonical, nil, nil, 1)
+		if err != nil || len(vers) == 0 {
+			continue
+		}
+		v := vers[0]
+		statuses, err := q.Builds.AggregateStatusByVersionIDs(ctx, []uint32{v.ID})
+		if err == nil {
+			if s, ok := statuses[v.ID]; ok {
+				v.Status = s
+			}
+		}
+		r.LatestVersion = v
+	}
+
+	return rs, nil
+}
+
 // GetPipelineResource retrieves a resource by its canonical name within a pipeline.
 func (q *PikoCI) GetPipelineResource(ctx context.Context, tc, pc, rCan string) (*resource.Resource, error) {
 	if !utils.ValidateCanonical(tc) {

--- a/pikoci/resources_test.go
+++ b/pikoci/resources_test.go
@@ -126,6 +126,42 @@ func TestListResourceVersions_WithStatus(t *testing.T) {
 	assert.Equal(t, "succeeded", vers[2].Status)
 }
 
+func TestListPipelineResources(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Resources.EXPECT().Filter(ctx, "main", "my-pipeline").Return([]*resource.Resource{
+		{Name: "res1", Canonical: "res1"},
+		{Name: "res2", Canonical: "res2"},
+	}, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "res1", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{
+		{ID: 10, Version: map[string]interface{}{"ref": "abc"}},
+	}, nil)
+	s.Builds.EXPECT().AggregateStatusByVersionIDs(ctx, []uint32{10}).Return(map[uint32]string{10: "succeeded"}, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "res2", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return(nil, nil)
+
+	rs, err := s.S.ListPipelineResources(ctx, "main", "my-pipeline")
+	require.NoError(t, err)
+	assert.Len(t, rs, 2)
+	require.NotNil(t, rs[0].LatestVersion)
+	assert.Equal(t, uint32(10), rs[0].LatestVersion.ID)
+	assert.Equal(t, "succeeded", rs[0].LatestVersion.Status)
+	assert.Nil(t, rs[1].LatestVersion)
+}
+
+func TestListPipelineResources_InvalidCanonical(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	_, err := s.S.ListPipelineResources(ctx, "INVALID", "my-pipeline")
+	require.Error(t, err)
+
+	_, err = s.S.ListPipelineResources(ctx, "main", "INVALID")
+	require.Error(t, err)
+}
+
 func TestGetPipelineResource(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := newService(ctrl)

--- a/pikoci/service.go
+++ b/pikoci/service.go
@@ -111,6 +111,9 @@ type Service interface {
 	// ListPublicJobBuilds returns paginated builds for a job on a public pipeline,
 	// with secret step logs redacted.
 	ListPublicJobBuilds(ctx context.Context, tc, pn, jn string, before *uint32, after *uint32, limit uint32) ([]*build.Build, bool, error)
+	// ListPublicPipelineResources returns all resources for a public pipeline with
+	// sensitive fields sanitized.
+	ListPublicPipelineResources(ctx context.Context, tc, pn string) ([]*resource.Resource, error)
 	// GetPublicPipelineResource retrieves a resource from a public pipeline with
 	// sensitive fields sanitized.
 	GetPublicPipelineResource(ctx context.Context, tc, pn, rCan string) (*resource.Resource, error)
@@ -167,6 +170,8 @@ type Service interface {
 	// upstream jobs succeeded with a common version), it creates a pending build.
 	EvaluateDownstreamJobs(ctx context.Context, tc, pn, completedJobName string) error
 
+	// ListPipelineResources returns all resources for the given pipeline.
+	ListPipelineResources(ctx context.Context, tc, pn string) ([]*resource.Resource, error)
 	// GetPipelineResource retrieves a resource by its canonical name within a pipeline.
 	GetPipelineResource(ctx context.Context, tc, pn, rCan string) (*resource.Resource, error)
 	// UpdatePipelineResource updates a resource's metadata within a pipeline.

--- a/pikoci/transport/http/assets/css/pikoci.css
+++ b/pikoci/transport/http/assets/css/pikoci.css
@@ -685,6 +685,99 @@ textarea.form-control {
 .piko-graph-container svg polygon[fill="#ffffff"] {
   fill: transparent;
 }
+/* Resources panel wrapper */
+.piko-graph-wrapper {
+  position: relative;
+  overflow: hidden;
+}
+/* Resources slide-out panel */
+.piko-resources-panel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 300px;
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  border-left: 2px solid var(--border-strong);
+  z-index: 20;
+  transform: translateX(100%);
+  transition: transform 0.25s ease, visibility 0s 0.25s;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  pointer-events: none;
+  visibility: hidden;
+}
+.piko-resources-panel.open {
+  transform: translateX(0);
+  pointer-events: auto;
+  visibility: visible;
+  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.3);
+  transition: transform 0.25s ease, visibility 0s 0s;
+}
+.piko-resources-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.piko-resources-panel-body {
+  overflow-y: auto;
+  padding: 0.75rem 1rem;
+  flex: 1;
+}
+.piko-resource-card {
+  padding: 0.6rem 0;
+  border-bottom: 1px solid var(--border);
+}
+.piko-resource-card:last-child {
+  border-bottom: none;
+}
+.piko-resource-card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.piko-resource-card-name {
+  color: var(--primary) !important;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+.piko-resource-card-name:hover {
+  text-decoration: underline;
+  color: var(--primary-hover) !important;
+}
+.piko-resource-card-type {
+  font-size: 0.7rem;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: var(--bg-muted);
+  color: var(--text-secondary) !important;
+}
+.piko-resource-card-version {
+  font-size: 0.72rem;
+  font-family: var(--font-mono);
+  color: var(--text-secondary) !important;
+  margin-top: 0.15rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.piko-resource-card-version span {
+  color: var(--primary) !important;
+}
+.piko-resource-card-meta {
+  font-size: 0.75rem;
+  color: var(--text-secondary) !important;
+  margin-top: 0.2rem;
+}
+
 .piko-graph-legend {
   display: flex;
   gap: 1.25rem;

--- a/pikoci/transport/http/assets/js/app/views/pipelines.js
+++ b/pikoci/transport/http/assets/js/app/views/pipelines.js
@@ -144,6 +144,69 @@ var PipelinesCardView = Backbone.View.extend({
   },
 });
 
+var PipelineResourcesPanelView = Backbone.View.extend({
+  template: _.template($('#pipeline-resources-panel-view').html()),
+  initialize: function(options) {
+    this.collection = options.collection;
+    this.pipeline = options.pipeline;
+    this.listenTo(this.collection, 'sync', this.render);
+    this.collection.fetch();
+    var that = this;
+    this.intervalID = window.setInterval(function() {
+      that.collection.fetch();
+    }, fetchInterval);
+  },
+  events: {
+    'click #close-resources-panel': 'closePanel',
+    'click .check-resource-now': 'checkNow',
+    'click .piko-resource-card-name': clickLink,
+  },
+  render: function() {
+    var teamCanonical = this.pipeline.collection ? this.pipeline.collection.team.get('canonical') : '';
+    var pipelineCanonical = this.pipeline.get('canonical');
+    var basePath = '/teams/' + teamCanonical + '/pipelines/' + pipelineCanonical;
+    var sf = addSessionFunctions({});
+    this.$el.html(this.template({
+      resources: this.collection.toJSON(),
+      isMember: sf.isMember(teamCanonical),
+      pikoTimeAgo: pikoTimeAgo,
+      resourceUrl: function(canonical) {
+        return basePath + '/resources/' + canonical + '/versions';
+      },
+    }));
+    return this;
+  },
+  closePanel: function(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    this.$el.removeClass('open');
+  },
+  checkNow: function(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    var canonical = $(event.currentTarget).data('canonical');
+    var teamCanonical = this.pipeline.collection ? this.pipeline.collection.team.get('canonical') : '';
+    var pipelineCanonical = this.pipeline.get('canonical');
+    var url = '/teams/' + teamCanonical + '/pipelines/' + pipelineCanonical + '/resources/' + canonical + '/trigger';
+    var that = this;
+    $.ajax({
+      url: url, type: 'POST', contentType: 'application/json',
+      headers: { 'Authorization': 'Bearer ' + session.get('jwt') },
+      success: function() {
+        window.app.apiNotice.setSuccess('Resource check triggered');
+        that.collection.fetch();
+      },
+      error: function() {
+        window.app.apiNotice.set({error: 'Failed to trigger resource check'});
+      },
+    });
+  },
+  remove: function() {
+    clearInterval(this.intervalID);
+    Backbone.View.prototype.remove.call(this);
+  },
+});
+
 export var PipelineShowView = Backbone.View.extend({
   template: _.template($('#pipeline-show-view').html()),
   initialize: function(options) {
@@ -159,6 +222,13 @@ export var PipelineShowView = Backbone.View.extend({
       }
     });
 
+    var pipelineModel = this.model;
+    var PanelResources = Backbone.Collection.extend({
+      url: function() { return pipelineModel.url() + "/resources"; },
+      parse: function(response) { return response.data; },
+    });
+    this.resourcesCollection = new PanelResources();
+
     var that = this;
     this.intervalID = window.setInterval(function() {
       that.image.fetch({isInterval: true});
@@ -170,6 +240,7 @@ export var PipelineShowView = Backbone.View.extend({
     'click #delete-pipeline': 'clickDelete',
     'click #pause-pipeline': 'clickPausePipeline',
     'click #unpause-pipeline': 'clickUnpausePipeline',
+    'click #toggle-resources-panel': 'toggleResourcesPanel',
   },
   render: function () {
     this.$el.html(this.template(addSessionFunctions({ pipeline: this.model.toJSON(), team: this.model.collection.team.toJSON() })));
@@ -184,16 +255,30 @@ export var PipelineShowView = Backbone.View.extend({
     }});
     this.$el.find("#graphviz").html(this.graphView.render().el);
     this.image.trigger("change", this.image);
+
+    this.panelView = new PipelineResourcesPanelView({
+      collection: this.resourcesCollection,
+      pipeline: this.model,
+      el: this.$el.find('#pipeline-resources-panel'),
+    });
+
     return this;
   },
   remove: function() {
     clearInterval(this.intervalID);
+    if (this.panelView) { this.panelView.remove(); }
     if (this.graphZoom) { this.graphZoom.destroy(); }
     Backbone.View.prototype.remove.call(this);
   },
-  clickPipeline: function(event) {
+  toggleResourcesPanel: function(event) {
     event.preventDefault();
-    if (event.target.parentElement.href !== undefined){
+    event.stopPropagation();
+    this.$el.find('#pipeline-resources-panel').toggleClass('open');
+  },
+  clickPipeline: function(event) {
+    // Only handle clicks on SVG links inside the graph
+    if (event.target.parentElement && event.target.parentElement.href && event.target.parentElement.href.baseVal) {
+      event.preventDefault();
       window.app.router.navigate(event.target.parentElement.href.baseVal, { trigger: true });
     }
   },

--- a/pikoci/transport/http/authorization.go
+++ b/pikoci/transport/http/authorization.go
@@ -59,6 +59,7 @@ var (
 		InsertBuildGetVersion:          admin,
 		FindBuildGetVersions:   admin,
 
+		ListPipelineResources:   member,
 		GetPipelineResource:     member,
 		UpdatePipelineResource:  admin,
 		TriggerPipelineResource: member,

--- a/pikoci/transport/http/client/client.go
+++ b/pikoci/transport/http/client/client.go
@@ -421,6 +421,11 @@ func (cl *Client) ListPublicJobBuilds(ctx context.Context, tc, pn, jn string, be
 	return cl.ListJobBuilds(ctx, tc, pn, jn, before, after, limit)
 }
 
+// ListPublicPipelineResources lists resources for a public pipeline. It delegates to ListPipelineResources.
+func (cl *Client) ListPublicPipelineResources(ctx context.Context, tc, pn string) ([]*resource.Resource, error) {
+	return cl.ListPipelineResources(ctx, tc, pn)
+}
+
 // GetPublicPipelineResource retrieves a resource from a public pipeline. It delegates to GetPipelineResource.
 func (cl *Client) GetPublicPipelineResource(ctx context.Context, tc, pn, rCan string) (*resource.Resource, error) {
 	return cl.GetPipelineResource(ctx, tc, pn, rCan)
@@ -895,6 +900,22 @@ func (cl *Client) ListResourceVersions(ctx context.Context, tc, pn, rCan string,
 	}
 
 	return resp.Versions, hasMore, nil
+}
+
+// ListPipelineResources returns all resources for a pipeline.
+func (cl *Client) ListPipelineResources(ctx context.Context, tc, pn string) ([]*resource.Resource, error) {
+	var resp thttp.ListPipelineResourcesResponse
+
+	err := cl.Request(ctx, http.MethodGet, fmt.Sprintf("%s/teams/%s/pipelines/%s/resources", cl.url, tc, pn), nil, &resp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make request: %w", err)
+	}
+
+	if resp.Err != "" {
+		return nil, fmt.Errorf("error from request: %s", resp.Err)
+	}
+
+	return resp.Resources, nil
 }
 
 // GetPipelineResource retrieves a single resource from a pipeline.

--- a/pikoci/transport/http/handler.go
+++ b/pikoci/transport/http/handler.go
@@ -36,7 +36,8 @@ var publicFallbackRoutes = map[RouteName]bool{
 	GetPipelineImage:     true,
 	GetPipelineJob:       true,
 	ListJobBuilds:        true,
-	GetPipelineResource:  true,
+	ListPipelineResources: true,
+	GetPipelineResource:   true,
 	ListResourceVersions: true,
 }
 
@@ -255,6 +256,7 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, 
 	api.Methods(http.MethodGet).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/builds-get-versions/{build_id}").Name(FindBuildGetVersions.String()).Handler(findBuildGetVersions(s))
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/builds/{build_id}/get-versions").Name(InsertBuildGetVersion.String()).Handler(insertBuildGetVersion(s))
 
+	api.Methods(http.MethodGet).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/resources").Name(ListPipelineResources.String()).Handler(listPipelineResources(s))
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/resources/{resource_canonical}/versions").Name(CreateResourceVersion.String()).Handler(createResourceVersion(s))
 	api.Methods(http.MethodGet).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/resources/{resource_canonical}/versions").Name(ListResourceVersions.String()).Handler(listResourceVersions(s))
 	api.Methods(http.MethodGet).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/resources/{resource_canonical}").Name(GetPipelineResource.String()).Handler(getPipelineResource(s))

--- a/pikoci/transport/http/handlers_coverage_test.go
+++ b/pikoci/transport/http/handlers_coverage_test.go
@@ -1511,6 +1511,79 @@ func TestListResourceVersions_Error(t *testing.T) {
 	assert.Equal(t, "db error", got.Err)
 }
 
+func TestListPipelineResources_Success(t *testing.T) {
+	e := newTestEnv(t)
+	e.expectMemberAuth()
+	resources := []*resource.Resource{
+		{Name: "res1", Canonical: "res1", WebhookToken: "secret1"},
+		{Name: "res2", Canonical: "res2", WebhookToken: "secret2"},
+	}
+	e.svc.EXPECT().ListPipelineResources(gomock.Any(), "main", "my-pipe").Return(resources, nil)
+
+	resp := doRequest(t, http.MethodGet, e.server.URL+"/teams/main/pipelines/my-pipe/resources", e.memberJWT(t), "")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	var got ListPipelineResourcesResponse
+	json.NewDecoder(resp.Body).Decode(&got)
+	assert.Empty(t, got.Err)
+	assert.Len(t, got.Resources, 2)
+	// Non-admin member should have webhook tokens stripped
+	assert.Empty(t, got.Resources[0].WebhookToken)
+	assert.Empty(t, got.Resources[1].WebhookToken)
+}
+
+func TestListPipelineResources_AdminSeesWebhookTokens(t *testing.T) {
+	e := newTestEnv(t)
+	e.expectAdminAuth()
+	resources := []*resource.Resource{
+		{Name: "res1", Canonical: "res1", WebhookToken: "secret1"},
+	}
+	e.svc.EXPECT().ListPipelineResources(gomock.Any(), "main", "my-pipe").Return(resources, nil)
+
+	resp := doRequest(t, http.MethodGet, e.server.URL+"/teams/main/pipelines/my-pipe/resources", e.adminJWT(t), "")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	var got ListPipelineResourcesResponse
+	json.NewDecoder(resp.Body).Decode(&got)
+	assert.Empty(t, got.Err)
+	assert.Equal(t, "secret1", got.Resources[0].WebhookToken)
+}
+
+func TestListPipelineResources_Error(t *testing.T) {
+	e := newTestEnv(t)
+	e.expectMemberAuth()
+	e.svc.EXPECT().ListPipelineResources(gomock.Any(), "main", "my-pipe").Return(nil, fmt.Errorf("db error"))
+
+	resp := doRequest(t, http.MethodGet, e.server.URL+"/teams/main/pipelines/my-pipe/resources", e.memberJWT(t), "")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	var got ListPipelineResourcesResponse
+	json.NewDecoder(resp.Body).Decode(&got)
+	assert.Equal(t, "db error", got.Err)
+}
+
+func TestListPipelineResources_PublicFallback(t *testing.T) {
+	e := newTestEnv(t)
+	pp := &pipeline.Pipeline{Name: "public-pipe", Canonical: "public-pipe", Public: true}
+	resources := []*resource.Resource{
+		{Name: "res1", Canonical: "res1"},
+	}
+	e.svc.EXPECT().GetPublicPipeline(gomock.Any(), "main", "public-pipe").Return(pp, nil)
+	e.svc.EXPECT().ListPublicPipelineResources(gomock.Any(), "main", "public-pipe").Return(resources, nil)
+
+	resp := doRequest(t, http.MethodGet, e.server.URL+"/teams/main/pipelines/public-pipe/resources", "", "")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	var got ListPipelineResourcesResponse
+	json.NewDecoder(resp.Body).Decode(&got)
+	assert.Empty(t, got.Err)
+	assert.Len(t, got.Resources, 1)
+}
+
 func TestGetPipelineResource_Success(t *testing.T) {
 	e := newTestEnv(t)
 	e.expectMemberAuth()

--- a/pikoci/transport/http/resources.go
+++ b/pikoci/transport/http/resources.go
@@ -10,6 +10,49 @@ import (
 	"github.com/pikoci/pikoci/pikoci/resource"
 )
 
+type ListPipelineResourcesResponse struct {
+	Resources []*resource.Resource `json:"data,omitempty"`
+	Err       string               `json:"error,omitempty"`
+}
+
+func (r ListPipelineResourcesResponse) Error() string { return r.Err }
+
+func listPipelineResources(s pikoci.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var ctx = r.Context()
+		vars := mux.Vars(r)
+		tc := vars["team_canonical"]
+		pc := vars["pipeline_canonical"]
+		var resources []*resource.Resource
+		var err error
+		if isPublic, _ := ctx.Value(IsPublicAccessKey).(bool); isPublic {
+			resources, err = s.ListPublicPipelineResources(ctx, tc, pc)
+		} else {
+			resources, err = s.ListPipelineResources(ctx, tc, pc)
+			if resources != nil {
+				un, _ := ctx.Value(UsernameContextKey).(string)
+				isAdmin := false
+				if un != "" {
+					um, uerr := s.GetUser(ctx, un)
+					if uerr == nil && um.IsAdmin(tc) {
+						isAdmin = true
+					}
+				}
+				if !isAdmin {
+					for _, res := range resources {
+						res.WebhookToken = ""
+					}
+				}
+			}
+		}
+		var errs string
+		if err != nil {
+			errs = err.Error()
+		}
+		encodeResponse(ListPipelineResourcesResponse{Resources: resources, Err: errs}, w)
+	}
+}
+
 type CreateResourceVersionRequest struct {
 	TeamCanonical     string           `json:"team_canonical"`
 	PipelineCanonical string           `json:"pipeline_canonical"`

--- a/pikoci/transport/http/route_names.go
+++ b/pikoci/transport/http/route_names.go
@@ -95,6 +95,8 @@ const (
 	// EvaluateDownstreamJobs is the route for evaluating downstream jobs after a build succeeds.
 	EvaluateDownstreamJobs
 
+	// ListPipelineResources is the route for listing all resources of a pipeline.
+	ListPipelineResources
 	// GetPipelineResource is the route for retrieving a single pipeline resource.
 	GetPipelineResource
 	// UpdatePipelineResource is the route for updating a pipeline resource.

--- a/pikoci/transport/http/route_names_string.go
+++ b/pikoci/transport/http/route_names_string.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _RouteNameName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobsget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_worker"
+const _RouteNameName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobslist_pipeline_resourcesget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_worker"
 
-var _RouteNameIndex = [...]uint16{0, 10, 23, 34, 44, 52, 63, 74, 89, 103, 114, 124, 132, 143, 154, 172, 190, 208, 223, 238, 250, 265, 279, 297, 318, 338, 354, 370, 392, 408, 424, 439, 463, 486, 499, 515, 530, 549, 574, 608, 632, 653, 677, 702, 725, 747, 767, 789, 813, 828, 852, 866, 885, 900, 914, 930, 939, 950, 961, 977, 989, 1003, 1016}
+var _RouteNameIndex = [...]uint16{0, 10, 23, 34, 44, 52, 63, 74, 89, 103, 114, 124, 132, 143, 154, 172, 190, 208, 223, 238, 250, 265, 279, 297, 318, 338, 354, 370, 392, 408, 424, 439, 463, 486, 499, 515, 530, 549, 574, 608, 632, 655, 676, 700, 725, 748, 770, 790, 812, 836, 851, 875, 889, 908, 923, 937, 953, 962, 973, 984, 1000, 1012, 1026, 1039}
 
-const _RouteNameLowerName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobsget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_worker"
+const _RouteNameLowerName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobslist_pipeline_resourcesget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_worker"
 
 func (i RouteName) String() string {
 	if i < 0 || i >= RouteName(len(_RouteNameIndex)-1) {
@@ -64,31 +64,32 @@ func _RouteNameNoOp() {
 	_ = x[FindOldestPendingBuild-(37)]
 	_ = x[NotifySerialGroupPendingBuilds-(38)]
 	_ = x[EvaluateDownstreamJobs-(39)]
-	_ = x[GetPipelineResource-(40)]
-	_ = x[UpdatePipelineResource-(41)]
-	_ = x[TriggerPipelineResource-(42)]
-	_ = x[CreateResourceVersion-(43)]
-	_ = x[ListResourceVersions-(44)]
-	_ = x[PinResourceVersion-(45)]
-	_ = x[UnpinResourceVersion-(46)]
-	_ = x[TriggerResourceVersion-(47)]
-	_ = x[WebhookTrigger-(48)]
-	_ = x[RegenerateWebhookToken-(49)]
-	_ = x[CreateTrigger-(50)]
-	_ = x[ListTriggersAfter-(51)]
-	_ = x[ExportDatabase-(52)]
-	_ = x[PausePipeline-(53)]
-	_ = x[UnpausePipeline-(54)]
-	_ = x[PauseJob-(55)]
-	_ = x[UnpauseJob-(56)]
-	_ = x[GetVersion-(57)]
-	_ = x[WorkerHeartbeat-(58)]
-	_ = x[ListWorkers-(59)]
-	_ = x[WorkersHealth-(60)]
-	_ = x[DeleteWorker-(61)]
+	_ = x[ListPipelineResources-(40)]
+	_ = x[GetPipelineResource-(41)]
+	_ = x[UpdatePipelineResource-(42)]
+	_ = x[TriggerPipelineResource-(43)]
+	_ = x[CreateResourceVersion-(44)]
+	_ = x[ListResourceVersions-(45)]
+	_ = x[PinResourceVersion-(46)]
+	_ = x[UnpinResourceVersion-(47)]
+	_ = x[TriggerResourceVersion-(48)]
+	_ = x[WebhookTrigger-(49)]
+	_ = x[RegenerateWebhookToken-(50)]
+	_ = x[CreateTrigger-(51)]
+	_ = x[ListTriggersAfter-(52)]
+	_ = x[ExportDatabase-(53)]
+	_ = x[PausePipeline-(54)]
+	_ = x[UnpausePipeline-(55)]
+	_ = x[PauseJob-(56)]
+	_ = x[UnpauseJob-(57)]
+	_ = x[GetVersion-(58)]
+	_ = x[WorkerHeartbeat-(59)]
+	_ = x[ListWorkers-(60)]
+	_ = x[WorkersHealth-(61)]
+	_ = x[DeleteWorker-(62)]
 }
 
-var _RouteNameValues = []RouteName{UserLogin, RefreshToken, CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser, ChangePassword, UpdateProfile, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, GetPipelineJob, CreateJobBuild, CreateRetryJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, InsertBuildGetVersion, FindBuildGetVersions, GetJobBuild, CancelJobBuild, RetryJobBuild, StartPendingBuild, FindOldestPendingBuild, NotifySerialGroupPendingBuilds, EvaluateDownstreamJobs, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions, PinResourceVersion, UnpinResourceVersion, TriggerResourceVersion, WebhookTrigger, RegenerateWebhookToken, CreateTrigger, ListTriggersAfter, ExportDatabase, PausePipeline, UnpausePipeline, PauseJob, UnpauseJob, GetVersion, WorkerHeartbeat, ListWorkers, WorkersHealth, DeleteWorker}
+var _RouteNameValues = []RouteName{UserLogin, RefreshToken, CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser, ChangePassword, UpdateProfile, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, GetPipelineJob, CreateJobBuild, CreateRetryJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, InsertBuildGetVersion, FindBuildGetVersions, GetJobBuild, CancelJobBuild, RetryJobBuild, StartPendingBuild, FindOldestPendingBuild, NotifySerialGroupPendingBuilds, EvaluateDownstreamJobs, ListPipelineResources, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions, PinResourceVersion, UnpinResourceVersion, TriggerResourceVersion, WebhookTrigger, RegenerateWebhookToken, CreateTrigger, ListTriggersAfter, ExportDatabase, PausePipeline, UnpausePipeline, PauseJob, UnpauseJob, GetVersion, WorkerHeartbeat, ListWorkers, WorkersHealth, DeleteWorker}
 
 var _RouteNameNameToValueMap = map[string]RouteName{
 	_RouteNameName[0:10]:           UserLogin,
@@ -171,50 +172,52 @@ var _RouteNameNameToValueMap = map[string]RouteName{
 	_RouteNameLowerName[574:608]:   NotifySerialGroupPendingBuilds,
 	_RouteNameName[608:632]:        EvaluateDownstreamJobs,
 	_RouteNameLowerName[608:632]:   EvaluateDownstreamJobs,
-	_RouteNameName[632:653]:        GetPipelineResource,
-	_RouteNameLowerName[632:653]:   GetPipelineResource,
-	_RouteNameName[653:677]:        UpdatePipelineResource,
-	_RouteNameLowerName[653:677]:   UpdatePipelineResource,
-	_RouteNameName[677:702]:        TriggerPipelineResource,
-	_RouteNameLowerName[677:702]:   TriggerPipelineResource,
-	_RouteNameName[702:725]:        CreateResourceVersion,
-	_RouteNameLowerName[702:725]:   CreateResourceVersion,
-	_RouteNameName[725:747]:        ListResourceVersions,
-	_RouteNameLowerName[725:747]:   ListResourceVersions,
-	_RouteNameName[747:767]:        PinResourceVersion,
-	_RouteNameLowerName[747:767]:   PinResourceVersion,
-	_RouteNameName[767:789]:        UnpinResourceVersion,
-	_RouteNameLowerName[767:789]:   UnpinResourceVersion,
-	_RouteNameName[789:813]:        TriggerResourceVersion,
-	_RouteNameLowerName[789:813]:   TriggerResourceVersion,
-	_RouteNameName[813:828]:        WebhookTrigger,
-	_RouteNameLowerName[813:828]:   WebhookTrigger,
-	_RouteNameName[828:852]:        RegenerateWebhookToken,
-	_RouteNameLowerName[828:852]:   RegenerateWebhookToken,
-	_RouteNameName[852:866]:        CreateTrigger,
-	_RouteNameLowerName[852:866]:   CreateTrigger,
-	_RouteNameName[866:885]:        ListTriggersAfter,
-	_RouteNameLowerName[866:885]:   ListTriggersAfter,
-	_RouteNameName[885:900]:        ExportDatabase,
-	_RouteNameLowerName[885:900]:   ExportDatabase,
-	_RouteNameName[900:914]:        PausePipeline,
-	_RouteNameLowerName[900:914]:   PausePipeline,
-	_RouteNameName[914:930]:        UnpausePipeline,
-	_RouteNameLowerName[914:930]:   UnpausePipeline,
-	_RouteNameName[930:939]:        PauseJob,
-	_RouteNameLowerName[930:939]:   PauseJob,
-	_RouteNameName[939:950]:        UnpauseJob,
-	_RouteNameLowerName[939:950]:   UnpauseJob,
-	_RouteNameName[950:961]:        GetVersion,
-	_RouteNameLowerName[950:961]:   GetVersion,
-	_RouteNameName[961:977]:        WorkerHeartbeat,
-	_RouteNameLowerName[961:977]:   WorkerHeartbeat,
-	_RouteNameName[977:989]:        ListWorkers,
-	_RouteNameLowerName[977:989]:   ListWorkers,
-	_RouteNameName[989:1003]:       WorkersHealth,
-	_RouteNameLowerName[989:1003]:  WorkersHealth,
-	_RouteNameName[1003:1016]:      DeleteWorker,
-	_RouteNameLowerName[1003:1016]: DeleteWorker,
+	_RouteNameName[632:655]:        ListPipelineResources,
+	_RouteNameLowerName[632:655]:   ListPipelineResources,
+	_RouteNameName[655:676]:        GetPipelineResource,
+	_RouteNameLowerName[655:676]:   GetPipelineResource,
+	_RouteNameName[676:700]:        UpdatePipelineResource,
+	_RouteNameLowerName[676:700]:   UpdatePipelineResource,
+	_RouteNameName[700:725]:        TriggerPipelineResource,
+	_RouteNameLowerName[700:725]:   TriggerPipelineResource,
+	_RouteNameName[725:748]:        CreateResourceVersion,
+	_RouteNameLowerName[725:748]:   CreateResourceVersion,
+	_RouteNameName[748:770]:        ListResourceVersions,
+	_RouteNameLowerName[748:770]:   ListResourceVersions,
+	_RouteNameName[770:790]:        PinResourceVersion,
+	_RouteNameLowerName[770:790]:   PinResourceVersion,
+	_RouteNameName[790:812]:        UnpinResourceVersion,
+	_RouteNameLowerName[790:812]:   UnpinResourceVersion,
+	_RouteNameName[812:836]:        TriggerResourceVersion,
+	_RouteNameLowerName[812:836]:   TriggerResourceVersion,
+	_RouteNameName[836:851]:        WebhookTrigger,
+	_RouteNameLowerName[836:851]:   WebhookTrigger,
+	_RouteNameName[851:875]:        RegenerateWebhookToken,
+	_RouteNameLowerName[851:875]:   RegenerateWebhookToken,
+	_RouteNameName[875:889]:        CreateTrigger,
+	_RouteNameLowerName[875:889]:   CreateTrigger,
+	_RouteNameName[889:908]:        ListTriggersAfter,
+	_RouteNameLowerName[889:908]:   ListTriggersAfter,
+	_RouteNameName[908:923]:        ExportDatabase,
+	_RouteNameLowerName[908:923]:   ExportDatabase,
+	_RouteNameName[923:937]:        PausePipeline,
+	_RouteNameLowerName[923:937]:   PausePipeline,
+	_RouteNameName[937:953]:        UnpausePipeline,
+	_RouteNameLowerName[937:953]:   UnpausePipeline,
+	_RouteNameName[953:962]:        PauseJob,
+	_RouteNameLowerName[953:962]:   PauseJob,
+	_RouteNameName[962:973]:        UnpauseJob,
+	_RouteNameLowerName[962:973]:   UnpauseJob,
+	_RouteNameName[973:984]:        GetVersion,
+	_RouteNameLowerName[973:984]:   GetVersion,
+	_RouteNameName[984:1000]:       WorkerHeartbeat,
+	_RouteNameLowerName[984:1000]:  WorkerHeartbeat,
+	_RouteNameName[1000:1012]:      ListWorkers,
+	_RouteNameLowerName[1000:1012]: ListWorkers,
+	_RouteNameName[1012:1026]:      WorkersHealth,
+	_RouteNameLowerName[1012:1026]: WorkersHealth,
+	_RouteNameName[1026:1039]:      DeleteWorker,
+	_RouteNameLowerName[1026:1039]: DeleteWorker,
 }
 
 var _RouteNameNames = []string{
@@ -258,28 +261,29 @@ var _RouteNameNames = []string{
 	_RouteNameName[549:574],
 	_RouteNameName[574:608],
 	_RouteNameName[608:632],
-	_RouteNameName[632:653],
-	_RouteNameName[653:677],
-	_RouteNameName[677:702],
-	_RouteNameName[702:725],
-	_RouteNameName[725:747],
-	_RouteNameName[747:767],
-	_RouteNameName[767:789],
-	_RouteNameName[789:813],
-	_RouteNameName[813:828],
-	_RouteNameName[828:852],
-	_RouteNameName[852:866],
-	_RouteNameName[866:885],
-	_RouteNameName[885:900],
-	_RouteNameName[900:914],
-	_RouteNameName[914:930],
-	_RouteNameName[930:939],
-	_RouteNameName[939:950],
-	_RouteNameName[950:961],
-	_RouteNameName[961:977],
-	_RouteNameName[977:989],
-	_RouteNameName[989:1003],
-	_RouteNameName[1003:1016],
+	_RouteNameName[632:655],
+	_RouteNameName[655:676],
+	_RouteNameName[676:700],
+	_RouteNameName[700:725],
+	_RouteNameName[725:748],
+	_RouteNameName[748:770],
+	_RouteNameName[770:790],
+	_RouteNameName[790:812],
+	_RouteNameName[812:836],
+	_RouteNameName[836:851],
+	_RouteNameName[851:875],
+	_RouteNameName[875:889],
+	_RouteNameName[889:908],
+	_RouteNameName[908:923],
+	_RouteNameName[923:937],
+	_RouteNameName[937:953],
+	_RouteNameName[953:962],
+	_RouteNameName[962:973],
+	_RouteNameName[973:984],
+	_RouteNameName[984:1000],
+	_RouteNameName[1000:1012],
+	_RouteNameName[1012:1026],
+	_RouteNameName[1026:1039],
 }
 
 // RouteNameString retrieves an enum value from the enum constants string name.

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -263,6 +263,7 @@
           <% } %>
         </h1>
         <div class="d-flex gap-2">
+          <button type="button" id="toggle-resources-panel" class="btn btn-outline-secondary"><i class="bi bi-box"></i> Resources</button>
           <% if (isMember(team.canonical) && pipeline.jobs && pipeline.jobs.length > 0) { %>
             <% if (pipeline.jobs.some(function(j) { return j.paused; })) { %>
               <button type="button" id="unpause-pipeline" class="btn btn-primary" data-loading-text="Unpausing..."><i class="bi bi-play-circle"></i> Unpause</button>
@@ -276,7 +277,10 @@
           <% } %>
         </div>
       </div>
-      <div class="piko-graph-container" id="graphviz"></div>
+      <div class="piko-graph-wrapper">
+        <div class="piko-graph-container" id="graphviz"></div>
+        <div id="pipeline-resources-panel" class="piko-resources-panel"></div>
+      </div>
       <div class="piko-graph-legend">
         <span class="piko-graph-legend-item">
           <svg width="22" height="14" viewBox="0 0 22 14"><polygon points="0,0 16,0 22,7 16,14 0,14" fill="#83769C" stroke="#5F574F" stroke-width="1"/></svg>
@@ -306,6 +310,47 @@
           <span class="piko-graph-legend-swatch" style="background:#29ADFF;"></span>
           Paused
         </span>
+      </div>
+    </script>
+
+    <script type="text/template" id="pipeline-resources-panel-view">
+      <div class="piko-resources-panel-header">
+        <span class="fw-bold">Resources</span>
+        <button type="button" id="close-resources-panel" style="background:none;border:none;color:var(--text-secondary);font-size:1.2rem;cursor:pointer;padding:0;line-height:1">&times;</button>
+      </div>
+      <div class="piko-resources-panel-body">
+        <% if (resources.length === 0) { %>
+          <p class="piko-resource-card-meta small mb-0">No resources in this pipeline.</p>
+        <% } else { %>
+          <% _.each(resources, function(r) { %>
+            <div class="piko-resource-card">
+              <div class="piko-resource-card-header">
+                <% if (r.latest_version && r.latest_version.status) { %>
+                  <span class="piko-version-status-dot" style="background:var(--status-<%= r.latest_version.status %>);" title="<%= r.latest_version.status %>"></span>
+                <% } %>
+                <a href="<%= resourceUrl(r.canonical) %>" class="piko-resource-card-name" data-navigate="true"><%- r.canonical %></a>
+                <span class="piko-resource-card-type"><%- r.type %></span>
+              </div>
+              <% if (r.latest_version && r.latest_version.version) { %>
+                <div class="piko-resource-card-version">
+                  <% _.each(r.latest_version.version, function(v, k) { %>
+                    <%- k %>: <span><%- v %></span>
+                  <% }); %>
+                </div>
+              <% } %>
+              <div class="piko-resource-card-meta">
+                <% if (r.last_check && !r.last_check.startsWith('0001-01-01')) { %>
+                  <span>Checked: <%- pikoTimeAgo(r.last_check) %></span>
+                <% } %>
+              </div>
+              <% if (isMember) { %>
+                <button class="btn btn-sm btn-outline-warning check-resource-now mt-1" data-canonical="<%- r.canonical %>">
+                  <i class="bi bi-arrow-clockwise"></i> Check Now
+                </button>
+              <% } %>
+            </div>
+          <% }); %>
+        <% } %>
       </div>
     </script>
 


### PR DESCRIPTION
## Summary

- Adds a "Resources" button to the pipeline show page header that opens a slide-out panel listing all pipeline resources
- Each resource shows: name (clickable link to versions page), type, latest version key-value, aggregate build status dot, last check time, and a "Check Now" button
- New `ListPipelineResources` API endpoint (`GET /teams/{tc}/pipelines/{pc}/resources`) with public pipeline fallback support

Closes #536