### PR TITLE
feat: add version tracking to scope pipeline views (#432)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Version tracking**: Track a specific resource version through the pipeline to see which jobs it passed through and their build status. Available from the resource versions page (Track button), the Resources panel (expandable version list with Track/Trigger/Pin), and a new version dropdown in the list view. When tracking, both graph and list views scope to only the version's path, a banner shows progress, and the URL is shareable via `?version=ID` ([#432](https://github.com/PikoCI/pikoci/issues/432))
+- New `GetResourceVersionPath` API endpoint (`GET /teams/{tc}/pipelines/{pc}/resources/{rCan}/versions/{vID}/path`) returns the ordered chain of jobs a version passes through, with build status for each job including retries. Follows version propagation through intermediate put/get resources ([#432](https://github.com/PikoCI/pikoci/issues/432))
+- Pipeline graph image endpoint now accepts a `version_id` query parameter to filter the graph to only the tracked version's path with version-specific build colors ([#432](https://github.com/PikoCI/pikoci/issues/432))
 - Resource version rows now show a colored status dot indicating the aggregate build status of all jobs that consumed that version ([#534](https://github.com/PikoCI/pikoci/issues/534))
 - Pipeline show page now has a "Resources" button that opens a slide-out panel listing all pipeline resources with name, type, latest version, build status, last check time, and a "Check Now" button ([#536](https://github.com/PikoCI/pikoci/issues/536))
 - Resource nodes in the pipeline graph view now show a native browser tooltip on hover with the latest version's key-value pairs and aggregate build status ([#537](https://github.com/PikoCI/pikoci/issues/537))
@@ -20,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- "Group parallel jobs" now correctly groups root jobs (jobs with no `passed` constraints) that share the same trigger resource, such as parallel CI jobs triggered by the same git resource ([#432](https://github.com/PikoCI/pikoci/issues/432))
 - List view: resource selector bar now polls for updates on the same interval as job data, keeping the status dot, latest version, and "checked X ago" timestamp fresh without manual refresh. Updates are applied in-place when the dropdown is open so it stays open ([#558](https://github.com/PikoCI/pikoci/issues/558))
 - List view: fan-in jobs (jobs with multiple upstream parents in a parallel group) now render with a left-side bar grouping their parents and the fan-in job indented after the bar, clearly showing the dependency relationship ([#551](https://github.com/PikoCI/pikoci/issues/551))
 - Retrying a build now reuses the resource versions from the original build instead of fetching the latest version ([#552](https://github.com/PikoCI/pikoci/issues/552))

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -325,7 +325,7 @@ var pipelinesGraphCmd = &cobra.Command{
 			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
 		}
 
-		image, err := c.GetPipelineImage(cmd.Context(), tc, pCan, format, false, false)
+		image, err := c.GetPipelineImage(cmd.Context(), tc, pCan, format, false, false, nil)
 		if err != nil {
 			return fmt.Errorf("failed to get pipeline graph for %q: %w", name, err)
 		}

--- a/pikoci/build/repository.go
+++ b/pikoci/build/repository.go
@@ -42,4 +42,8 @@ type Repository interface {
 	CountRunningInSerialGroups(ctx context.Context, tc, pn string, serialGroups []string, excludeJobName string) (int, error)
 	// AggregateStatusByVersionIDs returns the aggregate build status for each version ID.
 	AggregateStatusByVersionIDs(ctx context.Context, versionIDs []uint32) (map[uint32]string, error)
+	// FindByVersionAndJobs returns builds for the given version ID across the
+	// specified jobs, including retries of matched builds.
+	// The result maps job name to a slice of builds (main build first, retries after).
+	FindByVersionAndJobs(ctx context.Context, tc, pn string, versionID uint32, jobNames []string) (map[string][]*Build, error)
 }

--- a/pikoci/mock/build_repository.go
+++ b/pikoci/mock/build_repository.go
@@ -178,6 +178,21 @@ func (mr *BuildRepositoryMockRecorder) FindByID(ctx, buildID any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByID", reflect.TypeOf((*BuildRepository)(nil).FindByID), ctx, buildID)
 }
 
+// FindByVersionAndJobs mocks base method.
+func (m *BuildRepository) FindByVersionAndJobs(ctx context.Context, tc, pn string, versionID uint32, jobNames []string) (map[string][]*build.Build, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindByVersionAndJobs", ctx, tc, pn, versionID, jobNames)
+	ret0, _ := ret[0].(map[string][]*build.Build)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindByVersionAndJobs indicates an expected call of FindByVersionAndJobs.
+func (mr *BuildRepositoryMockRecorder) FindByVersionAndJobs(ctx, tc, pn, versionID, jobNames any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByVersionAndJobs", reflect.TypeOf((*BuildRepository)(nil).FindByVersionAndJobs), ctx, tc, pn, versionID, jobNames)
+}
+
 // FindGetVersions mocks base method.
 func (m *BuildRepository) FindGetVersions(ctx context.Context, buildID uint32) (map[string]uint32, error) {
 	m.ctrl.T.Helper()

--- a/pikoci/mock/resource_repository.go
+++ b/pikoci/mock/resource_repository.go
@@ -178,6 +178,22 @@ func (mr *ResourceRepositoryMockRecorder) FindByWebhookToken(ctx, token any) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByWebhookToken", reflect.TypeOf((*ResourceRepository)(nil).FindByWebhookToken), ctx, token)
 }
 
+// FindVersionByID mocks base method.
+func (m *ResourceRepository) FindVersionByID(ctx context.Context, versionID uint32) (*resource.Version, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindVersionByID", ctx, versionID)
+	ret0, _ := ret[0].(*resource.Version)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// FindVersionByID indicates an expected call of FindVersionByID.
+func (mr *ResourceRepositoryMockRecorder) FindVersionByID(ctx, versionID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindVersionByID", reflect.TypeOf((*ResourceRepository)(nil).FindVersionByID), ctx, versionID)
+}
+
 // PinVersion mocks base method.
 func (m *ResourceRepository) PinVersion(ctx context.Context, tc, pn, rCan string, versionID uint32) error {
 	m.ctrl.T.Helper()

--- a/pikoci/mock/service.go
+++ b/pikoci/mock/service.go
@@ -370,18 +370,18 @@ func (mr *ServiceMockRecorder) GetPipeline(ctx, tc, pn any) *gomock.Call {
 }
 
 // GetPipelineImage mocks base method.
-func (m *Service) GetPipelineImage(ctx context.Context, tc, pn, format string, hideIntermediates, groupParallel bool) ([]byte, error) {
+func (m *Service) GetPipelineImage(ctx context.Context, tc, pn, format string, hideIntermediates, groupParallel bool, versionID *uint32) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPipelineImage", ctx, tc, pn, format, hideIntermediates, groupParallel)
+	ret := m.ctrl.Call(m, "GetPipelineImage", ctx, tc, pn, format, hideIntermediates, groupParallel, versionID)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPipelineImage indicates an expected call of GetPipelineImage.
-func (mr *ServiceMockRecorder) GetPipelineImage(ctx, tc, pn, format, hideIntermediates, groupParallel any) *gomock.Call {
+func (mr *ServiceMockRecorder) GetPipelineImage(ctx, tc, pn, format, hideIntermediates, groupParallel, versionID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPipelineImage", reflect.TypeOf((*Service)(nil).GetPipelineImage), ctx, tc, pn, format, hideIntermediates, groupParallel)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPipelineImage", reflect.TypeOf((*Service)(nil).GetPipelineImage), ctx, tc, pn, format, hideIntermediates, groupParallel, versionID)
 }
 
 // GetPipelineJob mocks base method.
@@ -430,18 +430,18 @@ func (mr *ServiceMockRecorder) GetPublicPipeline(ctx, tc, pn any) *gomock.Call {
 }
 
 // GetPublicPipelineImage mocks base method.
-func (m *Service) GetPublicPipelineImage(ctx context.Context, tc, pn, format string, hideIntermediates, groupParallel bool) ([]byte, error) {
+func (m *Service) GetPublicPipelineImage(ctx context.Context, tc, pn, format string, hideIntermediates, groupParallel bool, versionID *uint32) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPublicPipelineImage", ctx, tc, pn, format, hideIntermediates, groupParallel)
+	ret := m.ctrl.Call(m, "GetPublicPipelineImage", ctx, tc, pn, format, hideIntermediates, groupParallel, versionID)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPublicPipelineImage indicates an expected call of GetPublicPipelineImage.
-func (mr *ServiceMockRecorder) GetPublicPipelineImage(ctx, tc, pn, format, hideIntermediates, groupParallel any) *gomock.Call {
+func (mr *ServiceMockRecorder) GetPublicPipelineImage(ctx, tc, pn, format, hideIntermediates, groupParallel, versionID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicPipelineImage", reflect.TypeOf((*Service)(nil).GetPublicPipelineImage), ctx, tc, pn, format, hideIntermediates, groupParallel)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicPipelineImage", reflect.TypeOf((*Service)(nil).GetPublicPipelineImage), ctx, tc, pn, format, hideIntermediates, groupParallel, versionID)
 }
 
 // GetPublicPipelineJob mocks base method.
@@ -472,6 +472,36 @@ func (m *Service) GetPublicPipelineResource(ctx context.Context, tc, pn, rCan st
 func (mr *ServiceMockRecorder) GetPublicPipelineResource(ctx, tc, pn, rCan any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicPipelineResource", reflect.TypeOf((*Service)(nil).GetPublicPipelineResource), ctx, tc, pn, rCan)
+}
+
+// GetPublicResourceVersionPath mocks base method.
+func (m *Service) GetPublicResourceVersionPath(ctx context.Context, tc, pn, rCan string, versionID uint32) (*resource.VersionPathResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPublicResourceVersionPath", ctx, tc, pn, rCan, versionID)
+	ret0, _ := ret[0].(*resource.VersionPathResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPublicResourceVersionPath indicates an expected call of GetPublicResourceVersionPath.
+func (mr *ServiceMockRecorder) GetPublicResourceVersionPath(ctx, tc, pn, rCan, versionID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicResourceVersionPath", reflect.TypeOf((*Service)(nil).GetPublicResourceVersionPath), ctx, tc, pn, rCan, versionID)
+}
+
+// GetResourceVersionPath mocks base method.
+func (m *Service) GetResourceVersionPath(ctx context.Context, tc, pn, rCan string, versionID uint32) (*resource.VersionPathResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetResourceVersionPath", ctx, tc, pn, rCan, versionID)
+	ret0, _ := ret[0].(*resource.VersionPathResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetResourceVersionPath indicates an expected call of GetResourceVersionPath.
+func (mr *ServiceMockRecorder) GetResourceVersionPath(ctx, tc, pn, rCan, versionID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourceVersionPath", reflect.TypeOf((*Service)(nil).GetResourceVersionPath), ctx, tc, pn, rCan, versionID)
 }
 
 // GetTeam mocks base method.

--- a/pikoci/mysql/build.go
+++ b/pikoci/mysql/build.go
@@ -630,6 +630,96 @@ func (r *BuildRepository) AggregateStatusByVersionIDs(ctx context.Context, versi
 	return result, nil
 }
 
+func (r *BuildRepository) FindByVersionAndJobs(ctx context.Context, tc, pn string, versionID uint32, jobNames []string) (map[string][]*build.Build, error) {
+	if len(jobNames) == 0 {
+		return nil, nil
+	}
+
+	placeholders := make([]string, len(jobNames))
+	args := make([]interface{}, 0, len(jobNames)+3)
+	args = append(args, tc, pn)
+	for i, jn := range jobNames {
+		placeholders[i] = "?"
+		args = append(args, jn)
+	}
+	args = append(args, versionID, versionID)
+
+	// Find builds that consumed this version, plus any retries of those builds.
+	// Retries may not have build_get_versions entries yet (pending/started),
+	// so we also match on retry_source_build_id.
+	query := `
+		SELECT b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical, b.retry_source_build_id, j.name
+		FROM builds AS b
+		JOIN jobs AS j ON b.job_id = j.id
+		JOIN pipelines AS p ON j.pipeline_id = p.id
+		JOIN teams AS t ON p.team_id = t.id
+		WHERE t.canonical = ? AND p.canonical = ?
+		  AND j.name IN (` + strings.Join(placeholders, ",") + `)
+		  AND (
+			b.id IN (
+				SELECT bgv.build_id
+				FROM build_get_versions bgv
+				WHERE bgv.version_id = ?
+			)
+			OR b.retry_source_build_id IN (
+				SELECT bgv.build_id
+				FROM build_get_versions bgv
+				WHERE bgv.version_id = ?
+			)
+		  )
+		ORDER BY j.name, b.id DESC
+	`
+
+	rows, err := r.querier.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query builds by version and jobs: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[string][]*build.Build)
+	for rows.Next() {
+		var dbb dbBuild
+		var jobName string
+		err := rows.Scan(
+			&dbb.ID,
+			&dbb.BuildNumber,
+			&dbb.Steps,
+			&dbb.Job,
+			&dbb.Status,
+			&dbb.Error,
+			&dbb.StartedAt,
+			&dbb.Duration,
+			&dbb.VersionID,
+			&dbb.ResourceCanonical,
+			&dbb.RetrySourceBuildID,
+			&jobName,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan build: %w", err)
+		}
+		result[jobName] = append(result[jobName], dbb.toDomainEntity())
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate builds: %w", err)
+	}
+
+	// Reorder: main builds first (no dot in build number), then retries
+	for jn, builds := range result {
+		var main []*build.Build
+		var retries []*build.Build
+		for _, b := range builds {
+			if strings.Contains(b.BuildNumber, ".") {
+				retries = append(retries, b)
+			} else {
+				main = append(main, b)
+			}
+		}
+		result[jn] = append(main, retries...)
+	}
+
+	return result, nil
+}
+
 func scanBuild(s sqlr.Scanner) (*build.Build, error) {
 	var b dbBuild
 

--- a/pikoci/mysql/resource.go
+++ b/pikoci/mysql/resource.go
@@ -405,6 +405,23 @@ func (r *ResourceRepository) FilterVersions(ctx context.Context, tc, pn, rCan st
 	return rvs, nil
 }
 
+// FindVersionByID retrieves a single version by its ID, returning the version
+// and the canonical of the resource it belongs to.
+func (r *ResourceRepository) FindVersionByID(ctx context.Context, versionID uint32) (*resource.Version, string, error) {
+	var v dbResourceVersion
+	var rCan string
+	err := r.querier.QueryRowContext(ctx, `
+		SELECT rv.id, rv.version, res.canonical
+		FROM resource_versions AS rv
+		JOIN resources AS res ON rv.resource_id = res.id
+		WHERE rv.id = ?
+	`, versionID).Scan(&v.ID, &v.Version, &rCan)
+	if err != nil {
+		return nil, "", fmt.Errorf("version %d not found: %w", versionID, err)
+	}
+	return v.toDomainEntity(), rCan, nil
+}
+
 func (r *ResourceRepository) PinVersion(ctx context.Context, tc, pn, rCan string, versionID uint32) error {
 	res, err := r.querier.ExecContext(ctx, `
 		UPDATE resources AS r

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -508,9 +508,18 @@ var (
 	colorPinned         = `"#FFA300"`
 )
 
+// versionFilterOpts holds the parameters for filtering a pipeline graph to
+// show only jobs in a specific version's path.
+type versionFilterOpts struct {
+	resourceCanonical string
+	versionID         uint32
+	chainJobs         map[string]bool
+	buildsByJob       map[string][]*build.Build
+}
+
 // GetPipelineImage generates a DOT graph representation of a pipeline's jobs
 // and resources, colored by the latest build status of each job.
-func (q *PikoCI) GetPipelineImage(ctx context.Context, tc, pCan, format string, hideIntermediates, groupParallel bool) ([]byte, error) {
+func (q *PikoCI) GetPipelineImage(ctx context.Context, tc, pCan, format string, hideIntermediates, groupParallel bool, versionID *uint32) ([]byte, error) {
 	if !utils.ValidateCanonical(tc) {
 		return nil, fmt.Errorf("invalid Team Canonical format %q", tc)
 	} else if !utils.ValidateCanonical(pCan) {
@@ -532,12 +541,48 @@ func (q *PikoCI) GetPipelineImage(ctx context.Context, tc, pCan, format string, 
 		return nil, fmt.Errorf("failed to get Pipeline %q: %w", pCan, err)
 	}
 
-	img, err := q.generateImage(ctx, tc, pp, hideIntermediates, groupParallel)
+	var vf *versionFilterOpts
+	if versionID != nil {
+		vf, err = q.buildVersionFilter(ctx, tc, pCan, pp, *versionID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build version filter: %w", err)
+		}
+	}
+
+	img, err := q.generateImage(ctx, tc, pp, hideIntermediates, groupParallel, vf)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate image: %w", err)
 	}
 
 	return convertDOTImage(ctx, img, format)
+}
+
+// buildVersionFilter resolves the version's chain and fetches builds,
+// returning filter options for generateImage.
+func (q *PikoCI) buildVersionFilter(ctx context.Context, tc, pn string, pp *pipeline.Pipeline, versionID uint32) (*versionFilterOpts, error) {
+	// Look up which resource this version belongs to
+	_, rCan, err := q.Resources.FindVersionByID(ctx, versionID)
+	if err != nil {
+		return nil, fmt.Errorf("version %d not found: %w", versionID, err)
+	}
+
+	chain := resolveResourceChain(pp.Jobs, rCan)
+	chainSet := make(map[string]bool, len(chain))
+	for _, jn := range chain {
+		chainSet[jn] = true
+	}
+
+	buildsByJob, err := q.chainWalkBuilds(ctx, tc, pn, versionID, chain)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find builds: %w", err)
+	}
+
+	return &versionFilterOpts{
+		resourceCanonical: rCan,
+		versionID:         versionID,
+		chainJobs:         chainSet,
+		buildsByJob:       buildsByJob,
+	}, nil
 }
 
 // resolvedBuildStatus holds the latest completed and running builds for a job.
@@ -638,13 +683,53 @@ func (q *PikoCI) resolveJobVisuals(ctx context.Context, tc string, pp *pipeline.
 	}, nil
 }
 
+// resolveJobVisualsFromBuilds computes job node visuals from a provided set of
+// builds rather than fetching from the database. Used when rendering a
+// version-scoped graph where only specific builds are relevant.
+func resolveJobVisualsFromBuilds(builds []*build.Build, j job.Job) jobNodeVisuals {
+	color := colorDefault
+	borderColor := colorDefaultBorder
+
+	bs := resolveBuildStatus(builds)
+
+	if bs.completedBuild != nil {
+		if c, ok := jobColors[bs.completedBuild.Status]; ok {
+			color = c
+		}
+		if c, ok := jobBorderColors[bs.completedBuild.Status]; ok {
+			borderColor = c
+		}
+	}
+
+	if j.Paused {
+		color = colorPaused
+		borderColor = colorPausedBorder
+	}
+
+	clusterStyle := "invis"
+	clusterBorderColor := jobBorderColors[build.Started]
+	if bs.runningBuild != nil {
+		clusterStyle = `"dashed,bold"`
+		if bs.runningBuild.Status == build.Pending {
+			clusterBorderColor = colorDefaultBorder
+		}
+	}
+
+	return jobNodeVisuals{
+		color:              color,
+		borderColor:        borderColor,
+		clusterStyle:       clusterStyle,
+		clusterBorderColor: clusterBorderColor,
+	}
+}
+
 // generateImage builds a DOT-format directed graph representing the pipeline's
 // jobs, resources, and their interconnections. Each job node is colored based on
 // its latest build status, and running builds are highlighted with a dashed border.
 // When hideIntermediates is true, intermediate resource nodes (between jobs via
 // passed constraints and put outputs) are removed, keeping only entry-point
 // trigger resources and drawing direct job-to-job edges.
-func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipeline, hideRes, groupParallel bool) ([]byte, error) {
+func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipeline, hideRes, groupParallel bool, versionFilter *versionFilterOpts) ([]byte, error) {
 	var (
 		pn  = fmt.Sprintf(`"%s"`, pp.Canonical)
 		err error
@@ -654,6 +739,19 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 	graph.SetName(pn)
 	graph.SetStrict(true)
 	graph.AddAttr(pn, string(gographviz.RankDir), "LR")
+
+	// When version filter is active, work with a local copy restricted to chain jobs
+	if versionFilter != nil {
+		var filteredJobs []job.Job
+		for _, j := range pp.Jobs {
+			if versionFilter.chainJobs[j.Name] {
+				filteredJobs = append(filteredJobs, j)
+			}
+		}
+		localPP := *pp
+		localPP.Jobs = filteredJobs
+		pp = &localPP
+	}
 
 	// Collect resources referenced by get steps without passed constraints.
 	// Resources only accessed via get-with-passed don't need a standalone node
@@ -782,18 +880,31 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 					allPassed = append(allPassed, expandPassed(g.Passed)...)
 				}
 			}
+			var key string
 			if len(allPassed) == 0 {
-				continue // root jobs are never grouped
-			}
-			sort.Strings(allPassed)
-			// Deduplicate
-			deduped := allPassed[:0]
-			for i, p := range allPassed {
-				if i == 0 || p != allPassed[i-1] {
-					deduped = append(deduped, p)
+				// Root jobs: group by their trigger resource set
+				var triggerResources []string
+				for _, g := range j.GetSteps() {
+					if len(g.Passed) == 0 {
+						triggerResources = append(triggerResources, g.ResourceCanonical())
+					}
 				}
+				if len(triggerResources) == 0 {
+					continue
+				}
+				sort.Strings(triggerResources)
+				key = "root:" + strings.Join(triggerResources, ",")
+			} else {
+				sort.Strings(allPassed)
+				// Deduplicate
+				deduped := allPassed[:0]
+				for i, p := range allPassed {
+					if i == 0 || p != allPassed[i-1] {
+						deduped = append(deduped, p)
+					}
+				}
+				key = strings.Join(deduped, ",")
 			}
-			key := strings.Join(deduped, ",")
 			if _, ok := keyToJobs[key]; !ok {
 				keyOrder = append(keyOrder, key)
 			}
@@ -827,9 +938,16 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 			continue // grouped jobs are rendered as part of their parallel group node
 		}
 
-		vis, err := q.resolveJobVisuals(ctx, tc, pp, j)
-		if err != nil {
-			return nil, err
+		var vis jobNodeVisuals
+		if versionFilter != nil {
+			// Use only the version-specific builds for coloring
+			vis = resolveJobVisualsFromBuilds(versionFilter.buildsByJob[j.Name], j)
+		} else {
+			var verr error
+			vis, verr = q.resolveJobVisuals(ctx, tc, pp, j)
+			if verr != nil {
+				return nil, verr
+			}
 		}
 
 		jg := fmt.Sprintf("cluster_%d", i)
@@ -925,23 +1043,28 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 		var worstStatus build.Status
 		var rows []string
 		for _, j := range pg.jobs {
-			vis, verr := q.resolveJobVisuals(ctx, tc, pp, j)
-			if verr != nil {
-				return nil, verr
+			var vis jobNodeVisuals
+			var jobBuilds []*build.Build
+			if versionFilter != nil {
+				vis = resolveJobVisualsFromBuilds(versionFilter.buildsByJob[j.Name], j)
+				jobBuilds = versionFilter.buildsByJob[j.Name]
+			} else {
+				var verr error
+				vis, verr = q.resolveJobVisuals(ctx, tc, pp, j)
+				if verr != nil {
+					return nil, verr
+				}
+				jobBuilds, _ = q.Builds.Filter(ctx, tc, pp.Canonical, j.Name, nil, nil, 0)
 			}
 			dotColor := strings.Trim(vis.color, `"`)
-			builds, berr := q.Builds.Filter(ctx, tc, pp.Canonical, j.Name, nil, nil, 0)
-			if berr == nil {
-				bs := resolveBuildStatus(builds)
+			if len(jobBuilds) > 0 {
+				bs := resolveBuildStatus(jobBuilds)
 				if bs.completedBuild != nil {
 					if p, ok := statusPriority[bs.completedBuild.Status]; ok && p > worstPriority {
 						worstPriority = p
 						worstStatus = bs.completedBuild.Status
 					}
 				}
-				// Running/pending builds override the dot color so the
-				// status is visible (normal nodes use a dashed cluster
-				// border, but grouped jobs have no individual cluster).
 				if bs.runningBuild != nil {
 					if c, ok := jobColors[bs.runningBuild.Status]; ok {
 						dotColor = strings.Trim(c, `"`)
@@ -1376,7 +1499,7 @@ func (q *PikoCI) CreatePipelineImage(ctx context.Context, tc string, pipeline []
 		return nil, fmt.Errorf("invalid image format %q", format)
 	}
 
-	img, err := q.generateImage(ctx, tc, pp, false, false)
+	img, err := q.generateImage(ctx, tc, pp, false, false, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate image: %w", err)
 	}
@@ -1488,7 +1611,7 @@ func (q *PikoCI) GetPublicPipeline(ctx context.Context, tc, pCan string) (*pipel
 }
 
 // GetPublicPipelineImage generates a DOT graph image for a public pipeline.
-func (q *PikoCI) GetPublicPipelineImage(ctx context.Context, tc, pCan, format string, hideIntermediates, groupParallel bool) ([]byte, error) {
+func (q *PikoCI) GetPublicPipelineImage(ctx context.Context, tc, pCan, format string, hideIntermediates, groupParallel bool, versionID *uint32) ([]byte, error) {
 	pp, err := q.Pipelines.FindPublic(ctx, tc, pCan)
 	if err != nil {
 		return nil, fmt.Errorf("pipeline not found or not public: %w", err)
@@ -1504,7 +1627,15 @@ func (q *PikoCI) GetPublicPipelineImage(ctx context.Context, tc, pCan, format st
 		return nil, fmt.Errorf("invalid image format %q", format)
 	}
 
-	img, err := q.generateImage(ctx, tc, pp, hideIntermediates, groupParallel)
+	var vf *versionFilterOpts
+	if versionID != nil {
+		vf, err = q.buildVersionFilter(ctx, tc, pCan, pp, *versionID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build version filter: %w", err)
+		}
+	}
+
+	img, err := q.generateImage(ctx, tc, pp, hideIntermediates, groupParallel, vf)
 	if err != nil {
 		return nil, err
 	}

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -1415,7 +1415,7 @@ func TestGetPipelineImage_HidesUnlinkedResources(t *testing.T) {
 	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "github-check.ci", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
-	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false)
+	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false, nil)
 	require.NoError(t, err)
 
 	dot := string(img)
@@ -1465,7 +1465,7 @@ func TestGetPipelineImage_QuotesHyphenatedName(t *testing.T) {
 	s.Builds.EXPECT().Filter(ctx, "main", "hello-world", "hello", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
 	s.Resources.EXPECT().FilterVersions(ctx, "main", "hello-world", "cron.tick", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
-	img, err := s.S.GetPipelineImage(ctx, "main", "hello-world", "dot", false, false)
+	img, err := s.S.GetPipelineImage(ctx, "main", "hello-world", "dot", false, false, nil)
 	require.NoError(t, err)
 
 	dot := string(img)
@@ -1510,7 +1510,7 @@ func TestGetPipelineImage_ShowsLinkedResources(t *testing.T) {
 	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "git.repo", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
-	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false)
+	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false, nil)
 	require.NoError(t, err)
 
 	dot := string(img)
@@ -1564,7 +1564,7 @@ func TestGetPipelineImage_PassedReusesPutOutputNode(t *testing.T) {
 	s.Resources.EXPECT().FilterVersions(ctx, "main", "artifact-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 	s.Resources.EXPECT().FilterVersions(ctx, "main", "artifact-pipeline", "artifact.output", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
-	img, err := s.S.GetPipelineImage(ctx, "main", "artifact-pipeline", "dot", false, false)
+	img, err := s.S.GetPipelineImage(ctx, "main", "artifact-pipeline", "dot", false, false, nil)
 	require.NoError(t, err)
 
 	dot := string(img)
@@ -1765,7 +1765,7 @@ func TestGetPipelineImage_JobStatusColors(t *testing.T) {
 			s.Builds.EXPECT().Filter(ctx, "main", "p", "j", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return(tt.builds, nil)
 			s.Resources.EXPECT().FilterVersions(ctx, "main", "p", "cron.tick", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
-			img, err := s.S.GetPipelineImage(ctx, "main", "p", "dot", false, false)
+			img, err := s.S.GetPipelineImage(ctx, "main", "p", "dot", false, false, nil)
 			require.NoError(t, err)
 
 			dot := string(img)
@@ -3746,7 +3746,7 @@ func TestGetPublicPipelineImage_DOT(t *testing.T) {
 	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
-	img, err := s.S.GetPublicPipelineImage(ctx, "main", "my-pipeline", "dot", false, false)
+	img, err := s.S.GetPublicPipelineImage(ctx, "main", "my-pipeline", "dot", false, false, nil)
 	require.NoError(t, err)
 	assert.Contains(t, string(img), "graph")
 }
@@ -3758,7 +3758,7 @@ func TestGetPublicPipelineImage_NotFound(t *testing.T) {
 
 	s.Pipelines.EXPECT().FindPublic(ctx, "main", "my-pipeline").Return(nil, assert.AnError)
 
-	_, err := s.S.GetPublicPipelineImage(ctx, "main", "my-pipeline", "dot", false, false)
+	_, err := s.S.GetPublicPipelineImage(ctx, "main", "my-pipeline", "dot", false, false, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pipeline not found or not public")
 }
@@ -3776,7 +3776,7 @@ func TestGetPublicPipelineImage_InvalidFormat(t *testing.T) {
 
 	s.Pipelines.EXPECT().FindPublic(ctx, "main", "my-pipeline").Return(pp, nil)
 
-	_, err := s.S.GetPublicPipelineImage(ctx, "main", "my-pipeline", "bmp", false, false)
+	_, err := s.S.GetPublicPipelineImage(ctx, "main", "my-pipeline", "bmp", false, false, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid image format")
 }
@@ -3786,7 +3786,7 @@ func TestGetPipelineImage_InvalidTeamCanonical(t *testing.T) {
 	s := newService(ctrl)
 	ctx := context.TODO()
 
-	_, err := s.S.GetPipelineImage(ctx, "INVALID", "my-pipeline", "dot", false, false)
+	_, err := s.S.GetPipelineImage(ctx, "INVALID", "my-pipeline", "dot", false, false, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid Team Canonical")
 }
@@ -3796,7 +3796,7 @@ func TestGetPipelineImage_InvalidPipelineCanonical(t *testing.T) {
 	s := newService(ctrl)
 	ctx := context.TODO()
 
-	_, err := s.S.GetPipelineImage(ctx, "main", "INVALID", "dot", false, false)
+	_, err := s.S.GetPipelineImage(ctx, "main", "INVALID", "dot", false, false, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid Pipeline Canonical")
 }
@@ -3806,7 +3806,7 @@ func TestGetPipelineImage_InvalidFormat(t *testing.T) {
 	s := newService(ctrl)
 	ctx := context.TODO()
 
-	_, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "bmp", false, false)
+	_, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "bmp", false, false, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid image format")
 }
@@ -3837,7 +3837,7 @@ func TestGetPipelineImage_DOT(t *testing.T) {
 	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
-	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false)
+	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false, nil)
 	require.NoError(t, err)
 	assert.Contains(t, string(img), "graph")
 }
@@ -3857,7 +3857,7 @@ func TestGetPipelineImage_FormatFromExtension(t *testing.T) {
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
 
-	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "image.dot", false, false)
+	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "image.dot", false, false, nil)
 	require.NoError(t, err)
 	assert.Contains(t, string(img), "graph")
 }
@@ -3877,7 +3877,7 @@ func TestGetPipelineImage_EmptyFormat(t *testing.T) {
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
 
-	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "", false, false)
+	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "", false, false, nil)
 	require.NoError(t, err)
 	assert.Contains(t, string(img), "graph")
 }
@@ -3943,7 +3943,7 @@ func TestGetPipelineImage_WithBuildStatuses(t *testing.T) {
 	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "git.repo", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
-	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false)
+	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false, nil)
 	require.NoError(t, err)
 	result := string(img)
 	assert.Contains(t, result, "graph")
@@ -3986,7 +3986,7 @@ func TestGetPipelineImage_WithPassedConstraints(t *testing.T) {
 	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "downstream", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
-	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false)
+	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false, nil)
 	require.NoError(t, err)
 	result := string(img)
 	assert.Contains(t, result, "upstream")
@@ -4019,7 +4019,7 @@ func TestGetPipelineImage_ResourceWithError(t *testing.T) {
 	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
-	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false)
+	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false, nil)
 	require.NoError(t, err)
 	assert.Contains(t, string(img), "graph")
 }
@@ -4051,7 +4051,7 @@ func TestGetPipelineImage_PinnedResource(t *testing.T) {
 	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
-	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false)
+	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false, nil)
 	require.NoError(t, err)
 	assert.Contains(t, string(img), "graph")
 }
@@ -4085,7 +4085,7 @@ func TestGetPipelineImage_ResourceTooltip(t *testing.T) {
 	}, nil)
 	s.Builds.EXPECT().AggregateStatusByVersionIDs(ctx, []uint32{10}).Return(map[uint32]string{10: "succeeded"}, nil)
 
-	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false)
+	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false, nil)
 	require.NoError(t, err)
 
 	dot := string(img)
@@ -4118,7 +4118,7 @@ func TestGetPipelineImage_ResourceTooltipNoVersions(t *testing.T) {
 	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
-	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false)
+	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false, nil)
 	require.NoError(t, err)
 
 	dot := string(img)
@@ -4155,7 +4155,7 @@ func TestGetPipelineImage_ResourceTooltipNoStatus(t *testing.T) {
 	}, nil)
 	s.Builds.EXPECT().AggregateStatusByVersionIDs(ctx, []uint32{5}).Return(nil, nil)
 
-	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false)
+	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false, nil)
 	require.NoError(t, err)
 
 	dot := string(img)
@@ -4700,7 +4700,7 @@ func TestGetPipelineImage_HideIntermediates(t *testing.T) {
 	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "artifact.output", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
-	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", true, false)
+	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", true, false, nil)
 	require.NoError(t, err)
 
 	dot := string(img)
@@ -4762,7 +4762,7 @@ func TestGetPipelineImage_GroupParallel(t *testing.T) {
 	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "vet", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
 	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
-	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, true)
+	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, true, nil)
 	require.NoError(t, err)
 
 	dot := string(img)
@@ -4811,7 +4811,7 @@ func TestGetPipelineImage_GroupParallel_SingleJob(t *testing.T) {
 	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "deploy", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
-	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, true)
+	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, true, nil)
 	require.NoError(t, err)
 
 	dot := string(img)
@@ -4863,7 +4863,7 @@ func TestGetPipelineImage_GroupParallel_WithHideIntermediates(t *testing.T) {
 	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "artifact.output", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
-	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", true, true)
+	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", true, true, nil)
 	require.NoError(t, err)
 
 	dot := string(img)
@@ -4923,7 +4923,7 @@ func TestGetPipelineImage_GroupParallel_EdgeRemapping(t *testing.T) {
 	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "release", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
 
-	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", true, true)
+	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", true, true, nil)
 	require.NoError(t, err)
 
 	dot := string(img)
@@ -4931,8 +4931,204 @@ func TestGetPipelineImage_GroupParallel_EdgeRemapping(t *testing.T) {
 	assert.Contains(t, dot, `PARALLEL (2 JOBS)`)
 	// Edges from group node to release: the passed edges from lint,vet → release should
 	// be remapped to group_node → release
-	assert.Contains(t, dot, `"parallel_0"`)
+	assert.Contains(t, dot, `"parallel_1"`)
 	// Individual job names should not appear as edge sources/targets
 	assert.NotContains(t, dot, `"lint"--"release"`)
 	assert.NotContains(t, dot, `"vet"--"release"`)
+}
+
+func TestGetPipelineImage_WithVersionFilter(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	// Pipeline: build and test both get git.repo; deploy gets a different resource.
+	// Only build and test are in the chain for git.repo version 42.
+	pp := &pipeline.Pipeline{
+		ID:        1,
+		Name:      "my-pipeline",
+		Canonical: "my-pipeline",
+		Jobs: []job.Job{
+			{
+				Name: "build",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "git", Name: "repo", Trigger: true}},
+				},
+			},
+			{
+				Name: "test",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "git", Name: "repo", Passed: []string{"build"}}},
+				},
+			},
+			{
+				Name: "deploy",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "cron", Name: "timer", Trigger: true}},
+				},
+			},
+		},
+		Resources: []resource.Resource{
+			{ID: 1, Canonical: "git.repo", Name: "repo", Type: "git"},
+			{ID: 2, Canonical: "cron.timer", Name: "timer", Type: "cron"},
+		},
+	}
+
+	versionID := uint32(42)
+
+	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
+
+	// buildVersionFilter: resolve which resource owns version 42
+	s.Resources.EXPECT().FindVersionByID(ctx, versionID).Return(
+		&resource.Version{ID: versionID, Version: map[string]interface{}{"ref": "abc123"}},
+		"git.repo",
+		nil,
+	)
+
+	// chainWalkBuilds round 1: search build and test (the chain) with version 42
+	s.Builds.EXPECT().FindByVersionAndJobs(ctx, "main", "my-pipeline", versionID, []string{"build", "test"}).Return(
+		map[string][]*build.Build{
+			"build": {{ID: 10, BuildNumber: "1", Status: build.Succeeded}},
+			"test":  {{ID: 11, BuildNumber: "2", Status: build.Succeeded}},
+		},
+		nil,
+	)
+	// chainWalkBuilds: get versions produced by found builds (same version, no new IDs)
+	s.Builds.EXPECT().FindGetVersions(ctx, uint32(10)).Return(map[string]uint32{"repo": versionID}, nil)
+	s.Builds.EXPECT().FindGetVersions(ctx, uint32(11)).Return(map[string]uint32{"repo": versionID}, nil)
+
+	// generateImage: FilterVersions for all resources in the pipeline (used for tooltips)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "git.repo", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+
+	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false, &versionID)
+	require.NoError(t, err)
+
+	dot := string(img)
+	assert.Contains(t, dot, "graph")
+	// build and test are in the chain — they must appear as job nodes
+	assert.Contains(t, dot, `"build" [`)
+	assert.Contains(t, dot, `"test" [`)
+	// deploy is NOT in the chain — it must not appear as a job node
+	assert.NotContains(t, dot, `"deploy" [`)
+}
+
+func TestGetPipelineImage_WithVersionFilter_DoesNotMutatePipeline(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	// Pipeline with 3 jobs; only build/test are in the git.repo chain.
+	pp := &pipeline.Pipeline{
+		ID:        1,
+		Name:      "my-pipeline",
+		Canonical: "my-pipeline",
+		Jobs: []job.Job{
+			{
+				Name: "build",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "git", Name: "repo", Trigger: true}},
+				},
+			},
+			{
+				Name: "test",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "git", Name: "repo", Passed: []string{"build"}}},
+				},
+			},
+			{
+				Name: "deploy",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "cron", Name: "timer", Trigger: true}},
+				},
+			},
+		},
+		Resources: []resource.Resource{
+			{ID: 1, Canonical: "git.repo", Name: "repo", Type: "git"},
+			{ID: 2, Canonical: "cron.timer", Name: "timer", Type: "cron"},
+		},
+	}
+
+	versionID := uint32(42)
+
+	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
+	s.Resources.EXPECT().FindVersionByID(ctx, versionID).Return(
+		&resource.Version{ID: versionID, Version: map[string]interface{}{"ref": "abc123"}},
+		"git.repo",
+		nil,
+	)
+	s.Builds.EXPECT().FindByVersionAndJobs(ctx, "main", "my-pipeline", versionID, []string{"build", "test"}).Return(
+		map[string][]*build.Build{
+			"build": {{ID: 10, BuildNumber: "1", Status: build.Succeeded}},
+		},
+		nil,
+	)
+	s.Builds.EXPECT().FindGetVersions(ctx, uint32(10)).Return(map[string]uint32{"repo": versionID}, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "git.repo", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+
+	_, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false, &versionID)
+	require.NoError(t, err)
+
+	// The original pipeline's Jobs slice must not be modified by the version filter logic.
+	require.Len(t, pp.Jobs, 3, "original pipeline Jobs slice must not be mutated by version filtering")
+	assert.Equal(t, "build", pp.Jobs[0].Name)
+	assert.Equal(t, "test", pp.Jobs[1].Name)
+	assert.Equal(t, "deploy", pp.Jobs[2].Name)
+}
+
+func TestGetPipelineImage_GroupParallel_RootJobs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	// Three root jobs all triggered by the same resource and no passed constraints.
+	// With groupParallel=true they should be collapsed into a single "PARALLEL (3 JOBS)" node.
+	pp := &pipeline.Pipeline{
+		Name:      "my-pipeline",
+		Canonical: "my-pipeline",
+		Jobs: []job.Job{
+			{
+				Name: "unit",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "git", Name: "repo", Trigger: true}},
+				},
+			},
+			{
+				Name: "lint",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "git", Name: "repo", Trigger: true}},
+				},
+			},
+			{
+				Name: "vet",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "git", Name: "repo", Trigger: true}},
+				},
+			},
+		},
+		Resources: []resource.Resource{
+			{ID: 1, Canonical: "git.repo", Name: "repo", Type: "git"},
+		},
+	}
+
+	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
+	// resolveJobVisuals is called twice per grouped job (once for coloring, once for the group node label)
+	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "unit", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
+	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "lint", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
+	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "vet", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
+	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "git.repo", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+
+	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, true, nil)
+	require.NoError(t, err)
+
+	dot := string(img)
+	assert.Contains(t, dot, `PARALLEL (3 JOBS)`)
+	assert.Contains(t, dot, "unit")
+	assert.Contains(t, dot, "lint")
+	assert.Contains(t, dot, "vet")
+	// Individual standalone job nodes should NOT appear — they are merged into the group
+	assert.NotContains(t, dot, `"unit" [`)
+	assert.NotContains(t, dot, `"lint" [`)
+	assert.NotContains(t, dot, `"vet" [`)
 }

