### PR TITLE
fix: add timeout to gRPC GracefulStop during SIGQUIT shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `GracefulStop()` hanging indefinitely after SIGQUIT when workers reconnect during drain, leaving the server alive but not accepting connections (502 from reverse proxy) (#572).
+
 ## [0.6.1] - 2026-06-23
 
 ### Fixed

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -350,7 +350,22 @@ var serverCmd = &cobra.Command{
 
 			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer shutdownCancel()
-			grpcSrv.GracefulStop()
+
+			// GracefulStop doesn't accept a context, so enforce the
+			// shutdown timeout manually and fall back to a hard Stop.
+			grpcDone := make(chan struct{})
+			go func() {
+				grpcSrv.GracefulStop()
+				close(grpcDone)
+			}()
+			select {
+			case <-grpcDone:
+			case <-shutdownCtx.Done():
+				logger.Warn("gRPC graceful stop timed out, forcing stop")
+				grpcSrv.Stop()
+			}
+
+			// shutdownCtx is shared: HTTP shutdown gets whatever time remains.
 			svr.Shutdown(shutdownCtx)
 
 		case sig := <-stop:


### PR DESCRIPTION
Closes #572

## Summary

- Wrap `grpcSrv.GracefulStop()` in a goroutine bounded by the existing 10s shutdown context
- Fall back to `grpcSrv.Stop()` if graceful stop doesn't complete in time
- Prevents the server from hanging indefinitely with no listener after SIGQUIT when workers reconnect during the drain period