### PR TITLE
fix: retry build fetches wrong resource version (#552)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Retrying a build now reuses the resource versions from the original build instead of fetching the latest version ([#552](https://github.com/PikoCI/pikoci/issues/552))
 - `in_parallel` sub-step durations now display as formatted time (`HH:MM:SS`) instead of raw nanoseconds ([#526](https://github.com/PikoCI/pikoci/issues/526))
 - Webhook triggers now work correctly after the `tags` column was added to resources. `FindByWebhookToken` was missing the `tags` Scan destination, causing all webhook calls to return 400 ([#544](https://github.com/PikoCI/pikoci/issues/544))
 

--- a/pikoci/build/build.go
+++ b/pikoci/build/build.go
@@ -46,6 +46,8 @@ type Build struct {
 	VersionID         uint32 `json:"version_id,omitempty"`
 	ResourceCanonical string `json:"resource_canonical,omitempty"`
 
+	RetrySourceBuildID uint32 `json:"retry_source_build_id,omitempty"`
+
 	// SuppressUpdates prevents updateBuild from persisting this build.
 	// Used by in_parallel goroutines that operate on local build copies.
 	SuppressUpdates bool `json:"-"`

--- a/pikoci/builds.go
+++ b/pikoci/builds.go
@@ -239,8 +239,14 @@ func (q *PikoCI) RetryJobBuild(ctx context.Context, tc, pc, jn, buildNumber stri
 		parentBN = buildNumber[:idx]
 	}
 
+	// Find the parent build to get its ID for version pinning
+	parentBuild, err := q.Builds.Find(ctx, tc, pc, jn, parentBN)
+	if err != nil {
+		return fmt.Errorf("failed to Find parent Build %q: %w", parentBN, err)
+	}
+
 	// Create a pending retry build first
-	_, err = q.CreateRetryJobBuild(ctx, tc, pc, jn, parentBN, build.Build{Status: build.Pending})
+	_, err = q.CreateRetryJobBuild(ctx, tc, pc, jn, parentBN, build.Build{Status: build.Pending, RetrySourceBuildID: parentBuild.ID})
 	if err != nil {
 		return fmt.Errorf("failed to create pending retry build: %w", err)
 	}

--- a/pikoci/builds_test.go
+++ b/pikoci/builds_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/pikoci/pikoci/pikoci/job"
 	"github.com/pikoci/pikoci/pikoci/pipeline"
 	"github.com/pikoci/pikoci/pikoci/resource"
+	"github.com/pikoci/pikoci/pikoci/team"
+	"github.com/pikoci/pikoci/pikoci/workitem"
 	"go.uber.org/mock/gomock"
 )
 
@@ -976,4 +978,62 @@ func TestEvaluateDownstreamJobs_ForEachGroupExpansion(t *testing.T) {
 
 	err := s.S.EvaluateDownstreamJobs(ctx, "main", "my-pipeline", "lint-go")
 	require.NoError(t, err)
+}
+
+// --- NextWork tests ---
+
+func TestNextWork_RetryBuildSetsRetryFields(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Pipelines.EXPECT().FilterAll(ctx).Return([]*pipeline.WithTeam{
+		{
+			Pipeline: pipeline.Pipeline{Canonical: "my-pipeline", Jobs: []job.Job{{Name: "my-job"}}},
+			Team:     team.Team{Canonical: "main"},
+		},
+	}, nil)
+	s.Builds.EXPECT().FindOldestPending(ctx, "main", "my-pipeline", "my-job").
+		Return(&build.Build{ID: 10, BuildNumber: "3.1", Status: build.Pending, RetrySourceBuildID: 5}, nil)
+	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "my-job").
+		Return(&job.Job{Name: "my-job"}, nil)
+	s.Builds.EXPECT().StartPending(ctx, "main", "my-pipeline", "my-job", uint32(10)).Return(nil)
+	s.Builds.EXPECT().FindByID(ctx, uint32(10)).Return(
+		&build.Build{ID: 10, BuildNumber: "3.1", Status: build.Started, VersionID: 42, RetrySourceBuildID: 5}, nil)
+
+	item, err := s.P.NextWork(ctx, workitem.WorkerContext{})
+	require.NoError(t, err)
+	require.NotNil(t, item)
+	assert.Equal(t, "job", item.Type)
+	assert.Equal(t, uint32(5), item.Body.RetryBuildID)
+	assert.Equal(t, "3", item.Body.RetryBuildNumber)
+	assert.Equal(t, uint32(10), item.Body.BuildID)
+	assert.Equal(t, "3.1", item.Body.BuildNumber)
+}
+
+func TestNextWork_NonRetryBuildNoRetryFields(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Pipelines.EXPECT().FilterAll(ctx).Return([]*pipeline.WithTeam{
+		{
+			Pipeline: pipeline.Pipeline{Canonical: "my-pipeline", Jobs: []job.Job{{Name: "my-job"}}},
+			Team:     team.Team{Canonical: "main"},
+		},
+	}, nil)
+	s.Builds.EXPECT().FindOldestPending(ctx, "main", "my-pipeline", "my-job").
+		Return(&build.Build{ID: 7, BuildNumber: "1", Status: build.Pending}, nil)
+	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "my-job").
+		Return(&job.Job{Name: "my-job"}, nil)
+	s.Builds.EXPECT().StartPending(ctx, "main", "my-pipeline", "my-job", uint32(7)).Return(nil)
+	s.Builds.EXPECT().FindByID(ctx, uint32(7)).Return(
+		&build.Build{ID: 7, BuildNumber: "1", Status: build.Started, VersionID: 10}, nil)
+
+	item, err := s.P.NextWork(ctx, workitem.WorkerContext{})
+	require.NoError(t, err)
+	require.NotNil(t, item)
+	assert.Equal(t, "job", item.Type)
+	assert.Equal(t, uint32(0), item.Body.RetryBuildID)
+	assert.Equal(t, "", item.Body.RetryBuildNumber)
 }

--- a/pikoci/builds_test.go
+++ b/pikoci/builds_test.go
@@ -150,10 +150,13 @@ func TestRetryJobBuild_BaseBuild(t *testing.T) {
 	ctx := context.TODO()
 
 	s.Builds.EXPECT().Find(ctx, "main", "my-pipeline", "my-job", "3").
-		Return(&build.Build{ID: 5, BuildNumber: "3", Status: build.Succeeded}, nil)
-	// RetryJobBuild now creates a pending build first
+		Return(&build.Build{ID: 5, BuildNumber: "3", Status: build.Succeeded}, nil).Times(2)
+	// RetryJobBuild now creates a pending build with RetrySourceBuildID set
 	s.Builds.EXPECT().CreateRetry(ctx, "main", "my-pipeline", "my-job", "3", gomock.Any()).
-		Return(uint32(10), "3.1", nil)
+		DoAndReturn(func(ctx context.Context, tc, pc, jn, pbn string, b build.Build) (uint32, string, error) {
+			assert.Equal(t, uint32(5), b.RetrySourceBuildID)
+			return uint32(10), "3.1", nil
+		})
 
 	err := s.S.RetryJobBuild(ctx, "main", "my-pipeline", "my-job", "3")
 	require.NoError(t, err)
@@ -167,9 +170,15 @@ func TestRetryJobBuild_RetryOfRetry(t *testing.T) {
 	// Retrying "3.1" should extract parent "3"
 	s.Builds.EXPECT().Find(ctx, "main", "my-pipeline", "my-job", "3.1").
 		Return(&build.Build{ID: 7, BuildNumber: "3.1", Status: build.Failed}, nil)
+	// Find parent build "3" to get its ID for version pinning
+	s.Builds.EXPECT().Find(ctx, "main", "my-pipeline", "my-job", "3").
+		Return(&build.Build{ID: 5, BuildNumber: "3", Status: build.Succeeded}, nil)
 	// RetryJobBuild creates a pending build using parent build number
 	s.Builds.EXPECT().CreateRetry(ctx, "main", "my-pipeline", "my-job", "3", gomock.Any()).
-		Return(uint32(12), "3.2", nil)
+		DoAndReturn(func(ctx context.Context, tc, pc, jn, pbn string, b build.Build) (uint32, string, error) {
+			assert.Equal(t, uint32(5), b.RetrySourceBuildID)
+			return uint32(12), "3.2", nil
+		})
 
 	err := s.S.RetryJobBuild(ctx, "main", "my-pipeline", "my-job", "3.1")
 	require.NoError(t, err)

--- a/pikoci/mysql/build.go
+++ b/pikoci/mysql/build.go
@@ -42,8 +42,9 @@ type dbBuild struct {
 	Error             sql.NullString
 	StartedAt         sql.NullTime
 	Duration          sql.NullInt64
-	VersionID         sql.NullInt64
-	ResourceCanonical sql.NullString
+	VersionID            sql.NullInt64
+	ResourceCanonical    sql.NullString
+	RetrySourceBuildID   int64
 }
 
 func newDBBuild(b build.Build) dbBuild {
@@ -56,8 +57,9 @@ func newDBBuild(b build.Build) dbBuild {
 		Error:             toNullString(b.Error),
 		StartedAt:         toNullTime(b.StartedAt),
 		Duration:          toNullInt64(int(b.Duration)),
-		VersionID:         toNullInt64(int(b.VersionID)),
-		ResourceCanonical: toNullString(b.ResourceCanonical),
+		VersionID:          toNullInt64(int(b.VersionID)),
+		ResourceCanonical:  toNullString(b.ResourceCanonical),
+		RetrySourceBuildID: int64(b.RetrySourceBuildID),
 	}
 }
 
@@ -70,8 +72,9 @@ func (dbb *dbBuild) toDomainEntity() *build.Build {
 		Error:             dbb.Error.String,
 		StartedAt:         dbb.StartedAt.Time,
 		Duration:          time.Duration(dbb.Duration.Int64),
-		VersionID:         uint32(dbb.VersionID.Int64),
-		ResourceCanonical: dbb.ResourceCanonical.String,
+		VersionID:          uint32(dbb.VersionID.Int64),
+		ResourceCanonical:  dbb.ResourceCanonical.String,
+		RetrySourceBuildID: uint32(dbb.RetrySourceBuildID),
 	}
 
 	_ = json.Unmarshal([]byte(dbb.Steps.String), &b.Steps)
@@ -108,8 +111,8 @@ func (r *BuildRepository) Create(ctx context.Context, tc, pn, jn string, b build
 		buildNumber := fmt.Sprintf("%d", nextNum)
 
 		res, err := r.querier.ExecContext(ctx, `
-			INSERT INTO builds(steps, job, status, error, started_at, duration, build_number, version_id, resource_canonical, job_id)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,
+			INSERT INTO builds(steps, job, status, error, started_at, duration, build_number, version_id, resource_canonical, retry_source_build_id, job_id)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 				-- job_id
 				(
 					SELECT j.id
@@ -119,7 +122,7 @@ func (r *BuildRepository) Create(ctx context.Context, tc, pn, jn string, b build
 					JOIN teams AS t
 						ON p.team_id = t.id
 					WHERE t.canonical = ? AND p.canonical = ? AND j.name = ?
-				))`, dbb.Steps, dbb.Job, dbb.Status, dbb.Error, dbb.StartedAt, dbb.Duration, buildNumber, dbb.VersionID, dbb.ResourceCanonical, tc, pn, jn)
+				))`, dbb.Steps, dbb.Job, dbb.Status, dbb.Error, dbb.StartedAt, dbb.Duration, buildNumber, dbb.VersionID, dbb.ResourceCanonical, dbb.RetrySourceBuildID, tc, pn, jn)
 		if err != nil {
 			if isUniqueViolation(err) {
 				continue
@@ -167,8 +170,8 @@ func (r *BuildRepository) CreateRetry(ctx context.Context, tc, pn, jn, parentBui
 		buildNumber := fmt.Sprintf("%s.%d", parentBuildNumber, nextNum)
 
 		res, err := r.querier.ExecContext(ctx, `
-			INSERT INTO builds(steps, job, status, error, started_at, duration, build_number, version_id, resource_canonical, job_id)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,
+			INSERT INTO builds(steps, job, status, error, started_at, duration, build_number, version_id, resource_canonical, retry_source_build_id, job_id)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 				(
 					SELECT j.id
 					FROM jobs AS j
@@ -177,7 +180,7 @@ func (r *BuildRepository) CreateRetry(ctx context.Context, tc, pn, jn, parentBui
 					JOIN teams AS t
 						ON p.team_id = t.id
 					WHERE t.canonical = ? AND p.canonical = ? AND j.name = ?
-				))`, dbb.Steps, dbb.Job, dbb.Status, dbb.Error, dbb.StartedAt, dbb.Duration, buildNumber, dbb.VersionID, dbb.ResourceCanonical, tc, pn, jn)
+				))`, dbb.Steps, dbb.Job, dbb.Status, dbb.Error, dbb.StartedAt, dbb.Duration, buildNumber, dbb.VersionID, dbb.ResourceCanonical, dbb.RetrySourceBuildID, tc, pn, jn)
 		if err != nil {
 			if isUniqueViolation(err) {
 				continue
@@ -222,7 +225,7 @@ func (r *BuildRepository) FindGetVersions(ctx context.Context, buildID uint32) (
 
 func (r *BuildRepository) Find(ctx context.Context, tc, pn, jn string, buildNumber string) (*build.Build, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical
+		SELECT b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical, b.retry_source_build_id
 		FROM builds AS b
 		JOIN jobs AS j
 			ON b.job_id = j.id
@@ -243,7 +246,7 @@ func (r *BuildRepository) Find(ctx context.Context, tc, pn, jn string, buildNumb
 
 func (r *BuildRepository) Filter(ctx context.Context, tc, pn, jn string, before *uint32, after *uint32, limit uint32) ([]*build.Build, error) {
 	query := `
-		SELECT b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical
+		SELECT b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical, b.retry_source_build_id
 		FROM builds AS b
 		JOIN jobs AS j
 			ON b.job_id = j.id
@@ -518,7 +521,7 @@ func (r *BuildRepository) CountRunningInSerialGroups(ctx context.Context, tc, pn
 
 func (r *BuildRepository) FindByID(ctx context.Context, buildID uint32) (*build.Build, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical
+		SELECT b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical, b.retry_source_build_id
 		FROM builds AS b
 		WHERE b.id = ?
 	`, buildID)
@@ -532,7 +535,7 @@ func (r *BuildRepository) FindByID(ctx context.Context, buildID uint32) (*build.
 
 func (r *BuildRepository) FindOldestPending(ctx context.Context, tc, pn, jn string) (*build.Build, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical
+		SELECT b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical, b.retry_source_build_id
 		FROM builds AS b
 		JOIN jobs AS j
 			ON b.job_id = j.id
@@ -641,6 +644,7 @@ func scanBuild(s sqlr.Scanner) (*build.Build, error) {
 		&b.Duration,
 		&b.VersionID,
 		&b.ResourceCanonical,
+		&b.RetrySourceBuildID,
 	)
 
 	if err != nil {

--- a/pikoci/mysql/migrate/migrations/V38RetrySourceBuildID.go
+++ b/pikoci/mysql/migrate/migrations/V38RetrySourceBuildID.go
@@ -1,0 +1,6 @@
+package migrations
+
+var V38RetrySourceBuildID = Migration{
+	Name: "RetrySourceBuildID",
+	SQL:  "ALTER TABLE builds ADD COLUMN retry_source_build_id INTEGER NOT NULL DEFAULT 0;",
+}

--- a/pikoci/mysql/migrate/migrations/migrations.go
+++ b/pikoci/mysql/migrate/migrations/migrations.go
@@ -16,7 +16,7 @@ type Migration struct {
 // Migrations is the ordered list of all schema migrations. It is defined as
 // a fixed-size array so that the compiler catches ordering conflicts when
 // multiple developers add migrations concurrently.
-var Migrations = [38]Migration{
+var Migrations = [39]Migration{
 	V0Initial,
 	V1ResourceCheckInterval,
 	V2JobsAndBuilds,
@@ -55,4 +55,5 @@ var Migrations = [38]Migration{
 	V35BaselineVersionID,
 	V36RunnerOverride,
 	V37WorkerCommit,
+	V38RetrySourceBuildID,
 }

--- a/pikoci/work.go
+++ b/pikoci/work.go
@@ -3,6 +3,7 @@ package pikoci
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/pikoci/pikoci/pikoci/scheduler"
@@ -56,7 +57,7 @@ func (q *PikoCI) NextWork(ctx context.Context, wc workitem.WorkerContext) (*work
 				continue
 			}
 
-			return &workitem.Item{
+			item := &workitem.Item{
 				Type: "job",
 				Body: workitem.Body{
 					TeamCanonical:     pwt.Team.Canonical,
@@ -66,7 +67,14 @@ func (q *PikoCI) NextWork(ctx context.Context, wc workitem.WorkerContext) (*work
 					BuildNumber:       started.BuildNumber,
 					VersionID:         started.VersionID,
 				},
-			}, nil
+			}
+			if started.RetrySourceBuildID != 0 {
+				item.Body.RetryBuildID = started.RetrySourceBuildID
+				if idx := strings.Index(started.BuildNumber, "."); idx != -1 {
+					item.Body.RetryBuildNumber = started.BuildNumber[:idx]
+				}
+			}
+			return item, nil
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Add `retry_source_build_id` DB column (migration V38) and wire it through the build domain model, DB layer, service layer, and work dispatch
- `RetryJobBuild` now looks up the parent build and sets `RetrySourceBuildID` so the worker reuses resource versions from the original build
- `NextWork` populates `RetryBuildID` and `RetryBuildNumber` on the work item when dispatching retry builds

Fixes #552