### PR TITLE
feat: add graph view resource node tooltips (#537)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Resource version rows now show a colored status dot indicating the aggregate build status of all jobs that consumed that version ([#534](https://github.com/PikoCI/pikoci/issues/534))
 - Pipeline show page now has a "Resources" button that opens a slide-out panel listing all pipeline resources with name, type, latest version, build status, last check time, and a "Check Now" button ([#536](https://github.com/PikoCI/pikoci/issues/536))
+- Resource nodes in the pipeline graph view now show a native browser tooltip on hover with the latest version's key-value pairs and aggregate build status ([#537](https://github.com/PikoCI/pikoci/issues/537))
 
 ### Fixed
 

--- a/pikoci/for_each_test.go
+++ b/pikoci/for_each_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pikoci/pikoci/pikoci/job"
 	"github.com/pikoci/pikoci/pikoci/pipeline"
+	"github.com/pikoci/pikoci/pikoci/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -540,6 +541,8 @@ job "deploy" {
 	// Expect Build.Filter for each expanded job + regular jobs
 	s.Builds.EXPECT().Filter(ctx, "main", "pikoci", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, nil).AnyTimes()
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "pikoci", gomock.Any(), (*uint32)(nil), (*uint32)(nil), uint32(1)).
+		Return([]*resource.Version{}, nil).AnyTimes()
 
 	img, err := s.S.CreatePipelineImage(ctx, "main", hclConfig, nil, "dot")
 	require.NoError(t, err)

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"os/exec"
+	"sort"
 	"regexp"
 	"strconv"
 	"strings"
@@ -565,6 +566,23 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 		}
 	}
 
+	// Build tooltip text for each resource from its latest version.
+	resourceTooltips := make(map[string]string)
+	for _, r := range pp.Resources {
+		vers, err := q.Resources.FilterVersions(ctx, tc, pp.Canonical, r.Canonical, nil, nil, 1)
+		if err != nil || len(vers) == 0 {
+			continue
+		}
+		v := vers[0]
+		statuses, err := q.Builds.AggregateStatusByVersionIDs(ctx, []uint32{v.ID})
+		if err == nil {
+			if s, ok := statuses[v.ID]; ok {
+				v.Status = s
+			}
+		}
+		resourceTooltips[r.Canonical] = buildResourceTooltip(v)
+	}
+
 	resourceBorders := make(map[string]string)
 	resourceStyles := make(map[string]string)
 	resourcePenwidths := make(map[string]string)
