### PR TITLE
fix: add missing tags column to FindByWebhookToken Scan (#544)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `in_parallel` sub-step durations now display as formatted time (`HH:MM:SS`) instead of raw nanoseconds ([#526](https://github.com/PikoCI/pikoci/issues/526))
+- Webhook triggers now work correctly after the `tags` column was added to resources. `FindByWebhookToken` was missing the `tags` Scan destination, causing all webhook calls to return 400 ([#544](https://github.com/PikoCI/pikoci/issues/544))
 
 ## [0.5.1] - 2026-06-16
 

--- a/pikoci/mysql/resource.go
+++ b/pikoci/mysql/resource.go
@@ -211,6 +211,7 @@ func (r *ResourceRepository) FindByWebhookToken(ctx context.Context, token strin
 		&dbr.LastCheck,
 		&dbr.NextCheck,
 		&dbr.WebhookToken,
+		&dbr.Tags,
 		&dbr.Cache,
 		&dbr.PinnedVersionID,
 		&tc,

--- a/pikoci/mysql/resource_test.go
+++ b/pikoci/mysql/resource_test.go
@@ -1,0 +1,43 @@
+package mysql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pikoci/pikoci/pikoci/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindByWebhookToken(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	res, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'wh-pipe', 'wh-pipe')`)
+	require.NoError(t, err)
+	ppID, _ := res.LastInsertId()
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO resources (pipeline_id, name, type, canonical, webhook_token, tags, cache)
+		 VALUES (?, 'repo', 'git', 'git.repo', 'git.repo_abc123', '["deploy"]', 0)`, ppID)
+	require.NoError(t, err)
+
+	rr := mysql.NewResourceRepository(db, mysql.Mem)
+
+	r, tc, pc, err := rr.FindByWebhookToken(ctx, "git.repo_abc123")
+	require.NoError(t, err)
+	assert.Equal(t, "git.repo", r.Canonical)
+	assert.Equal(t, "main", tc)
+	assert.Equal(t, "wh-pipe", pc)
+}
+
+func TestFindByWebhookToken_NotFound(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	rr := mysql.NewResourceRepository(db, mysql.Mem)
+
+	_, _, _, err := rr.FindByWebhookToken(ctx, "nonexistent-token")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}


### PR DESCRIPTION
## Summary

- `FindByWebhookToken` SELECT has 15 columns but Scan only had 14 destinations (missing `&dbr.Tags`), causing all webhook triggers to return 400
- Added DB-level integration test for `FindByWebhookToken`

Closes #544