### PR TITLE
fix: list view fan-in rendering with left-side bar grouping (#551)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- List view: fan-in jobs (jobs with multiple upstream parents in a parallel group) now render with a left-side bar grouping their parents and the fan-in job indented after the bar, clearly showing the dependency relationship ([#551](https://github.com/PikoCI/pikoci/issues/551))
 - Retrying a build now reuses the resource versions from the original build instead of fetching the latest version ([#552](https://github.com/PikoCI/pikoci/issues/552))
 - `in_parallel` sub-step durations now display as formatted time (`HH:MM:SS`) instead of raw nanoseconds ([#526](https://github.com/PikoCI/pikoci/issues/526))
 - Webhook triggers now work correctly after the `tags` column was added to resources. `FindByWebhookToken` was missing the `tags` Scan destination, causing all webhook calls to return 400 ([#544](https://github.com/PikoCI/pikoci/issues/544))

--- a/pikoci/transport/http/assets/css/pikoci.css
+++ b/pikoci/transport/http/assets/css/pikoci.css
@@ -970,6 +970,23 @@ textarea.form-control {
 .piko-job-children {
   margin-left: 10px;
 }
+/* Fan-in: bordered section groups the fan-in parents */
+.piko-fan-in-section {
+  border-left: 2px solid var(--text-muted);
+  margin-left: 6px;
+}
+.piko-fan-in-section > .piko-job-row {
+  padding-left: 12px;
+}
+/* Fan-in continuation: same indent as inside the section, no border */
+.piko-fan-in-cont {
+  margin-left: 8px;
+  padding-left: 12px;
+}
+/* Non-fan-in jobs get extra padding to align dots with fan-in-section jobs */
+.piko-fan-in-aligned {
+  padding-left: 20px !important;
+}
 .piko-parallel-counts {
   display: flex;
   align-items: center;

--- a/pikoci/transport/http/assets/js/app/views/pipelines.js
+++ b/pikoci/transport/http/assets/js/app/views/pipelines.js
@@ -867,12 +867,12 @@ var PipelineListView = Backbone.View.extend({
     this.$('.piko-job-list').html(html);
   },
 
-  _renderJobRow: function(data) {
+  _renderJobRow: function(data, extraClass) {
     var status = data.latest_status || '';
     if (data.has_running) status = 'started';
     if (data.paused) status = 'paused';
     var isActive = this.selectedJob === data.name;
-    return '<div class="piko-job-row' + (isActive ? ' active' : '') + '" data-job="' + _.escape(data.name) + '">' +
+    return '<div class="piko-job-row' + (isActive ? ' active' : '') + (extraClass || '') + '" data-job="' + _.escape(data.name) + '">' +
       this.jobRowTemplate({
         name: data.name,
         status: status,
@@ -901,11 +901,10 @@ var PipelineListView = Backbone.View.extend({
     html += '<div class="piko-parallel-nested"' + (isCollapsed ? ' style="display:none"' : '') + '>';
 
     // Identify fan-in children: jobs whose parents are ALL members of this parallel group.
-    // Mark them as rendered so they're skipped inside individual members,
-    // then render them after the parallel block.
     var groupSet = {};
     for (var i = 0; i < jobNames.length; i++) groupSet[jobNames[i]] = true;
     var fanInChildren = [];
+    var fanInParentSet = {};
     for (var i = 0; i < jobNames.length; i++) {
       var kids = tree.children[jobNames[i]] || [];
       for (var k = 0; k < kids.length; k++) {
@@ -919,14 +918,61 @@ var PipelineListView = Backbone.View.extend({
           if (allInGroup) {
             rendered[kids[k]] = true;
             fanInChildren.push(kids[k]);
+            for (var p = 0; p < kidParents.length; p++) {
+              fanInParentSet[kidParents[p]] = true;
+            }
           }
         }
       }
     }
 
+    var hasFanIn = fanInChildren.length > 0;
+
+    // Build the fan-in section HTML (parents in bordered block + children after)
+    var fanInHtml = '';
+    if (hasFanIn) {
+      fanInHtml += '<div class="piko-fan-in-section">';
+      for (var j = 0; j < jobNames.length; j++) {
+        if (!fanInParentSet[jobNames[j]]) continue;
+        var data = statusMap[jobNames[j]] || { name: jobNames[j], latest_status: '' };
+        fanInHtml += this._renderJobRow(data);
+        if (renderChildrenFn) {
+          var childHtml = renderChildrenFn([jobNames[j]]);
+          if (childHtml) {
+            fanInHtml += '<div class="piko-job-children">' + childHtml + '</div>';
+          }
+        }
+      }
+      fanInHtml += '</div>';
+      fanInHtml += '<div class="piko-fan-in-cont">';
+      for (var i = 0; i < fanInChildren.length; i++) {
+        var data = statusMap[fanInChildren[i]] || { name: fanInChildren[i], latest_status: '' };
+        fanInHtml += this._renderJobRow(data);
+        if (renderChildrenFn) {
+          var childHtml = renderChildrenFn([fanInChildren[i]]);
+          if (childHtml) {
+            fanInHtml += '<div class="piko-job-children">' + childHtml + '</div>';
+          }
+        }
+      }
+      fanInHtml += '</div>';
+    }
+
+    // Render members in order; non-fan-in-parent jobs get extra padding when
+    // fan-in exists so all dots align. Insert the fan-in section at the
+    // position of the first fan-in parent.
+    var fanInInserted = false;
+    var alignClass = hasFanIn ? ' piko-fan-in-aligned' : '';
     for (var j = 0; j < jobNames.length; j++) {
+      if (fanInParentSet[jobNames[j]]) {
+        if (!fanInInserted) {
+          html += fanInHtml;
+          fanInInserted = true;
+        }
+        continue;
+      }
       var data = statusMap[jobNames[j]] || { name: jobNames[j], latest_status: '' };
-      html += this._renderJobRow(data);
+      html += this._renderJobRow(data, alignClass);
       if (renderChildrenFn) {
         var childHtml = renderChildrenFn([jobNames[j]]);
         if (childHtml) {
@@ -934,18 +980,8 @@ var PipelineListView = Backbone.View.extend({
         }
       }
     }
-
-    // Render fan-in children inside the nested block, continuing the flow
-    // at the same indentation as the parallel siblings
-    for (var i = 0; i < fanInChildren.length; i++) {
-      var data = statusMap[fanInChildren[i]] || { name: fanInChildren[i], latest_status: '' };
-      html += this._renderJobRow(data);
-      if (renderChildrenFn) {
-        var childHtml = renderChildrenFn([fanInChildren[i]]);
-        if (childHtml) {
-          html += '<div class="piko-job-children">' + childHtml + '</div>';
-        }
-      }
+    if (fanInHtml && !fanInInserted) {
+      html += fanInHtml;
     }
 
     html += '</div>';


### PR DESCRIPTION
## Summary

Closes #551

- Fan-in jobs (jobs with multiple upstream parents in a parallel group) now render with a left-side border bar grouping their parent jobs, and the fan-in child indented after the bar
- Non-fan-in parallel siblings get extra padding so all dots align vertically with the fan-in section jobs
- Fan-in section is inserted at the position of the first fan-in parent in the original job order, so it doesn't appear attached to unrelated jobs

## Files changed

- `pikoci/transport/http/assets/css/pikoci.css` — added `.piko-fan-in-section`, `.piko-fan-in-cont`, `.piko-fan-in-aligned` classes
- `pikoci/transport/http/assets/js/app/views/pipelines.js` — updated `_renderParallelGroup` to detect fan-in parents, group them in a bordered section, and render fan-in children after; updated `_renderJobRow` to accept optional extra CSS class
- `CHANGELOG.md` — added entry