### PR TITLE
fix: recover builds stuck in started after server restart (#569)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Builds stuck in "started" status after server restart (#569). Server now polls DB for running builds during SIGQUIT graceful shutdown (not just embedded workers), recovers orphaned builds on startup, and workers retry build updates with backoff.
+
 ## [0.6.0] - 2026-06-22
 
 ### Changed

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -129,6 +129,14 @@ var serverCmd = &cobra.Command{
 
 		logger.Info("initializing service")
 		var svc = pikoci.New(ctx, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, wr, suow, jwtSecret, wn, logger)
+
+		// Recover builds orphaned by a previous crash or unclean shutdown.
+		if n, err := svc.RecoverOrphanedBuilds(ctx); err != nil {
+			logger.Error("failed to recover orphaned builds", "error", err)
+		} else if n > 0 {
+			logger.Warn("failed orphaned builds from previous shutdown", "count", n)
+		}
+
 		svc.StartScheduler(ctx)
 		logger.Info("initialized service")
 
@@ -289,6 +297,9 @@ var serverCmd = &cobra.Command{
 		case sig := <-quit:
 			logger.Info("received signal, starting graceful shutdown", "signal", sig)
 
+			// Single deadline shared across both embedded and separated worker drain.
+			deadline := time.After(drainTimeout)
+
 			if cfg.RunWorker && workers != nil {
 				for _, w := range workers {
 					w.Drain()
@@ -300,11 +311,38 @@ var serverCmd = &cobra.Command{
 
 				select {
 				case <-done:
-					logger.Info("all workers finished")
-				case <-time.After(drainTimeout):
-					logger.Warn("graceful shutdown timed out, forcing exit")
+					logger.Info("all embedded workers finished")
+				case <-deadline:
+					logger.Warn("embedded worker drain timed out")
 				}
 			}
+
+			// Wait for any remaining started builds (from separated workers).
+			for {
+				n, err := svc.CountStartedBuilds(ctx)
+				if err != nil {
+					logger.Error("failed to count started builds during drain", "error", err)
+					break
+				}
+				if n == 0 {
+					logger.Info("no running builds remaining")
+					break
+				}
+				logger.Info("waiting for running builds to finish", "count", n)
+				select {
+				case <-time.After(2 * time.Second):
+					continue
+				case <-deadline:
+					failed, err := svc.RecoverOrphanedBuilds(ctx)
+					if err != nil {
+						logger.Error("failed to recover orphaned builds during drain", "error", err)
+					} else {
+						logger.Warn("drain timeout expired, failed remaining builds", "count", failed)
+					}
+					goto shutdown
+				}
+			}
+		shutdown:
 
 			// Cancel the main context so any blocked Receive() calls
 			// unblock and worker goroutines can exit.

--- a/integration/backends/grpc_worker_test.go
+++ b/integration/backends/grpc_worker_test.go
@@ -207,3 +207,283 @@ job "grpc-test" {
 	}
 	assert.True(t, found, "worker should be registered via heartbeat")
 }
+
+// TestStartupRecoveryFailsOrphanedBuilds verifies that RecoverOrphanedBuilds
+// transitions "started" builds to "failed" without affecting other statuses.
+func TestStartupRecoveryFailsOrphanedBuilds(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})).With("test", "startup-recovery")
+
+	// --- Set up DB + service ---
+	dbFile := t.TempDir() + "/test.db"
+	db, err := mysql.New("", 0, "", "", mysql.Options{
+		MultiStatements: true,
+		ClientFoundRows: true,
+		System:          mysql.SQLite,
+		DBName:          dbFile,
+		DBFile:          dbFile,
+	})
+	require.NoError(t, err)
+	require.NoError(t, migrate.Migrate(db, mysql.SQLite))
+
+	ur := mysql.NewUserRepository(db)
+	tr := mysql.NewTeamRepository(db)
+	ppr := mysql.NewPipelineRepository(db)
+	jr := mysql.NewJobRepository(db)
+	rr := mysql.NewResourceRepository(db, mysql.SQLite)
+	rt := mysql.NewResourceTypeRepository(db)
+	br := mysql.NewBuildRepository(db, mysql.SQLite)
+	rur := mysql.NewRunnerRepository(db)
+	str := mysql.NewSecretTypeRepository(db)
+	tgr := mysql.NewTriggerRepository(db)
+	wr := mysql.NewWorkerRepository(db, mysql.SQLite)
+	suow := unitwork.NewStartUnitOfWork(db, mysql.SQLite)
+
+	jwtSecret := []byte("test-secret")
+	wn := notifier.New()
+	svc := pikoci.New(ctx, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, wr, suow, jwtSecret, wn, logger)
+
+	// Create a pipeline + job so we can create builds
+	hclConfig := []byte(`
+resource "cron" "trigger" {
+  check_interval = "@every 1h"
+}
+
+job "recovery-test" {
+  get "cron" "trigger" {
+    trigger = true
+  }
+  task "work" {
+    run "exec" {
+      path = "/bin/sh"
+      args = ["-ec", "echo hello"]
+    }
+  }
+}
+`)
+	_, err = svc.CreatePipeline(ctx, "main", "recovery-test", hclConfig, nil)
+	require.NoError(t, err)
+
+	// Seed a resource version
+	_, err = svc.CreateResourceVersion(ctx, "main", "recovery-test", "cron.trigger", resource.Version{
+		Version: map[string]interface{}{"date": "seed"},
+	})
+	require.NoError(t, err)
+
+	// Create builds in various statuses
+	pendingBuild, err := svc.CreateJobBuild(ctx, "main", "recovery-test", "recovery-test", build.Build{})
+	require.NoError(t, err)
+
+	startedBuild, err := svc.CreateJobBuild(ctx, "main", "recovery-test", "recovery-test", build.Build{})
+	require.NoError(t, err)
+	// Transition to started via StartPending
+	_, err = svc.StartPendingBuild(ctx, "main", "recovery-test", "recovery-test", startedBuild.ID)
+	require.NoError(t, err)
+
+	succeededBuild, err := svc.CreateJobBuild(ctx, "main", "recovery-test", "recovery-test", build.Build{})
+	require.NoError(t, err)
+	_, err = svc.StartPendingBuild(ctx, "main", "recovery-test", "recovery-test", succeededBuild.ID)
+	require.NoError(t, err)
+	err = svc.UpdateJobBuild(ctx, "main", "recovery-test", "recovery-test", succeededBuild.BuildNumber, build.Build{
+		Status:    build.Succeeded,
+		StartedAt: time.Now(),
+	})
+	require.NoError(t, err)
+
+	// Verify started count before recovery
+	count, err := svc.CountStartedBuilds(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	// Run recovery
+	n, err := svc.RecoverOrphanedBuilds(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n, "should have recovered exactly 1 orphaned build")
+
+	// Verify no started builds remain
+	count, err = svc.CountStartedBuilds(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+
+	// Verify the started build is now failed with the right message
+	b, err := svc.GetJobBuild(ctx, "main", "recovery-test", "recovery-test", startedBuild.BuildNumber)
+	require.NoError(t, err)
+	assert.Equal(t, build.Failed, b.Status)
+	assert.Contains(t, b.Error, "server shutdown")
+
+	// Verify pending build is still pending
+	b, err = svc.GetJobBuild(ctx, "main", "recovery-test", "recovery-test", pendingBuild.BuildNumber)
+	require.NoError(t, err)
+	assert.Equal(t, build.Pending, b.Status)
+
+	// Verify succeeded build is still succeeded
+	b, err = svc.GetJobBuild(ctx, "main", "recovery-test", "recovery-test", succeededBuild.BuildNumber)
+	require.NoError(t, err)
+	assert.Equal(t, build.Succeeded, b.Status)
+}
+
+// TestServerDrainWaitsForSeparatedWorkerBuilds verifies that SIGQUIT-style
+// drain waits for started builds to reach a terminal status before shutting down.
+func TestServerDrainWaitsForSeparatedWorkerBuilds(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})).With("test", "drain-wait")
+
+	// --- Set up DB + service ---
+	dbFile := t.TempDir() + "/test.db"
+	db, err := mysql.New("", 0, "", "", mysql.Options{
+		MultiStatements: true,
+		ClientFoundRows: true,
+		System:          mysql.SQLite,
+		DBName:          dbFile,
+		DBFile:          dbFile,
+	})
+	require.NoError(t, err)
+	require.NoError(t, migrate.Migrate(db, mysql.SQLite))
+
+	ur := mysql.NewUserRepository(db)
+	tr := mysql.NewTeamRepository(db)
+	ppr := mysql.NewPipelineRepository(db)
+	jr := mysql.NewJobRepository(db)
+	rr := mysql.NewResourceRepository(db, mysql.SQLite)
+	rt := mysql.NewResourceTypeRepository(db)
+	br := mysql.NewBuildRepository(db, mysql.SQLite)
+	rur := mysql.NewRunnerRepository(db)
+	str := mysql.NewSecretTypeRepository(db)
+	tgr := mysql.NewTriggerRepository(db)
+	wr := mysql.NewWorkerRepository(db, mysql.SQLite)
+	suow := unitwork.NewStartUnitOfWork(db, mysql.SQLite)
+
+	jwtSecret := []byte("test-secret")
+	wn := notifier.New()
+	svc := pikoci.New(ctx, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, wr, suow, jwtSecret, wn, logger)
+	svc.StartScheduler(ctx)
+
+	// Create admin user
+	svc.CreateUser(ctx, user.User{
+		FullName: "admin",
+		Username: "admin",
+		Password: "$2a$14$rwQk8Qvc2rij7qhFO4P1W.OiSF6AkgVU1RCrLaY2wawJcpkPEKwbm",
+	}, true)
+
+	// --- Start HTTP + gRPC server ---
+	streamMgr := pikogrpc.NewWorkerStreamManager()
+	grpcServer := pikogrpc.NewServer(svc, wn, streamMgr, jwtSecret, logger.With("component", "gRPC"))
+	grpcSrv := grpc.NewServer()
+	workerv1.RegisterWorkerServiceServer(grpcSrv, grpcServer)
+	svc.GRPCServer = grpcServer
+
+	httpHandler := tshttp.Handler(svc, jwtSecret, logger.With("component", "HTTP"), db, mysql.SQLite, "test", "test")
+	httpSrv := &http.Server{Handler: handlers.CombinedLoggingHandler(os.Stderr, httpHandler)}
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := lis.Addr().String()
+
+	m := cmux.New(lis)
+	grpcLis := m.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
+	httpLis := m.Match(cmux.Any())
+
+	go grpcSrv.Serve(grpcLis)
+	go httpSrv.Serve(httpLis)
+	go m.Serve()
+	t.Cleanup(func() {
+		grpcSrv.Stop()
+		httpSrv.Close()
+	})
+
+	workerToken := generateTestWorkerJWT(jwtSecret)
+	httpClient, err := client.New(fmt.Sprintf("http://%s", addr), workerToken)
+	require.NoError(t, err)
+
+	grpcConn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { grpcConn.Close() })
+	grpcClient := workerv1.NewWorkerServiceClient(grpcConn)
+
+	// Start standalone worker with a slow job
+	w := worker.NewGRPC(httpClient, grpcClient, logger.With("worker", "drain-worker-1"), "drain-worker-1", "test", "", 1, workerToken, addr, nil, false)
+	go w.Run(ctx)
+
+	require.Eventually(t, func() bool {
+		return streamMgr.ConnectedCount() > 0
+	}, 3*time.Second, 50*time.Millisecond, "worker should connect via gRPC")
+
+	// Create pipeline with a slow job (sleeps 3 seconds)
+	hclConfig := []byte(`
+resource "cron" "trigger" {
+  check_interval = "@every 1h"
+}
+
+job "drain-test" {
+  get "cron" "trigger" {
+    trigger = true
+  }
+  task "slow-work" {
+    run "exec" {
+      path = "/bin/sh"
+      args = ["-ec", "sleep 3 && echo done"]
+    }
+  }
+}
+`)
+	_, err = svc.CreatePipeline(ctx, "main", "drain-test", hclConfig, nil)
+	require.NoError(t, err)
+
+	// Seed + trigger
+	_, err = svc.CreateResourceVersion(ctx, "main", "drain-test", "cron.trigger", resource.Version{
+		Version: map[string]interface{}{"date": "seed"},
+	})
+	require.NoError(t, err)
+	_, err = svc.CreateResourceVersion(ctx, "main", "drain-test", "cron.trigger", resource.Version{
+		Version: map[string]interface{}{"date": "v2"},
+	})
+	require.NoError(t, err)
+	err = svc.TriggerPipelineJob(ctx, "main", "drain-test", "drain-test")
+	require.NoError(t, err)
+
+	// Wait until the build is started
+	require.Eventually(t, func() bool {
+		builds, _, err := svc.ListJobBuilds(ctx, "main", "drain-test", "drain-test", nil, nil, 0)
+		if err != nil || len(builds) == 0 {
+			return false
+		}
+		return builds[0].Status == build.Started
+	}, 10*time.Second, 200*time.Millisecond, "build should reach started status")
+
+	// Now simulate drain: poll CountStartedBuilds until 0
+	drainDone := make(chan struct{})
+	go func() {
+		defer close(drainDone)
+		deadline := time.After(15 * time.Second)
+		for {
+			n, err := svc.CountStartedBuilds(ctx)
+			if err != nil || n == 0 {
+				return
+			}
+			select {
+			case <-time.After(500 * time.Millisecond):
+			case <-deadline:
+				return
+			}
+		}
+	}()
+
+	// Drain should complete within the build's runtime (~3s) + buffer
+	select {
+	case <-drainDone:
+		// Drain completed - build should be in terminal status
+	case <-time.After(15 * time.Second):
+		t.Fatal("drain did not complete in time")
+	}
+
+	// Verify build reached terminal status
+	builds, _, err := svc.ListJobBuilds(ctx, "main", "drain-test", "drain-test", nil, nil, 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, builds)
+	b := builds[0]
+	assert.Equal(t, build.Succeeded, b.Status, "build should have succeeded, got: %s (error: %s)", b.Status, b.Error)
+}