@@ -599,6 +617,9 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 		}
 		if penwidth != "" {
 			attrs["penwidth"] = penwidth
+		}
+		if tip, ok := resourceTooltips[r.Canonical]; ok {
+			attrs[string(gographviz.Tooltip)] = fmt.Sprintf(`"%s"`, tip)
 		}
 		err = graph.AddNode(pn, fmt.Sprintf(`"%s"`, r.Canonical), attrs)
 		if err != nil {
@@ -745,6 +766,9 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 			if pw := resourcePenwidths[rCan]; pw != "" {
 				putAttrs["penwidth"] = pw
 			}
+			if tip, ok := resourceTooltips[rCan]; ok {
+				putAttrs[string(gographviz.Tooltip)] = fmt.Sprintf(`"%s"`, tip)
+			}
 			err = graph.AddNode(pn, nn, putAttrs)
 			if err != nil {
 				return nil, fmt.Errorf("failed to add node to Graph: %w", err)
@@ -823,6 +847,9 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 					if pw := resourcePenwidths[rCan]; pw != "" {
 						passedAttrs["penwidth"] = pw
 					}
+					if tip, ok := resourceTooltips[rCan]; ok {
+						passedAttrs[string(gographviz.Tooltip)] = fmt.Sprintf(`"%s"`, tip)
+					}
 					err = graph.AddNode(pn, nn, passedAttrs)
 					if err != nil {
 						return nil, fmt.Errorf("failed to add node to Graph: %w", err)
@@ -843,6 +870,26 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 
 	str := graph.String()
 	return []byte(str), nil
+}
+
+// buildResourceTooltip formats a resource version's key-value pairs and
+// aggregate build status into a newline-separated tooltip string.
+func buildResourceTooltip(v *resource.Version) string {
+	keys := make([]string, 0, len(v.Version))
+	for k := range v.Version {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var lines []string
+	for _, k := range keys {
+		val := fmt.Sprintf("%v", v.Version[k])
+		val = strings.ReplaceAll(val, `"`, `\"`)
+		lines = append(lines, fmt.Sprintf("%s: %s", k, val))
+	}
+	if v.Status != "" {
+		lines = append(lines, v.Status)
+	}
+	return strings.Join(lines, "\\n")
 }
 
 // convertDOTImage converts raw DOT bytes to the requested format.

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -1412,6 +1412,8 @@ func TestGetPipelineImage_HidesUnlinkedResources(t *testing.T) {
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
 	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "build", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "github-check.ci", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot")
 	require.NoError(t, err)
@@ -1461,6 +1463,7 @@ func TestGetPipelineImage_QuotesHyphenatedName(t *testing.T) {
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "hello-world").Return(pp, nil)
 	s.Builds.EXPECT().Filter(ctx, "main", "hello-world", "hello", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "hello-world", "cron.tick", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "hello-world", "dot")
 	require.NoError(t, err)
@@ -1504,6 +1507,8 @@ func TestGetPipelineImage_ShowsLinkedResources(t *testing.T) {
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
 	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "test", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "git.repo", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot")
 	require.NoError(t, err)
@@ -1556,6 +1561,8 @@ func TestGetPipelineImage_PassedReusesPutOutputNode(t *testing.T) {
 	s.Pipelines.EXPECT().Find(ctx, "main", "artifact-pipeline").Return(pp, nil)
 	s.Builds.EXPECT().Filter(ctx, "main", "artifact-pipeline", "build", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
 	s.Builds.EXPECT().Filter(ctx, "main", "artifact-pipeline", "deploy", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "artifact-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "artifact-pipeline", "artifact.output", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "artifact-pipeline", "dot")
 	require.NoError(t, err)
@@ -1756,6 +1763,7 @@ func TestGetPipelineImage_JobStatusColors(t *testing.T) {
 			pp := makePipeline()
 			s.Pipelines.EXPECT().Find(ctx, "main", "p").Return(pp, nil)
 			s.Builds.EXPECT().Filter(ctx, "main", "p", "j", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return(tt.builds, nil)
+			s.Resources.EXPECT().FilterVersions(ctx, "main", "p", "cron.tick", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
 			img, err := s.S.GetPipelineImage(ctx, "main", "p", "dot")
 			require.NoError(t, err)
@@ -3629,6 +3637,7 @@ job "test" {
 
 	// No builds for the job
 	s.Builds.EXPECT().Filter(ctx, "main", "pikoci", "test", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "pikoci", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
 	img, err := s.S.CreatePipelineImage(ctx, "main", hclConfig, nil, "dot")
 	require.NoError(t, err)
@@ -3704,6 +3713,7 @@ job "test" {
 
 	// No builds for the job
 	s.Builds.EXPECT().Filter(ctx, "main", "pikoci", "test", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "pikoci", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
 	img, err := s.S.CreatePipelineImage(ctx, "main", hclConfig, nil, "image.dot")
 	require.NoError(t, err)
@@ -3734,6 +3744,7 @@ func TestGetPublicPipelineImage_DOT(t *testing.T) {
 
 	s.Pipelines.EXPECT().FindPublic(ctx, "main", "my-pipeline").Return(pp, nil)
 	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
 	img, err := s.S.GetPublicPipelineImage(ctx, "main", "my-pipeline", "dot")
 	require.NoError(t, err)
@@ -3824,6 +3835,7 @@ func TestGetPipelineImage_DOT(t *testing.T) {
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
 	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot")
 	require.NoError(t, err)
@@ -3928,6 +3940,8 @@ func TestGetPipelineImage_WithBuildStatuses(t *testing.T) {
 	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "running-job", gomock.Any(), gomock.Any(), gomock.Any()).Return([]*build.Build{
 		{ID: 3, BuildNumber: "1", Status: build.Started},
 	}, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "git.repo", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot")
 	require.NoError(t, err)
@@ -3970,6 +3984,7 @@ func TestGetPipelineImage_WithPassedConstraints(t *testing.T) {
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
 	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "upstream", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "downstream", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot")
 	require.NoError(t, err)
@@ -4002,6 +4017,7 @@ func TestGetPipelineImage_ResourceWithError(t *testing.T) {
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
 	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot")
 	require.NoError(t, err)
@@ -4033,10 +4049,118 @@ func TestGetPipelineImage_PinnedResource(t *testing.T) {
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
 	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot")
 	require.NoError(t, err)
 	assert.Contains(t, string(img), "graph")
+}
+
+func TestGetPipelineImage_ResourceTooltip(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	pp := &pipeline.Pipeline{
+		ID:        1,
+		Name:      "my-pipeline",
+		Canonical: "my-pipeline",
+		Jobs: []job.Job{
+			{
+				Name: "my-job",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "git", Name: "repo"}},
+				},
+			},
+		},
+		Resources: []resource.Resource{
+			{ID: 1, Canonical: "git.repo", Name: "repo", Type: "git"},
+		},
+	}
+
+	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
+	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "git.repo", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{
+		{ID: 10, Version: map[string]interface{}{"ref": "abc1234", "sha": "deadbeef"}},
+	}, nil)
+	s.Builds.EXPECT().AggregateStatusByVersionIDs(ctx, []uint32{10}).Return(map[uint32]string{10: "succeeded"}, nil)
+
+	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot")
+	require.NoError(t, err)
+
+	dot := string(img)
+	assert.Contains(t, dot, `tooltip="ref: abc1234\nsha: deadbeef\nsucceeded"`)
+}
+
+func TestGetPipelineImage_ResourceTooltipNoVersions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	pp := &pipeline.Pipeline{
+		ID:        1,
+		Name:      "my-pipeline",
+		Canonical: "my-pipeline",
+		Jobs: []job.Job{
+			{
+				Name: "my-job",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "cron", Name: "timer"}},
+				},
+			},
+		},
+		Resources: []resource.Resource{
+			{ID: 1, Canonical: "cron.timer", Name: "timer", Type: "cron"},
+		},
+	}
+
+	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
+	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+
+	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot")
+	require.NoError(t, err)
+
+	dot := string(img)
+	// No tooltip attribute should be present when there are no versions
+	assert.NotContains(t, dot, "tooltip=")
+}
+
+func TestGetPipelineImage_ResourceTooltipNoStatus(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	pp := &pipeline.Pipeline{
+		ID:        1,
+		Name:      "my-pipeline",
+		Canonical: "my-pipeline",
+		Jobs: []job.Job{
+			{
+				Name: "my-job",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "git", Name: "repo"}},
+				},
+			},
+		},
+		Resources: []resource.Resource{
+			{ID: 1, Canonical: "git.repo", Name: "repo", Type: "git"},
+		},
+	}
+
+	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
+	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "git.repo", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{
+		{ID: 5, Version: map[string]interface{}{"ref": "main"}},
+	}, nil)
+	s.Builds.EXPECT().AggregateStatusByVersionIDs(ctx, []uint32{5}).Return(nil, nil)
+
+	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot")
+	require.NoError(t, err)
+
+	dot := string(img)
+	// Tooltip should only show version KVs, no status line
+	assert.Contains(t, dot, `tooltip="ref: main"`)
 }
 
 func TestCreatePipeline_WithRunnerType(t *testing.T) {


### PR DESCRIPTION
## Summary

- Resource nodes in the pipeline graph view now show a native browser tooltip on hover with the latest version's key-value pairs and aggregate build status
- Tooltips are applied to all three resource node types: standalone, put output, and passed-constraint intermediate nodes
- Resources with no versions show no tooltip (default Graphviz behavior)

Closes #537