### PR TITLE
fix: poll resource selector in list view to keep status fresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- List view: resource selector bar now polls for updates on the same interval as job data, keeping the status dot, latest version, and "checked X ago" timestamp fresh without manual refresh. Updates are applied in-place when the dropdown is open so it stays open ([#558](https://github.com/PikoCI/pikoci/issues/558))
 - List view: fan-in jobs (jobs with multiple upstream parents in a parallel group) now render with a left-side bar grouping their parents and the fan-in job indented after the bar, clearly showing the dependency relationship ([#551](https://github.com/PikoCI/pikoci/issues/551))
 - Retrying a build now reuses the resource versions from the original build instead of fetching the latest version ([#552](https://github.com/PikoCI/pikoci/issues/552))
 - `in_parallel` sub-step durations now display as formatted time (`HH:MM:SS`) instead of raw nanoseconds ([#526](https://github.com/PikoCI/pikoci/issues/526))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `ListPipelineJobs` API endpoint (`GET /teams/{tc}/pipelines/{pc}/jobs`) returns all pipeline jobs enriched with latest build status, running state, build number, duration, and start time. Supports public pipeline fallback ([#538](https://github.com/PikoCI/pikoci/issues/538))
 - Pipeline graph view now has a gear icon (⚙) with a "Hide intermediate resources" toggle that removes resource nodes between jobs and draws direct job-to-job edges, keeping only entry-point trigger resources ([#548](https://github.com/PikoCI/pikoci/issues/548), [#539](https://github.com/PikoCI/pikoci/issues/539), [#431](https://github.com/PikoCI/pikoci/issues/431))
 - Gear panel now has a "Group parallel jobs" toggle that collapses jobs sharing identical upstream parents into a single compact node with a colored status dot per job and individually clickable rows ([#540](https://github.com/PikoCI/pikoci/issues/540))
+- Pipeline graph view now has a share button that opens a panel with copyable SVG, PNG, and Markdown image URLs reflecting the current gear options. List view linear job chains no longer render nested — only parallel groups and fan-in structures create visual nesting ([#517](https://github.com/PikoCI/pikoci/issues/517))
 
 ### Fixed
 

--- a/docs/Public-Pipelines.md
+++ b/docs/Public-Pipelines.md
@@ -43,6 +43,31 @@ The following data is **removed** for security:
 
 SVG and PNG endpoints return raw image data with the appropriate `Content-Type` header and `Access-Control-Allow-Origin: *` for cross-origin embedding. The pipeline must be public for unauthenticated access.
 
+### Query parameters
+
+The SVG, PNG, and DOT image endpoints accept optional query parameters to customize the rendered graph:
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| `hide_intermediates` | `1` | Hide intermediate resource nodes between jobs, drawing direct job-to-job edges (keeps only entry-point trigger resources) |
+| `group_parallel` | `1` | Collapse jobs sharing identical upstream parents into a single compact node |
+
+Example:
+
+```
+/teams/main/pipelines/my-pipeline/image.svg?hide_intermediates=1&group_parallel=1
+```
+
+## Sharing pipeline graphs
+
+In the graph view, click the **share button** (<i class="bi bi-share"></i>) next to the gear icon to open a panel with copyable URLs for the pipeline graph:
+
+- **SVG** — direct link to the SVG image
+- **PNG** — direct link to the PNG image
+- **Markdown** — ready-to-paste `![pipeline](url)` snippet
+
+The URLs automatically include query parameters matching your current gear options (hide intermediates, group parallel), so what you see is what gets shared.
+
 ## Embedding pipeline graphs
 
 Public pipelines can be embedded directly in READMEs, dashboards, or any HTML page. **The pipeline must be marked as public** (see above) for unauthenticated embedding to work — non-public pipelines require authentication and will return an error for anonymous requests.
@@ -51,6 +76,12 @@ Public pipelines can be embedded directly in READMEs, dashboards, or any HTML pa
 
 ```markdown
 ![Pipeline](https://ci.example.com/teams/main/pipelines/my-pipeline/image.svg)
+```
+
+**Markdown with options:**
+
+```markdown
+![Pipeline](https://ci.example.com/teams/main/pipelines/my-pipeline/image.svg?hide_intermediates=1&group_parallel=1)
 ```
 
 **HTML:**

--- a/pikoci/transport/http/assets/css/pikoci.css
+++ b/pikoci/transport/http/assets/css/pikoci.css
@@ -724,6 +724,7 @@ textarea.form-control {
 /* Gear panel */
 .piko-gear-wrap {
   position: relative;
+  margin-left: auto;
 }
 .piko-gear-btn {
   font-size: 12px;
@@ -767,6 +768,65 @@ textarea.form-control {
 .piko-gear-option:has(input[disabled]) {
   opacity: 0.5;
   cursor: not-allowed;
+}
+/* Share panel */
+.piko-share-wrap {
+  position: relative;
+}
+.piko-share-panel {
+  display: none;
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.12);
+  z-index: 30;
+  padding: 8px 12px;
+  min-width: 380px;
+}
+.piko-share-panel.open {
+  display: block;
+}
+.piko-share-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 0;
+}
+.piko-share-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  width: 62px;
+  flex-shrink: 0;
+}
+.piko-share-url {
+  flex: 1;
+  font-size: 11px;
+  font-family: monospace;
+  padding: 3px 6px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  outline: none;
+  min-width: 0;
+}
+.piko-share-copy {
+  font-size: 11px;
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.piko-share-copy:hover {
+  background: var(--bg-hover);
 }
 /* List view layout */
 .piko-view-list {

--- a/pikoci/transport/http/assets/js/app/views/pipelines.js
+++ b/pikoci/transport/http/assets/js/app/views/pipelines.js
@@ -528,6 +528,9 @@ var PipelineListView = Backbone.View.extend({
     this._jobsIntervalID = window.setInterval(function() {
       that._fetchJobs();
     }, fetchInterval);
+    this._resourcesIntervalID = window.setInterval(function() {
+      that.resourcesCollection.fetch();
+    }, fetchInterval);
   },
   events: {
     'click .piko-job-row': '_onClickJob',
@@ -614,10 +617,51 @@ var PipelineListView = Backbone.View.extend({
   },
 
   _renderResourceSelector: function() {
-    // Don't re-render while the dropdown is open
-    if (this.$('.piko-rsel-menu').hasClass('open')) return;
-
     var bar = this.$('.piko-list-resource-bar');
+    var menuOpen = this.$('.piko-rsel-menu').hasClass('open');
+
+    if (menuOpen) {
+      // Targeted in-place update: refresh status dots and info without closing the dropdown
+      var resMap = {};
+      this.resourcesCollection.each(function(r) {
+        resMap[r.get('canonical')] = r.toJSON();
+      });
+      var selRes = resMap[this.selectedResource] || {};
+      var selLv = selRes.latest_version;
+      var selStatus = (selLv && selLv.status) ? selLv.status : '';
+
+      // Update trigger button dot
+      var triggerDot = this.$('.piko-rsel-trigger .piko-rsel-dot');
+      triggerDot.attr('class', 'piko-rsel-dot piko-status-dot-' + selStatus);
+
+      // Update each option dot
+      this.$('.piko-rsel-option').each(function() {
+        var canonical = $(this).data('canonical');
+        var r = resMap[canonical] || {};
+        var rlv = r.latest_version;
+        var rStatus = (rlv && rlv.status) ? rlv.status : '';
+        $(this).find('.piko-rsel-dot').attr('class', 'piko-rsel-dot piko-status-dot-' + rStatus);
+      });
+
+      // Update info text
+      var infoHtml = '';
+      if (selLv && selLv.version) {
+        for (var key in selLv.version) {
+          if (selLv.version.hasOwnProperty(key)) {
+            infoHtml += '<span class="piko-resource-bar-ver">' + _.escape(key + ': ' + selLv.version[key]) + '</span>';
+            break;
+          }
+        }
+      }
+      if (selRes.check_interval) {
+        infoHtml += '<span class="piko-resource-bar-meta">' + _.escape(selRes.check_interval) + '</span>';
+      }
+      if (selRes.last_check) {
+        infoHtml += '<span class="piko-resource-bar-meta">checked ' + pikoTimeAgo(selRes.last_check) + '</span>';
+      }
+      this.$('.piko-resource-bar-info').html(infoHtml);
+      return;
+    }
     if (this.triggerResources.length === 0) {
       bar.html('<span style="color:var(--text-muted)">No trigger resources</span>');
       return;
@@ -1099,13 +1143,21 @@ var PipelineListView = Backbone.View.extend({
       clearInterval(this._jobsIntervalID);
       this._jobsIntervalID = null;
     }
+    if (this._resourcesIntervalID) {
+      clearInterval(this._resourcesIntervalID);
+      this._resourcesIntervalID = null;
+    }
   },
   resumePolling: function() {
     if (this._jobsIntervalID) return;
     this._fetchJobs();
+    this.resourcesCollection.fetch();
     var that = this;
     this._jobsIntervalID = window.setInterval(function() {
       that._fetchJobs();
+    }, fetchInterval);
+    this._resourcesIntervalID = window.setInterval(function() {
+      that.resourcesCollection.fetch();
     }, fetchInterval);
   },
   remove: function() {

--- a/pikoci/transport/http/assets/js/app/views/pipelines.js
+++ b/pikoci/transport/http/assets/js/app/views/pipelines.js
@@ -260,6 +260,8 @@ export var PipelineShowView = Backbone.View.extend({
     'click #unpause-pipeline': 'clickUnpausePipeline',
     'click #toggle-resources-panel': 'toggleResourcesPanel',
     'click #toggle-gear-panel': 'toggleGearPanel',
+    'click #toggle-share-panel': 'toggleSharePanel',
+    'click .piko-share-copy': 'copyShareUrl',
     'change #gear-hide-intermediates': 'toggleHideIntermediates',
     'change #gear-group-parallel': 'toggleGroupParallel',
     'click .piko-view-btn': 'switchView',
@@ -297,7 +299,9 @@ export var PipelineShowView = Backbone.View.extend({
       this.$('.piko-view-graph').hide();
       this.$('.piko-view-list').show();
       this.$('.piko-gear-wrap').hide();
+      this.$('.piko-share-wrap').hide();
       this.$('#gear-panel').removeClass('open');
+      this.$('#share-panel').removeClass('open');
       if (!this.listView) {
         this.listView = new PipelineListView({
           el: this.$('.piko-view-list'),
@@ -311,6 +315,7 @@ export var PipelineShowView = Backbone.View.extend({
       this.$('.piko-view-graph').show();
       this.$('.piko-view-list').hide();
       this.$('.piko-gear-wrap').show();
+      this.$('.piko-share-wrap').show();
       if (this.listView) { this.listView.pausePolling(); }
     }
   },
@@ -367,6 +372,7 @@ export var PipelineShowView = Backbone.View.extend({
   toggleGearPanel: function(event) {
     event.preventDefault();
     event.stopPropagation();
+    this.$('#share-panel').removeClass('open');
     var panel = this.$('#gear-panel');
     panel.toggleClass('open');
     if (panel.hasClass('open')) {
@@ -380,6 +386,49 @@ export var PipelineShowView = Backbone.View.extend({
       };
       $(document).one('click', closeHandler);
     }
+  },
+  toggleSharePanel: function(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    this.$('#gear-panel').removeClass('open');
+    var panel = this.$('#share-panel');
+    panel.toggleClass('open');
+    if (panel.hasClass('open')) {
+      var tc = this.model.collection.team.get('canonical');
+      var pc = this.model.get('canonical');
+      var base = window.location.origin + '/teams/' + tc + '/pipelines/' + pc;
+      var params = [];
+      if (this.image.hideIntermediates) params.push('hide_intermediates=1');
+      if (this.image.groupParallel) params.push('group_parallel=1');
+      var qs = params.length ? '?' + params.join('&') : '';
+      var svgUrl = base + '/image.svg' + qs;
+      var pngUrl = base + '/image.png' + qs;
+      var pipelineName = this.model.get('name');
+      this.$('#share-svg-url').val(svgUrl);
+      this.$('#share-png-url').val(pngUrl);
+      this.$('#share-md-url').val('![' + pipelineName + '](' + svgUrl + ')');
+      var that = this;
+      var closeHandler = function(e) {
+        if (!$(e.target).closest('#share-panel').length) {
+          that.$('#share-panel').removeClass('open');
+        } else {
+          $(document).one('click', closeHandler);
+        }
+      };
+      $(document).one('click', closeHandler);
+    }
+  },
+  copyShareUrl: function(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    var btn = $(event.currentTarget);
+    var targetId = btn.data('target');
+    var value = this.$('#' + targetId).val();
+    navigator.clipboard.writeText(value).then(function() {
+      var original = btn.text();
+      btn.text('Copied!');
+      setTimeout(function() { btn.text(original); }, 1500);
+    });
   },
   clickPipeline: function(event) {
     // Only handle clicks on SVG links inside the graph
@@ -835,8 +884,7 @@ var PipelineListView = Backbone.View.extend({
           rendered[name] = true;
           var data = statusMap[name] || { name: name, latest_status: '' };
           html += that._renderJobRow(data);
-          var childHtml = renderChildren(name);
-          if (childHtml) html += '<div class="piko-job-children">' + childHtml + '</div>';
+          html += renderChildren(name);
         }
       }
       return html;
@@ -860,8 +908,7 @@ var PipelineListView = Backbone.View.extend({
       rendered[roots[0]] = true;
       var data = statusMap[roots[0]] || { name: roots[0], latest_status: '' };
       html += this._renderJobRow(data);
-      var childHtml = renderChildren(roots[0]);
-      if (childHtml) html += '<div class="piko-job-children">' + childHtml + '</div>';
+      html += renderChildren(roots[0]);
     }
 
     this.$('.piko-job-list').html(html);
@@ -937,10 +984,7 @@ var PipelineListView = Backbone.View.extend({
         var data = statusMap[jobNames[j]] || { name: jobNames[j], latest_status: '' };
         fanInHtml += this._renderJobRow(data);
         if (renderChildrenFn) {
-          var childHtml = renderChildrenFn([jobNames[j]]);
-          if (childHtml) {
-            fanInHtml += '<div class="piko-job-children">' + childHtml + '</div>';
-          }
+          fanInHtml += renderChildrenFn([jobNames[j]]);
         }
       }
       fanInHtml += '</div>';
@@ -949,10 +993,7 @@ var PipelineListView = Backbone.View.extend({
         var data = statusMap[fanInChildren[i]] || { name: fanInChildren[i], latest_status: '' };
         fanInHtml += this._renderJobRow(data);
         if (renderChildrenFn) {
-          var childHtml = renderChildrenFn([fanInChildren[i]]);
-          if (childHtml) {
-            fanInHtml += '<div class="piko-job-children">' + childHtml + '</div>';
-          }
+          fanInHtml += renderChildrenFn([fanInChildren[i]]);
         }
       }
       fanInHtml += '</div>';
@@ -974,10 +1015,7 @@ var PipelineListView = Backbone.View.extend({
       var data = statusMap[jobNames[j]] || { name: jobNames[j], latest_status: '' };
       html += this._renderJobRow(data, alignClass);
       if (renderChildrenFn) {
-        var childHtml = renderChildrenFn([jobNames[j]]);
-        if (childHtml) {
-          html += '<div class="piko-job-children">' + childHtml + '</div>';
-        }
+        html += renderChildrenFn([jobNames[j]]);
       }
     }
     if (fanInHtml && !fanInInserted) {

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -292,6 +292,26 @@
             </label>
           </div>
         </div>
+        <div class="piko-share-wrap">
+          <button class="piko-gear-btn" id="toggle-share-panel"><i class="bi bi-share"></i></button>
+          <div class="piko-share-panel" id="share-panel">
+            <div class="piko-share-row">
+              <span class="piko-share-label">SVG</span>
+              <input type="text" class="piko-share-url" id="share-svg-url" readonly>
+              <button class="piko-share-copy" data-target="share-svg-url">Copy</button>
+            </div>
+            <div class="piko-share-row">
+              <span class="piko-share-label">PNG</span>
+              <input type="text" class="piko-share-url" id="share-png-url" readonly>
+              <button class="piko-share-copy" data-target="share-png-url">Copy</button>
+            </div>
+            <div class="piko-share-row">
+              <span class="piko-share-label">Markdown</span>
+              <input type="text" class="piko-share-url" id="share-md-url" readonly>
+              <button class="piko-share-copy" data-target="share-md-url">Copy</button>
+            </div>
+          </div>
+        </div>
       </div>
       <div class="piko-pipeline-body">
       <div id="pipeline-resources-panel" class="piko-resources-panel"></div>


### PR DESCRIPTION
## Summary

- Add periodic polling of `resourcesCollection` on the same `fetchInterval` used by jobs, so the resource selector bar's status dot, latest version, and "checked X ago" timestamp stay fresh automatically.
- When the dropdown is open, apply targeted in-place DOM updates instead of replacing the full bar HTML, so the menu stays open during refreshes.
- Integrate the new `_resourcesIntervalID` into `pausePolling` / `resumePolling` / `remove` lifecycle.

Closes #558