### PR TITLE
feat: add HTTP integration tests and reorganize integration directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- HTTP API integration tests covering all endpoints with real in-memory DB, organized under `integration/http/` ([#545](https://github.com/PikoCI/pikoci/issues/545))
+- Selenium tests for view switcher, gear/share/resources panels, and version scope banner across admin, member, and public contexts ([#545](https://github.com/PikoCI/pikoci/issues/545))
+- `test-http` CI pipeline job and `make test-http` target ([#545](https://github.com/PikoCI/pikoci/issues/545))
+
+### Changed
+
+- Reorganized `integration/` directory: Selenium tests moved to `integration/selenium/`, HTTP tests in `integration/http/` ([#545](https://github.com/PikoCI/pikoci/issues/545))
+
 - **Version tracking**: Track a specific resource version through the pipeline to see which jobs it passed through and their build status. Available from the resource versions page (Track button), the Resources panel (expandable version list with Track/Trigger/Pin), and a new version dropdown in the list view. When tracking, both graph and list views scope to only the version's path, a banner shows progress, and the URL is shareable via `?version=ID` ([#432](https://github.com/PikoCI/pikoci/issues/432))
 - New `GetResourceVersionPath` API endpoint (`GET /teams/{tc}/pipelines/{pc}/resources/{rCan}/versions/{vID}/path`) returns the ordered chain of jobs a version passes through, with build status for each job including retries. Follows version propagation through intermediate put/get resources ([#432](https://github.com/PikoCI/pikoci/issues/432))
 - Pipeline graph image endpoint now accepts a `version_id` query parameter to filter the graph to only the tracked version's path with version-specific build colors ([#432](https://github.com/PikoCI/pikoci/issues/432))

--- a/Makefile
+++ b/Makefile
@@ -63,16 +63,20 @@ lint: ## Runs staticcheck linter
 	GOFLAGS=-buildvcs=false go tool staticcheck ./...
 
 .PHONY: test
-test: test-mock test-integration test-backends ## Runs all tests
+test: test-mock test-http test-integration test-backends ## Runs all tests
 
 .PHONY: test-mock
 test-mock: ## Runs unit/mock tests (no services needed)
 	go test ./... -timeout 120s -coverprofile=coverage.out
 
+.PHONY: test-http
+test-http: ## Runs HTTP API integration tests (no browser needed)
+	go test -tags integration ./integration/http/... -v
+
 .PHONY: test-integration
 test-integration: ## Runs UI and backend integration tests (requires geckodriver + Xvfb + Firefox)
 	@PIKOCI_TEST_DB_SYSTEMS=$${PIKOCI_TEST_DB_SYSTEMS:-mem,sqlite} \
-	go test -tags integration ./integration/
+	go test -tags integration ./integration/selenium/
 
 .PHONY: test-backends
 test-backends: ## Runs integration tests with all backends (requires test-services-up)

--- a/deploy/pipeline.hcl
+++ b/deploy/pipeline.hcl
@@ -124,6 +124,30 @@ job "test-mock" {
   }
 }
 
+job "test-http" {
+  get "git" "pikoci_pr" {
+    trigger = true
+  }
+  notify "github-check" "ci" { status = "in_progress" }
+  task "make" {
+    run "docker" {
+      image = var.go_image
+      cmd   = "export PATH=/pikoci-tools:$PATH LD_LIBRARY_PATH=/pikoci-tools:$LD_LIBRARY_PATH GVBINDIR=/pikoci-tools/graphviz && cd ${var.git_name} && make test-http"
+      args  = [
+        "-v", "pikoci-go-mod:/go/pkg/mod",
+        "-v", "pikoci-build:/root/.cache/go-build",
+        "-v", "pikoci-tools:/pikoci-tools",
+      ]
+    }
+  }
+  on_success {
+    notify "github-check" "ci" { conclusion = "success" }
+  }
+  on_failure {
+    notify "github-check" "ci" { conclusion = "failure" }
+  }
+}
+
 job "test-integration" {
   get "git" "pikoci_pr" {
     trigger = true
@@ -179,7 +203,7 @@ job "test-backends" {
   concurrency = 1
   get "git" "pikoci_pr" {
     trigger = true
-    passed  = ["lint", "test-mock", "test-integration"]
+    passed  = ["lint", "test-mock", "test-http", "test-integration"]
   }
 
   notify "github-check" "ci" { status = "in_progress" }

--- a/integration/http/helper_test.go
+++ b/integration/http/helper_test.go
@@ -1,0 +1,64 @@
+//go:build integration
+
+package http_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	thttp "github.com/pikoci/pikoci/pikoci/transport/http"
+	"github.com/stretchr/testify/require"
+)
+
+// doJSONRequest makes an HTTP request with Content-Type: application/json and optional Bearer token.
+func doJSONRequest(t *testing.T, method, url, jwt, body string) *http.Response {
+	t.Helper()
+	var reader *strings.Reader
+	if body != "" {
+		reader = strings.NewReader(body)
+	} else {
+		reader = strings.NewReader("")
+	}
+	req, err := http.NewRequest(method, url, reader)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	if jwt != "" {
+		req.Header.Set("Authorization", "Bearer "+jwt)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+// loginAndGetJWT posts to /login and returns the JWT string.
+func loginAndGetJWT(t *testing.T, serverURL, username, password string) string {
+	t.Helper()
+	body, _ := json.Marshal(thttp.UserLoginRequest{
+		Username: username,
+		Password: password,
+	})
+	resp := doJSONRequest(t, http.MethodPost, serverURL+"/login", "", string(body))
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var lr thttp.UserLoginResponse
+	err := json.NewDecoder(resp.Body).Decode(&lr)
+	require.NoError(t, err)
+	require.Empty(t, lr.Err, "login error: %s", lr.Err)
+	require.NotEmpty(t, lr.Data.JWT)
+	return lr.Data.JWT
+}
+
+// requireOK asserts status 200.
+func requireOK(t *testing.T, resp *http.Response) {
+	t.Helper()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// decodeBody decodes JSON response body into target.
+func decodeBody(t *testing.T, resp *http.Response, target interface{}) {
+	t.Helper()
+	err := json.NewDecoder(resp.Body).Decode(target)
+	require.NoError(t, err)
+}

--- a/integration/http/http_test.go
+++ b/integration/http/http_test.go
@@ -1,0 +1,643 @@
+//go:build integration
+
+package http_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	thttp "github.com/pikoci/pikoci/pikoci/transport/http"
+)
+
+const pipelineHCL = `
+resource "cron" "timer" {
+  check_interval = "@every 1m"
+}
+
+job "test-job" {
+  get "cron" "timer" {
+    trigger = true
+  }
+  task "echo" {
+    run "exec" {
+      path = "echo"
+      args = ["hello"]
+    }
+  }
+}
+`
+
+func TestHTTPEndpoints(t *testing.T) {
+	var adminJWT string
+	var memberJWT string
+	var webhookToken string
+	var versionID uint32
+
+	// ---- Auth ----
+	t.Run("GetVersion", func(t *testing.T) {
+		resp := doJSONRequest(t, http.MethodGet, pikoURL+"/version", "", "")
+		defer resp.Body.Close()
+		requireOK(t, resp)
+		var body map[string]string
+		decodeBody(t, resp, &body)
+		assert.Equal(t, "test", body["version"])
+		assert.Equal(t, "abc1234", body["commit"])
+	})
+
+	t.Run("Login", func(t *testing.T) {
+		adminJWT = loginAndGetJWT(t, pikoURL, "admin", "admin123")
+		require.NotEmpty(t, adminJWT)
+	})
+
+	t.Run("LoginFail", func(t *testing.T) {
+		body, _ := json.Marshal(thttp.UserLoginRequest{Username: "admin", Password: "wrong"})
+		resp := doJSONRequest(t, http.MethodPost, pikoURL+"/login", "", string(body))
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		var lr thttp.UserLoginResponse
+		decodeBody(t, resp, &lr)
+		assert.NotEmpty(t, lr.Err)
+	})
+
+	// ---- Users ----
+	t.Run("Users", func(t *testing.T) {
+		t.Run("Create", func(t *testing.T) {
+			body, _ := json.Marshal(thttp.CreateUserRequest{
+				Username: "pepito",
+				Password: "pepito123",
+				FullName: "Pepito Grillo",
+			})
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/users", adminJWT, string(body))
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var cr thttp.CreateUserResponse
+			decodeBody(t, resp, &cr)
+			assert.Empty(t, cr.Err)
+			assert.Equal(t, "pepito", cr.User.Username)
+		})
+
+		t.Run("List", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodGet, pikoURL+"/users", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var lr thttp.ListUsersResponse
+			decodeBody(t, resp, &lr)
+			assert.Empty(t, lr.Err)
+			assert.GreaterOrEqual(t, len(lr.Users), 2)
+		})
+
+		t.Run("Get", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodGet, pikoURL+"/users/pepito", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var gr thttp.GetUserResponse
+			decodeBody(t, resp, &gr)
+			assert.Empty(t, gr.Err)
+			assert.Equal(t, "pepito", gr.User.Username)
+			assert.Equal(t, "Pepito Grillo", gr.User.FullName)
+		})
+
+		t.Run("Update", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPut, pikoURL+"/users/pepito", adminJWT, `{"full_name":"Pepito Updated"}`)
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var ur thttp.UpdateUserResponse
+			decodeBody(t, resp, &ur)
+			assert.Empty(t, ur.Err)
+			assert.Equal(t, "Pepito Updated", ur.User.FullName)
+		})
+
+		t.Run("UpdateProfile", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPut, pikoURL+"/profile", adminJWT, `{"full_name":"Admin Profile"}`)
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var ur thttp.UpdateProfileResponse
+			decodeBody(t, resp, &ur)
+			assert.Empty(t, ur.Err)
+		})
+
+		t.Run("ChangePassword", func(t *testing.T) {
+			memberJWT = loginAndGetJWT(t, pikoURL, "pepito", "pepito123")
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/users/change-password", memberJWT, `{"old_password":"pepito123","new_password":"pepito456"}`)
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var cr thttp.ChangePasswordResponse
+			decodeBody(t, resp, &cr)
+			assert.Empty(t, cr.Err)
+
+			// Re-login with new password
+			memberJWT = loginAndGetJWT(t, pikoURL, "pepito", "pepito456")
+		})
+
+		t.Run("Delete", func(t *testing.T) {
+			// Create a temp user, then delete
+			body, _ := json.Marshal(thttp.CreateUserRequest{
+				Username: "temp-user",
+				Password: "temp123",
+				FullName: "Temp User",
+			})
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/users", adminJWT, string(body))
+			defer resp.Body.Close()
+			requireOK(t, resp)
+
+			resp2 := doJSONRequest(t, http.MethodDelete, pikoURL+"/users/temp-user", adminJWT, "")
+			defer resp2.Body.Close()
+			requireOK(t, resp2)
+			var dr thttp.DeleteUserResponse
+			decodeBody(t, resp2, &dr)
+			assert.Empty(t, dr.Err)
+		})
+	})
+
+	// ---- Teams ----
+	t.Run("Teams", func(t *testing.T) {
+		t.Run("Create", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams", adminJWT, `{"name":"Test Team"}`)
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var cr thttp.CreateTeamResponse
+			decodeBody(t, resp, &cr)
+			assert.Empty(t, cr.Err)
+			assert.NotNil(t, cr.Team)
+			assert.Equal(t, "Test Team", cr.Team.Name)
+		})
+
+		t.Run("List", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodGet, pikoURL+"/teams", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var lr thttp.ListTeamsResponse
+			decodeBody(t, resp, &lr)
+			assert.Empty(t, lr.Err)
+			assert.GreaterOrEqual(t, len(lr.Teams), 2) // main + test-team
+		})
+
+		t.Run("Get", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodGet, pikoURL+"/teams/test-team", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var gr thttp.GetTeamResponse
+			decodeBody(t, resp, &gr)
+			assert.Empty(t, gr.Err)
+			assert.Equal(t, "Test Team", gr.Team.Name)
+		})
+
+		t.Run("Update", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPut, pikoURL+"/teams/test-team", adminJWT, `{"name":"Test Team Updated"}`)
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var ur thttp.UpdateTeamResponse
+			decodeBody(t, resp, &ur)
+			assert.Empty(t, ur.Err)
+			assert.Equal(t, "Test Team Updated", ur.Team.Name)
+		})
+
+		t.Run("Members", func(t *testing.T) {
+			t.Run("Create", func(t *testing.T) {
+				body := `{"user":{"username":"pepito"},"admin":false}`
+				resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/members", adminJWT, body)
+				defer resp.Body.Close()
+				requireOK(t, resp)
+				var cr thttp.CreateTeamMemberResponse
+				decodeBody(t, resp, &cr)
+				assert.Empty(t, cr.Err)
+			})
+
+			t.Run("Update", func(t *testing.T) {
+				resp := doJSONRequest(t, http.MethodPut, pikoURL+"/teams/main/members/pepito", adminJWT, `{"admin":true}`)
+				defer resp.Body.Close()
+				requireOK(t, resp)
+				var ur thttp.UpdateTeamMemberResponse
+				decodeBody(t, resp, &ur)
+				assert.Empty(t, ur.Err)
+				assert.True(t, ur.Member.Admin)
+			})
+
+			t.Run("Delete", func(t *testing.T) {
+				resp := doJSONRequest(t, http.MethodDelete, pikoURL+"/teams/main/members/pepito", adminJWT, "")
+				defer resp.Body.Close()
+				requireOK(t, resp)
+				var dr thttp.DeleteTeamMemberResponse
+				decodeBody(t, resp, &dr)
+				assert.Empty(t, dr.Err)
+			})
+		})
+
+		t.Run("Delete", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodDelete, pikoURL+"/teams/test-team-updated", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var dr thttp.DeleteTeamResponse
+			decodeBody(t, resp, &dr)
+			assert.Empty(t, dr.Err)
+		})
+	})
+
+	// ---- Pipelines ----
+	t.Run("Pipelines", func(t *testing.T) {
+		t.Run("Create", func(t *testing.T) {
+			body, _ := json.Marshal(struct {
+				Name   string `json:"name"`
+				Config []byte `json:"config"`
+			}{
+				Name:   "test-pipe",
+				Config: []byte(pipelineHCL),
+			})
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/pipelines", adminJWT, string(body))
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var cr thttp.CreatePipelineResponse
+			decodeBody(t, resp, &cr)
+			assert.Empty(t, cr.Err)
+			assert.NotNil(t, cr.Pipeline)
+			assert.Equal(t, "test-pipe", cr.Pipeline.Canonical)
+		})
+
+		t.Run("List", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodGet, pikoURL+"/teams/main/pipelines", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var lr thttp.ListPipelinesResponse
+			decodeBody(t, resp, &lr)
+			assert.Empty(t, lr.Err)
+			assert.GreaterOrEqual(t, len(lr.Pipelines), 1)
+		})
+
+		t.Run("Get", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodGet, pikoURL+"/teams/main/pipelines/test-pipe", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var gr thttp.GetPipelineResponse
+			decodeBody(t, resp, &gr)
+			assert.Empty(t, gr.Err)
+			assert.Equal(t, "test-pipe", gr.Pipeline.Canonical)
+		})
+
+		t.Run("Update", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPut, pikoURL+"/teams/main/pipelines/test-pipe", adminJWT, `{"public":true}`)
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var ur thttp.UpdatePipelineResponse
+			decodeBody(t, resp, &ur)
+			assert.Empty(t, ur.Err)
+		})
+
+		t.Run("Image", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodGet, pikoURL+"/teams/main/pipelines/test-pipe/image.dot", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+		})
+
+		t.Run("Pause", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/pipelines/test-pipe/pause", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var pr thttp.PausePipelineResponse
+			decodeBody(t, resp, &pr)
+			assert.Empty(t, pr.Err)
+		})
+
+		t.Run("Unpause", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/pipelines/test-pipe/unpause", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var ur thttp.UnpausePipelineResponse
+			decodeBody(t, resp, &ur)
+			assert.Empty(t, ur.Err)
+		})
+	})
+
+	// ---- Jobs ----
+	t.Run("Jobs", func(t *testing.T) {
+		t.Run("List", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodGet, pikoURL+"/teams/main/pipelines/test-pipe/jobs", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var lr thttp.ListPipelineJobsResponse
+			decodeBody(t, resp, &lr)
+			assert.Empty(t, lr.Err)
+			assert.GreaterOrEqual(t, len(lr.Jobs), 1)
+			found := false
+			for _, j := range lr.Jobs {
+				if j.Name == "test-job" {
+					found = true
+				}
+			}
+			assert.True(t, found, "expected to find test-job")
+		})
+
+		t.Run("Get", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodGet, pikoURL+"/teams/main/pipelines/test-pipe/jobs/test-job", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var gr thttp.GetPipelineJobResponse
+			decodeBody(t, resp, &gr)
+			assert.Empty(t, gr.Err)
+			assert.Equal(t, "test-job", gr.Job.Name)
+		})
+
+		t.Run("Pause", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/pipelines/test-pipe/jobs/test-job/pause", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var pr thttp.PauseJobResponse
+			decodeBody(t, resp, &pr)
+			assert.Empty(t, pr.Err)
+		})
+
+		t.Run("Unpause", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/pipelines/test-pipe/jobs/test-job/unpause", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var ur thttp.UnpauseJobResponse
+			decodeBody(t, resp, &ur)
+			assert.Empty(t, ur.Err)
+		})
+
+		t.Run("Trigger", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/pipelines/test-pipe/jobs/test-job/trigger", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var tr thttp.TriggerPipelineJobResponse
+			decodeBody(t, resp, &tr)
+			assert.Empty(t, tr.Err)
+		})
+	})
+
+	// ---- Resources ----
+	t.Run("Resources", func(t *testing.T) {
+		t.Run("List", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodGet, pikoURL+"/teams/main/pipelines/test-pipe/resources", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var lr thttp.ListPipelineResourcesResponse
+			decodeBody(t, resp, &lr)
+			assert.Empty(t, lr.Err)
+			assert.GreaterOrEqual(t, len(lr.Resources), 1)
+			found := false
+			for _, r := range lr.Resources {
+				if r.Canonical == "cron.timer" {
+					found = true
+				}
+			}
+			assert.True(t, found, "expected to find cron.timer resource")
+		})
+
+		t.Run("Get", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodGet, pikoURL+"/teams/main/pipelines/test-pipe/resources/cron.timer", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var gr thttp.GetPipelineResourceResponse
+			decodeBody(t, resp, &gr)
+			assert.Empty(t, gr.Err)
+			assert.Equal(t, "cron.timer", gr.Resource.Canonical)
+			webhookToken = gr.Resource.WebhookToken
+		})
+
+		t.Run("Trigger", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/pipelines/test-pipe/resources/cron.timer/trigger", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var tr thttp.TriggerPipelineResourceResponse
+			decodeBody(t, resp, &tr)
+			assert.Empty(t, tr.Err)
+		})
+
+		t.Run("CreateVersion", func(t *testing.T) {
+			body := `{"version":{"version":{"trigger":"manual"}}}`
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/pipelines/test-pipe/resources/cron.timer/versions", adminJWT, body)
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var cr thttp.CreateResourceVersionResponse
+			decodeBody(t, resp, &cr)
+			assert.Empty(t, cr.Err)
+			require.NotNil(t, cr.Version)
+			versionID = cr.Version.ID
+			assert.NotZero(t, versionID)
+		})
+
+		t.Run("ListVersions", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodGet, pikoURL+"/teams/main/pipelines/test-pipe/resources/cron.timer/versions", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var lr thttp.ListResourceVersionsResponse
+			decodeBody(t, resp, &lr)
+			assert.Empty(t, lr.Err)
+			assert.GreaterOrEqual(t, len(lr.Versions), 1)
+		})
+
+		t.Run("TriggerVersion", func(t *testing.T) {
+			url := fmt.Sprintf("%s/teams/main/pipelines/test-pipe/resources/cron.timer/versions/%d/trigger", pikoURL, versionID)
+			resp := doJSONRequest(t, http.MethodPost, url, adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var tr thttp.TriggerResourceVersionResponse
+			decodeBody(t, resp, &tr)
+			assert.Empty(t, tr.Err)
+		})
+
+		t.Run("Pin", func(t *testing.T) {
+			body := fmt.Sprintf(`{"version_id":%d}`, versionID)
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/pipelines/test-pipe/resources/cron.timer/pin", adminJWT, body)
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var pr thttp.PinResourceVersionResponse
+			decodeBody(t, resp, &pr)
+			assert.Empty(t, pr.Err)
+		})
+
+		t.Run("Unpin", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/pipelines/test-pipe/resources/cron.timer/unpin", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var ur thttp.UnpinResourceVersionResponse
+			decodeBody(t, resp, &ur)
+			assert.Empty(t, ur.Err)
+		})
+
+		t.Run("RegenerateWebhookToken", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/pipelines/test-pipe/resources/cron.timer/webhook_token", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var rr thttp.RegenerateWebhookTokenResponse
+			decodeBody(t, resp, &rr)
+			assert.Empty(t, rr.Err)
+			assert.NotEmpty(t, rr.Token)
+			assert.NotEqual(t, webhookToken, rr.Token)
+			webhookToken = rr.Token
+		})
+	})
+
+	// ---- Webhooks (the original #545 request) ----
+	t.Run("Webhooks", func(t *testing.T) {
+		t.Run("Trigger", func(t *testing.T) {
+			require.NotEmpty(t, webhookToken, "webhook token must be set from Resources.Get or RegenerateWebhookToken")
+			req, err := http.NewRequest(http.MethodPost, pikoURL+"/webhooks/"+webhookToken, nil)
+			require.NoError(t, err)
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var wr thttp.WebhookTriggerResponse
+			decodeBody(t, resp, &wr)
+			assert.Empty(t, wr.Err)
+		})
+
+		t.Run("TriggerNotFound", func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodPost, pikoURL+"/webhooks/bad-token-12345", nil)
+			require.NoError(t, err)
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			var wr thttp.WebhookTriggerResponse
+			decodeBody(t, resp, &wr)
+			assert.NotEmpty(t, wr.Err)
+		})
+	})
+
+	// ---- Builds ----
+	t.Run("Builds", func(t *testing.T) {
+		t.Run("List", func(t *testing.T) {
+			var builds thttp.ListJobBuildsResponse
+			require.Eventually(t, func() bool {
+				resp := doJSONRequest(t, http.MethodGet, pikoURL+"/teams/main/pipelines/test-pipe/jobs/test-job/builds", adminJWT, "")
+				defer resp.Body.Close()
+				if resp.StatusCode != http.StatusOK {
+					return false
+				}
+				builds = thttp.ListJobBuildsResponse{}
+				decodeBody(t, resp, &builds)
+				return len(builds.Builds) > 0
+			}, 30*time.Second, 500*time.Millisecond, "expected at least one build")
+			assert.Empty(t, builds.Err)
+		})
+
+		t.Run("Get", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodGet, pikoURL+"/teams/main/pipelines/test-pipe/jobs/test-job/builds/1", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var gr thttp.GetJobBuildResponse
+			decodeBody(t, resp, &gr)
+			assert.Empty(t, gr.Err)
+			assert.NotNil(t, gr.Build)
+		})
+
+		t.Run("Cancel", func(t *testing.T) {
+			doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/pipelines/test-pipe/jobs/test-job/trigger", adminJWT, "").Body.Close()
+			time.Sleep(200 * time.Millisecond)
+
+			resp := doJSONRequest(t, http.MethodGet, pikoURL+"/teams/main/pipelines/test-pipe/jobs/test-job/builds", adminJWT, "")
+			defer resp.Body.Close()
+			var lr thttp.ListJobBuildsResponse
+			decodeBody(t, resp, &lr)
+			require.NotEmpty(t, lr.Builds)
+			latestNum := lr.Builds[0].BuildNumber
+
+			resp2 := doJSONRequest(t, http.MethodPost, fmt.Sprintf("%s/teams/main/pipelines/test-pipe/jobs/test-job/builds/%s/cancel", pikoURL, latestNum), adminJWT, "")
+			defer resp2.Body.Close()
+			var cr thttp.CancelJobBuildResponse
+			decodeBody(t, resp2, &cr)
+		})
+
+		t.Run("Retry", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/pipelines/test-pipe/jobs/test-job/builds/1/retry", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var rr thttp.RetryJobBuildResponse
+			decodeBody(t, resp, &rr)
+			assert.Empty(t, rr.Err)
+		})
+	})
+
+	// ---- Workers ----
+	t.Run("Workers", func(t *testing.T) {
+		t.Run("List", func(t *testing.T) {
+			var lr thttp.ListWorkersResponse
+			require.Eventually(t, func() bool {
+				resp := doJSONRequest(t, http.MethodGet, pikoURL+"/workers", adminJWT, "")
+				defer resp.Body.Close()
+				if resp.StatusCode != http.StatusOK {
+					return false
+				}
+				lr = thttp.ListWorkersResponse{}
+				decodeBody(t, resp, &lr)
+				return len(lr.Workers) > 0
+			}, 10*time.Second, 500*time.Millisecond, "expected at least one worker")
+			assert.Empty(t, lr.Err)
+		})
+
+		t.Run("Health", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodGet, pikoURL+"/workers/health", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var hr thttp.WorkersHealthResponse
+			decodeBody(t, resp, &hr)
+			assert.Empty(t, hr.Err)
+		})
+	})
+
+	// ---- Triggers ----
+	t.Run("Triggers", func(t *testing.T) {
+		t.Run("Create", func(t *testing.T) {
+			body := `{"version":{"key":"value"}}`
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/triggers/test-trigger", adminJWT, body)
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var cr thttp.CreateTriggerResponse
+			decodeBody(t, resp, &cr)
+			assert.Empty(t, cr.Err)
+			assert.NotNil(t, cr.Trigger)
+		})
+
+		t.Run("ListAfter", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodGet, pikoURL+"/teams/main/triggers/test-trigger", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var lr thttp.ListTriggersAfterResponse
+			decodeBody(t, resp, &lr)
+			assert.Empty(t, lr.Err)
+			assert.GreaterOrEqual(t, len(lr.Triggers), 1)
+		})
+	})
+
+	// ---- Admin ----
+	t.Run("Admin", func(t *testing.T) {
+		t.Run("Export", func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, pikoURL+"/admin/export", nil)
+			require.NoError(t, err)
+			req.Header.Set("Authorization", "Bearer "+adminJWT)
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			assert.Equal(t, "application/octet-stream", resp.Header.Get("Content-Type"))
+		})
+
+		t.Run("ExportUnauth", func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, pikoURL+"/admin/export", nil)
+			require.NoError(t, err)
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+	})
+
+	// ---- Auth edge cases ----
+	t.Run("RefreshToken", func(t *testing.T) {
+		resp := doJSONRequest(t, http.MethodPost, pikoURL+"/refresh-token", adminJWT, "")
+		defer resp.Body.Close()
+		requireOK(t, resp)
+		var rr thttp.RefreshTokenResponse
+		decodeBody(t, resp, &rr)
+		assert.Empty(t, rr.Err)
+		assert.NotEmpty(t, rr.Data.JWT)
+	})
+}

