### PR TITLE
feat: add list view with view switcher (#538)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resource version rows now show a colored status dot indicating the aggregate build status of all jobs that consumed that version ([#534](https://github.com/PikoCI/pikoci/issues/534))
 - Pipeline show page now has a "Resources" button that opens a slide-out panel listing all pipeline resources with name, type, latest version, build status, last check time, and a "Check Now" button ([#536](https://github.com/PikoCI/pikoci/issues/536))
 - Resource nodes in the pipeline graph view now show a native browser tooltip on hover with the latest version's key-value pairs and aggregate build status ([#537](https://github.com/PikoCI/pikoci/issues/537))
+- Pipeline show page now has a **List view** with a [Graph] [Pipeline] [List] view switcher toolbar. The list view shows an execution chain scoped to a selected trigger resource, with jobs displayed in a tree layout reflecting the pipeline DAG. Parallel siblings are grouped under collapsible headers. Clicking a job shows its builds in the right panel (reusing the existing job builds view). A resource selector bar at the top lets you switch between trigger resources and trigger resource checks. View preference, selected resource/job, and collapsed groups persist across reloads ([#538](https://github.com/PikoCI/pikoci/issues/538))
+- New `ListPipelineJobs` API endpoint (`GET /teams/{tc}/pipelines/{pc}/jobs`) returns all pipeline jobs enriched with latest build status, running state, build number, duration, and start time. Supports public pipeline fallback ([#538](https://github.com/PikoCI/pikoci/issues/538))
 
 ### Fixed
 

--- a/pikoci/job/job.go
+++ b/pikoci/job/job.go
@@ -225,3 +225,14 @@ type InParallelStep struct {
 	Limit    int        `json:"limit,omitempty"`
 	FailFast bool       `json:"fail_fast,omitempty"`
 }
+
+// WithStatus enriches a Job with its latest build status information,
+// used by the list view to show job status without fetching full builds.
+type WithStatus struct {
+	Job
+	LatestStatus        string     `json:"latest_status"`
+	HasRunning          bool       `json:"has_running"`
+	LatestBuildNumber   string     `json:"latest_build_number"`
+	LatestBuildDuration int64      `json:"latest_build_duration"`
+	StartedAt           *time.Time `json:"started_at,omitempty"`
+}

--- a/pikoci/jobs.go
+++ b/pikoci/jobs.go
@@ -3,6 +3,7 @@ package pikoci
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/pikoci/pikoci/pikoci/build"
 	"github.com/pikoci/pikoci/pikoci/job"
@@ -83,6 +84,105 @@ func (q *PikoCI) UnpauseJob(ctx context.Context, tc, pc, jn string) error {
 		return fmt.Errorf("invalid Job Name format %q", jn)
 	}
 	return q.Jobs.SetPaused(ctx, tc, pc, jn, false)
+}
+
+// ListPipelineJobs returns all jobs for the given pipeline enriched with
+// their latest build status information.
+func (q *PikoCI) ListPipelineJobs(ctx context.Context, tc, pn string) ([]job.WithStatus, error) {
+	if !utils.ValidateCanonical(tc) {
+		return nil, fmt.Errorf("invalid Team Canonical format %q", tc)
+	} else if !utils.ValidateCanonical(pn) {
+		return nil, fmt.Errorf("invalid Pipeline Canonical format %q", pn)
+	}
+
+	pp, err := q.Pipelines.Find(ctx, tc, pn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Pipeline %q: %w", pn, err)
+	}
+
+	return q.enrichJobsWithStatus(ctx, tc, pn, pp.Jobs)
+}
+
+// ListPublicPipelineJobs returns all jobs for a public pipeline enriched
+// with their latest build status.
+func (q *PikoCI) ListPublicPipelineJobs(ctx context.Context, tc, pn string) ([]job.WithStatus, error) {
+	pp, err := q.Pipelines.FindPublic(ctx, tc, pn)
+	if err != nil {
+		return nil, fmt.Errorf("pipeline not found or not public: %w", err)
+	}
+
+	return q.enrichJobsWithStatus(ctx, tc, pn, pp.Jobs)
+}
+
+// enrichJobsWithStatus enriches a slice of jobs with build status information.
+func (q *PikoCI) enrichJobsWithStatus(ctx context.Context, tc, pn string, jobs []job.Job) ([]job.WithStatus, error) {
+	result := make([]job.WithStatus, 0, len(jobs))
+	for _, j := range jobs {
+		ws := job.WithStatus{Job: j}
+
+		builds, err := q.Builds.Filter(ctx, tc, pn, j.Name, nil, nil, 0)
+		if err != nil {
+			return nil, fmt.Errorf("failed to filter builds for job %q: %w", j.Name, err)
+		}
+
+		// Find latest completed build (including retries) and any running build.
+		// Same logic as generateImage in pipelines.go.
+		var cb *build.Build
+		var rb *build.Build
+		for _, b := range builds {
+			if b.Status == build.Started && (rb == nil || rb.Status == build.Pending) {
+				rb = b
+			} else if b.Status == build.Pending && rb == nil {
+				rb = b
+			}
+		}
+		seen := map[string]bool{}
+		for cb == nil {
+			var mainBN string
+			for _, b := range builds {
+				if !strings.Contains(b.BuildNumber, ".") && !seen[b.BuildNumber] {
+					mainBN = b.BuildNumber
+					break
+				}
+			}
+			if mainBN == "" {
+				break
+			}
+			seen[mainBN] = true
+			for _, b := range builds {
+				if b.BuildNumber == mainBN || strings.HasPrefix(b.BuildNumber, mainBN+".") {
+					if b.Status != build.Started && b.Status != build.Pending {
+						cb = b
+						break
+					}
+				}
+			}
+		}
+
+		if cb != nil {
+			ws.LatestStatus = cb.Status.String()
+			ws.LatestBuildNumber = cb.BuildNumber
+			ws.LatestBuildDuration = int64(cb.Duration)
+			if !cb.StartedAt.IsZero() {
+				t := cb.StartedAt
+				ws.StartedAt = &t
+			}
+		}
+
+		if rb != nil {
+			ws.HasRunning = true
+			if cb == nil {
+				ws.LatestBuildNumber = rb.BuildNumber
+				if !rb.StartedAt.IsZero() {
+					t := rb.StartedAt
+					ws.StartedAt = &t
+				}
+			}
+		}
+
+		result = append(result, ws)
+	}
+	return result, nil
 }
 
 // GetPipelineJob retrieves a job by its name within a pipeline.

--- a/pikoci/mock/service.go
+++ b/pikoci/mock/service.go
@@ -534,6 +534,21 @@ func (mr *ServiceMockRecorder) ListJobBuilds(ctx, tc, pn, jn, before, after, lim
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobBuilds", reflect.TypeOf((*Service)(nil).ListJobBuilds), ctx, tc, pn, jn, before, after, limit)
 }
 
+// ListPipelineJobs mocks base method.
+func (m *Service) ListPipelineJobs(ctx context.Context, tc, pn string) ([]job.WithStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPipelineJobs", ctx, tc, pn)
+	ret0, _ := ret[0].([]job.WithStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPipelineJobs indicates an expected call of ListPipelineJobs.
+func (mr *ServiceMockRecorder) ListPipelineJobs(ctx, tc, pn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPipelineJobs", reflect.TypeOf((*Service)(nil).ListPipelineJobs), ctx, tc, pn)
+}
+
 // ListPipelineResources mocks base method.
 func (m *Service) ListPipelineResources(ctx context.Context, tc, pn string) ([]*resource.Resource, error) {
 	m.ctrl.T.Helper()
@@ -578,6 +593,21 @@ func (m *Service) ListPublicJobBuilds(ctx context.Context, tc, pn, jn string, be
 func (mr *ServiceMockRecorder) ListPublicJobBuilds(ctx, tc, pn, jn, before, after, limit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPublicJobBuilds", reflect.TypeOf((*Service)(nil).ListPublicJobBuilds), ctx, tc, pn, jn, before, after, limit)
+}
+
+// ListPublicPipelineJobs mocks base method.
+func (m *Service) ListPublicPipelineJobs(ctx context.Context, tc, pn string) ([]job.WithStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPublicPipelineJobs", ctx, tc, pn)
+	ret0, _ := ret[0].([]job.WithStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPublicPipelineJobs indicates an expected call of ListPublicPipelineJobs.
+func (mr *ServiceMockRecorder) ListPublicPipelineJobs(ctx, tc, pn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPublicPipelineJobs", reflect.TypeOf((*Service)(nil).ListPublicPipelineJobs), ctx, tc, pn)
 }
 
 // ListPublicPipelineResources mocks base method.

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -4418,3 +4418,249 @@ job "test" {
 	_, err := s.S.CreatePipeline(ctx, "main", "boolvar-override", hclConfig, vars)
 	require.NoError(t, err)
 }
+
+func TestListPipelineJobs_NoBuilds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+	tc := "main"
+	pn := "my-pipeline"
+
+	pp := &pipeline.Pipeline{
+		ID: 1, Name: pn, Canonical: pn,
+		Jobs: []job.Job{
+			{ID: 1, Name: "job-a"},
+			{ID: 2, Name: "job-b"},
+		},
+	}
+	s.Pipelines.EXPECT().Find(ctx, tc, pn).Return(pp, nil)
+	s.Builds.EXPECT().Filter(ctx, tc, pn, "job-a", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
+	s.Builds.EXPECT().Filter(ctx, tc, pn, "job-b", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
+
+	result, err := s.S.ListPipelineJobs(ctx, tc, pn)
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	assert.Equal(t, "job-a", result[0].Name)
+	assert.Equal(t, "", result[0].LatestStatus)
+	assert.False(t, result[0].HasRunning)
+	assert.Equal(t, "job-b", result[1].Name)
+	assert.Equal(t, "", result[1].LatestStatus)
+	assert.False(t, result[1].HasRunning)
+}
+
+func TestListPipelineJobs_SucceededBuild(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+	tc := "main"
+	pn := "my-pipeline"
+
+	startedAt := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	pp := &pipeline.Pipeline{
+		ID: 1, Name: pn, Canonical: pn,
+		Jobs: []job.Job{{ID: 1, Name: "build"}},
+	}
+	s.Pipelines.EXPECT().Find(ctx, tc, pn).Return(pp, nil)
+	s.Builds.EXPECT().Filter(ctx, tc, pn, "build", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{
+		{ID: 1, BuildNumber: "1", Status: build.Succeeded, Duration: time.Second, StartedAt: startedAt},
+	}, nil)
+
+	result, err := s.S.ListPipelineJobs(ctx, tc, pn)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, build.Succeeded.String(), result[0].LatestStatus)
+	assert.False(t, result[0].HasRunning)
+	assert.Equal(t, "1", result[0].LatestBuildNumber)
+	assert.Equal(t, int64(time.Second), result[0].LatestBuildDuration)
+	require.NotNil(t, result[0].StartedAt)
+	assert.Equal(t, startedAt, *result[0].StartedAt)
+}
+
+func TestListPipelineJobs_FailedBuild(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+	tc := "main"
+	pn := "my-pipeline"
+
+	pp := &pipeline.Pipeline{
+		ID: 1, Name: pn, Canonical: pn,
+		Jobs: []job.Job{{ID: 1, Name: "test"}},
+	}
+	s.Pipelines.EXPECT().Find(ctx, tc, pn).Return(pp, nil)
+	s.Builds.EXPECT().Filter(ctx, tc, pn, "test", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{
+		{ID: 1, BuildNumber: "1", Status: build.Failed, Duration: 2 * time.Second, StartedAt: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)},
+	}, nil)
+
+	result, err := s.S.ListPipelineJobs(ctx, tc, pn)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, build.Failed.String(), result[0].LatestStatus)
+	assert.False(t, result[0].HasRunning)
+}
+
+func TestListPipelineJobs_RunningBuild(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+	tc := "main"
+	pn := "my-pipeline"
+
+	pp := &pipeline.Pipeline{
+		ID: 1, Name: pn, Canonical: pn,
+		Jobs: []job.Job{{ID: 1, Name: "deploy"}},
+	}
+	s.Pipelines.EXPECT().Find(ctx, tc, pn).Return(pp, nil)
+	s.Builds.EXPECT().Filter(ctx, tc, pn, "deploy", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{
+		{ID: 1, BuildNumber: "1", Status: build.Started},
+	}, nil)
+
+	result, err := s.S.ListPipelineJobs(ctx, tc, pn)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.True(t, result[0].HasRunning)
+	// No completed build, so LatestStatus should be empty
+	assert.Equal(t, "", result[0].LatestStatus)
+}
+
+func TestListPipelineJobs_PendingBuild(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+	tc := "main"
+	pn := "my-pipeline"
+
+	pp := &pipeline.Pipeline{
+		ID: 1, Name: pn, Canonical: pn,
+		Jobs: []job.Job{{ID: 1, Name: "gen"}},
+	}
+	s.Pipelines.EXPECT().Find(ctx, tc, pn).Return(pp, nil)
+	s.Builds.EXPECT().Filter(ctx, tc, pn, "gen", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{
+		{ID: 1, BuildNumber: "1", Status: build.Pending},
+	}, nil)
+
+	result, err := s.S.ListPipelineJobs(ctx, tc, pn)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.True(t, result[0].HasRunning)
+	assert.Equal(t, "", result[0].LatestStatus)
+}
+
+func TestListPipelineJobs_MixedStatuses(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+	tc := "main"
+	pn := "my-pipeline"
+
+	pp := &pipeline.Pipeline{
+		ID: 1, Name: pn, Canonical: pn,
+		Jobs: []job.Job{
+			{ID: 1, Name: "job-ok"},
+			{ID: 2, Name: "job-fail"},
+		},
+	}
+	s.Pipelines.EXPECT().Find(ctx, tc, pn).Return(pp, nil)
+	s.Builds.EXPECT().Filter(ctx, tc, pn, "job-ok", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{
+		{ID: 1, BuildNumber: "1", Status: build.Succeeded, StartedAt: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)},
+	}, nil)
+	s.Builds.EXPECT().Filter(ctx, tc, pn, "job-fail", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{
+		{ID: 2, BuildNumber: "1", Status: build.Failed, StartedAt: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)},
+	}, nil)
+
+	result, err := s.S.ListPipelineJobs(ctx, tc, pn)
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	assert.Equal(t, build.Succeeded.String(), result[0].LatestStatus)
+	assert.Equal(t, build.Failed.String(), result[1].LatestStatus)
+}
+
+func TestListPipelineJobs_RetryBuild(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+	tc := "main"
+	pn := "my-pipeline"
+
+	startedAt := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	pp := &pipeline.Pipeline{
+		ID: 1, Name: pn, Canonical: pn,
+		Jobs: []job.Job{{ID: 1, Name: "build"}},
+	}
+	s.Pipelines.EXPECT().Find(ctx, tc, pn).Return(pp, nil)
+	s.Builds.EXPECT().Filter(ctx, tc, pn, "build", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{
+		{ID: 2, BuildNumber: "1.1", Status: build.Succeeded, Duration: 5 * time.Second, StartedAt: startedAt},
+		{ID: 1, BuildNumber: "1", Status: build.Failed, Duration: 3 * time.Second, StartedAt: startedAt},
+	}, nil)
+
+	result, err := s.S.ListPipelineJobs(ctx, tc, pn)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, build.Succeeded.String(), result[0].LatestStatus)
+	assert.Equal(t, "1.1", result[0].LatestBuildNumber)
+}
+
+func TestListPipelineJobs_JobOrder(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+	tc := "main"
+	pn := "my-pipeline"
+
+	pp := &pipeline.Pipeline{
+		ID: 1, Name: pn, Canonical: pn,
+		Jobs: []job.Job{
+			{ID: 1, Name: "first"},
+			{ID: 2, Name: "second"},
+			{ID: 3, Name: "third"},
+		},
+	}
+	s.Pipelines.EXPECT().Find(ctx, tc, pn).Return(pp, nil)
+	s.Builds.EXPECT().Filter(ctx, tc, pn, "first", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
+	s.Builds.EXPECT().Filter(ctx, tc, pn, "second", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
+	s.Builds.EXPECT().Filter(ctx, tc, pn, "third", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
+
+	result, err := s.S.ListPipelineJobs(ctx, tc, pn)
+	require.NoError(t, err)
+	require.Len(t, result, 3)
+	assert.Equal(t, "first", result[0].Name)
+	assert.Equal(t, "second", result[1].Name)
+	assert.Equal(t, "third", result[2].Name)
+}
+
+func TestListPublicPipelineJobs_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+	tc := "main"
+	pn := "my-pipeline"
+
+	startedAt := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	pp := &pipeline.Pipeline{
+		ID: 1, Name: pn, Canonical: pn,
+		Jobs: []job.Job{{ID: 1, Name: "build"}},
+	}
+	s.Pipelines.EXPECT().FindPublic(ctx, tc, pn).Return(pp, nil)
+	s.Builds.EXPECT().Filter(ctx, tc, pn, "build", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{
+		{ID: 1, BuildNumber: "1", Status: build.Succeeded, Duration: time.Second, StartedAt: startedAt},
+	}, nil)
+
+	result, err := s.S.ListPublicPipelineJobs(ctx, tc, pn)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, build.Succeeded.String(), result[0].LatestStatus)
+	assert.Equal(t, "1", result[0].LatestBuildNumber)
+}
+
+func TestListPublicPipelineJobs_NotPublic(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+	tc := "main"
+	pn := "private-pipeline"
+
+	s.Pipelines.EXPECT().FindPublic(ctx, tc, pn).Return(nil, assert.AnError)
+
+	_, err := s.S.ListPublicPipelineJobs(ctx, tc, pn)
+	require.Error(t, err)
+}

--- a/pikoci/service.go
+++ b/pikoci/service.go
@@ -130,6 +130,12 @@ type Service interface {
 	// TriggerPipelineJob creates a pending build for the specified job and enqueues
 	// it for execution.
 	TriggerPipelineJob(ctx context.Context, tc, pn, jn string) error
+	// ListPipelineJobs returns all jobs for the given pipeline enriched with
+	// their latest build status.
+	ListPipelineJobs(ctx context.Context, tc, pn string) ([]job.WithStatus, error)
+	// ListPublicPipelineJobs returns all jobs for a public pipeline enriched
+	// with their latest build status.
+	ListPublicPipelineJobs(ctx context.Context, tc, pn string) ([]job.WithStatus, error)
 	// GetPipelineJob retrieves a job by its name within a pipeline.
 	GetPipelineJob(ctx context.Context, tc, pn, jn string) (*job.Job, error)
 

--- a/pikoci/testdata/cron.hcl
+++ b/pikoci/testdata/cron.hcl
@@ -96,6 +96,35 @@ job "failing" {
   }
 }
 
+resource "cron" "nightly" {
+  check_interval = "@every 60s"
+}
+
+job "nightly-cleanup" {
+  get "cron" "nightly" {
+    trigger = true
+  }
+  task "cleanup" {
+    run "exec" {
+      path = "/bin/sh"
+      args = ["-ec", "echo '--- nightly-cleanup ---' && echo 'cleaning old artifacts...' && sleep 2 && echo 'done'"]
+    }
+  }
+}
+
+job "nightly-report" {
+  get "cron" "nightly" {
+    trigger = true
+    passed  = ["nightly-cleanup"]
+  }
+  task "report" {
+    run "exec" {
+      path = "/bin/sh"
+      args = ["-ec", "echo '--- nightly-report ---' && echo 'generating report...' && sleep 2 && echo 'done'"]
+    }
+  }
+}
+
 job "monitor" {
   get "cron" "my_cron" {
     trigger = true

--- a/pikoci/transport/http/assets/css/pikoci.css
+++ b/pikoci/transport/http/assets/css/pikoci.css
@@ -685,10 +685,257 @@ textarea.form-control {
 .piko-graph-container svg polygon[fill="#ffffff"] {
   fill: transparent;
 }
-/* Resources panel wrapper */
-.piko-graph-wrapper {
+/* View switcher toolbar */
+.piko-view-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-body);
+}
+.piko-view-btn {
+  font-size: 12px;
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+.piko-view-btn:hover:not(.piko-view-btn-disabled) {
+  background: var(--bg-hover);
+}
+.piko-view-btn.active {
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  border-color: var(--text-primary);
+}
+.piko-view-btn-disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.piko-view-sep {
+  width: 1px;
+  height: 16px;
+  background: var(--border);
+  margin: 0 4px;
+}
+/* List view layout */
+.piko-view-list {
+  display: flex;
+  flex-direction: column;
+  min-height: 380px;
+}
+.piko-list-resource-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-body);
+  font-size: 12px;
+  flex-shrink: 0;
+}
+/* Custom resource dropdown */
+.piko-rsel {
+  position: relative;
+}
+.piko-rsel-trigger {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.piko-rsel-trigger:hover {
+  border-color: var(--text-muted);
+}
+.piko-rsel-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.piko-rsel-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.piko-rsel-arrow {
+  font-size: 10px;
+  color: var(--text-muted);
+  margin-left: 2px;
+}
+.piko-rsel-menu {
+  display: none;
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  min-width: 100%;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.12);
+  z-index: 30;
+  overflow: hidden;
+}
+.piko-rsel-menu.open {
+  display: block;
+}
+.piko-rsel-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 12px;
+  font-size: 12px;
+  color: var(--text-primary);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.piko-rsel-option:hover {
+  background: var(--bg-body);
+}
+.piko-rsel-option.active {
+  font-weight: 600;
+  background: var(--bg-body);
+}
+.piko-rsel-status {
+  font-size: 10px;
+  color: var(--text-muted);
+  margin-left: auto;
+}
+.piko-resource-bar-info {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  overflow: hidden;
+}
+.piko-resource-bar-ver {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 250px;
+}
+.piko-resource-bar-meta {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+.piko-resource-check-btn {
+  margin-left: auto;
+  flex-shrink: 0;
+}
+.piko-list-panels {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+.piko-list-left {
+  width: 240px;
+  min-width: 240px;
+  border-right: 1px solid var(--border);
+  overflow-y: auto;
+}
+.piko-job-list {
+  overflow-y: auto;
+  flex: 1;
+}
+/* Job detail (right panel) */
+.piko-job-detail {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px;
+}
+.piko-job-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--text-primary);
+}
+.piko-job-row:hover {
+  background: var(--bg-hover);
+}
+.piko-job-row.active {
+  background: var(--bg-hover);
+  border-left: 2px solid var(--primary, #378ADD);
+}
+.piko-job-row-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.piko-status-dot-succeeded { background: var(--status-succeeded); }
+.piko-status-dot-failed { background: var(--status-failed); }
+.piko-status-dot-started { background: var(--status-started); }
+.piko-status-dot-pending { background: var(--status-pending); }
+.piko-status-dot-cancelled { background: var(--status-cancelled); }
+.piko-status-dot-paused { background: #29ADFF; }
+.piko-status-dot- { background: var(--status-pending); }
+.piko-job-row-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.piko-job-row-badge {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 99px;
+  font-weight: 500;
+  flex-shrink: 0;
+}
+/* Parallel group */
+.piko-parallel-header {
+  padding: 6px 14px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.piko-parallel-header:hover {
+  background: var(--bg-hover);
+}
+.piko-parallel-nested {
+  border-left: 2px solid var(--border);
+  margin-left: 22px;
+}
+.piko-parallel-nested > .piko-job-row {
+  padding-left: 12px;
+}
+.piko-job-children {
+  margin-left: 10px;
+}
+.piko-parallel-counts {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+  font-size: 11px;
+}
+/* Pipeline body — shared wrapper for graph/list + resources panel */
+.piko-pipeline-body {
   position: relative;
   overflow: hidden;
+}
+.piko-graph-wrapper {
 }
 /* Resources slide-out panel */
 .piko-resources-panel {

--- a/pikoci/transport/http/assets/js/app/router.js
+++ b/pikoci/transport/http/assets/js/app/router.js
@@ -204,6 +204,12 @@ export var Router = Backbone.Router.extend({
     if (!this.setup(!isLogin, true)) {
       return;
     }
+    // If user prefers list view, redirect to pipeline show (list view will pick up the job)
+    if (localStorage.getItem("piko-pipeline-view") === "list") {
+      localStorage.setItem('piko-list-' + pn + '-job', jn);
+      this.navigate('teams/' + tc + '/pipelines/' + pn, { trigger: true, replace: true });
+      return;
+    }
     var promises = [];
     var t = teams.get(tc);
     if (t === undefined) {

--- a/pikoci/transport/http/assets/js/app/views/jobs.js
+++ b/pikoci/transport/http/assets/js/app/views/jobs.js
@@ -12,6 +12,7 @@ export var JobBuildsView = Backbone.View.extend({
 
     this.job = opts.job;
     this.pipeline = opts.pipeline;
+    this.embedded = opts.embedded || false;
 
     var that = this;
     this.collection.fetch({
@@ -70,9 +71,11 @@ export var JobBuildsView = Backbone.View.extend({
   doActivate: function(bid) {
     bid = this.collection.setActive(bid);
     this.currentBuildID = bid;
-    var tc = this.collection.job.collection.pipeline.collection.team.get("canonical");
-    var url = new URL(location.origin+"/teams/"+tc+"/pipelines/"+this.pipeline.get("canonical")+"/jobs/"+this.job.get("name")+"/builds/"+bid);
-    window.app.router.navigate(url.pathname, { trigger: false, replace: true });
+    if (!this.embedded) {
+      var tc = this.collection.job.collection.pipeline.collection.team.get("canonical");
+      var url = new URL(location.origin+"/teams/"+tc+"/pipelines/"+this.pipeline.get("canonical")+"/jobs/"+this.job.get("name")+"/builds/"+bid);
+      window.app.router.navigate(url.pathname, { trigger: false, replace: true });
+    }
   },
   bindScrollListener: function() {
     var that = this;
@@ -166,9 +169,11 @@ export var JobBuildsView = Backbone.View.extend({
     var bid = el.id.split("-")[1];
     this.collection.setActive(bid);
     this.currentBuildID = bid;
-    var tc = this.collection.job.collection.pipeline.collection.team.get("canonical");
-    var url = new URL(location.origin+"/teams/"+tc+"/pipelines/"+this.pipeline.get("canonical")+"/jobs/"+this.job.get("name")+"/builds/"+bid);
-    window.app.router.navigate(url.pathname, { trigger: false, replace: true });
+    if (!this.embedded) {
+      var tc = this.collection.job.collection.pipeline.collection.team.get("canonical");
+      var url = new URL(location.origin+"/teams/"+tc+"/pipelines/"+this.pipeline.get("canonical")+"/jobs/"+this.job.get("name")+"/builds/"+bid);
+      window.app.router.navigate(url.pathname, { trigger: false, replace: true });
+    }
   }
 });
 

--- a/pikoci/transport/http/assets/js/app/views/pipelines.js
+++ b/pikoci/transport/http/assets/js/app/views/pipelines.js
@@ -1,8 +1,9 @@
 'use strict';
 
-import { session } from '../collections.js';
-import { PipelineImage } from '../models.js';
+import { session, Builds, Jobs } from '../collections.js';
+import { PipelineImage, Job, Pipeline } from '../models.js';
 import { addSessionFunctions, clickLink, fetchInterval, pikoTimeAgo, withLoading } from '../namespace.js';
+import { JobBuildsView } from './jobs.js';
 import { PipelineGraphView, PikoGraphZoom } from './editor.js';
 
 export var PipelinesView = Backbone.View.extend({
@@ -229,6 +230,9 @@ export var PipelineShowView = Backbone.View.extend({
     });
     this.resourcesCollection = new PanelResources();
 
+    this.listView = null;
+    this.currentView = localStorage.getItem("piko-pipeline-view") || "graph";
+
     var that = this;
     this.intervalID = window.setInterval(function() {
       that.image.fetch({isInterval: true});
@@ -241,6 +245,7 @@ export var PipelineShowView = Backbone.View.extend({
     'click #pause-pipeline': 'clickPausePipeline',
     'click #unpause-pipeline': 'clickUnpausePipeline',
     'click #toggle-resources-panel': 'toggleResourcesPanel',
+    'click .piko-view-btn': 'switchView',
   },
   render: function () {
     this.$el.html(this.template(addSessionFunctions({ pipeline: this.model.toJSON(), team: this.model.collection.team.toJSON() })));
@@ -262,12 +267,53 @@ export var PipelineShowView = Backbone.View.extend({
       el: this.$el.find('#pipeline-resources-panel'),
     });
 
+    this._applyView(this.currentView);
+
     return this;
+  },
+  _applyView: function(mode) {
+    this.$('.piko-view-btn').removeClass('active');
+    this.$('.piko-view-btn[data-view="' + mode + '"]').addClass('active');
+    if (mode === 'list') {
+      this.$('.piko-view-graph').hide();
+      this.$('.piko-view-list').show();
+      if (!this.listView) {
+        this.listView = new PipelineListView({
+          el: this.$('.piko-view-list'),
+          pipeline: this.model,
+          resourcesCollection: this.resourcesCollection,
+        });
+      }
+    } else {
+      this.$('.piko-view-graph').show();
+      this.$('.piko-view-list').hide();
+    }
+  },
+  switchView: function(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    var btn = $(event.currentTarget);
+    var mode = btn.data('view');
+    if (!mode) return;
+    if (btn.hasClass('piko-view-btn-disabled')) return;
+    if (btn.attr('id') === 'toggle-resources-panel') return;
+    this.currentView = mode;
+    localStorage.setItem("piko-pipeline-view", mode);
+    this._applyView(mode);
+    // Update URL to match the current view
+    var tc = this.model.collection.team.get('canonical');
+    var pc = this.model.get('canonical');
+    if (mode === 'list' && this.listView && this.listView.selectedJob) {
+      window.app.router.navigate('teams/' + tc + '/pipelines/' + pc + '/jobs/' + this.listView.selectedJob + '/builds', { trigger: false, replace: true });
+    } else {
+      window.app.router.navigate('teams/' + tc + '/pipelines/' + pc, { trigger: false, replace: true });
+    }
   },
   remove: function() {
     clearInterval(this.intervalID);
     if (this.panelView) { this.panelView.remove(); }
     if (this.graphZoom) { this.graphZoom.destroy(); }
+    if (this.listView) { this.listView.remove(); }
     Backbone.View.prototype.remove.call(this);
   },
   toggleResourcesPanel: function(event) {
@@ -325,5 +371,556 @@ export var PipelineShowView = Backbone.View.extend({
         },
       });
     });
+  },
+});
+
+// --- PipelineListView ---
+
+var statusLabels = {
+  succeeded: 'passed',
+  failed: 'failed',
+  started: 'running',
+  pending: 'pending',
+  cancelled: 'cancelled',
+};
+
+var PipelineListView = Backbone.View.extend({
+  jobRowTemplate: _.template($('#pipeline-list-job-row').html()),
+  initialize: function(options) {
+    this.pipeline = options.pipeline;
+    this.resourcesCollection = options.resourcesCollection;
+    this.jobsData = [];
+    this.selectedJob = null;
+    this.selectedResource = null;
+    this.chainJobs = [];
+    this.jobBuildsView = null;
+    this._storagePrefix = 'piko-list-' + this.pipeline.get('canonical') + '-';
+    this.collapsedGroups = JSON.parse(localStorage.getItem(this._storagePrefix + 'collapsed') || '{}');
+
+    // Find trigger resources (resources consumed by a get step with trigger=true and no passed)
+    this.triggerResources = this._findTriggerResources();
+
+    // Restore from localStorage or default to first trigger resource
+    var savedResource = localStorage.getItem(this._storagePrefix + 'resource');
+    if (savedResource && this.triggerResources.indexOf(savedResource) >= 0) {
+      this.selectedResource = savedResource;
+    } else if (this.triggerResources.length > 0) {
+      this.selectedResource = this.triggerResources[0];
+    }
+
+    this.listenTo(this.resourcesCollection, 'sync', this._renderResourceSelector);
+    if (this.resourcesCollection.length === 0) {
+      this.resourcesCollection.fetch();
+    }
+
+    this._renderResourceSelector();
+    this._fetchJobs();
+    var that = this;
+    this._jobsIntervalID = window.setInterval(function() {
+      that._fetchJobs();
+    }, fetchInterval);
+  },
+  events: {
+    'click .piko-job-row': '_onClickJob',
+    'click .piko-parallel-header': '_onToggleParallel',
+    'click .piko-rsel-trigger': '_onToggleResourceMenu',
+    'click .piko-rsel-option': '_onSelectResource',
+    'click .piko-resource-check-btn': '_onCheckResource',
+  },
+
+  // --- Resource & chain resolution ---
+
+  _findTriggerResources: function() {
+    var jobs = this.pipeline.get('jobs') || [];
+    var seen = {};
+    var result = [];
+    for (var i = 0; i < jobs.length; i++) {
+      var plan = jobs[i].plan || [];
+      for (var j = 0; j < plan.length; j++) {
+        var s = plan[j];
+        if (s.type === 'get' && s.get && s.get.trigger && (!s.get.passed || s.get.passed.length === 0)) {
+          var canonical = s.get.type + '.' + s.get.name;
+          if (!seen[canonical]) {
+            seen[canonical] = true;
+            result.push(canonical);
+          }
+        }
+      }
+    }
+    return result;
+  },
+
+  _resolveChain: function(resourceCanonical) {
+    var allJobs = this.pipeline.get('jobs') || [];
+    var jobByName = {};
+    for (var i = 0; i < allJobs.length; i++) {
+      jobByName[allJobs[i].name] = allJobs[i];
+    }
+
+    // Step 1: find entry-point jobs that get this resource directly (no passed)
+    var visited = {};
+    var queue = [];
+    var chain = [];
+    for (var i = 0; i < allJobs.length; i++) {
+      var plan = allJobs[i].plan || [];
+      for (var j = 0; j < plan.length; j++) {
+        var s = plan[j];
+        if (s.type === 'get' && s.get) {
+          var can = s.get.type + '.' + s.get.name;
+          if (can === resourceCanonical && (!s.get.passed || s.get.passed.length === 0)) {
+            if (!visited[allJobs[i].name]) {
+              visited[allJobs[i].name] = true;
+              queue.push(allJobs[i].name);
+            }
+          }
+        }
+      }
+    }
+
+    // Step 2: BFS — for each job in the chain, find downstream jobs via passed constraints
+    while (queue.length > 0) {
+      var jobName = queue.shift();
+      chain.push(jobName);
+      // Find all jobs that have a get step with passed containing jobName
+      for (var i = 0; i < allJobs.length; i++) {
+        if (visited[allJobs[i].name]) continue;
+        var plan = allJobs[i].plan || [];
+        for (var j = 0; j < plan.length; j++) {
+          var s = plan[j];
+          if (s.type === 'get' && s.get && s.get.passed) {
+            for (var k = 0; k < s.get.passed.length; k++) {
+              if (s.get.passed[k] === jobName) {
+                visited[allJobs[i].name] = true;
+                queue.push(allJobs[i].name);
+                break;
+              }
+            }
+          }
+          if (visited[allJobs[i].name]) break;
+        }
+      }
+    }
+
+    return chain;
+  },
+
+  _renderResourceSelector: function() {
+    // Don't re-render while the dropdown is open
+    if (this.$('.piko-rsel-menu').hasClass('open')) return;
+
+    var bar = this.$('.piko-list-resource-bar');
+    if (this.triggerResources.length === 0) {
+      bar.html('<span style="color:var(--text-muted)">No trigger resources</span>');
+      return;
+    }
+    var resMap = {};
+    this.resourcesCollection.each(function(r) {
+      resMap[r.get('canonical')] = r.toJSON();
+    });
+
+    var res = resMap[this.selectedResource] || {};
+    var lv = res.latest_version;
+    var statusClass = (lv && lv.status) ? lv.status : '';
+
+    // Custom dropdown trigger
+    var html = '<div class="piko-rsel">';
+    html += '<button class="piko-rsel-trigger" type="button">';
+    if (statusClass) {
+      html += '<span class="piko-rsel-dot piko-status-dot-' + statusClass + '"></span>';
+    }
+    html += '<span class="piko-rsel-label">' + _.escape(this.selectedResource) + '</span>';
+    html += '<i class="bi bi-chevron-down piko-rsel-arrow"></i>';
+    html += '</button>';
+
+    // Dropdown menu
+    html += '<div class="piko-rsel-menu">';
+    for (var i = 0; i < this.triggerResources.length; i++) {
+      var canonical = this.triggerResources[i];
+      var r = resMap[canonical] || {};
+      var rlv = r.latest_version;
+      var rStatus = (rlv && rlv.status) ? rlv.status : '';
+      var active = canonical === this.selectedResource ? ' active' : '';
+      html += '<div class="piko-rsel-option' + active + '" data-canonical="' + _.escape(canonical) + '">';
+      html += '<span class="piko-rsel-dot piko-status-dot-' + rStatus + '"></span>';
+      html += '<span>' + _.escape(canonical) + '</span>';
+      html += '</div>';
+    }
+    html += '</div></div>';
+
+    // Version + check info
+    html += '<span class="piko-resource-bar-info">';
+    if (lv && lv.version) {
+      for (var key in lv.version) {
+        if (lv.version.hasOwnProperty(key)) {
+          html += '<span class="piko-resource-bar-ver">' + _.escape(key + ': ' + lv.version[key]) + '</span>';
+          break;
+        }
+      }
+    }
+    if (res.check_interval) {
+      html += '<span class="piko-resource-bar-meta">' + _.escape(res.check_interval) + '</span>';
+    }
+    if (res.last_check) {
+      html += '<span class="piko-resource-bar-meta">checked ' + pikoTimeAgo(res.last_check) + '</span>';
+    }
+    html += '</span>';
+
+    if (!session.isEmpty()) {
+      html += '<button class="btn btn-sm btn-outline-warning piko-resource-check-btn"><i class="bi bi-arrow-clockwise"></i> Check Now</button>';
+    }
+
+    bar.html(html);
+  },
+
+  _onToggleResourceMenu: function(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    var menu = this.$('.piko-rsel-menu');
+    var isOpen = menu.hasClass('open');
+    menu.toggleClass('open');
+    if (!isOpen) {
+      // Close on outside click
+      var that = this;
+      $(document).one('click', function() { that.$('.piko-rsel-menu').removeClass('open'); });
+    }
+  },
+
+  _onSelectResource: function(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    var canonical = $(event.currentTarget).data('canonical');
+    this.$('.piko-rsel-menu').removeClass('open');
+    if (!canonical || canonical === this.selectedResource) return;
+    this.selectedResource = canonical;
+    localStorage.setItem(this._storagePrefix + 'resource', canonical);
+    this.selectedJob = null;
+    if (this.jobBuildsView) {
+      this.jobBuildsView.remove();
+      this.jobBuildsView = null;
+    }
+    this.$('.piko-job-detail').empty();
+    this._renderResourceSelector();
+    this._renderJobList();
+    if (this.chainJobs.length > 0) {
+      this._selectJob(this.chainJobs[0]);
+    }
+  },
+
+  _onCheckResource: function(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    var canonical = this.selectedResource;
+    if (!canonical) return;
+    var tc = this.pipeline.collection ? this.pipeline.collection.team.get('canonical') : '';
+    var pc = this.pipeline.get('canonical');
+    var url = '/teams/' + tc + '/pipelines/' + pc + '/resources/' + canonical + '/trigger';
+    var that = this;
+    $.ajax({
+      url: url, type: 'POST', contentType: 'application/json',
+      headers: { 'Authorization': 'Bearer ' + session.get('jwt') },
+      success: function() {
+        window.app.apiNotice.setSuccess('Resource check triggered');
+        that.resourcesCollection.fetch();
+      },
+      error: function() {
+        window.app.apiNotice.set({error: 'Failed to trigger resource check'});
+      },
+    });
+  },
+
+  // --- Data fetching ---
+
+  _fetchJobs: function() {
+    var that = this;
+    var url = this.pipeline.url() + "/jobs";
+    $.ajax({
+      url: url,
+      type: 'GET',
+      contentType: 'application/json',
+      headers: session.isEmpty() ? {} : { 'Authorization': 'Bearer ' + session.get('jwt') },
+      success: function(resp) {
+        if (resp && resp.data) {
+          that.jobsData = resp.data;
+          that._renderJobList();
+          // Auto-select saved job or first non-succeeded job
+          if (!that.selectedJob && that.chainJobs.length > 0) {
+            var pick = null;
+            var savedJob = localStorage.getItem(that._storagePrefix + 'job');
+            if (savedJob && that.chainJobs.indexOf(savedJob) >= 0) {
+              pick = savedJob;
+            } else {
+              pick = that.chainJobs[0];
+              var statusMap = that._buildStatusMap();
+              for (var i = 0; i < that.chainJobs.length; i++) {
+                var d = statusMap[that.chainJobs[i]];
+                if (d && d.latest_status && d.latest_status !== 'succeeded') {
+                  pick = that.chainJobs[i];
+                  break;
+                }
+              }
+            }
+            that._selectJob(pick);
+          }
+        }
+      },
+    });
+  },
+
+  _buildStatusMap: function() {
+    var statusMap = {};
+    for (var i = 0; i < this.jobsData.length; i++) {
+      statusMap[this.jobsData[i].name] = this.jobsData[i];
+    }
+    return statusMap;
+  },
+
+  // --- Rendering ---
+
+  _buildTree: function(chainJobs) {
+    // Build a parent→children map and find roots (entry-point jobs).
+    var allJobs = this.pipeline.get('jobs') || [];
+    var jobByName = {};
+    for (var i = 0; i < allJobs.length; i++) jobByName[allJobs[i].name] = allJobs[i];
+    var chainSet = {};
+    for (var i = 0; i < chainJobs.length; i++) chainSet[chainJobs[i]] = true;
+
+    // For each chain job, find its upstream parents (passed constraints within the chain)
+    var parents = {}; // jobName → [parentJobName, ...]
+    var children = {}; // jobName → [childJobName, ...]
+    for (var i = 0; i < chainJobs.length; i++) {
+      parents[chainJobs[i]] = [];
+      children[chainJobs[i]] = [];
+    }
+    for (var i = 0; i < chainJobs.length; i++) {
+      var name = chainJobs[i];
+      var pj = jobByName[name];
+      if (!pj) continue;
+      var plan = pj.plan || [];
+      for (var j = 0; j < plan.length; j++) {
+        var s = plan[j];
+        if (s.type === 'get' && s.get && s.get.passed) {
+          for (var k = 0; k < s.get.passed.length; k++) {
+            if (chainSet[s.get.passed[k]]) {
+              parents[name].push(s.get.passed[k]);
+              children[s.get.passed[k]].push(name);
+            }
+          }
+        }
+      }
+    }
+
+    // Roots are jobs with no parents in the chain
+    var roots = [];
+    for (var i = 0; i < chainJobs.length; i++) {
+      if (parents[chainJobs[i]].length === 0) {
+        roots.push(chainJobs[i]);
+      }
+    }
+
+    return { roots: roots, children: children, parents: parents };
+  },
+
+  _renderJobList: function() {
+    if (!this.selectedResource) return;
+
+    this.chainJobs = this._resolveChain(this.selectedResource);
+    var statusMap = this._buildStatusMap();
+    var tree = this._buildTree(this.chainJobs);
+
+    // Render tree recursively. Siblings (jobs sharing the same set of parents)
+    // are grouped as parallel when there are 2+.
+    var that = this;
+    var rendered = {};
+
+    var renderChildren = function(parentName) {
+      var kids = tree.children[parentName] || [];
+      if (kids.length === 0) return '';
+
+      // Group siblings by their parent set (jobs with identical parents are parallel)
+      var groupKey = function(name) {
+        return (tree.parents[name] || []).slice().sort().join(',');
+      };
+      var keyToKids = {};
+      var kidOrder = [];
+      for (var i = 0; i < kids.length; i++) {
+        if (rendered[kids[i]]) continue;
+        var gk = groupKey(kids[i]);
+        if (!keyToKids[gk]) {
+          keyToKids[gk] = [];
+          kidOrder.push(gk);
+        }
+        keyToKids[gk].push(kids[i]);
+      }
+
+      var html = '';
+      for (var i = 0; i < kidOrder.length; i++) {
+        var group = keyToKids[kidOrder[i]];
+        // Filter out already rendered
+        group = group.filter(function(n) { return !rendered[n]; });
+        if (group.length === 0) continue;
+
+        if (group.length >= 2) {
+          html += that._renderParallelGroup(group, statusMap, function(names) {
+            var sub = '';
+            for (var j = 0; j < names.length; j++) {
+              rendered[names[j]] = true;
+            }
+            for (var j = 0; j < names.length; j++) {
+              sub += renderChildren(names[j]);
+            }
+            return sub;
+          });
+        } else {
+          var name = group[0];
+          rendered[name] = true;
+          var data = statusMap[name] || { name: name, latest_status: '' };
+          html += that._renderJobRow(data);
+          html += renderChildren(name);
+        }
+      }
+      return html;
+    };
+
+    // Render roots
+    var roots = tree.roots;
+    var html = '';
+    if (roots.length >= 2) {
+      html += this._renderParallelGroup(roots, statusMap, function(names) {
+        var sub = '';
+        for (var j = 0; j < names.length; j++) {
+          rendered[names[j]] = true;
+        }
+        for (var j = 0; j < names.length; j++) {
+          sub += renderChildren(names[j]);
+        }
+        return sub;
+      });
+    } else if (roots.length === 1) {
+      rendered[roots[0]] = true;
+      var data = statusMap[roots[0]] || { name: roots[0], latest_status: '' };
+      html += this._renderJobRow(data);
+      html += renderChildren(roots[0]);
+    }
+
+    this.$('.piko-job-list').html(html);
+  },
+
+  _renderJobRow: function(data) {
+    var status = data.latest_status || '';
+    if (data.has_running) status = 'started';
+    if (data.paused) status = 'paused';
+    var isActive = this.selectedJob === data.name;
+    return '<div class="piko-job-row' + (isActive ? ' active' : '') + '" data-job="' + _.escape(data.name) + '">' +
+      this.jobRowTemplate({
+        name: data.name,
+        status: status,
+        statusLabel: statusLabels[status] || '',
+      }) +
+      '</div>';
+  },
+
+  // renderChildrenFn(jobNames) → html string for downstream jobs of the group members
+  _renderParallelGroup: function(jobNames, statusMap, renderChildrenFn) {
+    var groupKey = jobNames.slice().sort().join(',');
+    var isCollapsed = this.collapsedGroups[groupKey];
+    var arrow = isCollapsed ? '&#9654;' : '&#9660;';
+    var counts = {};
+    for (var i = 0; i < jobNames.length; i++) {
+      var d = statusMap[jobNames[i]] || {};
+      var s = d.paused ? 'paused' : (d.has_running ? 'started' : (d.latest_status || ''));
+      counts[s] = (counts[s] || 0) + 1;
+    }
+    var html = '<div class="piko-parallel-header" data-group="' + _.escape(groupKey) + '"><span>' + arrow + ' parallel</span>';
+    html += '<span class="piko-parallel-counts">';
+    for (var st in counts) {
+      if (st) html += '<span class="piko-status-dot-' + st + '" style="width:8px;height:8px;border-radius:50%;display:inline-block"></span> ' + counts[st] + ' ';
+    }
+    html += '</span></div>';
+    html += '<div class="piko-parallel-nested"' + (isCollapsed ? ' style="display:none"' : '') + '>';
+    for (var j = 0; j < jobNames.length; j++) {
+      var data = statusMap[jobNames[j]] || { name: jobNames[j], latest_status: '' };
+      html += this._renderJobRow(data);
+      if (renderChildrenFn) {
+        var childHtml = renderChildrenFn([jobNames[j]]);
+        if (childHtml) {
+          html += '<div class="piko-job-children">' + childHtml + '</div>';
+        }
+      }
+    }
+    html += '</div>';
+    return html;
+  },
+
+  // --- Job selection & detail ---
+
+  _onClickJob: function(event) {
+    event.preventDefault();
+    var jobName = $(event.currentTarget).data('job');
+    if (jobName) {
+      this._selectJob(jobName);
+    }
+  },
+
+  _selectJob: function(jobName) {
+    this.selectedJob = jobName;
+    localStorage.setItem(this._storagePrefix + 'job', jobName);
+    // Update URL to match the job builds path
+    var tc = this.pipeline.collection ? this.pipeline.collection.team.get('canonical') : '';
+    var pc = this.pipeline.get('canonical');
+    window.app.router.navigate('teams/' + tc + '/pipelines/' + pc + '/jobs/' + jobName + '/builds', { trigger: false, replace: true });
+    this.$('.piko-job-row').removeClass('active');
+    this.$('.piko-job-row[data-job="' + jobName + '"]').addClass('active');
+
+    if (this.jobBuildsView) {
+      this.jobBuildsView.remove();
+      this.jobBuildsView = null;
+    }
+
+    var jbs = new Jobs(null, { pipeline: this.pipeline });
+    var jb = new Job({ name: jobName }, { collection: jbs });
+    var builds = new Builds(null, { job: jb });
+
+    var that = this;
+    jb.fetch({
+      success: function() {
+        var detailEl = $('<div></div>');
+        that.$('.piko-job-detail').html(detailEl);
+        that.jobBuildsView = new JobBuildsView({
+          el: detailEl,
+          collection: builds,
+          job: jb,
+          pipeline: that.pipeline,
+          embedded: true,
+        });
+        that.jobBuildsView.render();
+      },
+      error: function() {
+        that.$('.piko-job-detail').html('<div style="padding:14px;color:var(--text-muted)">Failed to load job.</div>');
+      },
+    });
+  },
+
+  _onToggleParallel: function(event) {
+    var header = $(event.currentTarget);
+    var nested = header.next('.piko-parallel-nested');
+    nested.toggle();
+    var groupKey = header.data('group');
+    var isVisible = nested.is(':visible');
+    if (groupKey) {
+      if (isVisible) {
+        delete this.collapsedGroups[groupKey];
+      } else {
+        this.collapsedGroups[groupKey] = true;
+      }
+    }
+    localStorage.setItem(this._storagePrefix + 'collapsed', JSON.stringify(this.collapsedGroups));
+    var arrow = isVisible ? '&#9660;' : '&#9654;';
+    header.find('span:first').html(arrow + ' parallel');
+  },
+
+  remove: function() {
+    if (this._jobsIntervalID) clearInterval(this._jobsIntervalID);
+    if (this.jobBuildsView) { this.jobBuildsView.remove(); }
+    Backbone.View.prototype.remove.call(this);
   },
 });

--- a/pikoci/transport/http/authorization.go
+++ b/pikoci/transport/http/authorization.go
@@ -41,6 +41,7 @@ var (
 		GetPipelineImage:    member,
 		CreatePipelineImage: admin,
 
+		ListPipelineJobs:   member,
 		TriggerPipelineJob: member,
 		GetPipelineJob:     member,
 

--- a/pikoci/transport/http/client/client.go
+++ b/pikoci/transport/http/client/client.go
@@ -546,6 +546,29 @@ func (cl *Client) DeletePipeline(ctx context.Context, tc, pn string) error {
 	return nil
 }
 
+// ListPipelineJobs returns all jobs for a pipeline enriched with their latest
+// build status.
+func (cl *Client) ListPipelineJobs(ctx context.Context, tc, pn string) ([]job.WithStatus, error) {
+	var resp thttp.ListPipelineJobsResponse
+
+	err := cl.Request(ctx, http.MethodGet, fmt.Sprintf("%s/teams/%s/pipelines/%s/jobs", cl.url, tc, pn), nil, &resp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make request: %w", err)
+	}
+
+	if resp.Err != "" {
+		return nil, fmt.Errorf("error from request: %s", resp.Err)
+	}
+
+	return resp.Jobs, nil
+}
+
+// ListPublicPipelineJobs returns all jobs for a public pipeline enriched with
+// their latest build status.
+func (cl *Client) ListPublicPipelineJobs(ctx context.Context, tc, pn string) ([]job.WithStatus, error) {
+	return cl.ListPipelineJobs(ctx, tc, pn)
+}
+
 // TriggerPipelineJob triggers a manual run of the specified job.
 func (cl *Client) TriggerPipelineJob(ctx context.Context, tc, pn, jn string) error {
 	var resp thttp.TriggerPipelineJobResponse

--- a/pikoci/transport/http/handler.go
+++ b/pikoci/transport/http/handler.go
@@ -34,6 +34,7 @@ const (
 var publicFallbackRoutes = map[RouteName]bool{
 	GetPipeline:          true,
 	GetPipelineImage:     true,
+	ListPipelineJobs:     true,
 	GetPipelineJob:       true,
 	ListJobBuilds:        true,
 	ListPipelineResources: true,
@@ -239,6 +240,7 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, 
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/pause").Name(PauseJob.String()).Handler(pauseJob(s))
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/unpause").Name(UnpauseJob.String()).Handler(unpauseJob(s))
 
+	api.Methods(http.MethodGet).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs").Name(ListPipelineJobs.String()).Handler(listPipelineJobs(s))
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/trigger").Name(TriggerPipelineJob.String()).Handler(triggerPipelineJob(s))
 	api.Methods(http.MethodGet).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}").Name(GetPipelineJob.String()).Handler(getPipelineJob(s))
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/builds").Name(CreateJobBuild.String()).Handler(createJobBuild(s))

--- a/pikoci/transport/http/handlers_coverage_test.go
+++ b/pikoci/transport/http/handlers_coverage_test.go
@@ -2301,3 +2301,58 @@ func TestListResourceVersions_PublicFallback(t *testing.T) {
 	assert.Empty(t, got.Err)
 	assert.Len(t, got.Versions, 1)
 }
+
+func TestListPipelineJobs_Success(t *testing.T) {
+	e := newTestEnv(t)
+	e.expectMemberAuth()
+	jobs := []job.WithStatus{
+		{Job: job.Job{Name: "build"}, LatestStatus: "succeeded"},
+		{Job: job.Job{Name: "test"}, LatestStatus: "failed"},
+	}
+	e.svc.EXPECT().ListPipelineJobs(gomock.Any(), "main", "my-pipe").Return(jobs, nil)
+
+	resp := doRequest(t, http.MethodGet, e.server.URL+"/teams/main/pipelines/my-pipe/jobs", e.memberJWT(t), "")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	var got ListPipelineJobsResponse
+	json.NewDecoder(resp.Body).Decode(&got)
+	assert.Empty(t, got.Err)
+	assert.Len(t, got.Jobs, 2)
+	assert.Equal(t, "build", got.Jobs[0].Name)
+	assert.Equal(t, "succeeded", got.Jobs[0].LatestStatus)
+}
+
+func TestListPipelineJobs_Error(t *testing.T) {
+	e := newTestEnv(t)
+	e.expectMemberAuth()
+	e.svc.EXPECT().ListPipelineJobs(gomock.Any(), "main", "my-pipe").Return(nil, fmt.Errorf("db error"))
+
+	resp := doRequest(t, http.MethodGet, e.server.URL+"/teams/main/pipelines/my-pipe/jobs", e.memberJWT(t), "")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	var got ListPipelineJobsResponse
+	json.NewDecoder(resp.Body).Decode(&got)
+	assert.Equal(t, "db error", got.Err)
+}
+
+func TestListPipelineJobs_PublicFallback(t *testing.T) {
+	e := newTestEnv(t)
+	pp := &pipeline.Pipeline{Name: "public-pipe", Canonical: "public-pipe", Public: true}
+	jobs := []job.WithStatus{
+		{Job: job.Job{Name: "build"}, LatestStatus: "succeeded"},
+	}
+	e.svc.EXPECT().GetPublicPipeline(gomock.Any(), "main", "public-pipe").Return(pp, nil)
+	e.svc.EXPECT().ListPublicPipelineJobs(gomock.Any(), "main", "public-pipe").Return(jobs, nil)
+
+	resp := doRequest(t, http.MethodGet, e.server.URL+"/teams/main/pipelines/public-pipe/jobs", "", "")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	var got ListPipelineJobsResponse
+	json.NewDecoder(resp.Body).Decode(&got)
+	assert.Empty(t, got.Err)
+	assert.Len(t, got.Jobs, 1)
+	assert.Equal(t, "build", got.Jobs[0].Name)
+}

--- a/pikoci/transport/http/jobs.go
+++ b/pikoci/transport/http/jobs.go
@@ -8,6 +8,34 @@ import (
 	"github.com/pikoci/pikoci/pikoci/job"
 )
 
+type ListPipelineJobsResponse struct {
+	Jobs []job.WithStatus `json:"data,omitempty"`
+	Err  string           `json:"error,omitempty"`
+}
+
+func (r ListPipelineJobsResponse) Error() string { return r.Err }
+
+func listPipelineJobs(s pikoci.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var ctx = r.Context()
+		vars := mux.Vars(r)
+		tc := vars["team_canonical"]
+		pc := vars["pipeline_canonical"]
+		var jobs []job.WithStatus
+		var err error
+		if isPublic, _ := ctx.Value(IsPublicAccessKey).(bool); isPublic {
+			jobs, err = s.ListPublicPipelineJobs(ctx, tc, pc)
+		} else {
+			jobs, err = s.ListPipelineJobs(ctx, tc, pc)
+		}
+		var errs string
+		if err != nil {
+			errs = err.Error()
+		}
+		encodeResponse(ListPipelineJobsResponse{Jobs: jobs, Err: errs}, w)
+	}
+}
+
 type TriggerPipelineJobRequest struct {
 	TeamCanonical     string `json:"team_canonical"`
 	PipelineCanonical string `json:"pipeline_canonical"`

--- a/pikoci/transport/http/route_names.go
+++ b/pikoci/transport/http/route_names.go
@@ -63,6 +63,8 @@ const (
 
 	// TriggerPipelineJob is the route for triggering a pipeline job.
 	TriggerPipelineJob
+	// ListPipelineJobs is the route for listing all jobs of a pipeline with status.
+	ListPipelineJobs
 	// GetPipelineJob is the route for retrieving a single pipeline job.
 	GetPipelineJob
 

--- a/pikoci/transport/http/route_names_string.go
+++ b/pikoci/transport/http/route_names_string.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _RouteNameName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobslist_pipeline_resourcesget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_worker"
+const _RouteNameName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_joblist_pipeline_jobsget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobslist_pipeline_resourcesget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_worker"
 
-var _RouteNameIndex = [...]uint16{0, 10, 23, 34, 44, 52, 63, 74, 89, 103, 114, 124, 132, 143, 154, 172, 190, 208, 223, 238, 250, 265, 279, 297, 318, 338, 354, 370, 392, 408, 424, 439, 463, 486, 499, 515, 530, 549, 574, 608, 632, 655, 676, 700, 725, 748, 770, 790, 812, 836, 851, 875, 889, 908, 923, 937, 953, 962, 973, 984, 1000, 1012, 1026, 1039}
+var _RouteNameIndex = [...]uint16{0, 10, 23, 34, 44, 52, 63, 74, 89, 103, 114, 124, 132, 143, 154, 172, 190, 208, 223, 238, 250, 265, 279, 297, 318, 338, 356, 372, 388, 410, 426, 442, 457, 481, 504, 517, 533, 548, 567, 592, 626, 650, 673, 694, 718, 743, 766, 788, 808, 830, 854, 869, 893, 907, 926, 941, 955, 971, 980, 991, 1002, 1018, 1030, 1044, 1057}
 
-const _RouteNameLowerName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_jobget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobslist_pipeline_resourcesget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_worker"
+const _RouteNameLowerName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_joblist_pipeline_jobsget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobslist_pipeline_resourcesget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_worker"
 
 func (i RouteName) String() string {
 	if i < 0 || i >= RouteName(len(_RouteNameIndex)-1) {
@@ -49,47 +49,48 @@ func _RouteNameNoOp() {
 	_ = x[GetPipelineImage-(22)]
 	_ = x[CreatePipelineImage-(23)]
 	_ = x[TriggerPipelineJob-(24)]
-	_ = x[GetPipelineJob-(25)]
-	_ = x[CreateJobBuild-(26)]
-	_ = x[CreateRetryJobBuild-(27)]
-	_ = x[UpdateJobBuild-(28)]
-	_ = x[DeleteJobBuild-(29)]
-	_ = x[ListJobBuilds-(30)]
-	_ = x[InsertBuildGetVersion-(31)]
-	_ = x[FindBuildGetVersions-(32)]
-	_ = x[GetJobBuild-(33)]
-	_ = x[CancelJobBuild-(34)]
-	_ = x[RetryJobBuild-(35)]
-	_ = x[StartPendingBuild-(36)]
-	_ = x[FindOldestPendingBuild-(37)]
-	_ = x[NotifySerialGroupPendingBuilds-(38)]
-	_ = x[EvaluateDownstreamJobs-(39)]
-	_ = x[ListPipelineResources-(40)]
-	_ = x[GetPipelineResource-(41)]
-	_ = x[UpdatePipelineResource-(42)]
-	_ = x[TriggerPipelineResource-(43)]
-	_ = x[CreateResourceVersion-(44)]
-	_ = x[ListResourceVersions-(45)]
-	_ = x[PinResourceVersion-(46)]
-	_ = x[UnpinResourceVersion-(47)]
-	_ = x[TriggerResourceVersion-(48)]
-	_ = x[WebhookTrigger-(49)]
-	_ = x[RegenerateWebhookToken-(50)]
-	_ = x[CreateTrigger-(51)]
-	_ = x[ListTriggersAfter-(52)]
-	_ = x[ExportDatabase-(53)]
-	_ = x[PausePipeline-(54)]
-	_ = x[UnpausePipeline-(55)]
-	_ = x[PauseJob-(56)]
-	_ = x[UnpauseJob-(57)]
-	_ = x[GetVersion-(58)]
-	_ = x[WorkerHeartbeat-(59)]
-	_ = x[ListWorkers-(60)]
-	_ = x[WorkersHealth-(61)]
-	_ = x[DeleteWorker-(62)]
+	_ = x[ListPipelineJobs-(25)]
+	_ = x[GetPipelineJob-(26)]
+	_ = x[CreateJobBuild-(27)]
+	_ = x[CreateRetryJobBuild-(28)]
+	_ = x[UpdateJobBuild-(29)]
+	_ = x[DeleteJobBuild-(30)]
+	_ = x[ListJobBuilds-(31)]
+	_ = x[InsertBuildGetVersion-(32)]
+	_ = x[FindBuildGetVersions-(33)]
+	_ = x[GetJobBuild-(34)]
+	_ = x[CancelJobBuild-(35)]
+	_ = x[RetryJobBuild-(36)]
+	_ = x[StartPendingBuild-(37)]
+	_ = x[FindOldestPendingBuild-(38)]
+	_ = x[NotifySerialGroupPendingBuilds-(39)]
+	_ = x[EvaluateDownstreamJobs-(40)]
+	_ = x[ListPipelineResources-(41)]
+	_ = x[GetPipelineResource-(42)]
+	_ = x[UpdatePipelineResource-(43)]
+	_ = x[TriggerPipelineResource-(44)]
+	_ = x[CreateResourceVersion-(45)]
+	_ = x[ListResourceVersions-(46)]
+	_ = x[PinResourceVersion-(47)]
+	_ = x[UnpinResourceVersion-(48)]
+	_ = x[TriggerResourceVersion-(49)]
+	_ = x[WebhookTrigger-(50)]
+	_ = x[RegenerateWebhookToken-(51)]
+	_ = x[CreateTrigger-(52)]
+	_ = x[ListTriggersAfter-(53)]
+	_ = x[ExportDatabase-(54)]
+	_ = x[PausePipeline-(55)]
+	_ = x[UnpausePipeline-(56)]
+	_ = x[PauseJob-(57)]
+	_ = x[UnpauseJob-(58)]
+	_ = x[GetVersion-(59)]
+	_ = x[WorkerHeartbeat-(60)]
+	_ = x[ListWorkers-(61)]
+	_ = x[WorkersHealth-(62)]
+	_ = x[DeleteWorker-(63)]
 }
 
-var _RouteNameValues = []RouteName{UserLogin, RefreshToken, CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser, ChangePassword, UpdateProfile, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, GetPipelineJob, CreateJobBuild, CreateRetryJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, InsertBuildGetVersion, FindBuildGetVersions, GetJobBuild, CancelJobBuild, RetryJobBuild, StartPendingBuild, FindOldestPendingBuild, NotifySerialGroupPendingBuilds, EvaluateDownstreamJobs, ListPipelineResources, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions, PinResourceVersion, UnpinResourceVersion, TriggerResourceVersion, WebhookTrigger, RegenerateWebhookToken, CreateTrigger, ListTriggersAfter, ExportDatabase, PausePipeline, UnpausePipeline, PauseJob, UnpauseJob, GetVersion, WorkerHeartbeat, ListWorkers, WorkersHealth, DeleteWorker}
+var _RouteNameValues = []RouteName{UserLogin, RefreshToken, CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser, ChangePassword, UpdateProfile, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, ListPipelineJobs, GetPipelineJob, CreateJobBuild, CreateRetryJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, InsertBuildGetVersion, FindBuildGetVersions, GetJobBuild, CancelJobBuild, RetryJobBuild, StartPendingBuild, FindOldestPendingBuild, NotifySerialGroupPendingBuilds, EvaluateDownstreamJobs, ListPipelineResources, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions, PinResourceVersion, UnpinResourceVersion, TriggerResourceVersion, WebhookTrigger, RegenerateWebhookToken, CreateTrigger, ListTriggersAfter, ExportDatabase, PausePipeline, UnpausePipeline, PauseJob, UnpauseJob, GetVersion, WorkerHeartbeat, ListWorkers, WorkersHealth, DeleteWorker}
 
 var _RouteNameNameToValueMap = map[string]RouteName{
 	_RouteNameName[0:10]:           UserLogin,
@@ -142,82 +143,84 @@ var _RouteNameNameToValueMap = map[string]RouteName{
 	_RouteNameLowerName[297:318]:   CreatePipelineImage,
 	_RouteNameName[318:338]:        TriggerPipelineJob,
 	_RouteNameLowerName[318:338]:   TriggerPipelineJob,
-	_RouteNameName[338:354]:        GetPipelineJob,
-	_RouteNameLowerName[338:354]:   GetPipelineJob,
-	_RouteNameName[354:370]:        CreateJobBuild,
-	_RouteNameLowerName[354:370]:   CreateJobBuild,
-	_RouteNameName[370:392]:        CreateRetryJobBuild,
-	_RouteNameLowerName[370:392]:   CreateRetryJobBuild,
-	_RouteNameName[392:408]:        UpdateJobBuild,
-	_RouteNameLowerName[392:408]:   UpdateJobBuild,
-	_RouteNameName[408:424]:        DeleteJobBuild,
-	_RouteNameLowerName[408:424]:   DeleteJobBuild,
-	_RouteNameName[424:439]:        ListJobBuilds,
-	_RouteNameLowerName[424:439]:   ListJobBuilds,
-	_RouteNameName[439:463]:        InsertBuildGetVersion,
-	_RouteNameLowerName[439:463]:   InsertBuildGetVersion,
-	_RouteNameName[463:486]:        FindBuildGetVersions,
-	_RouteNameLowerName[463:486]:   FindBuildGetVersions,
-	_RouteNameName[486:499]:        GetJobBuild,
-	_RouteNameLowerName[486:499]:   GetJobBuild,
-	_RouteNameName[499:515]:        CancelJobBuild,
-	_RouteNameLowerName[499:515]:   CancelJobBuild,
-	_RouteNameName[515:530]:        RetryJobBuild,
-	_RouteNameLowerName[515:530]:   RetryJobBuild,
-	_RouteNameName[530:549]:        StartPendingBuild,
-	_RouteNameLowerName[530:549]:   StartPendingBuild,
-	_RouteNameName[549:574]:        FindOldestPendingBuild,
-	_RouteNameLowerName[549:574]:   FindOldestPendingBuild,
-	_RouteNameName[574:608]:        NotifySerialGroupPendingBuilds,
-	_RouteNameLowerName[574:608]:   NotifySerialGroupPendingBuilds,
-	_RouteNameName[608:632]:        EvaluateDownstreamJobs,
-	_RouteNameLowerName[608:632]:   EvaluateDownstreamJobs,
-	_RouteNameName[632:655]:        ListPipelineResources,
-	_RouteNameLowerName[632:655]:   ListPipelineResources,
-	_RouteNameName[655:676]:        GetPipelineResource,
-	_RouteNameLowerName[655:676]:   GetPipelineResource,
-	_RouteNameName[676:700]:        UpdatePipelineResource,
-	_RouteNameLowerName[676:700]:   UpdatePipelineResource,
-	_RouteNameName[700:725]:        TriggerPipelineResource,
-	_RouteNameLowerName[700:725]:   TriggerPipelineResource,
-	_RouteNameName[725:748]:        CreateResourceVersion,
-	_RouteNameLowerName[725:748]:   CreateResourceVersion,
-	_RouteNameName[748:770]:        ListResourceVersions,
-	_RouteNameLowerName[748:770]:   ListResourceVersions,
-	_RouteNameName[770:790]:        PinResourceVersion,
-	_RouteNameLowerName[770:790]:   PinResourceVersion,
-	_RouteNameName[790:812]:        UnpinResourceVersion,
-	_RouteNameLowerName[790:812]:   UnpinResourceVersion,
-	_RouteNameName[812:836]:        TriggerResourceVersion,
-	_RouteNameLowerName[812:836]:   TriggerResourceVersion,
-	_RouteNameName[836:851]:        WebhookTrigger,
-	_RouteNameLowerName[836:851]:   WebhookTrigger,
-	_RouteNameName[851:875]:        RegenerateWebhookToken,
-	_RouteNameLowerName[851:875]:   RegenerateWebhookToken,
-	_RouteNameName[875:889]:        CreateTrigger,
-	_RouteNameLowerName[875:889]:   CreateTrigger,
-	_RouteNameName[889:908]:        ListTriggersAfter,
-	_RouteNameLowerName[889:908]:   ListTriggersAfter,
-	_RouteNameName[908:923]:        ExportDatabase,
-	_RouteNameLowerName[908:923]:   ExportDatabase,
-	_RouteNameName[923:937]:        PausePipeline,
-	_RouteNameLowerName[923:937]:   PausePipeline,
-	_RouteNameName[937:953]:        UnpausePipeline,
-	_RouteNameLowerName[937:953]:   UnpausePipeline,
-	_RouteNameName[953:962]:        PauseJob,
-	_RouteNameLowerName[953:962]:   PauseJob,
-	_RouteNameName[962:973]:        UnpauseJob,
-	_RouteNameLowerName[962:973]:   UnpauseJob,
-	_RouteNameName[973:984]:        GetVersion,
-	_RouteNameLowerName[973:984]:   GetVersion,
-	_RouteNameName[984:1000]:       WorkerHeartbeat,
-	_RouteNameLowerName[984:1000]:  WorkerHeartbeat,
-	_RouteNameName[1000:1012]:      ListWorkers,
-	_RouteNameLowerName[1000:1012]: ListWorkers,
-	_RouteNameName[1012:1026]:      WorkersHealth,
-	_RouteNameLowerName[1012:1026]: WorkersHealth,
-	_RouteNameName[1026:1039]:      DeleteWorker,
-	_RouteNameLowerName[1026:1039]: DeleteWorker,
+	_RouteNameName[338:356]:        ListPipelineJobs,
+	_RouteNameLowerName[338:356]:   ListPipelineJobs,
+	_RouteNameName[356:372]:        GetPipelineJob,
+	_RouteNameLowerName[356:372]:   GetPipelineJob,
+	_RouteNameName[372:388]:        CreateJobBuild,
+	_RouteNameLowerName[372:388]:   CreateJobBuild,
+	_RouteNameName[388:410]:        CreateRetryJobBuild,
+	_RouteNameLowerName[388:410]:   CreateRetryJobBuild,
+	_RouteNameName[410:426]:        UpdateJobBuild,
+	_RouteNameLowerName[410:426]:   UpdateJobBuild,
+	_RouteNameName[426:442]:        DeleteJobBuild,
+	_RouteNameLowerName[426:442]:   DeleteJobBuild,
+	_RouteNameName[442:457]:        ListJobBuilds,
+	_RouteNameLowerName[442:457]:   ListJobBuilds,
+	_RouteNameName[457:481]:        InsertBuildGetVersion,
+	_RouteNameLowerName[457:481]:   InsertBuildGetVersion,
+	_RouteNameName[481:504]:        FindBuildGetVersions,
+	_RouteNameLowerName[481:504]:   FindBuildGetVersions,
+	_RouteNameName[504:517]:        GetJobBuild,
+	_RouteNameLowerName[504:517]:   GetJobBuild,
+	_RouteNameName[517:533]:        CancelJobBuild,
+	_RouteNameLowerName[517:533]:   CancelJobBuild,
+	_RouteNameName[533:548]:        RetryJobBuild,
+	_RouteNameLowerName[533:548]:   RetryJobBuild,
+	_RouteNameName[548:567]:        StartPendingBuild,
+	_RouteNameLowerName[548:567]:   StartPendingBuild,
+	_RouteNameName[567:592]:        FindOldestPendingBuild,
+	_RouteNameLowerName[567:592]:   FindOldestPendingBuild,
+	_RouteNameName[592:626]:        NotifySerialGroupPendingBuilds,
+	_RouteNameLowerName[592:626]:   NotifySerialGroupPendingBuilds,
+	_RouteNameName[626:650]:        EvaluateDownstreamJobs,
+	_RouteNameLowerName[626:650]:   EvaluateDownstreamJobs,
+	_RouteNameName[650:673]:        ListPipelineResources,
+	_RouteNameLowerName[650:673]:   ListPipelineResources,
+	_RouteNameName[673:694]:        GetPipelineResource,
+	_RouteNameLowerName[673:694]:   GetPipelineResource,
+	_RouteNameName[694:718]:        UpdatePipelineResource,
+	_RouteNameLowerName[694:718]:   UpdatePipelineResource,
+	_RouteNameName[718:743]:        TriggerPipelineResource,
+	_RouteNameLowerName[718:743]:   TriggerPipelineResource,
+	_RouteNameName[743:766]:        CreateResourceVersion,
+	_RouteNameLowerName[743:766]:   CreateResourceVersion,
+	_RouteNameName[766:788]:        ListResourceVersions,
+	_RouteNameLowerName[766:788]:   ListResourceVersions,
+	_RouteNameName[788:808]:        PinResourceVersion,
+	_RouteNameLowerName[788:808]:   PinResourceVersion,
+	_RouteNameName[808:830]:        UnpinResourceVersion,
+	_RouteNameLowerName[808:830]:   UnpinResourceVersion,
+	_RouteNameName[830:854]:        TriggerResourceVersion,
+	_RouteNameLowerName[830:854]:   TriggerResourceVersion,
+	_RouteNameName[854:869]:        WebhookTrigger,
+	_RouteNameLowerName[854:869]:   WebhookTrigger,
+	_RouteNameName[869:893]:        RegenerateWebhookToken,
+	_RouteNameLowerName[869:893]:   RegenerateWebhookToken,
+	_RouteNameName[893:907]:        CreateTrigger,
+	_RouteNameLowerName[893:907]:   CreateTrigger,
+	_RouteNameName[907:926]:        ListTriggersAfter,
+	_RouteNameLowerName[907:926]:   ListTriggersAfter,
+	_RouteNameName[926:941]:        ExportDatabase,
+	_RouteNameLowerName[926:941]:   ExportDatabase,
+	_RouteNameName[941:955]:        PausePipeline,
+	_RouteNameLowerName[941:955]:   PausePipeline,
+	_RouteNameName[955:971]:        UnpausePipeline,
+	_RouteNameLowerName[955:971]:   UnpausePipeline,
+	_RouteNameName[971:980]:        PauseJob,
+	_RouteNameLowerName[971:980]:   PauseJob,
+	_RouteNameName[980:991]:        UnpauseJob,
+	_RouteNameLowerName[980:991]:   UnpauseJob,
+	_RouteNameName[991:1002]:       GetVersion,
+	_RouteNameLowerName[991:1002]:  GetVersion,
+	_RouteNameName[1002:1018]:      WorkerHeartbeat,
+	_RouteNameLowerName[1002:1018]: WorkerHeartbeat,
+	_RouteNameName[1018:1030]:      ListWorkers,
+	_RouteNameLowerName[1018:1030]: ListWorkers,
+	_RouteNameName[1030:1044]:      WorkersHealth,
+	_RouteNameLowerName[1030:1044]: WorkersHealth,
+	_RouteNameName[1044:1057]:      DeleteWorker,
+	_RouteNameLowerName[1044:1057]: DeleteWorker,
 }
 
 var _RouteNameNames = []string{
@@ -246,44 +249,45 @@ var _RouteNameNames = []string{
 	_RouteNameName[279:297],
 	_RouteNameName[297:318],
 	_RouteNameName[318:338],
-	_RouteNameName[338:354],
-	_RouteNameName[354:370],
-	_RouteNameName[370:392],
-	_RouteNameName[392:408],
-	_RouteNameName[408:424],
-	_RouteNameName[424:439],
-	_RouteNameName[439:463],
-	_RouteNameName[463:486],
-	_RouteNameName[486:499],
-	_RouteNameName[499:515],
-	_RouteNameName[515:530],
-	_RouteNameName[530:549],
-	_RouteNameName[549:574],
-	_RouteNameName[574:608],
-	_RouteNameName[608:632],
-	_RouteNameName[632:655],
-	_RouteNameName[655:676],
-	_RouteNameName[676:700],
-	_RouteNameName[700:725],
-	_RouteNameName[725:748],
-	_RouteNameName[748:770],
-	_RouteNameName[770:790],
-	_RouteNameName[790:812],
-	_RouteNameName[812:836],
-	_RouteNameName[836:851],
-	_RouteNameName[851:875],
-	_RouteNameName[875:889],
-	_RouteNameName[889:908],
-	_RouteNameName[908:923],
-	_RouteNameName[923:937],
-	_RouteNameName[937:953],
-	_RouteNameName[953:962],
-	_RouteNameName[962:973],
-	_RouteNameName[973:984],
-	_RouteNameName[984:1000],
-	_RouteNameName[1000:1012],
-	_RouteNameName[1012:1026],
-	_RouteNameName[1026:1039],
+	_RouteNameName[338:356],
+	_RouteNameName[356:372],
+	_RouteNameName[372:388],
+	_RouteNameName[388:410],
+	_RouteNameName[410:426],
+	_RouteNameName[426:442],
+	_RouteNameName[442:457],
+	_RouteNameName[457:481],
+	_RouteNameName[481:504],
+	_RouteNameName[504:517],
+	_RouteNameName[517:533],
+	_RouteNameName[533:548],
+	_RouteNameName[548:567],
+	_RouteNameName[567:592],
+	_RouteNameName[592:626],
+	_RouteNameName[626:650],
+	_RouteNameName[650:673],
+	_RouteNameName[673:694],
+	_RouteNameName[694:718],
+	_RouteNameName[718:743],
+	_RouteNameName[743:766],
+	_RouteNameName[766:788],
+	_RouteNameName[788:808],
+	_RouteNameName[808:830],
+	_RouteNameName[830:854],
+	_RouteNameName[854:869],
+	_RouteNameName[869:893],
+	_RouteNameName[893:907],
+	_RouteNameName[907:926],
+	_RouteNameName[926:941],
+	_RouteNameName[941:955],
+	_RouteNameName[955:971],
+	_RouteNameName[971:980],
+	_RouteNameName[980:991],
+	_RouteNameName[991:1002],
+	_RouteNameName[1002:1018],
+	_RouteNameName[1018:1030],
+	_RouteNameName[1030:1044],
+	_RouteNameName[1044:1057],
 }
 
 // RouteNameString retrieves an enum value from the enum constants string name.

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -263,7 +263,6 @@
           <% } %>
         </h1>
         <div class="d-flex gap-2">
-          <button type="button" id="toggle-resources-panel" class="btn btn-outline-secondary"><i class="bi bi-box"></i> Resources</button>
           <% if (isMember(team.canonical) && pipeline.jobs && pipeline.jobs.length > 0) { %>
             <% if (pipeline.jobs.some(function(j) { return j.paused; })) { %>
               <button type="button" id="unpause-pipeline" class="btn btn-primary" data-loading-text="Unpausing..."><i class="bi bi-play-circle"></i> Unpause</button>
@@ -277,41 +276,67 @@
           <% } %>
         </div>
       </div>
-      <div class="piko-graph-wrapper">
-        <div class="piko-graph-container" id="graphviz"></div>
-        <div id="pipeline-resources-panel" class="piko-resources-panel"></div>
+      <div class="piko-view-toolbar">
+        <button class="piko-view-btn" data-view="graph">Graph</button>
+        <button class="piko-view-btn piko-view-btn-disabled" data-view="pipeline">Pipeline</button>
+        <button class="piko-view-btn" data-view="list">List</button>
+        <div class="piko-view-sep"></div>
+        <button class="piko-view-btn" id="toggle-resources-panel"><i class="bi bi-box"></i> Resources</button>
       </div>
-      <div class="piko-graph-legend">
-        <span class="piko-graph-legend-item">
-          <svg width="22" height="14" viewBox="0 0 22 14"><polygon points="0,0 16,0 22,7 16,14 0,14" fill="#83769C" stroke="#5F574F" stroke-width="1"/></svg>
-          Resource
-        </span>
-        <span class="piko-graph-legend-item">
-          <span class="piko-graph-legend-swatch" style="background:var(--status-succeeded);"></span>
-          Succeeded
-        </span>
-        <span class="piko-graph-legend-item">
-          <span class="piko-graph-legend-swatch" style="background:var(--status-failed);"></span>
-          Failed
-        </span>
-        <span class="piko-graph-legend-item">
-          <span class="piko-graph-legend-swatch" style="background:var(--status-started);border:1.5px dashed var(--status-started);"></span>
-          Running
-        </span>
-        <span class="piko-graph-legend-item">
-          <span class="piko-graph-legend-swatch" style="background:var(--status-cancelled);"></span>
-          Cancelled
-        </span>
-        <span class="piko-graph-legend-item">
-          <span class="piko-graph-legend-swatch" style="background:#83769C;"></span>
-          No builds
-        </span>
-        <span class="piko-graph-legend-item">
-          <span class="piko-graph-legend-swatch" style="background:#29ADFF;"></span>
-          Paused
-        </span>
+      <div class="piko-pipeline-body">
+      <div id="pipeline-resources-panel" class="piko-resources-panel"></div>
+      <div class="piko-view-graph">
+        <div class="piko-graph-wrapper">
+          <div class="piko-graph-container" id="graphviz"></div>
+        </div>
+        <div class="piko-graph-legend">
+          <span class="piko-graph-legend-item">
+            <svg width="22" height="14" viewBox="0 0 22 14"><polygon points="0,0 16,0 22,7 16,14 0,14" fill="#83769C" stroke="#5F574F" stroke-width="1"/></svg>
+            Resource
+          </span>
+          <span class="piko-graph-legend-item">
+            <span class="piko-graph-legend-swatch" style="background:var(--status-succeeded);"></span>
+            Succeeded
+          </span>
+          <span class="piko-graph-legend-item">
+            <span class="piko-graph-legend-swatch" style="background:var(--status-failed);"></span>
+            Failed
+          </span>
+          <span class="piko-graph-legend-item">
+            <span class="piko-graph-legend-swatch" style="background:var(--status-started);border:1.5px dashed var(--status-started);"></span>
+            Running
+          </span>
+          <span class="piko-graph-legend-item">
+            <span class="piko-graph-legend-swatch" style="background:var(--status-cancelled);"></span>
+            Cancelled
+          </span>
+          <span class="piko-graph-legend-item">
+            <span class="piko-graph-legend-swatch" style="background:#83769C;"></span>
+            No builds
+          </span>
+          <span class="piko-graph-legend-item">
+            <span class="piko-graph-legend-swatch" style="background:#29ADFF;"></span>
+            Paused
+          </span>
+        </div>
+      </div>
+      <div class="piko-view-list" style="display:none">
+        <div class="piko-list-resource-bar"></div>
+        <div class="piko-list-panels">
+          <div class="piko-list-left">
+            <div class="piko-job-list"></div>
+          </div>
+          <div class="piko-job-detail"></div>
+        </div>
+      </div>
       </div>
     </script>
+
+    <script type="text/template" id="pipeline-list-job-row">
+      <div class="piko-job-row-dot piko-status-dot-<%= status %>"></div>
+      <span class="piko-job-row-name"><%- name %></span>
+    </script>
+
 
     <script type="text/template" id="pipeline-resources-panel-view">
       <div class="piko-resources-panel-header">
@@ -339,6 +364,9 @@
                 </div>
               <% } %>
               <div class="piko-resource-card-meta">
+                <% if (r.check_interval) { %>
+                  <span><%- r.check_interval %></span>
+                <% } %>
                 <% if (r.last_check && !r.last_check.startsWith('0001-01-01')) { %>
                   <span>Checked: <%- pikoTimeAgo(r.last_check) %></span>
                 <% } %>


### PR DESCRIPTION
## Summary

- Add a **list view** to the pipeline show page with a `[Graph] [Pipeline] [List]` view switcher toolbar
- List view shows jobs scoped to a selected trigger resource's execution chain in a tree layout with collapsible parallel groups
- Clicking a job shows its builds in an embedded right panel (reuses existing `JobBuildsView`)
- Resource selector bar at top with status dot, latest version, check interval, and "Check Now" button
- New `ListPipelineJobs` API endpoint returning jobs enriched with build status
- View preference, selected resource/job, and collapsed groups persist via localStorage
- URL updates to the job builds path when a job is selected; reloading respects the view preference
- Paused jobs display with the paused color indicator

Closes #538