--- a/pikoci/resource/repository.go
+++ b/pikoci/resource/repository.go
@@ -36,6 +36,9 @@ type Repository interface {
 	CreateVersion(ctx context.Context, tc, pn, rCan string, v Version) (uint32, error)
 	// FilterVersions returns a paginated list of versions for the given resource.
 	FilterVersions(ctx context.Context, tc, pn, rCan string, before *uint32, after *uint32, limit uint32) ([]*Version, error)
+	// FindVersionByID retrieves a single version by its ID, also returning
+	// the resource canonical it belongs to.
+	FindVersionByID(ctx context.Context, versionID uint32) (*Version, string, error)
 }
 
 // ResourceWithPipeline embeds a Resource along with its owning team and pipeline canonicals.

--- a/pikoci/resource/resource.go
+++ b/pikoci/resource/resource.go
@@ -3,7 +3,11 @@
 // images) that are checked for new versions and used as inputs/outputs in jobs.
 package resource
 
-import "time"
+import (
+	"time"
+
+	"github.com/pikoci/pikoci/pikoci/build"
+)
 
 // Resource represents a versioned external artifact tracked by a pipeline.
 // Each resource has a type, a name, optional parameters, and a check interval
@@ -51,4 +55,28 @@ type Version struct {
 	ID      uint32                 `json:"id"`
 	Version map[string]interface{} `json:"version"`
 	Status  string                 `json:"status,omitempty"`
+}
+
+// VersionPathEntry represents a single job in a version's path through the
+// pipeline, along with the build (if any) that consumed this version.
+type VersionPathEntry struct {
+	JobName string         `json:"job_name"`
+	Build   *build.Build   `json:"build"`
+	Retries []*build.Build `json:"retries"`
+}
+
+// VersionPathResponse is the response from the version path endpoint. It
+// includes the resource and version being tracked, the ordered path of jobs,
+// and progress summary.
+type VersionPathResponse struct {
+	Resource  VersionPathResource `json:"resource"`
+	Path      []VersionPathEntry  `json:"path"`
+	Completed int                 `json:"completed"`
+	Total     int                 `json:"total"`
+}
+
+// VersionPathResource identifies the resource and version being tracked.
+type VersionPathResource struct {
+	Canonical string                 `json:"canonical"`
+	Version   map[string]interface{} `json:"version"`
 }