--- a/integration/http/main_test.go
+++ b/integration/http/main_test.go
@@ -1,0 +1,119 @@
+//go:build integration
+
+package http_test
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/pikoci/pikoci/pikoci"
+	"github.com/pikoci/pikoci/pikoci/mysql"
+	"github.com/pikoci/pikoci/pikoci/mysql/migrate"
+	"github.com/pikoci/pikoci/pikoci/notifier"
+	tshttp "github.com/pikoci/pikoci/pikoci/transport/http"
+	"github.com/pikoci/pikoci/pikoci/unitwork"
+	"github.com/pikoci/pikoci/pikoci/user"
+	"github.com/pikoci/pikoci/worker"
+)
+
+var (
+	pikoURL   string
+	jwtSecret = []byte("test-secret")
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(runTests(m))
+}
+
+func runTests(m *testing.M) int {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})).With("service", "pikoci")
+
+	db, err := mysql.New("", 0, "", "", mysql.Options{
+		MultiStatements: true,
+		ClientFoundRows: true,
+		System:          mysql.Mem,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	err = migrate.Migrate(db, mysql.Mem)
+	if err != nil {
+		panic(err)
+	}
+
+	ur := mysql.NewUserRepository(db)
+	tr := mysql.NewTeamRepository(db)
+	ppr := mysql.NewPipelineRepository(db)
+	jr := mysql.NewJobRepository(db)
+	rr := mysql.NewResourceRepository(db, mysql.Mem)
+	rt := mysql.NewResourceTypeRepository(db)
+	br := mysql.NewBuildRepository(db, mysql.Mem)
+	rur := mysql.NewRunnerRepository(db)
+	str := mysql.NewSecretTypeRepository(db)
+	tgr := mysql.NewTriggerRepository(db)
+	wr := mysql.NewWorkerRepository(db, mysql.Mem)
+	suow := unitwork.NewStartUnitOfWork(db, mysql.Mem)
+	wn := notifier.New()
+
+	var svc = pikoci.New(ctx, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, wr, suow, jwtSecret, wn, logger)
+	svc.StartScheduler(ctx)
+
+	var handler = tshttp.Handler(svc, jwtSecret, logger.With("component", "HTTP"), db, mysql.Mem, "test", "abc1234")
+	server := httptest.NewServer(handler)
+	pikoURL = server.URL
+	defer server.Close()
+
+	// Create the default admin user with a known password hash
+	isHash := true
+	// admin123
+	_, _ = svc.CreateUser(ctx, user.User{FullName: "Admin", Username: "admin", Password: "$2a$14$rwQk8Qvc2rij7qhFO4P1W.OiSF6AkgVU1RCrLaY2wawJcpkPEKwbm", Admin: true}, isHash)
+
+	// Start a background worker
+	go func() {
+		runWorker(ctx, svc, 1, "INFO")
+	}()
+
+	return m.Run()
+}
+
+func runWorker(ctx context.Context, s pikoci.Service, c int, llvl string) error {
+	var lvl slog.Level
+	switch llvl {
+	case "DEBUG":
+		lvl = slog.LevelDebug
+	case "WARN":
+		lvl = slog.LevelWarn
+	case "ERROR":
+		lvl = slog.LevelError
+	default:
+		lvl = slog.LevelInfo
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: lvl})).With("service", "worker")
+
+	var wg sync.WaitGroup
+	for i := range c {
+		wg.Add(1)
+		nlogger := logger.With("num", i+1)
+		nlogger.Info(fmt.Sprintf("Starting Worker %d", i+1))
+		w := worker.New(s, nlogger, fmt.Sprintf("test-worker-%d", i+1), "test", "", c, nil, false)
+
+		go func() {
+			err := w.Run(ctx)
+			if err != nil {
+				logger.Error("failed to Run worker", "error", err)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	return nil
+}

--- a/integration/selenium/helper_test.go
+++ b/integration/selenium/helper_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package integration_test
+package selenium_test
 
 import (
 	"fmt"
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,7 +26,7 @@ var geckoDriverPath string
 
 func init() {
 	_, f, _, _ := runtime.Caller(0)
-	geckoDriverPath = filepath.Join(filepath.Dir(f), "vendor", "geckodriver")
+	geckoDriverPath = filepath.Join(filepath.Dir(f), "..", "vendor", "geckodriver")
 }
 
 func getRemote(t *testing.T) selenium.WebDriver {
@@ -68,4 +69,27 @@ func getRemote(t *testing.T) selenium.WebDriver {
 	})
 
 	return wd
+}
+
+func hasClass(el selenium.WebElement, className string) bool {
+	cls, err := el.GetAttribute("class")
+	if err != nil {
+		return false
+	}
+	for _, c := range strings.Split(cls, " ") {
+		if c == className {
+			return true
+		}
+	}
+	return false
+}
+
+func waitForClass(by, value, className string, want bool) waitForFn {
+	return func(t *testing.T, wd selenium.WebDriver) bool {
+		el, err := wd.FindElement(by, value)
+		if err != nil {
+			return false
+		}
+		return hasClass(el, className) == want
+	}
 }

--- a/integration/selenium/main_test.go
+++ b/integration/selenium/main_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package integration_test
+package selenium_test
 
 import (
 	"context"
@@ -38,6 +38,9 @@ func runTests(m *testing.M) int {
 		ClientFoundRows: true,
 		System:          mysql.Mem,
 	})
+	if err != nil {
+		panic(err)
+	}
 
 	err = migrate.Migrate(db, mysql.Mem)
 	if err != nil {

--- a/integration/selenium/pikoci_test.go
+++ b/integration/selenium/pikoci_test.go
@@ -435,6 +435,16 @@ job "gen" {
 
 			waitFor(t, wd, waitForClass(selenium.ByCSSSelector, "#share-panel", "open", true), 5*time.Second)
 
+			// Wait for SVG URL to be populated
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				el, err := wd.FindElement(selenium.ByCSSSelector, "#share-svg-url")
+				if err != nil {
+					return false
+				}
+				val, _ := el.GetAttribute("value")
+				return val != ""
+			}, 5*time.Second)
+
 			svgURL, err := wd.FindElement(selenium.ByCSSSelector, "#share-svg-url")
 			require.NoError(t, err)
 			svgVal, err := svgURL.GetAttribute("value")
@@ -457,6 +467,7 @@ job "gen" {
 			require.NoError(t, err)
 			require.GreaterOrEqual(t, len(copyBtns), 1, "should have copy buttons")
 
+			// Close share panel and verify it's fully closed before next test
 			err = shareToggle.Click()
 			require.NoError(t, err)
 			waitFor(t, wd, waitForClass(selenium.ByCSSSelector, "#share-panel", "open", false), 5*time.Second)
@@ -1072,6 +1083,16 @@ job "gen" {
 			require.NoError(t, err)
 
 			waitFor(t, wd, waitForClass(selenium.ByCSSSelector, "#share-panel", "open", true), 5*time.Second)
+
+			// Wait for SVG URL to be populated
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				el, err := wd.FindElement(selenium.ByCSSSelector, "#share-svg-url")
+				if err != nil {
+					return false
+				}
+				val, _ := el.GetAttribute("value")
+				return val != ""
+			}, 5*time.Second)
 
 			svgURL, err := wd.FindElement(selenium.ByCSSSelector, "#share-svg-url")
 			require.NoError(t, err)

--- a/integration/selenium/pikoci_test.go
+++ b/integration/selenium/pikoci_test.go
@@ -616,15 +616,12 @@ job "gen" {
 			waitFor(t, wd, waitForClass(selenium.ByCSSSelector, "#pipeline-resources-panel", "open", false), 5*time.Second)
 		})
 		t.Run("Job Builds", func(t *testing.T) {
-			ppBtn, err := wd.FindElement(selenium.ByLinkText, "cron")
-			require.NoError(t, err)
-
-			err = ppBtn.Click()
+			// Navigate to pipeline page (may already be here after Version Scope Banner)
+			err := wd.Get(pikoURL + "/teams/main/pipelines/cron")
 			require.NoError(t, err)
 
 			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
 				_, err := wd.FindElement(selenium.ByCSSSelector, "div#pipeline-graph>svg")
-
 				return err == nil
 			}, 5*time.Second)
 

--- a/integration/selenium/pikoci_test.go
+++ b/integration/selenium/pikoci_test.go
@@ -435,33 +435,27 @@ job "gen" {
 
 			waitFor(t, wd, waitForClass(selenium.ByCSSSelector, "#share-panel", "open", true), 5*time.Second)
 
-			// Wait for SVG URL to be populated
+			// Wait for SVG URL to be populated (JS sets .value, not HTML attribute)
 			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
-				el, err := wd.FindElement(selenium.ByCSSSelector, "#share-svg-url")
+				val, err := wd.ExecuteScript("return document.getElementById('share-svg-url').value", nil)
 				if err != nil {
 					return false
 				}
-				val, _ := el.GetAttribute("value")
-				return val != ""
+				s, _ := val.(string)
+				return s != ""
 			}, 5*time.Second)
 