--- a/pikoci/build/repository.go
+++ b/pikoci/build/repository.go
@@ -46,4 +46,9 @@ type Repository interface {
 	// specified jobs, including retries of matched builds.
 	// The result maps job name to a slice of builds (main build first, retries after).
 	FindByVersionAndJobs(ctx context.Context, tc, pn string, versionID uint32, jobNames []string) (map[string][]*Build, error)
+	// CountStarted returns the total number of builds with status "started" across all jobs.
+	CountStarted(ctx context.Context) (int, error)
+	// FailStartedBuilds transitions all builds with status "started" to "failed" with the given reason.
+	// It returns the number of builds that were updated.
+	FailStartedBuilds(ctx context.Context, reason string) (int, error)
 }

--- a/pikoci/builds.go
+++ b/pikoci/builds.go
@@ -410,6 +410,18 @@ func (q *PikoCI) ReEnqueuePendingBuilds(ctx context.Context) error {
 	return nil
 }
 
+// CountStartedBuilds returns the total number of builds with status "started" across all jobs.
+func (q *PikoCI) CountStartedBuilds(ctx context.Context) (int, error) {
+	return q.Builds.CountStarted(ctx)
+}
+
+// RecoverOrphanedBuilds fails all builds stuck in "started" status. This is
+// used on startup to clean up builds orphaned by a previous server crash, and
+// during graceful shutdown when the drain timeout expires.
+func (q *PikoCI) RecoverOrphanedBuilds(ctx context.Context) (int, error) {
+	return q.Builds.FailStartedBuilds(ctx, "server shutdown: build was orphaned")
+}
+
 // resolvePassedJobNames expands for_each group names in a passed list to all
 // instance names. If a name matches a for_each group, it is replaced by all
 // instance names in that group. Non-group names are kept as-is.