--- a/pikoci/service.go
+++ b/pikoci/service.go
@@ -105,7 +105,7 @@ type Service interface {
 	// GetPublicPipeline retrieves a public pipeline with sensitive fields sanitized.
 	GetPublicPipeline(ctx context.Context, tc, pn string) (*pipeline.Pipeline, error)
 	// GetPublicPipelineImage generates a DOT graph image for a public pipeline.
-	GetPublicPipelineImage(ctx context.Context, tc, pn, format string, hideIntermediates, groupParallel bool) ([]byte, error)
+	GetPublicPipelineImage(ctx context.Context, tc, pn, format string, hideIntermediates, groupParallel bool, versionID *uint32) ([]byte, error)
 	// GetPublicPipelineJob retrieves a job from a public pipeline.
 	GetPublicPipelineJob(ctx context.Context, tc, pn, jn string) (*job.Job, error)
 	// ListPublicJobBuilds returns paginated builds for a job on a public pipeline,
@@ -120,11 +120,18 @@ type Service interface {
 	// ListPublicResourceVersions returns paginated resource versions for a public pipeline.
 	ListPublicResourceVersions(ctx context.Context, tc, pn, rCan string, before *uint32, after *uint32, limit uint32) ([]*resource.Version, bool, error)
 
+	// GetResourceVersionPath returns the path of jobs a specific resource version
+	// passes through, along with the build status for each job.
+	GetResourceVersionPath(ctx context.Context, tc, pn, rCan string, versionID uint32) (*resource.VersionPathResponse, error)
+	// GetPublicResourceVersionPath returns the version path for a public pipeline.
+	GetPublicResourceVersionPath(ctx context.Context, tc, pn, rCan string, versionID uint32) (*resource.VersionPathResponse, error)
+
 	// GetPipelineImage generates a DOT graph representation of a pipeline's jobs
 	// and resources. When hideIntermediates is true, intermediate resource nodes
 	// are removed and jobs connect directly. When groupParallel is true, jobs
 	// sharing identical upstream parents are collapsed into a single HTML label node.
-	GetPipelineImage(ctx context.Context, tc, pn, format string, hideIntermediates, groupParallel bool) ([]byte, error)
+	// When versionID is non-nil, the graph is filtered to show only the version's path.
+	GetPipelineImage(ctx context.Context, tc, pn, format string, hideIntermediates, groupParallel bool, versionID *uint32) ([]byte, error)
 	// CreatePipelineImage generates a DOT graph image from raw pipeline
 	// configuration bytes without persisting the pipeline.
 	CreatePipelineImage(ctx context.Context, tc string, pp []byte, vars map[string]interface{}, format string) ([]byte, error)

--- a/pikoci/transport/http/assets/css/pikoci.css
+++ b/pikoci/transport/http/assets/css/pikoci.css
@@ -1296,6 +1296,7 @@ textarea.form-control {
 .piko-badge-started { background: #fff0d0; color: #9a7000; }
 .piko-badge-cancelled { background: #f5e6df; color: #8A3F2B; }
 .piko-badge-pending { background: #e8e0f0; color: #5F574F; }
+.piko-badge-primary { background: rgba(41,173,255,0.15); color: #29ADFF; }
 [data-theme="dark"] .piko-badge-succeeded { background: rgba(0,168,58,0.15); color: #00E436; }
 [data-theme="dark"] .piko-badge-failed { background: rgba(255,0,77,0.15); color: #FF77A8; }
 [data-theme="dark"] .piko-badge-started { background: rgba(255,163,0,0.15); color: #FFA300; }
@@ -1795,4 +1796,233 @@ body.piko-fullscreen .btn-primary { display: none; }
     padding: 1.5rem 1.25rem;
     margin: 0 12px;
   }
+}
+
+/* ============================================================
+   Version Scope Banner
+   ============================================================ */
+.piko-version-banner {
+  background: linear-gradient(135deg, #1D2B53 0%, #2a3a65 100%);
+  border-bottom: 3px solid #29ADFF;
+  padding: 8px 16px;
+  display: flex;
+  align-items: center;
+}
+.piko-version-banner-inner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  font-size: 0.85rem;
+  color: #fff;
+}
+.piko-version-banner-icon {
+  color: #29ADFF;
+  font-size: 1rem;
+}
+.piko-version-banner-label {
+  color: #83769C;
+  font-weight: 500;
+}
+.piko-version-banner-resource {
+  color: #29ADFF;
+  font-weight: 600;
+}
+.piko-version-banner-ref {
+  font-family: 'JetBrains Mono', monospace;
+  background: rgba(41,173,255,0.15);
+  padding: 2px 8px;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 0.8rem;
+}
+.piko-version-banner-progress {
+  margin-left: auto;
+  color: #83769C;
+  font-size: 0.8rem;
+}
+.piko-version-banner-clear {
+  background: transparent;
+  border: 1px solid #5F574F;
+  color: #83769C;
+  border-radius: 4px;
+  padding: 3px 10px;
+  font-size: 0.78rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  transition: all 0.15s;
+}
+.piko-version-banner-clear:hover {
+  border-color: #29ADFF;
+  color: #fff;
+}
+
+/* ============================================================
+   Version Selector (List View)
+   ============================================================ */
+.piko-rsel-container {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  min-width: 0;
+}
+.piko-vsel-wrap {
+  position: relative;
+  display: inline-block;
+  margin-left: 8px;
+}
+.piko-vsel-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  background: #1D2B53;
+  border: 1px solid #5F574F;
+  border-radius: 6px;
+  color: #fff;
+  font-size: 0.82rem;
+  cursor: pointer;
+  font-family: 'JetBrains Mono', monospace;
+  transition: border-color 0.15s;
+}
+.piko-vsel-btn:hover {
+  border-color: #29ADFF;
+}
+.piko-vsel-menu {
+  display: none;
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  min-width: 280px;
+  max-height: 300px;
+  overflow-y: auto;
+  background: #1D2B53;
+  border: 1px solid #5F574F;
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+  z-index: 100;
+  padding: 4px 0;
+}
+.piko-vsel-menu.open {
+  display: block;
+}
+.piko-vsel-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  cursor: pointer;
+  font-size: 0.82rem;
+  color: #fff;
+  transition: background 0.1s;
+}
+.piko-vsel-item:hover {
+  background: rgba(41,173,255,0.12);
+}
+.piko-vsel-item.active {
+  background: rgba(41,173,255,0.2);
+}
+.piko-vsel-item-all {
+  border-bottom: 1px solid #5F574F;
+  color: #83769C;
+}
+.piko-vsel-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.piko-vsel-ref {
+  font-family: 'JetBrains Mono', monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ============================================================
+   Resources Panel - Track Button & Versions List
+   ============================================================ */
+.piko-panel-track-btn {
+  background: transparent;
+  border: 1px solid #5F574F;
+  color: #29ADFF;
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-size: 0.72rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  transition: all 0.15s;
+}
+.piko-panel-track-btn:hover {
+  border-color: #29ADFF;
+  background: rgba(41,173,255,0.1);
+}
+.piko-panel-trigger-btn,
+.piko-panel-pin-btn {
+  background: transparent;
+  border: 1px solid #5F574F;
+  color: #83769C;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.72rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  transition: all 0.15s;
+}
+.piko-panel-trigger-btn:hover {
+  border-color: #FFA300;
+  color: #FFA300;
+  background: rgba(255,163,0,0.1);
+}
+.piko-panel-pin-btn:hover {
+  border-color: #FFA300;
+  color: #FFA300;
+  background: rgba(255,163,0,0.1);
+}
+.piko-panel-pin-btn.pinned {
+  border-color: #FFA300;
+  color: #FFA300;
+}
+.piko-resource-panel-versions {
+  padding: 4px 0 8px 12px;
+  border-left: 2px solid #5F574F;
+  margin-left: 8px;
+}
+.piko-resource-panel-version-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  font-size: 0.78rem;
+  color: #fff;
+}
+.piko-resource-panel-version-item .piko-vsel-ref {
+  flex: 1;
+  min-width: 0;
+}
+.piko-resource-panel-version-item.tracked {
+  background: rgba(41,173,255,0.08);
+  border-radius: 4px;
+}
+.piko-panel-tracking-badge {
+  color: #29ADFF;
+  font-size: 0.78rem;
+  padding: 2px 6px;
+}
+.piko-resource-expand-toggle {
+  background: transparent;
+  border: none;
+  color: #83769C;
+  cursor: pointer;
+  padding: 2px 4px;
+  font-size: 0.72rem;
+}
+.piko-resource-expand-toggle:hover {
+  color: #29ADFF;
 }

--- a/pikoci/transport/http/assets/js/app/models.js
+++ b/pikoci/transport/http/assets/js/app/models.js
@@ -133,6 +133,7 @@ export var PipelineImage = Backbone.Model.extend({
     var params = [];
     if (this.hideIntermediates) params.push("hide_intermediates=1");
     if (this.groupParallel) params.push("group_parallel=1");
+    if (this.versionID) params.push("version_id=" + this.versionID);
     if (params.length > 0) base += "?" + params.join("&");
     return base;
   },
@@ -141,6 +142,7 @@ export var PipelineImage = Backbone.Model.extend({
     this.pipeline = opts.pipeline;
     this.hideIntermediates = false;
     this.groupParallel = false;
+    this.versionID = null;
   },
 });
 

--- a/pikoci/transport/http/assets/js/app/router.js
+++ b/pikoci/transport/http/assets/js/app/router.js
@@ -204,6 +204,15 @@ export var Router = Backbone.Router.extend({
     if (!this.setup(!isLogin, true)) {
       return;
     }
+    // Pick up tracked version: first from router property (set by graph click
+    // before navigate), then from URL query param (set after navigate for reload)
+    var trackedVersionID = this._trackedVersionID || null;
+    delete this._trackedVersionID;
+    if (!trackedVersionID) {
+      var urlParams = new URLSearchParams(window.location.search);
+      trackedVersionID = urlParams.get('version') ? parseInt(urlParams.get('version'), 10) : null;
+    }
+
     // If user prefers list view, redirect to pipeline show (list view will pick up the job)
     if (localStorage.getItem("piko-pipeline-view") === "list") {
       localStorage.setItem('piko-list-' + pn + '-job', jn);
@@ -233,6 +242,7 @@ export var Router = Backbone.Router.extend({
         currentBuildID: bid,
         job: jb,
         pipeline: pp,
+        trackedVersionID: trackedVersionID,
       });
       $('#main').html(that.contentView.render().el);
       $('#breadcrumb').html(new BreadcrumbView({

--- a/pikoci/transport/http/assets/js/app/views/jobs.js
+++ b/pikoci/transport/http/assets/js/app/views/jobs.js
@@ -13,20 +13,48 @@ export var JobBuildsView = Backbone.View.extend({
     this.job = opts.job;
     this.pipeline = opts.pipeline;
     this.embedded = opts.embedded || false;
+    this.trackedVersionID = opts.trackedVersionID || null;
 
     var that = this;
-    this.collection.fetch({
-      reset: true,
-      success: function(){
-        that.activateAndNavigate(opts.currentBuildID);
-        that.bindScrollListener();
-      },
-    });
+    if (this.trackedVersionID) {
+      // When tracking a version, fetch the version path to find the correct
+      // build IDs for this job, then filter to only show those
+      this._fetchTrackedBuilds(function() {
+        that.collection.fetch({
+          reset: true,
+          success: function() {
+            that._filterByTrackedBuildIDs();
+            that.activateAndNavigate(opts.currentBuildID);
+            that.bindScrollListener();
+          },
+        });
+      });
+    } else {
+      this.collection.fetch({
+        reset: true,
+        success: function(){
+          that.activateAndNavigate(opts.currentBuildID);
+          that.bindScrollListener();
+        },
+      });
+    }
 
     this.intervalID = window.setInterval(function() {
-      that.collection.fetchNew({
-        success: function() { that.fetchActiveBuild(); }
-      });
+      if (that.trackedVersionID) {
+        // Re-fetch tracked build IDs to pick up retries, then refresh builds
+        that._fetchTrackedBuilds(function() {
+          that.collection.fetchNew({
+            success: function() {
+              that._filterByTrackedBuildIDs();
+              that.fetchActiveBuild();
+            }
+          });
+        });
+      } else {
+        that.collection.fetchNew({
+          success: function() { that.fetchActiveBuild(); }
+        });
+      }
     }, fetchInterval);
   },
   events: {
@@ -34,6 +62,7 @@ export var JobBuildsView = Backbone.View.extend({
     'click #pause-job': 'clickPauseJob',
     'click #unpause-job': 'clickUnpauseJob',
     'click .piko-build-tab': 'clickOnTab',
+    'click #job-version-back': 'clickBackToPipeline',
   },
   addBuilds: function() {
     var that = this;
@@ -47,7 +76,58 @@ export var JobBuildsView = Backbone.View.extend({
       pipeline: this.collection.job.collection.pipeline.toJSON(),
       job: this.collection.job.toJSON(),
     })));
+    // Show version tracking banner if tracking (not when embedded in list view)
+    if (this.trackedVersionID && !this.embedded) {
+      this._showVersionBanner();
+    }
     return this;
+  },
+  _showVersionBanner: function() {
+    var banner = this.$('#job-version-banner');
+    if (!banner.length) return;
+    // Fetch version path to get resource name and ref
+    var that = this;
+    var tc = this.collection.job.collection.pipeline.collection.team.get('canonical');
+    var pc = this.pipeline.get('canonical');
+    var resources = this.pipeline.get('resources') || [];
+    var idx = 0;
+    function tryNext() {
+      if (idx >= resources.length) return;
+      var rCan = resources[idx].canonical;
+      idx++;
+      var url = '/teams/' + tc + '/pipelines/' + pc + '/resources/' + rCan + '/versions/' + that.trackedVersionID + '/path';
+      $.ajax({
+        url: url, type: 'GET', contentType: 'application/json',
+        headers: session.isEmpty() ? {} : { 'Authorization': 'Bearer ' + session.get('jwt') },
+        success: function(resp) {
+          if (resp.data && resp.data.path && resp.data.path.length > 0) {
+            var v = resp.data.resource.version || {};
+            that.$('#job-version-banner-resource').text(resp.data.resource.canonical);
+            that.$('#job-version-banner-ref').text(v.ref || v.digest || v.tag || (function() {
+              for (var k in v) { if (v.hasOwnProperty(k)) return k + ': ' + v[k]; }
+              return '';
+            })());
+            banner.show();
+          } else {
+            tryNext();
+          }
+        },
+        error: function() { tryNext(); },
+      });
+    }
+    tryNext();
+  },
+  clickBackToPipeline: function(event) {
+    event.preventDefault();
+    var tc = this.collection.job.collection.pipeline.collection.team.get('canonical');
+    var pc = this.pipeline.get('canonical');
+    if (this.trackedVersionID) {
+      window.app.router._trackedVersionID = this.trackedVersionID;
+    }
+    window.app.router.navigate('teams/' + tc + '/pipelines/' + pc, { trigger: true });
+    if (this.trackedVersionID) {
+      window.history.replaceState(null, '', '/teams/' + tc + '/pipelines/' + pc + '?version=' + this.trackedVersionID);
+    }
   },
   activateAndNavigate: function(requestedBID) {
     var that = this;
@@ -73,8 +153,12 @@ export var JobBuildsView = Backbone.View.extend({
     this.currentBuildID = bid;
     if (!this.embedded) {
       var tc = this.collection.job.collection.pipeline.collection.team.get("canonical");
-      var url = new URL(location.origin+"/teams/"+tc+"/pipelines/"+this.pipeline.get("canonical")+"/jobs/"+this.job.get("name")+"/builds/"+bid);
-      window.app.router.navigate(url.pathname, { trigger: false, replace: true });
+      var navPath = "teams/"+tc+"/pipelines/"+this.pipeline.get("canonical")+"/jobs/"+this.job.get("name")+"/builds/"+bid;
+      window.app.router.navigate(navPath, { trigger: false, replace: true });
+      // Preserve ?version= in URL via history API
+      if (this.trackedVersionID) {
+        window.history.replaceState(null, '', window.location.pathname + '?version=' + this.trackedVersionID);
+      }
     }
   },
   bindScrollListener: function() {
@@ -90,6 +174,10 @@ export var JobBuildsView = Backbone.View.extend({
   remove: function() {
     clearInterval(this.intervalID);
     this.$('#builds-tabs').off('scroll', this._scrollHandler);
+    // Preserve tracked version for the next view (e.g., navigating back to pipeline)
+    if (this.trackedVersionID) {
+      window.app.router._trackedVersionID = this.trackedVersionID;
+    }
     Backbone.View.prototype.remove.call(this);
   },
   addBuild: function(m) {
@@ -129,6 +217,74 @@ export var JobBuildsView = Backbone.View.extend({
         m.fetch();
       }
     });
+  },
+  _fetchTrackedBuilds: function(callback) {
+    // Find which resource has the tracked version and get path data
+    var that = this;
+    var tc = this.collection.job.collection.pipeline.collection.team.get('canonical');
+    var pn = this.pipeline.get('canonical');
+    var jn = this.job.get('name');
+    var resources = this.pipeline.get('resources') || [];
+    this._trackedBuildIDs = null;
+    // Try the pipeline resources endpoint to find path
+    var url = '/teams/' + tc + '/pipelines/' + pn + '/resources';
+    $.ajax({
+      url: url, type: 'GET', contentType: 'application/json',
+      headers: session.isEmpty() ? {} : { 'Authorization': 'Bearer ' + session.get('jwt') },
+      success: function(resp) {
+        if (!resp || !resp.data) { callback(); return; }
+        var resList = resp.data;
+        var idx = 0;
+        function tryNextResource() {
+          if (idx >= resList.length) { callback(); return; }
+          var rCan = resList[idx].canonical;
+          idx++;
+          var pathUrl = '/teams/' + tc + '/pipelines/' + pn + '/resources/' + rCan + '/versions/' + that.trackedVersionID + '/path';
+          $.ajax({
+            url: pathUrl, type: 'GET', contentType: 'application/json',
+            headers: session.isEmpty() ? {} : { 'Authorization': 'Bearer ' + session.get('jwt') },
+            success: function(pathResp) {
+              if (pathResp.data && pathResp.data.path && pathResp.data.path.length > 0) {
+                // Found the right resource - extract build IDs for this job
+                var ids = {};
+                for (var i = 0; i < pathResp.data.path.length; i++) {
+                  var entry = pathResp.data.path[i];
+                  if (entry.job_name === jn && entry.build) {
+                    ids[entry.build.id] = true;
+                    if (entry.retries) {
+                      for (var j = 0; j < entry.retries.length; j++) {
+                        ids[entry.retries[j].id] = true;
+                      }
+                    }
+                  }
+                }
+                that._trackedBuildIDs = ids;
+                callback();
+              } else {
+                tryNextResource();
+              }
+            },
+            error: function() { tryNextResource(); },
+          });
+        }
+        tryNextResource();
+      },
+      error: function() { callback(); },
+    });
+  },
+  _filterByTrackedBuildIDs: function() {
+    if (!this._trackedBuildIDs) return;
+    var ids = this._trackedBuildIDs;
+    var toRemove = this.collection.filter(function(m) {
+      return !ids[m.get('id')];
+    });
+    // Only re-render if the set of builds actually changed
+    if (toRemove.length === 0 && this._lastFilteredCount === this.collection.length) return;
+    this._lastFilteredCount = this.collection.length - toRemove.length;
+    this.collection.remove(toRemove, {silent: true});
+    this.$('#builds-tabs').empty();
+    this.$('#builds-content').empty();
+    this.addBuilds();
   },
   clickTriggerJob: function(event) {
     event.preventDefault();
@@ -171,8 +327,11 @@ export var JobBuildsView = Backbone.View.extend({
     this.currentBuildID = bid;
     if (!this.embedded) {
       var tc = this.collection.job.collection.pipeline.collection.team.get("canonical");
-      var url = new URL(location.origin+"/teams/"+tc+"/pipelines/"+this.pipeline.get("canonical")+"/jobs/"+this.job.get("name")+"/builds/"+bid);
-      window.app.router.navigate(url.pathname, { trigger: false, replace: true });
+      var navPath = "teams/"+tc+"/pipelines/"+this.pipeline.get("canonical")+"/jobs/"+this.job.get("name")+"/builds/"+bid;
+      window.app.router.navigate(navPath, { trigger: false, replace: true });
+      if (this.trackedVersionID) {
+        window.history.replaceState(null, '', window.location.pathname + '?version=' + this.trackedVersionID);
+      }
     }
   }
 });

--- a/pikoci/transport/http/assets/js/app/views/pipelines.js
+++ b/pikoci/transport/http/assets/js/app/views/pipelines.js
@@ -6,6 +6,22 @@ import { addSessionFunctions, clickLink, fetchInterval, pikoTimeAgo, withLoading
 import { JobBuildsView } from './jobs.js';
 import { PipelineGraphView, PikoGraphZoom } from './editor.js';
 
+// Extract a human-readable ref string from a version metadata map.
+function versionRef(v) {
+  if (!v) return '';
+  if (typeof v === 'string') return v;
+  if (v.ref) return v.ref;
+  if (v.digest) return v.digest;
+  if (v.tag) return v.tag;
+  if (typeof v.version === 'string') return v.version;
+  for (var key in v) {
+    if (v.hasOwnProperty(key)) {
+      return key + ': ' + v[key];
+    }
+  }
+  return '';
+}
+
 export var PipelinesView = Backbone.View.extend({
   template: _.template($('#pipelines-view').html()),
   initialize: function() {
@@ -150,7 +166,8 @@ var PipelineResourcesPanelView = Backbone.View.extend({
   initialize: function(options) {
     this.collection = options.collection;
     this.pipeline = options.pipeline;
-    this.listenTo(this.collection, 'sync', this.render);
+    this._expandedResources = {};
+    this.listenTo(this.collection, 'sync', this._onSync);
     this._polling = false;
   },
   startPolling: function() {
@@ -171,6 +188,43 @@ var PipelineResourcesPanelView = Backbone.View.extend({
     'click #close-resources-panel': 'closePanel',
     'click .check-resource-now': 'checkNow',
     'click .piko-resource-card-name': clickLink,
+    'click .piko-resource-expand-toggle': 'toggleVersionsList',
+    'click .piko-panel-track-btn': 'trackVersionFromPanel',
+    'click .piko-panel-trigger-btn': 'triggerVersionFromPanel',
+    'click .piko-panel-pin-btn': 'pinVersionFromPanel',
+  },
+  _onSync: function() {
+    // If any version lists are expanded, do targeted updates instead of full re-render
+    if (Object.keys(this._expandedResources).length > 0) {
+      this._updateResourceCards();
+      return;
+    }
+    this.render();
+  },
+  _updateResourceCards: function() {
+    var that = this;
+    this.collection.each(function(r) {
+      var rData = r.toJSON();
+      var card = that.$('.piko-resource-card[data-canonical="' + rData.canonical + '"]');
+      if (card.length === 0) return;
+      // Update status dot
+      var dot = card.find('.piko-version-status-dot');
+      if (rData.latest_version && rData.latest_version.status) {
+        if (dot.length) {
+          dot.css('background', 'var(--status-' + rData.latest_version.status + ')');
+        }
+      }
+      // Update meta
+      var meta = card.find('.piko-resource-card-meta');
+      var metaHtml = '';
+      if (rData.check_interval) {
+        metaHtml += '<span>' + _.escape(rData.check_interval) + '</span>';
+      }
+      if (rData.last_check && !rData.last_check.startsWith('0001-01-01')) {
+        metaHtml += '<span>Checked: ' + pikoTimeAgo(rData.last_check) + '</span>';
+      }
+      meta.html(metaHtml);
+    });
   },
   render: function() {
     var teamCanonical = this.pipeline.collection ? this.pipeline.collection.team.get('canonical') : '';
@@ -213,6 +267,135 @@ var PipelineResourcesPanelView = Backbone.View.extend({
       },
     });
   },
+  toggleVersionsList: function(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    var canonical = $(event.currentTarget).data('canonical');
+    var container = this.$('.piko-resource-panel-versions[data-canonical="' + canonical + '"]');
+    if (container.is(':visible')) {
+      container.hide();
+      delete this._expandedResources[canonical];
+      $(event.currentTarget).find('i').removeClass('bi-chevron-up').addClass('bi-chevron-down');
+      return;
+    }
+    $(event.currentTarget).find('i').removeClass('bi-chevron-down').addClass('bi-chevron-up');
+    container.show();
+    this._expandedResources[canonical] = true;
+    this._fetchPanelVersions(canonical, container);
+  },
+  _fetchPanelVersions: function(canonical, container) {
+    var teamCanonical = this.pipeline.collection ? this.pipeline.collection.team.get('canonical') : '';
+    var pipelineCanonical = this.pipeline.get('canonical');
+    var url = '/teams/' + teamCanonical + '/pipelines/' + pipelineCanonical + '/resources/' + canonical + '/versions?limit=5';
+    var resModel = this.collection.findWhere({canonical: canonical});
+    var pinnedVersionID = resModel ? resModel.get('pinned_version_id') : null;
+    var trackedVersionID = (this.parentShowView && this.parentShowView.trackedVersion) ? this.parentShowView.trackedVersion.versionID : null;
+    $.ajax({
+      url: url, type: 'GET', contentType: 'application/json',
+      headers: session.isEmpty() ? {} : { 'Authorization': 'Bearer ' + session.get('jwt') },
+      success: function(resp) {
+        if (!resp || !resp.data) return;
+        var html = '';
+        for (var i = 0; i < resp.data.length; i++) {
+          var v = resp.data[i];
+          var ref = v.version ? versionRef(v.version) : '';
+          var status = v.status || '';
+          var isPinned = pinnedVersionID === v.id;
+          var isTracked = trackedVersionID === v.id;
+          html += '<div class="piko-resource-panel-version-item' + (isTracked ? ' tracked' : '') + '">';
+          html += '<span class="piko-vsel-dot piko-status-dot-' + status + '"></span>';
+          html += '<span class="piko-vsel-ref">' + _.escape(ref) + '</span>';
+          if (isTracked) {
+            html += '<span class="piko-panel-tracking-badge"><i class="bi bi-signpost-2"></i></span>';
+          } else {
+            html += '<button class="piko-panel-track-btn" data-canonical="' + _.escape(canonical) + '" data-version-id="' + v.id + '" data-version-ref="' + _.escape(ref) + '" title="Track"><i class="bi bi-signpost-2"></i></button>';
+          }
+          html += '<button class="piko-panel-trigger-btn" data-canonical="' + _.escape(canonical) + '" data-version-id="' + v.id + '" title="Trigger"><i class="bi bi-play-fill"></i></button>';
+          html += '<button class="piko-panel-pin-btn ' + (isPinned ? 'pinned' : '') + '" data-canonical="' + _.escape(canonical) + '" data-version-id="' + v.id + '" title="' + (isPinned ? 'Unpin' : 'Pin') + '"><i class="bi ' + (isPinned ? 'bi-pin-fill' : 'bi-pin') + '"></i></button>';
+          html += '</div>';
+        }
+        container.html(html);
+      },
+    });
+  },
+  trackVersionFromPanel: function(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    var btn = $(event.currentTarget);
+    var canonical = btn.data('canonical');
+    var versionID = parseInt(btn.data('version-id'), 10);
+    var ref = btn.data('version-ref') || '';
+    if (typeof ref === 'object') ref = versionRef(ref);
+    if (this.parentShowView && this.parentShowView.trackVersion) {
+      this.parentShowView.trackVersion(canonical, versionID, ref);
+    }
+  },
+  triggerVersionFromPanel: function(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    var btn = $(event.currentTarget);
+    var canonical = btn.data('canonical');
+    var versionID = parseInt(btn.data('version-id'), 10);
+    var tc = this.pipeline.collection ? this.pipeline.collection.team.get('canonical') : '';
+    var pc = this.pipeline.get('canonical');
+    var url = '/teams/' + tc + '/pipelines/' + pc + '/resources/' + canonical + '/versions/' + versionID + '/trigger';
+    withLoading(btn, function() {
+      return $.ajax({
+        url: url, type: 'POST', contentType: 'application/json',
+        headers: { 'Authorization': 'Bearer ' + session.get('jwt') },
+        success: function() {
+          window.app.apiNotice.setSuccess('Triggered downstream jobs with version #' + versionID);
+        },
+      });
+    });
+  },
+  pinVersionFromPanel: function(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    var btn = $(event.currentTarget);
+    var canonical = btn.data('canonical');
+    var versionID = parseInt(btn.data('version-id'), 10);
+    var tc = this.pipeline.collection ? this.pipeline.collection.team.get('canonical') : '';
+    var pc = this.pipeline.get('canonical');
+    var isPinned = btn.hasClass('pinned');
+    var that = this;
+    var url;
+    if (isPinned) {
+      url = '/teams/' + tc + '/pipelines/' + pc + '/resources/' + canonical + '/unpin';
+      withLoading(btn, function() {
+        return $.ajax({
+          url: url, type: 'POST', contentType: 'application/json',
+          headers: { 'Authorization': 'Bearer ' + session.get('jwt') },
+          success: function() {
+            window.app.apiNotice.setSuccess('Resource unpinned');
+            that.collection.fetch();
+          },
+        });
+      });
+    } else {
+      url = '/teams/' + tc + '/pipelines/' + pc + '/resources/' + canonical + '/pin';
+      withLoading(btn, function() {
+        return $.ajax({
+          url: url, type: 'POST', contentType: 'application/json',
+          data: JSON.stringify({version_id: versionID}),
+          headers: { 'Authorization': 'Bearer ' + session.get('jwt') },
+          success: function() {
+            window.app.apiNotice.setSuccess('Resource pinned to version #' + versionID);
+            that.collection.fetch();
+          },
+        });
+      });
+    }
+  },
+  refreshExpandedVersions: function() {
+    var that = this;
+    _.each(this._expandedResources, function(val, canonical) {
+      var container = that.$('.piko-resource-panel-versions[data-canonical="' + canonical + '"]');
+      if (container.length && container.is(':visible')) {
+        that._fetchPanelVersions(canonical, container);
+      }
+    });
+  },
   remove: function() {
     this.stopPolling();
     Backbone.View.prototype.remove.call(this);
@@ -225,6 +408,26 @@ export var PipelineShowView = Backbone.View.extend({
     this.image = options.image;
     this.image.hideIntermediates = localStorage.getItem("piko-hide-intermediates") === "1";
     this.image.groupParallel = localStorage.getItem("piko-group-parallel") === "1";
+
+    this.listView = null;
+    this.trackedVersion = null;
+    this.versionPathData = null;
+    var savedView = localStorage.getItem("piko-pipeline-view") || "graph";
+    this.currentView = savedView === "pipeline" ? "graph" : savedView;
+
+    // Check for tracked version: first from router property (in-app navigation),
+    // then from URL query param (page reload / direct link)
+    var urlVersionID = window.app.router._trackedVersionID || null;
+    delete window.app.router._trackedVersionID;
+    if (!urlVersionID) {
+      var urlParams = new URLSearchParams(window.location.search);
+      urlVersionID = urlParams.get('version') ? parseInt(urlParams.get('version'), 10) : null;
+    }
+    if (urlVersionID) {
+      this._pendingVersionID = urlVersionID;
+      this.image.versionID = this._pendingVersionID;
+    }
+
     this.image.fetch({
       error: function(model, xhr) {
         try {
@@ -243,13 +446,12 @@ export var PipelineShowView = Backbone.View.extend({
     });
     this.resourcesCollection = new PanelResources();
 
-    this.listView = null;
-    var savedView = localStorage.getItem("piko-pipeline-view") || "graph";
-    this.currentView = savedView === "pipeline" ? "graph" : savedView;
-
     var that = this;
     this.intervalID = window.setInterval(function() {
       that.image.fetch({isInterval: true});
+      if (that.trackedVersion) {
+        that._pollVersionPath();
+      }
     }, fetchInterval);
   },
   events: {
@@ -265,6 +467,7 @@ export var PipelineShowView = Backbone.View.extend({
     'change #gear-hide-intermediates': 'toggleHideIntermediates',
     'change #gear-group-parallel': 'toggleGroupParallel',
     'click .piko-view-btn': 'switchView',
+    'click #clear-version-scope': 'clearVersionScope',
   },
   render: function () {
     this.$el.html(this.template(addSessionFunctions({ pipeline: this.model.toJSON(), team: this.model.collection.team.toJSON() })));
@@ -290,6 +493,21 @@ export var PipelineShowView = Backbone.View.extend({
     this.$('#gear-group-parallel').prop('checked', this.image.groupParallel);
     this._applyView(this.currentView);
 
+    // If loaded with ?version= param, find the resource and initiate tracking.
+    // The versionID was already set on image before the first fetch in initialize().
+    if (this._pendingVersionID) {
+      var vid = this._pendingVersionID;
+      delete this._pendingVersionID;
+      var that = this;
+      this.resourcesCollection.fetch({
+        success: function() {
+          that._resolveVersionResource(vid);
+        },
+      });
+    }
+
+    this.panelView.parentShowView = this;
+
     return this;
   },
   _applyView: function(mode) {
@@ -307,6 +525,7 @@ export var PipelineShowView = Backbone.View.extend({
           el: this.$('.piko-view-list'),
           pipeline: this.model,
           resourcesCollection: this.resourcesCollection,
+          parentShowView: this,
         });
       } else {
         this.listView.resumePolling();
@@ -330,13 +549,17 @@ export var PipelineShowView = Backbone.View.extend({
     this.currentView = mode;
     localStorage.setItem("piko-pipeline-view", mode);
     this._applyView(mode);
-    // Update URL to match the current view
+    // Update URL to match the current view, preserving ?version= if tracking
     var tc = this.model.collection.team.get('canonical');
     var pc = this.model.get('canonical');
+    var vqs = (this.trackedVersion && this.trackedVersion.versionID) ? '?version=' + this.trackedVersion.versionID : '';
     if (mode === 'list' && this.listView && this.listView.selectedJob) {
       window.app.router.navigate('teams/' + tc + '/pipelines/' + pc + '/jobs/' + this.listView.selectedJob + '/builds', { trigger: false, replace: true });
     } else {
       window.app.router.navigate('teams/' + tc + '/pipelines/' + pc, { trigger: false, replace: true });
+    }
+    if (vqs) {
+      window.history.replaceState(null, '', window.location.pathname + vqs);
     }
   },
   remove: function() {
@@ -430,11 +653,119 @@ export var PipelineShowView = Backbone.View.extend({
       setTimeout(function() { btn.text(original); }, 1500);
     });
   },
+  trackVersion: function(resourceCanonical, versionID, versionRef) {
+    this.trackedVersion = { resource: resourceCanonical, versionID: versionID, ref: versionRef };
+    this.image.versionID = versionID;
+    this.image.fetch();
+    this._pollVersionPath();
+    this._updateVersionURL();
+    // Refresh expanded panel version lists to show tracked indicator
+    if (this.panelView) { this.panelView.refreshExpandedVersions(); }
+  },
+  clearVersionScope: function(event) {
+    if (event) { event.preventDefault(); event.stopPropagation(); }
+    this.trackedVersion = null;
+    this.versionPathData = null;
+    this.$('#version-scope-banner').hide();
+    this.image.versionID = null;
+    this.image.fetch();
+    if (this.listView) { this.listView.clearVersionScope(); }
+    // Remove ?version from URL using history API
+    var tc = this.model.collection.team.get('canonical');
+    var pc = this.model.get('canonical');
+    window.history.replaceState(null, '', '/teams/' + tc + '/pipelines/' + pc);
+    if (this.panelView) { this.panelView.refreshExpandedVersions(); }
+  },
+  showVersionBanner: function(resource, ref, completed, total) {
+    this.$('#version-banner-resource').text(resource);
+    this.$('#version-banner-ref').text(ref);
+    this.$('#version-banner-progress').text(completed + '/' + total + ' completed');
+    this.$('#version-scope-banner').show();
+  },
+  _pollVersionPath: function() {
+    if (!this.trackedVersion || !this.trackedVersion.resource) return;
+    var that = this;
+    var tv = this.trackedVersion;
+    var url = this.model.url() + '/resources/' + tv.resource + '/versions/' + tv.versionID + '/path';
+    $.ajax({
+      url: url,
+      type: 'GET',
+      contentType: 'application/json',
+      headers: { 'Authorization': 'Bearer ' + session.get('jwt') },
+      success: function(resp) {
+        if (!resp.data) return;
+        that.versionPathData = resp.data;
+        // Determine the ref to display
+        var ref = tv.ref || '';
+        if (!ref && resp.data.resource && resp.data.resource.version) {
+          var v = resp.data.resource.version;
+          ref = versionRef(v);
+        }
+        that.showVersionBanner(resp.data.resource.canonical, ref, resp.data.completed, resp.data.total);
+        if (that.listView && that.listView.applyVersionScope) {
+          that.listView.applyVersionScope(resp.data);
+        }
+      },
+    });
+  },
+  _updateVersionURL: function() {
+    if (!this.trackedVersion) return;
+    var tc = this.model.collection.team.get('canonical');
+    var pc = this.model.get('canonical');
+    var path = '/teams/' + tc + '/pipelines/' + pc;
+    // Use history.replaceState to set ?version= without triggering Backbone routing
+    window.history.replaceState(null, '', path + '?version=' + this.trackedVersion.versionID);
+  },
+  _resolveVersionResource: function(versionID) {
+    // Try each resource sequentially until we find the one that owns this version
+    var that = this;
+    var resources = this.resourcesCollection.toJSON();
+    var idx = 0;
+    function tryNext() {
+      if (idx >= resources.length) return;
+      var rCan = resources[idx].canonical;
+      idx++;
+      var url = that.model.url() + '/resources/' + rCan + '/versions/' + versionID + '/path';
+      $.ajax({
+        url: url, type: 'GET', contentType: 'application/json',
+        headers: session.isEmpty() ? {} : { 'Authorization': 'Bearer ' + session.get('jwt') },
+        success: function(resp) {
+          if (resp.data && resp.data.path && resp.data.path.length > 0) {
+            that.trackedVersion = { resource: rCan, versionID: versionID, ref: '' };
+            that.versionPathData = resp.data;
+            var v = resp.data.resource.version || {};
+            var ref = versionRef(v);
+            that.trackedVersion.ref = ref;
+            that.showVersionBanner(rCan, ref, resp.data.completed, resp.data.total);
+            if (that.listView && that.listView.applyVersionScope) {
+              that.listView.applyVersionScope(resp.data);
+            }
+          } else {
+            tryNext();
+          }
+        },
+        error: function() {
+          tryNext();
+        },
+      });
+    }
+    tryNext();
+  },
   clickPipeline: function(event) {
     // Only handle clicks on SVG links inside the graph
     if (event.target.parentElement && event.target.parentElement.href && event.target.parentElement.href.baseVal) {
       event.preventDefault();
-      window.app.router.navigate(event.target.parentElement.href.baseVal, { trigger: true });
+      var href = event.target.parentElement.href.baseVal;
+      // Pass tracked version via a property on the router so the handler
+      // can read it synchronously (Backbone can't handle query params).
+      if (this.trackedVersion && this.trackedVersion.versionID) {
+        window.app.router._trackedVersionID = this.trackedVersion.versionID;
+      }
+      window.app.router.navigate(href, { trigger: true });
+      // After navigate, set ?version= in URL for reload persistence
+      if (this.trackedVersion && this.trackedVersion.versionID) {
+        window.history.replaceState(null, '', window.location.pathname + '?version=' + this.trackedVersion.versionID);
+      }
     }
   },
   clickEdit: function(event){
@@ -498,6 +829,7 @@ var PipelineListView = Backbone.View.extend({
   initialize: function(options) {
     this.pipeline = options.pipeline;
     this.resourcesCollection = options.resourcesCollection;
+    this.parentShowView = options.parentShowView || null;
     this.jobsData = [];
     this.selectedJob = null;
     this.selectedResource = null;
@@ -538,6 +870,8 @@ var PipelineListView = Backbone.View.extend({
     'click .piko-rsel-trigger': '_onToggleResourceMenu',
     'click .piko-rsel-option': '_onSelectResource',
     'click .piko-resource-check-btn': '_onCheckResource',
+    'click .piko-vsel-btn': '_onToggleVersionMenu',
+    'click .piko-vsel-item': '_onSelectVersion',
   },
 
   // --- Resource & chain resolution ---
@@ -617,10 +951,11 @@ var PipelineListView = Backbone.View.extend({
   },
 
   _renderResourceSelector: function() {
-    var bar = this.$('.piko-list-resource-bar');
+    var container = this.$('.piko-rsel-container');
     var menuOpen = this.$('.piko-rsel-menu').hasClass('open');
+    var versionMenuOpen = this.$('.piko-vsel-menu').hasClass('open');
 
-    if (menuOpen) {
+    if (menuOpen || versionMenuOpen) {
       // Targeted in-place update: refresh status dots and info without closing the dropdown
       var resMap = {};
       this.resourcesCollection.each(function(r) {
@@ -663,7 +998,7 @@ var PipelineListView = Backbone.View.extend({
       return;
     }
     if (this.triggerResources.length === 0) {
-      bar.html('<span style="color:var(--text-muted)">No trigger resources</span>');
+      container.html('<span style="color:var(--text-muted)">No trigger resources</span>');
       return;
     }
     var resMap = {};
@@ -700,6 +1035,9 @@ var PipelineListView = Backbone.View.extend({
     }
     html += '</div></div>';
 
+    // Version selector placeholder (rendered by _renderVersionSelector)
+    html += '<div class="piko-vsel-wrap"></div>';
+
     // Version + check info
     html += '<span class="piko-resource-bar-info">';
     if (lv && lv.version) {
@@ -722,7 +1060,8 @@ var PipelineListView = Backbone.View.extend({
       html += '<button class="btn btn-sm btn-outline-warning piko-resource-check-btn"><i class="bi bi-arrow-clockwise"></i> Check Now</button>';
     }
 
-    bar.html(html);
+    container.html(html);
+    this._renderVersionSelector();
   },
 
   _onToggleResourceMenu: function(event) {
@@ -745,6 +1084,8 @@ var PipelineListView = Backbone.View.extend({
     this.$('.piko-rsel-menu').removeClass('open');
     if (!canonical || canonical === this.selectedResource) return;
     this.selectedResource = canonical;
+    this._recentVersions = null;
+    this.clearVersionScope();
     localStorage.setItem(this._storagePrefix + 'resource', canonical);
     this.selectedJob = null;
     if (this.jobBuildsView) {
@@ -779,6 +1120,204 @@ var PipelineListView = Backbone.View.extend({
         window.app.apiNotice.set({error: 'Failed to trigger resource check'});
       },
     });
+  },
+
+  // --- Version selector & scoping ---
+
+  _renderVersionSelector: function() {
+    // Skip re-render when the version menu is open to avoid destroying it
+    if (this.$('.piko-vsel-menu').hasClass('open')) {
+      return;
+    }
+    var wrap = this.$('.piko-vsel-wrap');
+    if (!this.selectedResource) {
+      wrap.empty();
+      return;
+    }
+    var label = this._scopedVersionRef || 'All';
+    var html = '<button class="piko-vsel-btn" type="button">';
+    html += '<i class="bi bi-signpost-2"></i>';
+    html += '<span>' + _.escape(label) + '</span>';
+    html += '<i class="bi bi-chevron-down"></i>';
+    html += '</button>';
+    html += '<div class="piko-vsel-menu">';
+    html += '<div class="piko-vsel-item piko-vsel-item-all" data-version-id="">All versions</div>';
+    if (this._recentVersions) {
+      for (var i = 0; i < this._recentVersions.length; i++) {
+        var v = this._recentVersions[i];
+        var ref = '';
+        if (v.version) {
+          ref = versionRef(v.version);
+        }
+        var status = v.status || '';
+        var active = (this._scopedVersionID && this._scopedVersionID === v.id) ? ' active' : '';
+        html += '<div class="piko-vsel-item' + active + '" data-version-id="' + v.id + '" data-version-ref="' + _.escape(ref) + '">';
+        html += '<span class="piko-vsel-dot piko-status-dot-' + status + '"></span>';
+        html += '<span class="piko-vsel-ref">' + _.escape(ref) + '</span>';
+        html += '</div>';
+      }
+    }
+    html += '</div>';
+    wrap.html(html);
+    // Fetch recent versions if not loaded
+    if (!this._recentVersions) {
+      this._fetchRecentVersions();
+    }
+  },
+
+  _fetchRecentVersions: function() {
+    if (!this.selectedResource) return;
+    var that = this;
+    var url = this.pipeline.url() + '/resources/' + this.selectedResource + '/versions?limit=10';
+    $.ajax({
+      url: url,
+      type: 'GET',
+      contentType: 'application/json',
+      headers: session.isEmpty() ? {} : { 'Authorization': 'Bearer ' + session.get('jwt') },
+      success: function(resp) {
+        if (resp && resp.data) {
+          that._recentVersions = resp.data;
+          // If menu is open, update items in-place instead of full re-render
+          var menu = that.$('.piko-vsel-menu');
+          if (menu.hasClass('open')) {
+            that._updateVersionMenuItems(menu);
+          } else {
+            that._renderVersionSelector();
+          }
+        }
+      },
+    });
+  },
+
+  _updateVersionMenuItems: function(menu) {
+    var html = '<div class="piko-vsel-item piko-vsel-item-all" data-version-id="">All versions</div>';
+    if (this._recentVersions) {
+      for (var i = 0; i < this._recentVersions.length; i++) {
+        var v = this._recentVersions[i];
+        var ref = '';
+        if (v.version) {
+          ref = versionRef(v.version);
+        }
+        var status = v.status || '';
+        var active = (this._scopedVersionID && this._scopedVersionID === v.id) ? ' active' : '';
+        html += '<div class="piko-vsel-item' + active + '" data-version-id="' + v.id + '" data-version-ref="' + _.escape(ref) + '">';
+        html += '<span class="piko-vsel-dot piko-status-dot-' + status + '"></span>';
+        html += '<span class="piko-vsel-ref">' + _.escape(ref) + '</span>';
+        html += '</div>';
+      }
+    }
+    menu.html(html);
+  },
+
+  _onToggleVersionMenu: function(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    var menu = this.$('.piko-vsel-menu');
+    var isOpen = menu.hasClass('open');
+    menu.toggleClass('open');
+    if (!isOpen) {
+      this._fetchRecentVersions();
+      var that = this;
+      setTimeout(function() {
+        $(document).one('click', function() { that.$('.piko-vsel-menu').removeClass('open'); });
+      }, 0);
+    }
+  },
+
+  _onSelectVersion: function(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    this.$('.piko-vsel-menu').removeClass('open');
+    var el = $(event.currentTarget);
+    var versionID = el.data('version-id');
+    if (versionID === '' || versionID === undefined) {
+      // "All" selected - clear scope
+      this.clearVersionScope();
+      if (this.parentShowView) {
+        this.parentShowView.clearVersionScope();
+      }
+      return;
+    }
+    var ref = el.data('version-ref') || '';
+    this._scopedVersionID = parseInt(versionID, 10);
+    this._scopedVersionRef = ref;
+    this._renderVersionSelector();
+    // Trigger tracking on parent PipelineShowView (updates banner, graph, and polls)
+    if (this.parentShowView && this.parentShowView.trackVersion) {
+      this.parentShowView.trackVersion(this.selectedResource, this._scopedVersionID, ref);
+    } else {
+      // Fallback: fetch path directly for list-only scoping
+      var url = this.pipeline.url() + '/resources/' + this.selectedResource + '/versions/' + this._scopedVersionID + '/path';
+      var that = this;
+      $.ajax({
+        url: url, type: 'GET', contentType: 'application/json',
+        headers: session.isEmpty() ? {} : { 'Authorization': 'Bearer ' + session.get('jwt') },
+        success: function(resp) {
+          if (resp && resp.data) {
+            that.applyVersionScope(resp.data);
+          }
+        },
+      });
+    }
+  },
+
+  applyVersionScope: function(pathData) {
+    if (!pathData || !pathData.path) return;
+    this._versionPathData = pathData;
+    if (pathData.resource && pathData.resource.version) {
+      var v = pathData.resource.version;
+      this._scopedVersionRef = versionRef(v);
+    }
+    // Try to extract version ID from path builds if not already set
+    if (!this._scopedVersionID) {
+      for (var i = 0; i < pathData.path.length; i++) {
+        if (pathData.path[i].build && pathData.path[i].build.version_id) {
+          this._scopedVersionID = pathData.path[i].build.version_id;
+          break;
+        }
+      }
+    }
+    // Override chain with path job names
+    var pathJobs = [];
+    var pathBuildMap = {};
+    for (var i = 0; i < pathData.path.length; i++) {
+      pathJobs.push(pathData.path[i].job_name);
+      if (pathData.path[i].build) {
+        pathBuildMap[pathData.path[i].job_name] = pathData.path[i].build;
+      }
+    }
+    var wasScoped = !!this._versionChainJobs;
+    this._versionChainJobs = pathJobs;
+    this._versionBuildMap = pathBuildMap;
+    this.chainJobs = pathJobs;
+    this._renderJobList();
+    this._renderVersionSelector();
+    // Only re-select the job when the scope is first applied (not on every poll)
+    if (!wasScoped) {
+      if (this.selectedJob && pathJobs.indexOf(this.selectedJob) >= 0) {
+        this._selectJob(this.selectedJob);
+      } else if (pathJobs.length > 0) {
+        this._selectJob(pathJobs[0]);
+      }
+    }
+  },
+
+  clearVersionScope: function() {
+    this._scopedVersionID = null;
+    this._scopedVersionRef = null;
+    this._versionPathData = null;
+    this._versionChainJobs = null;
+    this._versionBuildMap = null;
+    // Re-resolve normal chain
+    if (this.selectedResource) {
+      this.chainJobs = this._resolveChain(this.selectedResource);
+    }
+    this._renderJobList();
+    this._renderVersionSelector();
+    // Re-select current job to show all builds (no version filter)
+    if (this.selectedJob) {
+      this._selectJob(this.selectedJob);
+    }
   },
 
   // --- Data fetching ---
@@ -876,8 +1415,22 @@ var PipelineListView = Backbone.View.extend({
   _renderJobList: function() {
     if (!this.selectedResource) return;
 
-    this.chainJobs = this._resolveChain(this.selectedResource);
+    // Use version-scoped chain if tracking, otherwise resolve from pipeline
+    if (!this._versionChainJobs) {
+      this.chainJobs = this._resolveChain(this.selectedResource);
+    }
     var statusMap = this._buildStatusMap();
+    // When version-scoped, override status with the tracked version's build status
+    if (this._versionBuildMap) {
+      for (var jn in this._versionBuildMap) {
+        if (this._versionBuildMap.hasOwnProperty(jn)) {
+          var b = this._versionBuildMap[jn];
+          statusMap[jn] = statusMap[jn] || {};
+          statusMap[jn].latest_status = b.status;
+          statusMap[jn].has_running = (b.status === 'started' || b.status === 'pending');
+        }
+      }
+    }
     var tree = this._buildTree(this.chainJobs);
 
     // Render tree recursively. Siblings (jobs sharing the same set of parents)
@@ -1084,10 +1637,14 @@ var PipelineListView = Backbone.View.extend({
   _selectJob: function(jobName) {
     this.selectedJob = jobName;
     localStorage.setItem(this._storagePrefix + 'job', jobName);
-    // Update URL to match the job builds path
+    // Update URL to match the job builds path, preserving ?version= if tracking
     var tc = this.pipeline.collection ? this.pipeline.collection.team.get('canonical') : '';
     var pc = this.pipeline.get('canonical');
     window.app.router.navigate('teams/' + tc + '/pipelines/' + pc + '/jobs/' + jobName + '/builds', { trigger: false, replace: true });
+    var trackedVID = (this.parentShowView && this.parentShowView.trackedVersion) ? this.parentShowView.trackedVersion.versionID : null;
+    if (trackedVID) {
+      window.history.replaceState(null, '', window.location.pathname + '?version=' + trackedVID);
+    }
     this.$('.piko-job-row').removeClass('active');
     this.$('.piko-job-row[data-job="' + jobName + '"]').addClass('active');
 
@@ -1111,6 +1668,7 @@ var PipelineListView = Backbone.View.extend({
           job: jb,
           pipeline: that.pipeline,
           embedded: true,
+          trackedVersionID: trackedVID,
         });
         that.jobBuildsView.render();
       },

--- a/pikoci/transport/http/assets/js/app/views/resources.js
+++ b/pikoci/transport/http/assets/js/app/views/resources.js
@@ -187,6 +187,7 @@ export var ResourceVersionsView = Backbone.View.extend({
 var ResourceVersionView = Backbone.View.extend({
   template: _.template($('#resource-version-view').html()),
   events: {
+    'click .track-version': 'clickTrackVersion',
     'click .trigger-version': 'clickTriggerVersion',
     'click .pin-version': 'clickPinVersion',
   },
@@ -199,9 +200,21 @@ var ResourceVersionView = Backbone.View.extend({
     var data = this.model.toJSON();
     data.isFirst = this.isFirst;
     data.pinned_version_id = this.resource.get('pinned_version_id');
+    // Read tracked version from URL query param (not the router property, which is transient)
+    var urlParams = new URLSearchParams(window.location.search);
+    data.tracked_version_id = urlParams.get('version') ? parseInt(urlParams.get('version'), 10) : null;
     data.isMember = session.isMember(this.resource.collection.pipeline.collection.team.get('canonical'));
     this.$el.html(this.template(data));
     return this;
+  },
+  clickTrackVersion: function(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    var versionID = this.model.get('id');
+    var rs = this.resource;
+    var tc = rs.collection.pipeline.collection.team.get('canonical');
+    var pn = rs.collection.pipeline.get('canonical');
+    window.app.router.navigate('teams/' + tc + '/pipelines/' + pn + '?version=' + versionID, { trigger: true });
   },
   clickTriggerVersion: function(event) {
     event.preventDefault();

--- a/pikoci/transport/http/authorization.go
+++ b/pikoci/transport/http/authorization.go
@@ -70,6 +70,7 @@ var (
 		PinResourceVersion:     member,
 		UnpinResourceVersion:   member,
 		TriggerResourceVersion: member,
+		GetResourceVersionPath: member,
 
 		WebhookTrigger:         nothing,
 		RegenerateWebhookToken: admin,

--- a/pikoci/transport/http/client/client.go
+++ b/pikoci/transport/http/client/client.go
@@ -407,8 +407,8 @@ func (cl *Client) GetPublicPipeline(ctx context.Context, tc, pn string) (*pipeli
 }
 
 // GetPublicPipelineImage retrieves a public pipeline's image. It delegates to GetPipelineImage.
-func (cl *Client) GetPublicPipelineImage(ctx context.Context, tc, pn, format string, hideIntermediates, groupParallel bool) ([]byte, error) {
-	return cl.GetPipelineImage(ctx, tc, pn, format, hideIntermediates, groupParallel)
+func (cl *Client) GetPublicPipelineImage(ctx context.Context, tc, pn, format string, hideIntermediates, groupParallel bool, versionID *uint32) ([]byte, error) {
+	return cl.GetPipelineImage(ctx, tc, pn, format, hideIntermediates, groupParallel, versionID)
 }
 
 
@@ -436,6 +436,24 @@ func (cl *Client) GetPublicPipelineResource(ctx context.Context, tc, pn, rCan st
 // ListPublicResourceVersions lists versions for a resource on a public pipeline. It delegates to ListResourceVersions.
 func (cl *Client) ListPublicResourceVersions(ctx context.Context, tc, pn, rCan string, before *uint32, after *uint32, limit uint32) ([]*resource.Version, bool, error) {
 	return cl.ListResourceVersions(ctx, tc, pn, rCan, before, after, limit)
+}
+
+// GetResourceVersionPath retrieves the version path for a specific resource version.
+func (cl *Client) GetResourceVersionPath(ctx context.Context, tc, pn, rCan string, versionID uint32) (*resource.VersionPathResponse, error) {
+	var resp thttp.GetResourceVersionPathResponse
+	err := cl.Request(ctx, http.MethodGet, fmt.Sprintf("%s/teams/%s/pipelines/%s/resources/%s/versions/%d/path", cl.url, tc, pn, rCan, versionID), nil, &resp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make request: %w", err)
+	}
+	if resp.Err != "" {
+		return nil, fmt.Errorf("error from request: %s", resp.Err)
+	}
+	return resp.Data, nil
+}
+
+// GetPublicResourceVersionPath retrieves the version path for a public pipeline. It delegates to GetResourceVersionPath.
+func (cl *Client) GetPublicResourceVersionPath(ctx context.Context, tc, pn, rCan string, versionID uint32) (*resource.VersionPathResponse, error) {
+	return cl.GetResourceVersionPath(ctx, tc, pn, rCan, versionID)
 }
 
 // UpdatePipeline updates an existing pipeline's configuration, variables, and optionally its name.
@@ -478,13 +496,16 @@ func (cl *Client) GetPipeline(ctx context.Context, tc, pn string) (*pipeline.Pip
 }
 
 // GetPipelineImage retrieves the rendered image of a pipeline in the given format.
-func (cl *Client) GetPipelineImage(ctx context.Context, tc, pn, format string, hideIntermediates, groupParallel bool) ([]byte, error) {
+func (cl *Client) GetPipelineImage(ctx context.Context, tc, pn, format string, hideIntermediates, groupParallel bool, versionID *uint32) ([]byte, error) {
 	var params []string
 	if hideIntermediates {
 		params = append(params, "hide_intermediates=1")
 	}
 	if groupParallel {
 		params = append(params, "group_parallel=1")
+	}
+	if versionID != nil {
+		params = append(params, fmt.Sprintf("version_id=%d", *versionID))
 	}
 	q := ""
 	if len(params) > 0 {

--- a/pikoci/transport/http/client/client_test.go
+++ b/pikoci/transport/http/client/client_test.go
@@ -434,7 +434,7 @@ func TestGetPipelineImage_DOT(t *testing.T) {
 	c, err := client.New(ts.URL, "jwt")
 	require.NoError(t, err)
 
-	img, err := c.GetPipelineImage(context.Background(), "team", "mypipe", "dot", false, false)
+	img, err := c.GetPipelineImage(context.Background(), "team", "mypipe", "dot", false, false, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("dot-data"), img)
 }
@@ -451,7 +451,7 @@ func TestGetPipelineImage_SVG(t *testing.T) {
 	c, err := client.New(ts.URL, "jwt")
 	require.NoError(t, err)
 
-	img, err := c.GetPipelineImage(context.Background(), "team", "mypipe", "svg", false, false)
+	img, err := c.GetPipelineImage(context.Background(), "team", "mypipe", "svg", false, false, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("svg-data"), img)
 }
@@ -468,7 +468,7 @@ func TestGetPipelineImage_PNG(t *testing.T) {
 	c, err := client.New(ts.URL, "jwt")
 	require.NoError(t, err)
 
-	img, err := c.GetPipelineImage(context.Background(), "team", "mypipe", "png", false, false)
+	img, err := c.GetPipelineImage(context.Background(), "team", "mypipe", "png", false, false, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("png-data"), img)
 }
@@ -910,7 +910,7 @@ func TestGetPublicPipelineImage(t *testing.T) {
 	c, err := client.New(ts.URL, "jwt")
 	require.NoError(t, err)
 
-	img, err := c.GetPublicPipelineImage(context.Background(), "team", "mypipe", "dot", false, false)
+	img, err := c.GetPublicPipelineImage(context.Background(), "team", "mypipe", "dot", false, false, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("dot-data"), img)
 }
@@ -2244,7 +2244,7 @@ func TestGetPipelineImage_Error(t *testing.T) {
 	c, err := client.New(ts.URL, "jwt")
 	require.NoError(t, err)
 
-	_, err = c.GetPipelineImage(context.Background(), "team1", "pipe", "dot", false, false)
+	_, err = c.GetPipelineImage(context.Background(), "team1", "pipe", "dot", false, false, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
@@ -2326,7 +2326,7 @@ func TestRequestRaw_Error(t *testing.T) {
 	c, err := client.New(ts.URL, "jwt")
 	require.NoError(t, err)
 
-	_, err = c.GetPipelineImage(context.Background(), "team1", "nopipe", "svg", false, false)
+	_, err = c.GetPipelineImage(context.Background(), "team1", "nopipe", "svg", false, false, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pipeline not found")
 }
@@ -2351,7 +2351,7 @@ func TestRequestRaw_RefreshToken(t *testing.T) {
 	c, err := client.New(ts.URL, "jwt")
 	require.NoError(t, err)
 
-	data, err := c.GetPipelineImage(context.Background(), "team1", "pipe", "svg", false, false)
+	data, err := c.GetPipelineImage(context.Background(), "team1", "pipe", "svg", false, false, nil)
 	require.NoError(t, err)
 	assert.Contains(t, string(data), "<svg>")
 	assert.Equal(t, int32(1), refreshCalled.Load())
@@ -2449,7 +2449,7 @@ func TestGetPublicPipelineImage_DelegatesToGetPipelineImage(t *testing.T) {
 	c, err := client.New(ts.URL, "jwt")
 	require.NoError(t, err)
 
-	img, err := c.GetPublicPipelineImage(context.Background(), "team1", "pipe", "dot", false, false)
+	img, err := c.GetPublicPipelineImage(context.Background(), "team1", "pipe", "dot", false, false, nil)
 	require.NoError(t, err)
 	assert.Contains(t, string(img), "digraph")
 }
@@ -2605,4 +2605,105 @@ func TestDeleteWorker_Error(t *testing.T) {
 	err = c.DeleteWorker(context.Background(), "missing")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "worker not found")
+}
+
+func TestGetResourceVersionPath(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/{pn}/resources/{rCan}/versions/{vid}/path", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.GetResourceVersionPathResponse{
+			Data: &resource.VersionPathResponse{
+				Resource: resource.VersionPathResource{
+					Canonical: "git.repo",
+					Version:   map[string]interface{}{"ref": "abc123"},
+				},
+				Path:      []resource.VersionPathEntry{{JobName: "build"}},
+				Completed: 1,
+				Total:     2,
+			},
+		})
+	}).Methods("GET")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	resp, err := c.GetResourceVersionPath(context.Background(), "team", "pipe", "git.repo", 42)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "git.repo", resp.Resource.Canonical)
+	assert.Equal(t, "abc123", resp.Resource.Version["ref"])
+	assert.Len(t, resp.Path, 1)
+	assert.Equal(t, "build", resp.Path[0].JobName)
+	assert.Equal(t, 1, resp.Completed)
+	assert.Equal(t, 2, resp.Total)
+}
+
+func TestGetResourceVersionPath_Error(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/{pn}/resources/{rCan}/versions/{vid}/path", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.GetResourceVersionPathResponse{Err: "version not found"})
+	}).Methods("GET")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	resp, err := c.GetResourceVersionPath(context.Background(), "team", "pipe", "git.repo", 42)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "version not found")
+	assert.Nil(t, resp)
+}
+
+func TestGetPublicResourceVersionPath_DelegatesToGetResourceVersionPath(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/{pn}/resources/{rCan}/versions/{vid}/path", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.GetResourceVersionPathResponse{
+			Data: &resource.VersionPathResponse{
+				Resource: resource.VersionPathResource{
+					Canonical: "git.repo",
+					Version:   map[string]interface{}{"ref": "def456"},
+				},
+				Path:      []resource.VersionPathEntry{{JobName: "test"}},
+				Completed: 0,
+				Total:     1,
+			},
+		})
+	}).Methods("GET")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	resp, err := c.GetPublicResourceVersionPath(context.Background(), "team", "pipe", "git.repo", 42)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "git.repo", resp.Resource.Canonical)
+	assert.Equal(t, "def456", resp.Resource.Version["ref"])
+	assert.Len(t, resp.Path, 1)
+	assert.Equal(t, "test", resp.Path[0].JobName)
+	assert.Equal(t, 0, resp.Completed)
+	assert.Equal(t, 1, resp.Total)
+}
+
+func TestGetPipelineImage_WithVersionID(t *testing.T) {
+	var capturedURL string
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/{pn}/image.{format}", func(w http.ResponseWriter, req *http.Request) {
+		capturedURL = req.URL.String()
+		jsonHandler(w, thttp.GetPipelineImageResponse{Image: "digraph {}"})
+	}).Methods("GET")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	vid := uint32(99)
+	img, err := c.GetPipelineImage(context.Background(), "team", "pipe", "dot", false, false, &vid)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("digraph {}"), img)
+	assert.Contains(t, capturedURL, "version_id=99")
 }

--- a/pikoci/transport/http/handler.go
+++ b/pikoci/transport/http/handler.go
@@ -39,7 +39,8 @@ var publicFallbackRoutes = map[RouteName]bool{
 	ListJobBuilds:        true,
 	ListPipelineResources: true,
 	GetPipelineResource:   true,
-	ListResourceVersions: true,
+	ListResourceVersions:    true,
+	GetResourceVersionPath:  true,
 }
 
 // Handler creates and returns the main HTTP handler for the PikoCI API.
@@ -267,6 +268,7 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, 
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/resources/{resource_canonical}/pin").Name(PinResourceVersion.String()).Handler(pinResourceVersion(s))
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/resources/{resource_canonical}/unpin").Name(UnpinResourceVersion.String()).Handler(unpinResourceVersion(s))
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/resources/{resource_canonical}/versions/{version_id}/trigger").Name(TriggerResourceVersion.String()).Handler(triggerResourceVersion(s))
+	api.Methods(http.MethodGet).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/resources/{resource_canonical}/versions/{version_id}/path").Name(GetResourceVersionPath.String()).Handler(getResourceVersionPath(s))
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/resources/{resource_canonical}/webhook_token").Name(RegenerateWebhookToken.String()).Handler(regenerateWebhookToken(s))
 
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/triggers/{trigger_name}").Name(CreateTrigger.String()).Handler(createTrigger(s))

--- a/pikoci/transport/http/handler_test.go
+++ b/pikoci/transport/http/handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/pikoci/pikoci/pikoci/mock"
 	"github.com/pikoci/pikoci/pikoci/pipeline"
+	"github.com/pikoci/pikoci/pikoci/resource"
 	"github.com/pikoci/pikoci/pikoci/user"
 	"github.com/pikoci/pikoci/pikoci/wkr"
 	"go.uber.org/mock/gomock"
@@ -551,7 +552,7 @@ func TestGetPipelineImage_DOT_ReturnsJSON(t *testing.T) {
 
 	dotOutput := []byte(`digraph "test" { A -> B; }`)
 	s.EXPECT().GetUser(gomock.Any(), "admin").Return(um, nil).AnyTimes()
-	s.EXPECT().GetPipelineImage(gomock.Any(), "main", "my-pipeline", ".dot", false, false).Return(dotOutput, nil)
+	s.EXPECT().GetPipelineImage(gomock.Any(), "main", "my-pipeline", ".dot", false, false, (*uint32)(nil)).Return(dotOutput, nil)
 
 	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams/main/pipelines/my-pipeline/image.dot", nil)
 	require.NoError(t, err)
@@ -589,7 +590,7 @@ func TestGetPipelineImage_SVG_ReturnsRawSVG(t *testing.T) {
 
 	svgOutput := []byte(`<svg><text>hello</text></svg>`)
 	s.EXPECT().GetUser(gomock.Any(), "admin").Return(um, nil).AnyTimes()
-	s.EXPECT().GetPipelineImage(gomock.Any(), "main", "my-pipeline", ".svg", false, false).Return(svgOutput, nil)
+	s.EXPECT().GetPipelineImage(gomock.Any(), "main", "my-pipeline", ".svg", false, false, (*uint32)(nil)).Return(svgOutput, nil)
 
 	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams/main/pipelines/my-pipeline/image.svg", nil)
 	require.NoError(t, err)
@@ -625,7 +626,7 @@ func TestGetPipelineImage_PNG_ReturnsRawPNG(t *testing.T) {
 
 	pngOutput := []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}
 	s.EXPECT().GetUser(gomock.Any(), "admin").Return(um, nil).AnyTimes()
-	s.EXPECT().GetPipelineImage(gomock.Any(), "main", "my-pipeline", ".png", false, false).Return(pngOutput, nil)
+	s.EXPECT().GetPipelineImage(gomock.Any(), "main", "my-pipeline", ".png", false, false, (*uint32)(nil)).Return(pngOutput, nil)
 
 	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams/main/pipelines/my-pipeline/image.png", nil)
 	require.NoError(t, err)
@@ -661,7 +662,7 @@ func TestGetPipelineImage_SVG_NoJSONHeaderRequired(t *testing.T) {
 
 	svgOutput := []byte(`<svg><text>test</text></svg>`)
 	s.EXPECT().GetUser(gomock.Any(), "admin").Return(um, nil).AnyTimes()
-	s.EXPECT().GetPipelineImage(gomock.Any(), "main", "my-pipeline", ".svg", false, false).Return(svgOutput, nil)
+	s.EXPECT().GetPipelineImage(gomock.Any(), "main", "my-pipeline", ".svg", false, false, (*uint32)(nil)).Return(svgOutput, nil)
 
 	// No Content-Type header — simulates browser request
 	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams/main/pipelines/my-pipeline/image.svg", nil)
@@ -690,7 +691,7 @@ func TestGetPipelineImage_PublicFallback_SVG(t *testing.T) {
 	s.EXPECT().GetPublicPipeline(gomock.Any(), "main", "my-pipeline").Return(&pipeline.Pipeline{
 		Name: "my-pipeline", Canonical: "my-pipeline",
 	}, nil)
-	s.EXPECT().GetPublicPipelineImage(gomock.Any(), "main", "my-pipeline", ".svg", false, false).Return(svgOutput, nil)
+	s.EXPECT().GetPublicPipelineImage(gomock.Any(), "main", "my-pipeline", ".svg", false, false, (*uint32)(nil)).Return(svgOutput, nil)
 
 	// No auth header — should fall back to public
 	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams/main/pipelines/my-pipeline/image.svg", nil)
@@ -725,7 +726,7 @@ func TestGetPipelineImage_Error_ReturnsJSON(t *testing.T) {
 	jwtToken := signJWT(t, secret, um)
 
 	s.EXPECT().GetUser(gomock.Any(), "admin").Return(um, nil).AnyTimes()
-	s.EXPECT().GetPipelineImage(gomock.Any(), "main", "my-pipeline", ".svg", false, false).Return(nil, assert.AnError)
+	s.EXPECT().GetPipelineImage(gomock.Any(), "main", "my-pipeline", ".svg", false, false, (*uint32)(nil)).Return(nil, assert.AnError)
 
 	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams/main/pipelines/my-pipeline/image.svg", nil)
 	require.NoError(t, err)
@@ -948,4 +949,170 @@ func TestDeleteWorker_NonAdminForbidden(t *testing.T) {
 	defer resp.Body.Close()
 
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestGetResourceVersionPath_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	handler := Handler(s, secret, logger, nil, "", "test", "abc1234")
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	um := &user.WithMemberships{
+		User:        user.User{Username: "admin", Admin: true},
+		Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+	}
+	jwtToken := signJWT(t, secret, um)
+
+	versionPath := &resource.VersionPathResponse{
+		Resource: resource.VersionPathResource{
+			Canonical: "git.repo",
+			Version:   map[string]interface{}{"ref": "abc123"},
+		},
+		Path:      []resource.VersionPathEntry{{JobName: "build"}},
+		Completed: 1,
+		Total:     1,
+	}
+	s.EXPECT().GetUser(gomock.Any(), "admin").Return(um, nil).AnyTimes()
+	s.EXPECT().GetResourceVersionPath(gomock.Any(), "main", "my-pipeline", "git.repo", uint32(42)).Return(versionPath, nil)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams/main/pipelines/my-pipeline/resources/git.repo/versions/42/path", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+jwtToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/json")
+
+	var result GetResourceVersionPathResponse
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	require.NoError(t, err)
+	assert.Empty(t, result.Err)
+	require.NotNil(t, result.Data)
+	assert.Equal(t, "git.repo", result.Data.Resource.Canonical)
+	assert.Equal(t, 1, result.Data.Completed)
+	assert.Equal(t, 1, result.Data.Total)
+}
+
+func TestGetResourceVersionPath_InvalidVersionID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	handler := Handler(s, secret, logger, nil, "", "test", "abc1234")
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	um := &user.WithMemberships{
+		User:        user.User{Username: "admin", Admin: true},
+		Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+	}
+	jwtToken := signJWT(t, secret, um)
+
+	s.EXPECT().GetUser(gomock.Any(), "admin").Return(um, nil).AnyTimes()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams/main/pipelines/my-pipeline/resources/git.repo/versions/not-a-number/path", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+jwtToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/json")
+
+	var result GetResourceVersionPathResponse
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	require.NoError(t, err)
+	assert.Equal(t, "invalid version_id", result.Err)
+	assert.Nil(t, result.Data)
+}
+
+func TestGetResourceVersionPath_PublicFallback(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	handler := Handler(s, secret, logger, nil, "", "test", "abc1234")
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	versionPath := &resource.VersionPathResponse{
+		Resource: resource.VersionPathResource{
+			Canonical: "git.repo",
+			Version:   map[string]interface{}{"ref": "def456"},
+		},
+		Path:      []resource.VersionPathEntry{{JobName: "test"}},
+		Completed: 0,
+		Total:     1,
+	}
+	s.EXPECT().GetPublicPipeline(gomock.Any(), "main", "my-pipeline").Return(&pipeline.Pipeline{
+		Name: "my-pipeline", Canonical: "my-pipeline",
+	}, nil)
+	s.EXPECT().GetPublicResourceVersionPath(gomock.Any(), "main", "my-pipeline", "git.repo", uint32(42)).Return(versionPath, nil)
+
+	// No auth header — should fall back to public
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams/main/pipelines/my-pipeline/resources/git.repo/versions/42/path", nil)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/json")
+
+	var result GetResourceVersionPathResponse
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	require.NoError(t, err)
+	assert.Empty(t, result.Err)
+	require.NotNil(t, result.Data)
+	assert.Equal(t, "git.repo", result.Data.Resource.Canonical)
+}
+
+func TestGetResourceVersionPath_Error(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	handler := Handler(s, secret, logger, nil, "", "test", "abc1234")
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	um := &user.WithMemberships{
+		User:        user.User{Username: "admin", Admin: true},
+		Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+	}
+	jwtToken := signJWT(t, secret, um)
+
+	s.EXPECT().GetUser(gomock.Any(), "admin").Return(um, nil).AnyTimes()
+	s.EXPECT().GetResourceVersionPath(gomock.Any(), "main", "my-pipeline", "git.repo", uint32(42)).Return(nil, assert.AnError)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams/main/pipelines/my-pipeline/resources/git.repo/versions/42/path", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+jwtToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/json")
+
+	var result GetResourceVersionPathResponse
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	require.NoError(t, err)
+	assert.NotEmpty(t, result.Err)
 }

--- a/pikoci/transport/http/pipelines.go
+++ b/pikoci/transport/http/pipelines.go
@@ -3,6 +3,7 @@ package http
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/gorilla/mux"
@@ -228,12 +229,20 @@ func getPipelineImage(s pikoci.Service) http.HandlerFunc {
 		req.Format = vars["ext"]
 		hideIntermediates := r.URL.Query().Get("hide_intermediates") == "1"
 		groupParallel := r.URL.Query().Get("group_parallel") == "1"
+		var versionID *uint32
+		if vidStr := r.URL.Query().Get("version_id"); vidStr != "" {
+			vid, err := strconv.ParseUint(vidStr, 10, 32)
+			if err == nil {
+				v := uint32(vid)
+				versionID = &v
+			}
+		}
 		var img []byte
 		var err error
 		if isPublic, _ := ctx.Value(IsPublicAccessKey).(bool); isPublic {
-			img, err = s.GetPublicPipelineImage(ctx, req.TeamCanonical, req.Name, req.Format, hideIntermediates, groupParallel)
+			img, err = s.GetPublicPipelineImage(ctx, req.TeamCanonical, req.Name, req.Format, hideIntermediates, groupParallel, versionID)
 		} else {
-			img, err = s.GetPipelineImage(ctx, req.TeamCanonical, req.Name, req.Format, hideIntermediates, groupParallel)
+			img, err = s.GetPipelineImage(ctx, req.TeamCanonical, req.Name, req.Format, hideIntermediates, groupParallel, versionID)
 		}
 		if err != nil {
 			encodeResponse(GetPipelineImageResponse{Err: err.Error()}, w)

--- a/pikoci/transport/http/resources.go
+++ b/pikoci/transport/http/resources.go
@@ -355,6 +355,40 @@ func triggerResourceVersion(s pikoci.Service) http.HandlerFunc {
 	}
 }
 
+type GetResourceVersionPathResponse struct {
+	Data *resource.VersionPathResponse `json:"data,omitempty"`
+	Err  string                        `json:"error,omitempty"`
+}
+
+func (r GetResourceVersionPathResponse) Error() string { return r.Err }
+
+func getResourceVersionPath(s pikoci.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		tc := vars["team_canonical"]
+		pc := vars["pipeline_canonical"]
+		rCan := vars["resource_canonical"]
+		versionIDStr := vars["version_id"]
+		versionID, err := strconv.ParseUint(versionIDStr, 10, 32)
+		if err != nil {
+			encodeResponse(GetResourceVersionPathResponse{Err: "invalid version_id"}, w)
+			return
+		}
+		ctx := r.Context()
+		var resp *resource.VersionPathResponse
+		if isPublic, _ := ctx.Value(IsPublicAccessKey).(bool); isPublic {
+			resp, err = s.GetPublicResourceVersionPath(ctx, tc, pc, rCan, uint32(versionID))
+		} else {
+			resp, err = s.GetResourceVersionPath(ctx, tc, pc, rCan, uint32(versionID))
+		}
+		var errs string
+		if err != nil {
+			errs = err.Error()
+		}
+		encodeResponse(GetResourceVersionPathResponse{Data: resp, Err: errs}, w)
+	}
+}
+
 func triggerPipelineResource(s pikoci.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var (

--- a/pikoci/transport/http/route_names.go
+++ b/pikoci/transport/http/route_names.go
@@ -117,6 +117,9 @@ const (
 	// TriggerResourceVersion is the route for triggering downstream jobs with a specific version.
 	TriggerResourceVersion
 
+	// GetResourceVersionPath is the route for retrieving a version's path through the pipeline.
+	GetResourceVersionPath
+
 	// WebhookTrigger is the route for incoming webhook triggers.
 	WebhookTrigger
 	// RegenerateWebhookToken is the route for regenerating a resource's webhook token.

--- a/pikoci/transport/http/route_names_string.go
+++ b/pikoci/transport/http/route_names_string.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _RouteNameName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_joblist_pipeline_jobsget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobslist_pipeline_resourcesget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_worker"
+const _RouteNameName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_joblist_pipeline_jobsget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobslist_pipeline_resourcesget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionget_resource_version_pathwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_worker"
 
-var _RouteNameIndex = [...]uint16{0, 10, 23, 34, 44, 52, 63, 74, 89, 103, 114, 124, 132, 143, 154, 172, 190, 208, 223, 238, 250, 265, 279, 297, 318, 338, 356, 372, 388, 410, 426, 442, 457, 481, 504, 517, 533, 548, 567, 592, 626, 650, 673, 694, 718, 743, 766, 788, 808, 830, 854, 869, 893, 907, 926, 941, 955, 971, 980, 991, 1002, 1018, 1030, 1044, 1057}
+var _RouteNameIndex = [...]uint16{0, 10, 23, 34, 44, 52, 63, 74, 89, 103, 114, 124, 132, 143, 154, 172, 190, 208, 223, 238, 250, 265, 279, 297, 318, 338, 356, 372, 388, 410, 426, 442, 457, 481, 504, 517, 533, 548, 567, 592, 626, 650, 673, 694, 718, 743, 766, 788, 808, 830, 854, 879, 894, 918, 932, 951, 966, 980, 996, 1005, 1016, 1027, 1043, 1055, 1069, 1082}
 
-const _RouteNameLowerName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_joblist_pipeline_jobsget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobslist_pipeline_resourcesget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_worker"
+const _RouteNameLowerName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_joblist_pipeline_jobsget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobslist_pipeline_resourcesget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionget_resource_version_pathwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_worker"
 
 func (i RouteName) String() string {
 	if i < 0 || i >= RouteName(len(_RouteNameIndex)-1) {
@@ -74,23 +74,24 @@ func _RouteNameNoOp() {
 	_ = x[PinResourceVersion-(47)]
 	_ = x[UnpinResourceVersion-(48)]
 	_ = x[TriggerResourceVersion-(49)]
-	_ = x[WebhookTrigger-(50)]
-	_ = x[RegenerateWebhookToken-(51)]
-	_ = x[CreateTrigger-(52)]
-	_ = x[ListTriggersAfter-(53)]
-	_ = x[ExportDatabase-(54)]
-	_ = x[PausePipeline-(55)]
-	_ = x[UnpausePipeline-(56)]
-	_ = x[PauseJob-(57)]
-	_ = x[UnpauseJob-(58)]
-	_ = x[GetVersion-(59)]
-	_ = x[WorkerHeartbeat-(60)]
-	_ = x[ListWorkers-(61)]
-	_ = x[WorkersHealth-(62)]
-	_ = x[DeleteWorker-(63)]
+	_ = x[GetResourceVersionPath-(50)]
+	_ = x[WebhookTrigger-(51)]
+	_ = x[RegenerateWebhookToken-(52)]
+	_ = x[CreateTrigger-(53)]
+	_ = x[ListTriggersAfter-(54)]
+	_ = x[ExportDatabase-(55)]
+	_ = x[PausePipeline-(56)]
+	_ = x[UnpausePipeline-(57)]
+	_ = x[PauseJob-(58)]
+	_ = x[UnpauseJob-(59)]
+	_ = x[GetVersion-(60)]
+	_ = x[WorkerHeartbeat-(61)]
+	_ = x[ListWorkers-(62)]
+	_ = x[WorkersHealth-(63)]
+	_ = x[DeleteWorker-(64)]
 }
 
-var _RouteNameValues = []RouteName{UserLogin, RefreshToken, CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser, ChangePassword, UpdateProfile, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, ListPipelineJobs, GetPipelineJob, CreateJobBuild, CreateRetryJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, InsertBuildGetVersion, FindBuildGetVersions, GetJobBuild, CancelJobBuild, RetryJobBuild, StartPendingBuild, FindOldestPendingBuild, NotifySerialGroupPendingBuilds, EvaluateDownstreamJobs, ListPipelineResources, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions, PinResourceVersion, UnpinResourceVersion, TriggerResourceVersion, WebhookTrigger, RegenerateWebhookToken, CreateTrigger, ListTriggersAfter, ExportDatabase, PausePipeline, UnpausePipeline, PauseJob, UnpauseJob, GetVersion, WorkerHeartbeat, ListWorkers, WorkersHealth, DeleteWorker}
+var _RouteNameValues = []RouteName{UserLogin, RefreshToken, CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser, ChangePassword, UpdateProfile, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, ListPipelineJobs, GetPipelineJob, CreateJobBuild, CreateRetryJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, InsertBuildGetVersion, FindBuildGetVersions, GetJobBuild, CancelJobBuild, RetryJobBuild, StartPendingBuild, FindOldestPendingBuild, NotifySerialGroupPendingBuilds, EvaluateDownstreamJobs, ListPipelineResources, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions, PinResourceVersion, UnpinResourceVersion, TriggerResourceVersion, GetResourceVersionPath, WebhookTrigger, RegenerateWebhookToken, CreateTrigger, ListTriggersAfter, ExportDatabase, PausePipeline, UnpausePipeline, PauseJob, UnpauseJob, GetVersion, WorkerHeartbeat, ListWorkers, WorkersHealth, DeleteWorker}
 
 var _RouteNameNameToValueMap = map[string]RouteName{
 	_RouteNameName[0:10]:           UserLogin,
@@ -193,34 +194,36 @@ var _RouteNameNameToValueMap = map[string]RouteName{
 	_RouteNameLowerName[808:830]:   UnpinResourceVersion,
 	_RouteNameName[830:854]:        TriggerResourceVersion,
 	_RouteNameLowerName[830:854]:   TriggerResourceVersion,
-	_RouteNameName[854:869]:        WebhookTrigger,
-	_RouteNameLowerName[854:869]:   WebhookTrigger,
-	_RouteNameName[869:893]:        RegenerateWebhookToken,
-	_RouteNameLowerName[869:893]:   RegenerateWebhookToken,
-	_RouteNameName[893:907]:        CreateTrigger,
-	_RouteNameLowerName[893:907]:   CreateTrigger,
-	_RouteNameName[907:926]:        ListTriggersAfter,
-	_RouteNameLowerName[907:926]:   ListTriggersAfter,
-	_RouteNameName[926:941]:        ExportDatabase,
-	_RouteNameLowerName[926:941]:   ExportDatabase,
-	_RouteNameName[941:955]:        PausePipeline,
-	_RouteNameLowerName[941:955]:   PausePipeline,
-	_RouteNameName[955:971]:        UnpausePipeline,
-	_RouteNameLowerName[955:971]:   UnpausePipeline,
-	_RouteNameName[971:980]:        PauseJob,
-	_RouteNameLowerName[971:980]:   PauseJob,
-	_RouteNameName[980:991]:        UnpauseJob,
-	_RouteNameLowerName[980:991]:   UnpauseJob,
-	_RouteNameName[991:1002]:       GetVersion,
-	_RouteNameLowerName[991:1002]:  GetVersion,
-	_RouteNameName[1002:1018]:      WorkerHeartbeat,
-	_RouteNameLowerName[1002:1018]: WorkerHeartbeat,
-	_RouteNameName[1018:1030]:      ListWorkers,
-	_RouteNameLowerName[1018:1030]: ListWorkers,
-	_RouteNameName[1030:1044]:      WorkersHealth,
-	_RouteNameLowerName[1030:1044]: WorkersHealth,
-	_RouteNameName[1044:1057]:      DeleteWorker,
-	_RouteNameLowerName[1044:1057]: DeleteWorker,
+	_RouteNameName[854:879]:        GetResourceVersionPath,
+	_RouteNameLowerName[854:879]:   GetResourceVersionPath,
+	_RouteNameName[879:894]:        WebhookTrigger,
+	_RouteNameLowerName[879:894]:   WebhookTrigger,
+	_RouteNameName[894:918]:        RegenerateWebhookToken,
+	_RouteNameLowerName[894:918]:   RegenerateWebhookToken,
+	_RouteNameName[918:932]:        CreateTrigger,
+	_RouteNameLowerName[918:932]:   CreateTrigger,
+	_RouteNameName[932:951]:        ListTriggersAfter,
+	_RouteNameLowerName[932:951]:   ListTriggersAfter,
+	_RouteNameName[951:966]:        ExportDatabase,
+	_RouteNameLowerName[951:966]:   ExportDatabase,
+	_RouteNameName[966:980]:        PausePipeline,
+	_RouteNameLowerName[966:980]:   PausePipeline,
+	_RouteNameName[980:996]:        UnpausePipeline,
+	_RouteNameLowerName[980:996]:   UnpausePipeline,
+	_RouteNameName[996:1005]:       PauseJob,
+	_RouteNameLowerName[996:1005]:  PauseJob,
+	_RouteNameName[1005:1016]:      UnpauseJob,
+	_RouteNameLowerName[1005:1016]: UnpauseJob,
+	_RouteNameName[1016:1027]:      GetVersion,
+	_RouteNameLowerName[1016:1027]: GetVersion,
+	_RouteNameName[1027:1043]:      WorkerHeartbeat,
+	_RouteNameLowerName[1027:1043]: WorkerHeartbeat,
+	_RouteNameName[1043:1055]:      ListWorkers,
+	_RouteNameLowerName[1043:1055]: ListWorkers,
+	_RouteNameName[1055:1069]:      WorkersHealth,
+	_RouteNameLowerName[1055:1069]: WorkersHealth,
+	_RouteNameName[1069:1082]:      DeleteWorker,
+	_RouteNameLowerName[1069:1082]: DeleteWorker,
 }
 
 var _RouteNameNames = []string{
@@ -274,20 +277,21 @@ var _RouteNameNames = []string{
 	_RouteNameName[788:808],
 	_RouteNameName[808:830],
 	_RouteNameName[830:854],
-	_RouteNameName[854:869],
-	_RouteNameName[869:893],
-	_RouteNameName[893:907],
-	_RouteNameName[907:926],
-	_RouteNameName[926:941],
-	_RouteNameName[941:955],
-	_RouteNameName[955:971],
-	_RouteNameName[971:980],
-	_RouteNameName[980:991],
-	_RouteNameName[991:1002],
-	_RouteNameName[1002:1018],
-	_RouteNameName[1018:1030],
-	_RouteNameName[1030:1044],
-	_RouteNameName[1044:1057],
+	_RouteNameName[854:879],
+	_RouteNameName[879:894],
+	_RouteNameName[894:918],
+	_RouteNameName[918:932],
+	_RouteNameName[932:951],
+	_RouteNameName[951:966],
+	_RouteNameName[966:980],
+	_RouteNameName[980:996],
+	_RouteNameName[996:1005],
+	_RouteNameName[1005:1016],
+	_RouteNameName[1016:1027],
+	_RouteNameName[1027:1043],
+	_RouteNameName[1043:1055],
+	_RouteNameName[1055:1069],
+	_RouteNameName[1069:1082],
 }
 
 // RouteNameString retrieves an enum value from the enum constants string name.

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -313,6 +313,16 @@
           </div>
         </div>
       </div>
+      <div id="version-scope-banner" class="piko-version-banner" style="display:none;">
+        <div class="piko-version-banner-inner">
+          <i class="bi bi-signpost-2 piko-version-banner-icon"></i>
+          <span class="piko-version-banner-label">Tracking version</span>
+          <span class="piko-version-banner-resource" id="version-banner-resource"></span>
+          <span class="piko-version-banner-ref" id="version-banner-ref"></span>
+          <span class="piko-version-banner-progress" id="version-banner-progress"></span>
+          <button class="piko-version-banner-clear" id="clear-version-scope"><i class="bi bi-x-lg"></i> Clear</button>
+        </div>
+      </div>
       <div class="piko-pipeline-body">
       <div id="pipeline-resources-panel" class="piko-resources-panel"></div>
       <div class="piko-view-graph">
@@ -351,7 +361,9 @@
         </div>
       </div>
       <div class="piko-view-list" style="display:none">
-        <div class="piko-list-resource-bar"></div>
+        <div class="piko-list-resource-bar">
+          <div class="piko-rsel-container"></div>
+        </div>
         <div class="piko-list-panels">
           <div class="piko-list-left">
             <div class="piko-job-list"></div>
@@ -378,7 +390,7 @@
           <p class="piko-resource-card-meta small mb-0">No resources in this pipeline.</p>
         <% } else { %>
           <% _.each(resources, function(r) { %>
-            <div class="piko-resource-card">
+            <div class="piko-resource-card" data-canonical="<%- r.canonical %>">
               <div class="piko-resource-card-header">
                 <% if (r.latest_version && r.latest_version.status) { %>
                   <span class="piko-version-status-dot" style="background:var(--status-<%- r.latest_version.status %>);" title="<%- r.latest_version.status %>"></span>
@@ -402,10 +414,16 @@
                 <% } %>
               </div>
               <% if (isMember) { %>
-                <button class="btn btn-sm btn-outline-warning check-resource-now mt-1" data-canonical="<%- r.canonical %>">
-                  <i class="bi bi-arrow-clockwise"></i> Check Now
-                </button>
+                <div class="piko-resource-card-actions mt-1">
+                  <button class="btn btn-sm btn-outline-warning check-resource-now" data-canonical="<%- r.canonical %>">
+                    <i class="bi bi-arrow-clockwise"></i> Check Now
+                  </button>
+                  <button class="piko-resource-expand-toggle" data-canonical="<%- r.canonical %>">
+                    <i class="bi bi-chevron-down"></i> Versions
+                  </button>
+                </div>
               <% } %>
+              <div class="piko-resource-panel-versions" data-canonical="<%- r.canonical %>" style="display:none;"></div>
             </div>
           <% }); %>
         <% } %>
@@ -512,6 +530,15 @@
               <button type="button" id="pause-job" class="btn btn-primary" data-loading-text="Pausing..."><i class="bi bi-pause-circle"></i> Pause Job</button>
             <% } %>
           <% } %>
+        </div>
+      </div>
+      <div id="job-version-banner" class="piko-version-banner" style="display:none;">
+        <div class="piko-version-banner-inner">
+          <i class="bi bi-signpost-2 piko-version-banner-icon"></i>
+          <span class="piko-version-banner-label">Tracking version</span>
+          <span class="piko-version-banner-resource" id="job-version-banner-resource"></span>
+          <span class="piko-version-banner-ref" id="job-version-banner-ref"></span>
+          <a href="#" id="job-version-back" class="piko-version-banner-clear"><i class="bi bi-arrow-left"></i> Back to pipeline</a>
         </div>
       </div>
       <div class="piko-build-tabs" id="builds-tabs">
@@ -778,6 +805,9 @@
             <% if (pinned_version_id === id) { %>
               <span class="piko-badge piko-badge-pending">pinned</span>
             <% } %>
+            <% if (tracked_version_id === id) { %>
+              <span class="piko-badge piko-badge-primary"><i class="bi bi-signpost-2"></i> tracked</span>
+            <% } %>
             <% if (status) { %>
               <span class="piko-version-status-dot" style="background:var(--status-<%- status %>);" title="<%- status %>"></span>
             <% } %>
@@ -789,6 +819,7 @@
           </span>
           <% if (isMember) { %>
             <span class="piko-version-actions">
+              <button class="btn btn-sm btn-outline-primary track-version" title="Track this version through the pipeline"><i class="bi bi-signpost-2"></i></button>
               <button class="btn btn-sm btn-outline-warning trigger-version" title="Trigger downstream jobs with this version" data-loading-text="Triggering..."><i class="bi bi-play-fill"></i></button>
               <button class="btn btn-sm <%= pinned_version_id === id ? 'btn-warning' : 'btn-outline-secondary' %> pin-version" title="<%= pinned_version_id === id ? 'Unpin version' : 'Pin to this version' %>"><i class="bi <%= pinned_version_id === id ? 'bi-pin-fill' : 'bi-pin' %>"></i></button>
             </span>

--- a/pikoci/version_path.go
+++ b/pikoci/version_path.go
@@ -1,0 +1,272 @@
+package pikoci
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pikoci/pikoci/pikoci/build"
+	"github.com/pikoci/pikoci/pikoci/job"
+	"github.com/pikoci/pikoci/pikoci/pipeline"
+	"github.com/pikoci/pikoci/pikoci/resource"
+	"github.com/pikoci/pikoci/pikoci/utils"
+)
+
+// resolveResourceChain performs a BFS starting from jobs that get the given
+// resource without passed constraints, then follows downstream jobs via passed
+// constraints. It returns the ordered list of job names in the chain.
+func resolveResourceChain(jobs []job.Job, resourceCanonical string) []string {
+	// Build for_each group expansion map
+	forEachGroupInstances := make(map[string][]string)
+	for _, j := range jobs {
+		if j.ForEachGroup != "" {
+			forEachGroupInstances[j.ForEachGroup] = append(forEachGroupInstances[j.ForEachGroup], j.Name)
+		}
+	}
+
+	expandPassed := func(passed []string) []string {
+		var expanded []string
+		for _, name := range passed {
+			if instances, ok := forEachGroupInstances[name]; ok {
+				expanded = append(expanded, instances...)
+			} else {
+				expanded = append(expanded, name)
+			}
+		}
+		return expanded
+	}
+
+	// Step 1: find entry-point jobs that get this resource directly (no passed)
+	visited := make(map[string]bool)
+	var queue []string
+	var chain []string
+
+	for _, j := range jobs {
+		for _, g := range j.GetSteps() {
+			if g.ResourceCanonical() == resourceCanonical && len(g.Passed) == 0 {
+				if !visited[j.Name] {
+					visited[j.Name] = true
+					queue = append(queue, j.Name)
+				}
+				break
+			}
+		}
+	}
+
+	// Step 2: BFS through downstream jobs via passed constraints
+	for len(queue) > 0 {
+		jobName := queue[0]
+		queue = queue[1:]
+		chain = append(chain, jobName)
+
+		for _, j := range jobs {
+			if visited[j.Name] {
+				continue
+			}
+			for _, g := range j.GetSteps() {
+				if len(g.Passed) == 0 {
+					continue
+				}
+				expandedPassed := expandPassed(g.Passed)
+				for _, p := range expandedPassed {
+					if p == jobName {
+						visited[j.Name] = true
+						queue = append(queue, j.Name)
+						break
+					}
+				}
+				if visited[j.Name] {
+					break
+				}
+			}
+		}
+	}
+
+	return chain
+}
+
+// resolveVersionPath builds the version path response for a pipeline, resource,
+// and version. It resolves the chain, fetches builds, and assembles the response.
+func (q *PikoCI) resolveVersionPath(ctx context.Context, tc, pn, rCan string, pp *pipeline.Pipeline, versionID uint32, redactLogs bool) (*resource.VersionPathResponse, error) {
+	// Verify resource exists in pipeline
+	var found bool
+	for _, r := range pp.Resources {
+		if r.Canonical == rCan {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil, fmt.Errorf("resource %q not found in pipeline %q", rCan, pn)
+	}
+
+	// Get the version by ID and verify it belongs to the specified resource
+	version, versionResource, err := q.Resources.FindVersionByID(ctx, versionID)
+	if err != nil {
+		return nil, fmt.Errorf("version %d not found: %w", versionID, err)
+	}
+	if versionResource != rCan {
+		return nil, fmt.Errorf("version %d belongs to resource %q, not %q", versionID, versionResource, rCan)
+	}
+
+	// Resolve chain
+	chain := resolveResourceChain(pp.Jobs, rCan)
+	if len(chain) == 0 {
+		return &resource.VersionPathResponse{
+			Resource: resource.VersionPathResource{
+				Canonical: rCan,
+				Version:   version.Version,
+			},
+			Path:      []resource.VersionPathEntry{},
+			Completed: 0,
+			Total:     0,
+		}, nil
+	}
+
+	// Chain-walk through intermediate versions to find builds for all jobs.
+	// Entry-point jobs consumed the tracked version directly, but downstream
+	// jobs consume intermediate versions produced by upstream put steps.
+	buildsByJob, err := q.chainWalkBuilds(ctx, tc, pn, versionID, chain)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find builds by version chain walk: %w", err)
+	}
+
+	var path []resource.VersionPathEntry
+	completed := 0
+	for _, jn := range chain {
+		entry := resource.VersionPathEntry{JobName: jn}
+		if builds, ok := buildsByJob[jn]; ok && len(builds) > 0 {
+			entry.Build = builds[0]
+			if len(builds) > 1 {
+				entry.Retries = builds[1:]
+			}
+			if redactLogs {
+				redactBuildLogs(entry.Build)
+				for _, rb := range entry.Retries {
+					redactBuildLogs(rb)
+				}
+			}
+			if isTerminalStatus(entry.Build.Status) {
+				completed++
+			}
+		}
+		path = append(path, entry)
+	}
+
+	return &resource.VersionPathResponse{
+		Resource: resource.VersionPathResource{
+			Canonical: rCan,
+			Version:   version.Version,
+		},
+		Path:      path,
+		Completed: completed,
+		Total:     len(chain),
+	}, nil
+}
+
+// redactBuildLogs clears all log content from a build's steps and job logs.
+func redactBuildLogs(b *build.Build) {
+	for i := range b.Steps {
+		b.Steps[i].Logs = ""
+	}
+	for i := range b.Job {
+		b.Job[i].Logs = ""
+	}
+}
+
+// GetResourceVersionPath returns the version path for a specific resource version,
+// showing which jobs the version passes through and the build status for each.
+func (q *PikoCI) GetResourceVersionPath(ctx context.Context, tc, pn, rCan string, versionID uint32) (*resource.VersionPathResponse, error) {
+	if !utils.ValidateCanonical(tc) {
+		return nil, fmt.Errorf("invalid Team Canonical format %q", tc)
+	}
+	if !utils.ValidateCanonical(pn) {
+		return nil, fmt.Errorf("invalid Pipeline Canonical format %q", pn)
+	}
+
+	pp, err := q.GetPipeline(ctx, tc, pn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Pipeline %q: %w", pn, err)
+	}
+
+	return q.resolveVersionPath(ctx, tc, pn, rCan, pp, versionID, false)
+}
+
+// GetPublicResourceVersionPath returns the version path for a public pipeline.
+func (q *PikoCI) GetPublicResourceVersionPath(ctx context.Context, tc, pn, rCan string, versionID uint32) (*resource.VersionPathResponse, error) {
+	pp, err := q.Pipelines.FindPublic(ctx, tc, pn)
+	if err != nil {
+		return nil, fmt.Errorf("pipeline not found or not public: %w", err)
+	}
+
+	return q.resolveVersionPath(ctx, tc, pn, rCan, pp, versionID, true)
+}
+
+// chainWalkBuilds finds builds for all jobs in the chain by following version
+// propagation through put/get steps. Entry-point jobs consumed the tracked
+// version directly. For downstream jobs, we look at what versions the upstream
+// builds produced (via build_get_versions) and find downstream builds that
+// consumed those intermediate versions.
+func (q *PikoCI) chainWalkBuilds(ctx context.Context, tc, pn string, versionID uint32, chain []string) (map[string][]*build.Build, error) {
+	result := make(map[string][]*build.Build)
+	coveredJobs := make(map[string]bool)
+
+	// Start with the tracked version
+	pendingVersionIDs := []uint32{versionID}
+	seenVersionIDs := map[uint32]bool{versionID: true}
+
+	// BFS: expand version IDs → builds → new version IDs
+	for len(pendingVersionIDs) > 0 && len(coveredJobs) < len(chain) {
+		// Find builds in uncovered chain jobs that consumed any of the pending versions
+		var uncoveredJobs []string
+		for _, jn := range chain {
+			if !coveredJobs[jn] {
+				uncoveredJobs = append(uncoveredJobs, jn)
+			}
+		}
+		if len(uncoveredJobs) == 0 {
+			break
+		}
+
+		// Query builds for each pending version ID
+		var newBuildIDs []uint32
+		for _, vid := range pendingVersionIDs {
+			buildsByJob, err := q.Builds.FindByVersionAndJobs(ctx, tc, pn, vid, uncoveredJobs)
+			if err != nil {
+				return nil, fmt.Errorf("failed to find builds for version %d: %w", vid, err)
+			}
+			for jn, builds := range buildsByJob {
+				if !coveredJobs[jn] && len(builds) > 0 {
+					result[jn] = builds
+					coveredJobs[jn] = true
+					for _, b := range builds {
+						newBuildIDs = append(newBuildIDs, b.ID)
+					}
+				}
+			}
+		}
+
+		// From the newly found builds, collect all version IDs they
+		// consumed/produced (their build_get_versions entries)
+		pendingVersionIDs = nil
+		for _, buildID := range newBuildIDs {
+			getVersions, err := q.Builds.FindGetVersions(ctx, buildID)
+			if err != nil {
+				q.logger.Warn("chainWalkBuilds: failed to get versions for build", "build_id", buildID, "error", err)
+				continue
+			}
+			for _, vid := range getVersions {
+				if !seenVersionIDs[vid] {
+					seenVersionIDs[vid] = true
+					pendingVersionIDs = append(pendingVersionIDs, vid)
+				}
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// isTerminalStatus returns true if the build status is a terminal state.
+func isTerminalStatus(s build.Status) bool {
+	return s == build.Succeeded || s == build.Failed || s == build.Cancelled
+}

--- a/pikoci/version_path_test.go
+++ b/pikoci/version_path_test.go
@@ -1,0 +1,423 @@
+package pikoci_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/pikoci/pikoci/pikoci/build"
+	"github.com/pikoci/pikoci/pikoci/job"
+	"github.com/pikoci/pikoci/pikoci/pipeline"
+	"github.com/pikoci/pikoci/pikoci/resource"
+	"go.uber.org/mock/gomock"
+)
+
+func TestGetResourceVersionPath_SimpleChain(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	tc := "main"
+	pn := "my-pipeline"
+
+	pp := &pipeline.Pipeline{
+		Canonical: pn,
+		Jobs: []job.Job{
+			{
+				Name: "build",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "git", Name: "repo", Trigger: true}},
+				},
+			},
+			{
+				Name: "test",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "git", Name: "repo", Passed: []string{"build"}}},
+				},
+			},
+			{
+				Name: "deploy",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "git", Name: "repo", Passed: []string{"test"}}},
+				},
+			},
+		},
+		Resources: []resource.Resource{
+			{Canonical: "git.repo", Type: "git", Name: "repo"},
+		},
+	}
+
+	s.Pipelines.EXPECT().Find(gomock.Any(), tc, pn).Return(pp, nil)
+	s.Resources.EXPECT().FindVersionByID(gomock.Any(), uint32(42)).Return(
+		&resource.Version{ID: 42, Version: map[string]interface{}{"ref": "abc123"}},
+		"git.repo",
+		nil,
+	)
+	// Round 1: all 3 jobs searched with version 42 - build and test found
+	s.Builds.EXPECT().FindByVersionAndJobs(gomock.Any(), tc, pn, uint32(42), []string{"build", "test", "deploy"}).Return(
+		map[string][]*build.Build{
+			"build": {{ID: 1, BuildNumber: "1", Status: build.Succeeded}},
+			"test":  {{ID: 2, BuildNumber: "2", Status: build.Started}},
+		},
+		nil,
+	)
+	// Chain walk: get versions from found builds
+	s.Builds.EXPECT().FindGetVersions(gomock.Any(), uint32(1)).Return(map[string]uint32{"repo": 42}, nil)
+	s.Builds.EXPECT().FindGetVersions(gomock.Any(), uint32(2)).Return(map[string]uint32{"repo": 42}, nil)
+	// No new version IDs found, so no round 2 needed (version 42 already seen)
+
+	resp, err := s.S.GetResourceVersionPath(ctx, tc, pn, "git.repo", 42)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.Equal(t, "git.repo", resp.Resource.Canonical)
+	assert.Equal(t, "abc123", resp.Resource.Version["ref"])
+	assert.Equal(t, 3, resp.Total)
+	assert.Equal(t, 1, resp.Completed) // only "build" is terminal (succeeded)
+	require.Len(t, resp.Path, 3)
+	assert.Equal(t, "build", resp.Path[0].JobName)
+	assert.NotNil(t, resp.Path[0].Build)
+	assert.Equal(t, build.Succeeded, resp.Path[0].Build.Status)
+	assert.Equal(t, "test", resp.Path[1].JobName)
+	assert.NotNil(t, resp.Path[1].Build)
+	assert.Equal(t, build.Started, resp.Path[1].Build.Status)
+	assert.Equal(t, "deploy", resp.Path[2].JobName)
+	assert.Nil(t, resp.Path[2].Build) // not yet triggered
+}
+
+func TestGetResourceVersionPath_IntermediateResource(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	tc := "main"
+	pn := "my-pipeline"
+
+	// Pipeline: gen gets cron.timer, puts artifact.output → deploy-staging gets artifact.output (passed: [gen])
+	pp := &pipeline.Pipeline{
+		Canonical: pn,
+		Jobs: []job.Job{
+			{
+				Name: "gen",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "cron", Name: "timer", Trigger: true}},
+					{Type: job.StepTypePut, Put: &job.PutStep{Type: "artifact", Name: "output"}},
+				},
+			},
+			{
+				Name: "deploy-staging",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "artifact", Name: "output", Passed: []string{"gen"}}},
+				},
+			},
+		},
+		Resources: []resource.Resource{
+			{Canonical: "cron.timer", Type: "cron", Name: "timer"},
+			{Canonical: "artifact.output", Type: "artifact", Name: "output"},
+		},
+	}
+
+	s.Pipelines.EXPECT().Find(gomock.Any(), tc, pn).Return(pp, nil)
+	s.Resources.EXPECT().FindVersionByID(gomock.Any(), uint32(1)).Return(
+		&resource.Version{ID: 1, Version: map[string]interface{}{"date": "today"}},
+		"cron.timer",
+		nil,
+	)
+
+	// Round 1: search gen and deploy-staging for version 1
+	// Only gen consumed version 1 directly
+	s.Builds.EXPECT().FindByVersionAndJobs(gomock.Any(), tc, pn, uint32(1), []string{"gen", "deploy-staging"}).Return(
+		map[string][]*build.Build{
+			"gen": {{ID: 10, BuildNumber: "1", Status: build.Succeeded}},
+		},
+		nil,
+	)
+	// Chain walk: gen's build_get_versions has both the cron version (1) and artifact version (5)
+	s.Builds.EXPECT().FindGetVersions(gomock.Any(), uint32(10)).Return(
+		map[string]uint32{"timer": 1, "output": 5}, nil,
+	)
+	// Round 2: search deploy-staging for version 5 (the intermediate artifact version)
+	s.Builds.EXPECT().FindByVersionAndJobs(gomock.Any(), tc, pn, uint32(5), []string{"deploy-staging"}).Return(
+		map[string][]*build.Build{
+			"deploy-staging": {{ID: 11, BuildNumber: "1", Status: build.Succeeded}},
+		},
+		nil,
+	)
+	// Chain walk: deploy-staging's build_get_versions
+	s.Builds.EXPECT().FindGetVersions(gomock.Any(), uint32(11)).Return(
+		map[string]uint32{"output": 5}, nil,
+	)
+
+	resp, err := s.S.GetResourceVersionPath(ctx, tc, pn, "cron.timer", 1)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Path, 2)
+	assert.Equal(t, "gen", resp.Path[0].JobName)
+	assert.NotNil(t, resp.Path[0].Build)
+	assert.Equal(t, "deploy-staging", resp.Path[1].JobName)
+	assert.NotNil(t, resp.Path[1].Build)
+	assert.Equal(t, 2, resp.Completed)
+}
+
+func TestGetResourceVersionPath_EmptyChain(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	pp := &pipeline.Pipeline{
+		Canonical: "my-pipeline",
+		Jobs:      []job.Job{},
+		Resources: []resource.Resource{
+			{Canonical: "git.repo", Type: "git", Name: "repo"},
+		},
+	}
+
+	s.Pipelines.EXPECT().Find(gomock.Any(), "main", "my-pipeline").Return(pp, nil)
+	s.Resources.EXPECT().FindVersionByID(gomock.Any(), uint32(10)).Return(
+		&resource.Version{ID: 10, Version: map[string]interface{}{"ref": "xyz"}},
+		"git.repo",
+		nil,
+	)
+
+	resp, err := s.S.GetResourceVersionPath(ctx, "main", "my-pipeline", "git.repo", 10)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, 0, resp.Total)
+	assert.Empty(t, resp.Path)
+}
+
+func TestGetResourceVersionPath_ResourceNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	pp := &pipeline.Pipeline{
+		Canonical: "my-pipeline",
+		Resources: []resource.Resource{
+			{Canonical: "git.repo"},
+		},
+	}
+
+	s.Pipelines.EXPECT().Find(gomock.Any(), "main", "my-pipeline").Return(pp, nil)
+
+	_, err := s.S.GetResourceVersionPath(ctx, "main", "my-pipeline", "git.other", 42)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found in pipeline")
+}
+
+func TestGetResourceVersionPath_VersionBelongsToDifferentResource(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	pp := &pipeline.Pipeline{
+		Canonical: "my-pipeline",
+		Resources: []resource.Resource{
+			{Canonical: "git.repo"},
+			{Canonical: "cron.nightly"},
+		},
+	}
+
+	s.Pipelines.EXPECT().Find(gomock.Any(), "main", "my-pipeline").Return(pp, nil)
+	s.Resources.EXPECT().FindVersionByID(gomock.Any(), uint32(1)).Return(
+		&resource.Version{ID: 1, Version: map[string]interface{}{"date": "today"}},
+		"cron.nightly",
+		nil,
+	)
+
+	_, err := s.S.GetResourceVersionPath(ctx, "main", "my-pipeline", "git.repo", 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "belongs to resource")
+}
+
+func TestGetResourceVersionPath_VersionNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	pp := &pipeline.Pipeline{
+		Canonical: "my-pipeline",
+		Resources: []resource.Resource{
+			{Canonical: "git.repo"},
+		},
+	}
+
+	s.Pipelines.EXPECT().Find(gomock.Any(), "main", "my-pipeline").Return(pp, nil)
+	s.Resources.EXPECT().FindVersionByID(gomock.Any(), uint32(999)).Return(
+		nil, "", assert.AnError,
+	)
+
+	_, err := s.S.GetResourceVersionPath(ctx, "main", "my-pipeline", "git.repo", 999)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestGetResourceVersionPath_WithRetries(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	tc := "main"
+	pn := "my-pipeline"
+
+	pp := &pipeline.Pipeline{
+		Canonical: pn,
+		Jobs: []job.Job{
+			{
+				Name: "build",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "git", Name: "repo"}},
+				},
+			},
+		},
+		Resources: []resource.Resource{
+			{Canonical: "git.repo"},
+		},
+	}
+
+	s.Pipelines.EXPECT().Find(gomock.Any(), tc, pn).Return(pp, nil)
+	s.Resources.EXPECT().FindVersionByID(gomock.Any(), uint32(5)).Return(
+		&resource.Version{ID: 5, Version: map[string]interface{}{"ref": "abc"}},
+		"git.repo",
+		nil,
+	)
+	s.Builds.EXPECT().FindByVersionAndJobs(gomock.Any(), tc, pn, uint32(5), []string{"build"}).Return(
+		map[string][]*build.Build{
+			"build": {
+				{ID: 10, BuildNumber: "3", Status: build.Succeeded},
+				{ID: 11, BuildNumber: "3.1", Status: build.Failed},
+			},
+		},
+		nil,
+	)
+	s.Builds.EXPECT().FindGetVersions(gomock.Any(), uint32(10)).Return(map[string]uint32{"repo": 5}, nil)
+	s.Builds.EXPECT().FindGetVersions(gomock.Any(), uint32(11)).Return(map[string]uint32{"repo": 5}, nil)
+
+	resp, err := s.S.GetResourceVersionPath(ctx, tc, pn, "git.repo", 5)
+	require.NoError(t, err)
+	require.Len(t, resp.Path, 1)
+	assert.NotNil(t, resp.Path[0].Build)
+	assert.Equal(t, "3", resp.Path[0].Build.BuildNumber)
+	require.Len(t, resp.Path[0].Retries, 1)
+	assert.Equal(t, "3.1", resp.Path[0].Retries[0].BuildNumber)
+	assert.Equal(t, 1, resp.Completed)
+}
+
+func TestGetResourceVersionPath_ForEachExpansion(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	tc := "main"
+	pn := "my-pipeline"
+
+	pp := &pipeline.Pipeline{
+		Canonical: pn,
+		Jobs: []job.Job{
+			{
+				Name:         "build-a",
+				ForEachGroup: "build-group",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "git", Name: "repo"}},
+				},
+			},
+			{
+				Name:         "build-b",
+				ForEachGroup: "build-group",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "git", Name: "repo"}},
+				},
+			},
+			{
+				Name: "deploy",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "git", Name: "repo", Passed: []string{"build-group"}}},
+				},
+			},
+		},
+		Resources: []resource.Resource{
+			{Canonical: "git.repo"},
+		},
+	}
+
+	s.Pipelines.EXPECT().Find(gomock.Any(), tc, pn).Return(pp, nil)
+	s.Resources.EXPECT().FindVersionByID(gomock.Any(), uint32(1)).Return(
+		&resource.Version{ID: 1, Version: map[string]interface{}{"ref": "main"}},
+		"git.repo",
+		nil,
+	)
+	s.Builds.EXPECT().FindByVersionAndJobs(gomock.Any(), tc, pn, uint32(1), gomock.Any()).Return(
+		map[string][]*build.Build{},
+		nil,
+	)
+
+	resp, err := s.S.GetResourceVersionPath(ctx, tc, pn, "git.repo", 1)
+	require.NoError(t, err)
+	require.Len(t, resp.Path, 3)
+	assert.Equal(t, "build-a", resp.Path[0].JobName)
+	assert.Equal(t, "build-b", resp.Path[1].JobName)
+	assert.Equal(t, "deploy", resp.Path[2].JobName)
+}
+
+func TestGetResourceVersionPath_InvalidCanonicals(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	_, err := s.S.GetResourceVersionPath(ctx, "INVALID", "pipeline", "git.repo", 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid Team Canonical")
+
+	_, err = s.S.GetResourceVersionPath(ctx, "main", "INVALID", "git.repo", 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid Pipeline Canonical")
+}
+
+func TestGetPublicResourceVersionPath(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	tc := "main"
+	pn := "my-pipeline"
+
+	pp := &pipeline.Pipeline{
+		Canonical: pn,
+		Jobs: []job.Job{
+			{
+				Name: "build",
+				Plan: []job.PlanStep{
+					{Type: job.StepTypeGet, Get: &job.GetStep{Type: "git", Name: "repo"}},
+				},
+			},
+		},
+		Resources: []resource.Resource{
+			{Canonical: "git.repo"},
+		},
+	}
+
+	s.Pipelines.EXPECT().FindPublic(gomock.Any(), tc, pn).Return(pp, nil)
+	s.Resources.EXPECT().FindVersionByID(gomock.Any(), uint32(5)).Return(
+		&resource.Version{ID: 5, Version: map[string]interface{}{"ref": "abc"}},
+		"git.repo",
+		nil,
+	)
+	s.Builds.EXPECT().FindByVersionAndJobs(gomock.Any(), tc, pn, uint32(5), []string{"build"}).Return(
+		map[string][]*build.Build{
+			"build": {{
+				ID: 10, BuildNumber: "1", Status: build.Succeeded,
+				Steps: []build.Step{{Name: "get", Logs: "secret-log"}},
+				Job:   []build.Step{{Name: "job", Logs: "job-log"}},
+			}},
+		},
+		nil,
+	)
+	s.Builds.EXPECT().FindGetVersions(gomock.Any(), uint32(10)).Return(map[string]uint32{"repo": 5}, nil)
+
+	resp, err := s.S.GetPublicResourceVersionPath(ctx, tc, pn, "git.repo", 5)
+	require.NoError(t, err)
+	require.Len(t, resp.Path, 1)
+	assert.Empty(t, resp.Path[0].Build.Steps[0].Logs)
+	assert.Empty(t, resp.Path[0].Build.Job[0].Logs)
+}


### PR DESCRIPTION
## Summary

- Add version-scoped pipeline views: track a specific resource version to see only the jobs in its path with their build status
- New `GET /teams/:tc/pipelines/:pn/resources/:rCan/versions/:vID/path` API endpoint with chain-walk algorithm that follows version propagation through put/get steps
- Graph view filters to chain jobs with version-specific build colors when `version_id` query param is set
- Version scope banner between toolbar and content area showing resource, version ref, and progress
- Version dropdown in list view next to resource selector for selecting versions to track
- Track/Trigger/Pin buttons on expandable version lists in Resources panel
- Track button on resource versions page navigates to pipeline with `?version=ID`
- Job builds view filters to only tracked version's builds (including retries) and shows tracking banner
- URL shareability via `?version=ID` query parameter
- Fix "Group parallel jobs" not grouping root jobs sharing the same trigger resource

Closes #432