-			svgURL, err := wd.FindElement(selenium.ByCSSSelector, "#share-svg-url")
+			svgVal, err := wd.ExecuteScript("return document.getElementById('share-svg-url').value", nil)
 			require.NoError(t, err)
-			svgVal, err := svgURL.GetAttribute("value")
-			require.NoError(t, err)
-			require.Contains(t, svgVal, ".svg", "SVG URL should contain .svg")
+			require.Contains(t, svgVal.(string), ".svg", "SVG URL should contain .svg")
 
-			pngURL, err := wd.FindElement(selenium.ByCSSSelector, "#share-png-url")
+			pngVal, err := wd.ExecuteScript("return document.getElementById('share-png-url').value", nil)
 			require.NoError(t, err)
-			pngVal, err := pngURL.GetAttribute("value")
-			require.NoError(t, err)
-			require.Contains(t, pngVal, ".png", "PNG URL should contain .png")
+			require.Contains(t, pngVal.(string), ".png", "PNG URL should contain .png")
 
-			mdURL, err := wd.FindElement(selenium.ByCSSSelector, "#share-md-url")
+			mdVal, err := wd.ExecuteScript("return document.getElementById('share-md-url').value", nil)
 			require.NoError(t, err)
-			mdVal, err := mdURL.GetAttribute("value")
-			require.NoError(t, err)
-			require.Contains(t, mdVal, "![", "Markdown URL should contain ![ prefix")
+			require.Contains(t, mdVal.(string), "![", "Markdown URL should contain ![ prefix")
 
 			copyBtns, err := wd.FindElements(selenium.ByCSSSelector, ".piko-share-copy")
 			require.NoError(t, err)