--- a/pikoci/builds_test.go
+++ b/pikoci/builds_test.go
@@ -684,6 +684,42 @@ func TestCreateRetryJobBuild_InvalidCanonical(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestCountStartedBuilds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Builds.EXPECT().CountStarted(ctx).Return(3, nil)
+
+	n, err := s.P.CountStartedBuilds(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 3, n)
+}
+
+func TestRecoverOrphanedBuilds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Builds.EXPECT().FailStartedBuilds(ctx, "server shutdown: build was orphaned").Return(2, nil)
+
+	n, err := s.P.RecoverOrphanedBuilds(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+}
+
+func TestRecoverOrphanedBuilds_NoneOrphaned(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Builds.EXPECT().FailStartedBuilds(ctx, "server shutdown: build was orphaned").Return(0, nil)
+
+	n, err := s.P.RecoverOrphanedBuilds(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
 // --- EvaluateDownstreamJobs tests ---
 
 // makePipelineLintDeploy returns a pipeline with "lint" and "deploy" jobs.

--- a/pikoci/mock/build_repository.go
+++ b/pikoci/mock/build_repository.go
@@ -87,6 +87,21 @@ func (mr *BuildRepositoryMockRecorder) CountRunningInSerialGroups(ctx, tc, pn, s
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountRunningInSerialGroups", reflect.TypeOf((*BuildRepository)(nil).CountRunningInSerialGroups), ctx, tc, pn, serialGroups, excludeJobName)
 }
 
+// CountStarted mocks base method.
+func (m *BuildRepository) CountStarted(ctx context.Context) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountStarted", ctx)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountStarted indicates an expected call of CountStarted.
+func (mr *BuildRepositoryMockRecorder) CountStarted(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountStarted", reflect.TypeOf((*BuildRepository)(nil).CountStarted), ctx)
+}
+
 // Create mocks base method.
 func (m *BuildRepository) Create(ctx context.Context, tc, pn, jn string, b build.Build) (uint32, string, error) {
 	m.ctrl.T.Helper()
@@ -131,6 +146,21 @@ func (m *BuildRepository) Delete(ctx context.Context, tc, pn, jn, buildNumber st
 func (mr *BuildRepositoryMockRecorder) Delete(ctx, tc, pn, jn, buildNumber any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*BuildRepository)(nil).Delete), ctx, tc, pn, jn, buildNumber)
+}
+
+// FailStartedBuilds mocks base method.
+func (m *BuildRepository) FailStartedBuilds(ctx context.Context, reason string) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailStartedBuilds", ctx, reason)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FailStartedBuilds indicates an expected call of FailStartedBuilds.
+func (mr *BuildRepositoryMockRecorder) FailStartedBuilds(ctx, reason any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailStartedBuilds", reflect.TypeOf((*BuildRepository)(nil).FailStartedBuilds), ctx, reason)
 }
 
 // Filter mocks base method.

--- a/pikoci/mysql/build.go
+++ b/pikoci/mysql/build.go
@@ -720,6 +720,27 @@ func (r *BuildRepository) FindByVersionAndJobs(ctx context.Context, tc, pn strin
 	return result, nil
 }
 
+func (r *BuildRepository) CountStarted(ctx context.Context) (int, error) {
+	var count int
+	err := r.querier.QueryRowContext(ctx, `SELECT COUNT(*) FROM builds WHERE status = 'started'`).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count started builds: %w", err)
+	}
+	return count, nil
+}
+
+func (r *BuildRepository) FailStartedBuilds(ctx context.Context, reason string) (int, error) {
+	res, err := r.querier.ExecContext(ctx, `UPDATE builds SET status = 'failed', error = ? WHERE status = 'started'`, reason)
+	if err != nil {
+		return 0, fmt.Errorf("failed to fail started builds: %w", err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	return int(rows), nil
+}
+
 func scanBuild(s sqlr.Scanner) (*build.Build, error) {
 	var b dbBuild
 

--- a/pikoci/mysql/build_test.go
+++ b/pikoci/mysql/build_test.go
@@ -760,6 +760,103 @@ func TestCountRunningInSerialGroups(t *testing.T) {
 	assert.Equal(t, 0, count)
 }
 
+func TestCountStarted(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	// Clean up any started builds from other tests (shared in-memory DB)
+	_, _ = db.ExecContext(ctx, `UPDATE builds SET status = 'failed' WHERE status = 'started'`)
+
+	res, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'cs-pipe', 'cs-pipe')`)
+	require.NoError(t, err)
+	ppID, _ := res.LastInsertId()
+
+	res, err = db.ExecContext(ctx, `INSERT INTO jobs (pipeline_id, name) VALUES (?, 'build')`, ppID)
+	require.NoError(t, err)
+	jobID, _ := res.LastInsertId()
+
+	br := mysql.NewBuildRepository(db, mysql.Mem)
+
+	// Verify no started builds initially
+	count, err := br.CountStarted(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+
+	// Insert builds in various statuses
+	_, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, build_number) VALUES (?, 'started', '1')`, jobID)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, build_number) VALUES (?, 'started', '2')`, jobID)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, build_number) VALUES (?, 'pending', '3')`, jobID)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, build_number) VALUES (?, 'succeeded', '4')`, jobID)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, build_number) VALUES (?, 'failed', '5')`, jobID)
+	require.NoError(t, err)
+
+	count, err = br.CountStarted(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+}
+
+func TestFailStartedBuilds(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	// Clean up any started builds from other tests (shared in-memory DB)
+	_, _ = db.ExecContext(ctx, `UPDATE builds SET status = 'failed' WHERE status = 'started'`)
+
+	res, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'fsb-pipe', 'fsb-pipe')`)
+	require.NoError(t, err)
+	ppID, _ := res.LastInsertId()
+
+	res, err = db.ExecContext(ctx, `INSERT INTO jobs (pipeline_id, name) VALUES (?, 'build')`, ppID)
+	require.NoError(t, err)
+	jobID, _ := res.LastInsertId()
+
+	// Insert builds in various statuses
+	_, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, build_number) VALUES (?, 'started', '1')`, jobID)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, build_number) VALUES (?, 'started', '2')`, jobID)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, build_number) VALUES (?, 'pending', '3')`, jobID)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, build_number) VALUES (?, 'succeeded', '4')`, jobID)
+	require.NoError(t, err)
+
+	br := mysql.NewBuildRepository(db, mysql.Mem)
+
+	n, err := br.FailStartedBuilds(ctx, "server shutdown")
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+
+	// Verify started builds are now failed
+	b1, err := br.Find(ctx, "main", "fsb-pipe", "build", "1")
+	require.NoError(t, err)
+	assert.Equal(t, "failed", b1.Status.String())
+	assert.Equal(t, "server shutdown", b1.Error)
+
+	b2, err := br.Find(ctx, "main", "fsb-pipe", "build", "2")
+	require.NoError(t, err)
+	assert.Equal(t, "failed", b2.Status.String())
+	assert.Equal(t, "server shutdown", b2.Error)
+
+	// Verify pending build is untouched
+	b3, err := br.Find(ctx, "main", "fsb-pipe", "build", "3")
+	require.NoError(t, err)
+	assert.Equal(t, "pending", b3.Status.String())
+
+	// Verify succeeded build is untouched
+	b4, err := br.Find(ctx, "main", "fsb-pipe", "build", "4")
+	require.NoError(t, err)
+	assert.Equal(t, "succeeded", b4.Status.String())
+
+	// No started builds remain
+	count, err := br.CountStarted(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
 func TestCountRunningInSerialGroups_Empty(t *testing.T) {
 	db := setupTestDB(t)
 	ctx := context.Background()

--- a/worker/service.go
+++ b/worker/service.go
@@ -2208,7 +2208,7 @@ func (w *Worker) updateBuild(_ context.Context, m workitem.Body, b build.Build) 
 		return nil
 	}
 	dbCtx := w.dbContext()
-	err := w.pikoci.UpdateJobBuild(dbCtx, m.TeamCanonical, m.PipelineCanonical, m.JobName, b.BuildNumber, b)
+	err := w.updateBuildWithRetry(dbCtx, m, b)
 	if err != nil {
 		w.logger.Error("failed update build", "pipeline", m.PipelineCanonical, "job", m.JobName, "error", err)
 	}
@@ -2225,9 +2225,32 @@ func (w *Worker) failBuild(_ context.Context, m workitem.Body, b build.Build, er
 		return
 	}
 	dbCtx := w.dbContext()
-	if uerr := w.pikoci.UpdateJobBuild(dbCtx, m.TeamCanonical, m.PipelineCanonical, m.JobName, b.BuildNumber, b); uerr != nil {
+	if uerr := w.updateBuildWithRetry(dbCtx, m, b); uerr != nil {
 		w.logger.Error("failed update build", "pipeline", m.PipelineCanonical, "job", m.JobName, "error", uerr)
 	}
+}
+
+// updateBuildWithRetry retries the UpdateJobBuild call with exponential backoff.
+// This gives separated workers the best chance to report results when the server
+// is restarting.
+func (w *Worker) updateBuildWithRetry(ctx context.Context, m workitem.Body, b build.Build) error {
+	var err error
+	delays := []time.Duration{1 * time.Second, 2 * time.Second, 4 * time.Second}
+	for attempt := 0; attempt <= len(delays); attempt++ {
+		err = w.pikoci.UpdateJobBuild(ctx, m.TeamCanonical, m.PipelineCanonical, m.JobName, b.BuildNumber, b)
+		if err == nil {
+			return nil
+		}
+		if attempt < len(delays) {
+			w.logger.Warn("retrying build update", "pipeline", m.PipelineCanonical, "job", m.JobName, "attempt", attempt+1, "error", err)
+			select {
+			case <-time.After(delays[attempt]):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	}
+	return err
 }
 
 // dbContext returns the appropriate context for DB operations.

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -8808,3 +8808,103 @@ func TestProcessJob_EnsureHook_Fails_BuildStatusUnchanged(t *testing.T) {
 	}
 	assert.True(t, found, "should have found the ensure hook step")
 }
+
+func TestUpdateBuildWithRetry_SucceedsFirstAttempt(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc := newTestWorker(ctrl)
+	ctx := context.Background()
+	w.apiCtx = ctx
+
+	m := workitem.Body{TeamCanonical: "main", PipelineCanonical: "test-pipeline", JobName: "test-job"}
+	b := build.Build{BuildNumber: "1", Status: build.Succeeded, StartedAt: time.Now()}
+
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "1", gomock.Any()).Return(nil)
+
+	err := w.updateBuild(ctx, m, b)
+	assert.NoError(t, err)
+}
+
+func TestUpdateBuildWithRetry_FailsThenSucceeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc := newTestWorker(ctrl)
+	ctx := context.Background()
+	w.apiCtx = ctx
+
+	m := workitem.Body{TeamCanonical: "main", PipelineCanonical: "test-pipeline", JobName: "test-job"}
+	b := build.Build{BuildNumber: "1", Status: build.Succeeded, StartedAt: time.Now()}
+
+	gomock.InOrder(
+		svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "1", gomock.Any()).Return(fmt.Errorf("connection refused")),
+		svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "1", gomock.Any()).Return(nil),
+	)
+
+	err := w.updateBuild(ctx, m, b)
+	assert.NoError(t, err)
+}
+
+func TestUpdateBuildWithRetry_ExhaustsRetries(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc := newTestWorker(ctrl)
+	ctx := context.Background()
+	w.apiCtx = ctx
+
+	m := workitem.Body{TeamCanonical: "main", PipelineCanonical: "test-pipeline", JobName: "test-job"}
+	b := build.Build{BuildNumber: "1", Status: build.Succeeded, StartedAt: time.Now()}
+
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "1", gomock.Any()).
+		Return(fmt.Errorf("connection refused")).Times(4) // 1 initial + 3 retries
+
+	err := w.updateBuild(ctx, m, b)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "connection refused")
+}
+
+func TestUpdateBuildWithRetry_ContextCancelled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc := newTestWorker(ctrl)
+	ctx, cancel := context.WithCancel(context.Background())
+	w.apiCtx = ctx
+
+	m := workitem.Body{TeamCanonical: "main", PipelineCanonical: "test-pipeline", JobName: "test-job"}
+	b := build.Build{BuildNumber: "1", Status: build.Succeeded, StartedAt: time.Now()}
+
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "1", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, _ build.Build) error {
+			cancel() // Cancel context on first failure
+			return fmt.Errorf("connection refused")
+		})
+
+	err := w.updateBuild(ctx, m, b)
+	assert.Error(t, err)
+	assert.Equal(t, context.Canceled, err)
+}
+
+func TestFailBuildWithRetry(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc := newTestWorker(ctrl)
+	ctx := context.Background()
+	w.apiCtx = ctx
+
+	m := workitem.Body{TeamCanonical: "main", PipelineCanonical: "test-pipeline", JobName: "test-job"}
+	b := build.Build{BuildNumber: "1", Status: build.Started, StartedAt: time.Now()}
+
+	gomock.InOrder(
+		svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "1", gomock.Any()).Return(fmt.Errorf("connection refused")),
+		svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "1", gomock.Any()).Return(nil),
+	)
+
+	w.failBuild(ctx, m, b, fmt.Errorf("step failed"))
+}
+
+func TestUpdateBuild_SuppressUpdates(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, _ := newTestWorker(ctrl)
+
+	m := workitem.Body{TeamCanonical: "main", PipelineCanonical: "test-pipeline", JobName: "test-job"}
+	called := false
+	b := build.Build{BuildNumber: "1", SuppressUpdates: true, OnUpdate: func() { called = true }}
+
+	err := w.updateBuild(context.Background(), m, b)
+	assert.NoError(t, err)
+	assert.True(t, called, "OnUpdate should have been called")
+}


### PR DESCRIPTION
## Summary

- **Server SIGQUIT handler**: After draining embedded workers, polls DB for any remaining "started" builds every 2s. Uses a single shared drain timeout across both embedded and separated worker drain phases.
- **Startup recovery**: On boot, fails any "started" builds orphaned by a previous crash/SIGKILL before starting the scheduler.
- **Worker retry**: `updateBuild`/`failBuild` now retry with exponential backoff (1s, 2s, 4s) so separated workers can report results during server restart.
- **Integration tests**: `TestStartupRecoveryFailsOrphanedBuilds` and `TestServerDrainWaitsForSeparatedWorkerBuilds`.

Closes #569