@@ -1084,27 +1078,23 @@ job "gen" {
 
 			waitFor(t, wd, waitForClass(selenium.ByCSSSelector, "#share-panel", "open", true), 5*time.Second)
 
-			// Wait for SVG URL to be populated
+			// Wait for SVG URL to be populated (JS sets .value, not HTML attribute)
 			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
-				el, err := wd.FindElement(selenium.ByCSSSelector, "#share-svg-url")
+				val, err := wd.ExecuteScript("return document.getElementById('share-svg-url').value", nil)
 				if err != nil {
 					return false
 				}
-				val, _ := el.GetAttribute("value")
-				return val != ""
+				s, _ := val.(string)
+				return s != ""
 			}, 5*time.Second)
 
-			svgURL, err := wd.FindElement(selenium.ByCSSSelector, "#share-svg-url")
+			svgVal, err := wd.ExecuteScript("return document.getElementById('share-svg-url').value", nil)
 			require.NoError(t, err)
-			svgVal, err := svgURL.GetAttribute("value")
-			require.NoError(t, err)
-			require.Contains(t, svgVal, ".svg")
+			require.Contains(t, svgVal.(string), ".svg")
 
-			pngURL, err := wd.FindElement(selenium.ByCSSSelector, "#share-png-url")
+			pngVal, err := wd.ExecuteScript("return document.getElementById('share-png-url').value", nil)
 			require.NoError(t, err)
-			pngVal, err := pngURL.GetAttribute("value")
-			require.NoError(t, err)
-			require.Contains(t, pngVal, ".png")
+			require.Contains(t, pngVal.(string), ".png")
 
 			err = shareToggle.Click()
 			require.NoError(t, err)

--- a/integration/selenium/pikoci_test.go
+++ b/integration/selenium/pikoci_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package integration_test
+package selenium_test
 
 import (
 	"bytes"
@@ -344,6 +344,157 @@ job "gen" {
 
 			waitFor(t, wd, eqText(selenium.ByCSSSelector, "#a_node1", "cron.my_cron_edit"), 5*time.Second)
 		})
+		t.Run("View Switcher", func(t *testing.T) {
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				_, err := wd.FindElement(selenium.ByCSSSelector, "div#pipeline-graph>svg")
+				return err == nil
+			}, 5*time.Second)
+
+			graphBtn, err := wd.FindElement(selenium.ByCSSSelector, ".piko-view-btn[data-view='graph']")
+			require.NoError(t, err)
+			require.True(t, hasClass(graphBtn, "active"), "graph button should be active by default")
+
+			graphView, err := wd.FindElement(selenium.ByCSSSelector, ".piko-view-graph")
+			require.NoError(t, err)
+			gDisp, err := graphView.IsDisplayed()
+			require.NoError(t, err)
+			require.True(t, gDisp, "graph view should be visible")
+
+			listBtn, err := wd.FindElement(selenium.ByCSSSelector, ".piko-view-btn[data-view='list']")
+			require.NoError(t, err)
+			err = listBtn.Click()
+			require.NoError(t, err)
+
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				el, err := wd.FindElement(selenium.ByCSSSelector, ".piko-view-list")
+				if err != nil {
+					return false
+				}
+				d, err := el.IsDisplayed()
+				return err == nil && d
+			}, 5*time.Second)
+
+			jobRows, err := wd.FindElements(selenium.ByCSSSelector, ".piko-job-row")
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, len(jobRows), 1, "should have at least one job row")
+
+			_, err = wd.FindElement(selenium.ByCSSSelector, ".piko-rsel-container")
+			require.NoError(t, err, "resource selector should exist in list view")
+
+			graphBtn, err = wd.FindElement(selenium.ByCSSSelector, ".piko-view-btn[data-view='graph']")
+			require.NoError(t, err)
+			err = graphBtn.Click()
+			require.NoError(t, err)
+
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				el, err := wd.FindElement(selenium.ByCSSSelector, ".piko-view-graph")
+				if err != nil {
+					return false
+				}
+				d, err := el.IsDisplayed()
+				return err == nil && d
+			}, 5*time.Second)
+		})
+		t.Run("Gear Panel", func(t *testing.T) {
+			gearPanel, err := wd.FindElement(selenium.ByCSSSelector, "#gear-panel")
+			require.NoError(t, err)
+			require.False(t, hasClass(gearPanel, "open"), "gear panel should be closed initially")
+
+			toggleBtn, err := wd.FindElement(selenium.ByCSSSelector, "#toggle-gear-panel")
+			require.NoError(t, err)
+			err = toggleBtn.Click()
+			require.NoError(t, err)
+
+			waitFor(t, wd, waitForClass(selenium.ByCSSSelector, "#gear-panel", "open", true), 5*time.Second)
+
+			_, err = wd.FindElement(selenium.ByCSSSelector, "#gear-hide-intermediates")
+			require.NoError(t, err, "hide intermediates checkbox should exist")
+
+			_, err = wd.FindElement(selenium.ByCSSSelector, "#gear-group-parallel")
+			require.NoError(t, err, "group parallel checkbox should exist")
+
+			hiCheckbox, err := wd.FindElement(selenium.ByCSSSelector, "#gear-hide-intermediates")
+			require.NoError(t, err)
+			err = hiCheckbox.Click()
+			require.NoError(t, err)
+
+			time.Sleep(500 * time.Millisecond)
+
+			err = hiCheckbox.Click()
+			require.NoError(t, err)
+
+			err = toggleBtn.Click()
+			require.NoError(t, err)
+			waitFor(t, wd, waitForClass(selenium.ByCSSSelector, "#gear-panel", "open", false), 5*time.Second)
+		})
+		t.Run("Share Panel", func(t *testing.T) {
+			shareToggle, err := wd.FindElement(selenium.ByCSSSelector, "#toggle-share-panel")
+			require.NoError(t, err)
+			err = shareToggle.Click()
+			require.NoError(t, err)
+
+			waitFor(t, wd, waitForClass(selenium.ByCSSSelector, "#share-panel", "open", true), 5*time.Second)
+
+			svgURL, err := wd.FindElement(selenium.ByCSSSelector, "#share-svg-url")
+			require.NoError(t, err)
+			svgVal, err := svgURL.GetAttribute("value")
+			require.NoError(t, err)
+			require.Contains(t, svgVal, ".svg", "SVG URL should contain .svg")
+
+			pngURL, err := wd.FindElement(selenium.ByCSSSelector, "#share-png-url")
+			require.NoError(t, err)
+			pngVal, err := pngURL.GetAttribute("value")
+			require.NoError(t, err)
+			require.Contains(t, pngVal, ".png", "PNG URL should contain .png")
+
+			mdURL, err := wd.FindElement(selenium.ByCSSSelector, "#share-md-url")
+			require.NoError(t, err)
+			mdVal, err := mdURL.GetAttribute("value")
+			require.NoError(t, err)
+			require.Contains(t, mdVal, "![", "Markdown URL should contain ![ prefix")
+
+			copyBtns, err := wd.FindElements(selenium.ByCSSSelector, ".piko-share-copy")
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, len(copyBtns), 1, "should have copy buttons")
+
+			err = shareToggle.Click()
+			require.NoError(t, err)
+			waitFor(t, wd, waitForClass(selenium.ByCSSSelector, "#share-panel", "open", false), 5*time.Second)
+		})
+		t.Run("Resources Panel", func(t *testing.T) {
+			resToggle, err := wd.FindElement(selenium.ByCSSSelector, "#toggle-resources-panel")
+			require.NoError(t, err)
+			err = resToggle.Click()
+			require.NoError(t, err)
+
+			waitFor(t, wd, waitForClass(selenium.ByCSSSelector, "#pipeline-resources-panel", "open", true), 5*time.Second)
+
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				_, err := wd.FindElement(selenium.ByCSSSelector, ".piko-resource-card[data-canonical='cron.my_cron_edit']")
+				return err == nil
+			}, 5*time.Second)
+
+			cardName, err := wd.FindElement(selenium.ByCSSSelector, ".piko-resource-card[data-canonical='cron.my_cron_edit'] .piko-resource-card-name")
+			require.NoError(t, err)
+			nameTxt, err := cardName.Text()
+			require.NoError(t, err)
+			require.Contains(t, nameTxt, "cron.my_cron_edit")
+
+			cardType, err := wd.FindElement(selenium.ByCSSSelector, ".piko-resource-card[data-canonical='cron.my_cron_edit'] .piko-resource-card-type")
+			require.NoError(t, err)
+			typeTxt, err := cardType.Text()
+			require.NoError(t, err)
+			require.Contains(t, typeTxt, "cron")
+
+			_, err = wd.FindElement(selenium.ByCSSSelector, ".check-resource-now")
+			require.NoError(t, err, "admin should see check-resource-now button")
+
+			closeBtn, err := wd.FindElement(selenium.ByCSSSelector, "#close-resources-panel")
+			require.NoError(t, err)
+			err = closeBtn.Click()
+			require.NoError(t, err)
+			waitFor(t, wd, waitForClass(selenium.ByCSSSelector, "#pipeline-resources-panel", "open", false), 5*time.Second)
+		})
 		t.Run("Resource Versions", func(t *testing.T) {
 			// TODO: Find a way to click the PP SVG
 			res, err := wd.FindElement(selenium.ByCSSSelector, "#a_node1>a")
@@ -381,6 +532,83 @@ job "gen" {
 
 				return len(rvs) > 0
 			}, 5*time.Second)
+		})
+		t.Run("Version Scope Banner", func(t *testing.T) {
+			err := wd.Get(pikoURL + "/teams/main/pipelines/cron")
+			require.NoError(t, err)
+
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				_, err := wd.FindElement(selenium.ByCSSSelector, "div#pipeline-graph>svg")
+				return err == nil
+			}, 5*time.Second)
+
+			resToggle, err := wd.FindElement(selenium.ByCSSSelector, "#toggle-resources-panel")
+			require.NoError(t, err)
+			err = resToggle.Click()
+			require.NoError(t, err)
+
+			waitFor(t, wd, waitForClass(selenium.ByCSSSelector, "#pipeline-resources-panel", "open", true), 5*time.Second)
+
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				_, err := wd.FindElement(selenium.ByCSSSelector, ".piko-resource-card[data-canonical='cron.my_cron_edit']")
+				return err == nil
+			}, 5*time.Second)
+
+			expandToggle, err := wd.FindElement(selenium.ByCSSSelector, ".piko-resource-expand-toggle[data-canonical='cron.my_cron_edit']")
+			require.NoError(t, err)
+			err = expandToggle.Click()
+			require.NoError(t, err)
+
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				_, err := wd.FindElement(selenium.ByCSSSelector, ".piko-panel-track-btn")
+				return err == nil
+			}, 5*time.Second)
+
+			trackBtn, err := wd.FindElement(selenium.ByCSSSelector, ".piko-panel-track-btn")
+			require.NoError(t, err)
+			err = trackBtn.Click()
+			require.NoError(t, err)
+
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				el, err := wd.FindElement(selenium.ByCSSSelector, "#version-scope-banner")
+				if err != nil {
+					return false
+				}
+				d, err := el.IsDisplayed()
+				return err == nil && d
+			}, 5*time.Second)
+
+			bannerRes, err := wd.FindElement(selenium.ByCSSSelector, "#version-banner-resource")
+			require.NoError(t, err)
+			resTxt, err := bannerRes.Text()
+			require.NoError(t, err)
+			require.Equal(t, "cron.my_cron_edit", resTxt)
+
+			bannerProgress, err := wd.FindElement(selenium.ByCSSSelector, "#version-banner-progress")
+			require.NoError(t, err)
+			progTxt, err := bannerProgress.Text()
+			require.NoError(t, err)
+			require.Contains(t, progTxt, "completed")
+
+			clearBtn, err := wd.FindElement(selenium.ByCSSSelector, "#clear-version-scope")
+			require.NoError(t, err)
+			err = clearBtn.Click()
+			require.NoError(t, err)
+
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				el, err := wd.FindElement(selenium.ByCSSSelector, "#version-scope-banner")
+				if err != nil {
+					return true
+				}
+				d, err := el.IsDisplayed()
+				return err == nil && !d
+			}, 5*time.Second)
+
+			closeBtn, err := wd.FindElement(selenium.ByCSSSelector, "#close-resources-panel")
+			require.NoError(t, err)
+			err = closeBtn.Click()
+			require.NoError(t, err)
+			waitFor(t, wd, waitForClass(selenium.ByCSSSelector, "#pipeline-resources-panel", "open", false), 5*time.Second)
 		})
 		t.Run("Job Builds", func(t *testing.T) {
 			ppBtn, err := wd.FindElement(selenium.ByLinkText, "cron")
@@ -781,6 +1009,86 @@ job "gen" {
 			_, err = wd.FindElement(selenium.ByCSSSelector, "#edit-pipeline")
 			require.Error(t, err)
 		})
+		t.Run("View Switcher", func(t *testing.T) {
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				_, err := wd.FindElement(selenium.ByCSSSelector, "div#pipeline-graph>svg")
+				return err == nil
+			}, 5*time.Second)
+
+			listBtn, err := wd.FindElement(selenium.ByCSSSelector, ".piko-view-btn[data-view='list']")
+			require.NoError(t, err)
+			err = listBtn.Click()
+			require.NoError(t, err)
+
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				el, err := wd.FindElement(selenium.ByCSSSelector, ".piko-view-list")
+				if err != nil {
+					return false
+				}
+				d, err := el.IsDisplayed()
+				return err == nil && d
+			}, 5*time.Second)
+
+			graphBtn, err := wd.FindElement(selenium.ByCSSSelector, ".piko-view-btn[data-view='graph']")
+			require.NoError(t, err)
+			err = graphBtn.Click()
+			require.NoError(t, err)
+
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				el, err := wd.FindElement(selenium.ByCSSSelector, ".piko-view-graph")
+				if err != nil {
+					return false
+				}
+				d, err := el.IsDisplayed()
+				return err == nil && d
+			}, 5*time.Second)
+		})
+		t.Run("Resources Panel", func(t *testing.T) {
+			resToggle, err := wd.FindElement(selenium.ByCSSSelector, "#toggle-resources-panel")
+			require.NoError(t, err)
+			err = resToggle.Click()
+			require.NoError(t, err)
+
+			waitFor(t, wd, waitForClass(selenium.ByCSSSelector, "#pipeline-resources-panel", "open", true), 5*time.Second)
+
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				cards, err := wd.FindElements(selenium.ByCSSSelector, ".piko-resource-card")
+				return err == nil && len(cards) > 0
+			}, 5*time.Second)
+
+			_, err = wd.FindElement(selenium.ByCSSSelector, ".check-resource-now")
+			require.NoError(t, err, "member should see check-resource-now button")
+
+			closeBtn, err := wd.FindElement(selenium.ByCSSSelector, "#close-resources-panel")
+			require.NoError(t, err)
+			err = closeBtn.Click()
+			require.NoError(t, err)
+			waitFor(t, wd, waitForClass(selenium.ByCSSSelector, "#pipeline-resources-panel", "open", false), 5*time.Second)
+		})
+		t.Run("Share Panel", func(t *testing.T) {
+			shareToggle, err := wd.FindElement(selenium.ByCSSSelector, "#toggle-share-panel")
+			require.NoError(t, err)
+			err = shareToggle.Click()
+			require.NoError(t, err)
+
+			waitFor(t, wd, waitForClass(selenium.ByCSSSelector, "#share-panel", "open", true), 5*time.Second)
+
+			svgURL, err := wd.FindElement(selenium.ByCSSSelector, "#share-svg-url")
+			require.NoError(t, err)
+			svgVal, err := svgURL.GetAttribute("value")
+			require.NoError(t, err)
+			require.Contains(t, svgVal, ".svg")
+
+			pngURL, err := wd.FindElement(selenium.ByCSSSelector, "#share-png-url")
+			require.NoError(t, err)
+			pngVal, err := pngURL.GetAttribute("value")
+			require.NoError(t, err)
+			require.Contains(t, pngVal, ".png")
+
+			err = shareToggle.Click()
+			require.NoError(t, err)
+			waitFor(t, wd, waitForClass(selenium.ByCSSSelector, "#share-panel", "open", false), 5*time.Second)
+		})
 		t.Run("Resource Versions", func(t *testing.T) {
 			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
 				_, err := wd.FindElement(selenium.ByCSSSelector, "div#pipeline-graph>svg")
@@ -911,6 +1219,59 @@ job "gen" {
 				_, err := wd.FindElement(selenium.ByCSSSelector, "div#pipeline-graph>svg")
 				return err == nil
 			}, 5*time.Second)
+		})
+
+		t.Run("ViewSwitcherPublic", func(t *testing.T) {
+			listBtn, err := wd.FindElement(selenium.ByCSSSelector, ".piko-view-btn[data-view='list']")
+			require.NoError(t, err)
+			err = listBtn.Click()
+			require.NoError(t, err)
+
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				el, err := wd.FindElement(selenium.ByCSSSelector, ".piko-view-list")
+				if err != nil {
+					return false
+				}
+				d, err := el.IsDisplayed()
+				return err == nil && d
+			}, 5*time.Second)
+
+			graphBtn, err := wd.FindElement(selenium.ByCSSSelector, ".piko-view-btn[data-view='graph']")
+			require.NoError(t, err)
+			err = graphBtn.Click()
+			require.NoError(t, err)
+
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				el, err := wd.FindElement(selenium.ByCSSSelector, ".piko-view-graph")
+				if err != nil {
+					return false
+				}
+				d, err := el.IsDisplayed()
+				return err == nil && d
+			}, 5*time.Second)
+		})
+
+		t.Run("ResourcesPanelPublicHidden", func(t *testing.T) {
+			resToggle, err := wd.FindElement(selenium.ByCSSSelector, "#toggle-resources-panel")
+			require.NoError(t, err)
+			err = resToggle.Click()
+			require.NoError(t, err)
+
+			waitFor(t, wd, waitForClass(selenium.ByCSSSelector, "#pipeline-resources-panel", "open", true), 5*time.Second)
+
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				cards, err := wd.FindElements(selenium.ByCSSSelector, ".piko-resource-card")
+				return err == nil && len(cards) > 0
+			}, 5*time.Second)
+
+			_, err = wd.FindElement(selenium.ByCSSSelector, ".check-resource-now")
+			require.Error(t, err, "public viewer should not see check-resource-now button")
+
+			closeBtn, err := wd.FindElement(selenium.ByCSSSelector, "#close-resources-panel")
+			require.NoError(t, err)
+			err = closeBtn.Click()
+			require.NoError(t, err)
+			waitFor(t, wd, waitForClass(selenium.ByCSSSelector, "#pipeline-resources-panel", "open", false), 5*time.Second)
 		})
 
 		t.Run("CanViewJobBuilds", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Reorganize `integration/`**: Move Selenium tests to `integration/selenium/`, create `integration/http/` for HTTP API tests
- **HTTP integration tests**: 41 endpoint tests using real in-memory DB + real service + httptest server covering auth, users, teams, pipelines, jobs, resources, webhooks, builds, workers, triggers, and admin endpoints
- **Selenium improvements**: New subtests for view switcher, gear panel, share panel, resources panel, and version scope banner across admin, member, and public user contexts
- **Pipeline**: Add `test-http` job to CI pipeline

Closes #545