### PR TITLE
feat: add RBAC with 4 hierarchical team roles

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/adrg/xdg"
 	"github.com/spf13/cobra"
 	"github.com/pikoci/pikoci/pikoci"
+	"github.com/pikoci/pikoci/pikoci/role"
 	"github.com/pikoci/pikoci/pikoci/team"
 	"github.com/pikoci/pikoci/pikoci/transport/http/client"
 	"github.com/pikoci/pikoci/pikoci/user"
@@ -878,7 +879,7 @@ var teamsMembersCreateCmd = &cobra.Command{
 		jwt, _ := cmd.Flags().GetString("jwt")
 		tc, _ := cmd.Flags().GetString("team-canonical")
 		username, _ := cmd.Flags().GetString("username")
-		admin, _ := cmd.Flags().GetBool("admin")
+		memberRole, _ := cmd.Flags().GetString("role")
 
 		c, err := newClientWithConfig(url, jwt)
 		if err != nil {
@@ -886,8 +887,8 @@ var teamsMembersCreateCmd = &cobra.Command{
 		}
 
 		m, err := c.CreateTeamMember(cmd.Context(), tc, team.Member{
-			Admin: admin,
-			User:  user.User{Username: username},
+			Role: role.Role(memberRole),
+			User: user.User{Username: username},
 		})
 		if err != nil {
 			return fmt.Errorf("failed to add member %q to team %q: %w", username, tc, err)
@@ -900,7 +901,7 @@ var teamsMembersCreateCmd = &cobra.Command{
 
 func init() {
 	teamsMembersCreateCmd.Flags().String("username", "", "Username of the member to add")
-	teamsMembersCreateCmd.Flags().Bool("admin", false, "Whether the member is a team admin")
+	teamsMembersCreateCmd.Flags().String("role", "maintainer", "Role for the member (viewer, operator, maintainer, admin)")
 	teamsMembersCreateCmd.MarkFlagRequired("username")
 }
 
@@ -912,7 +913,7 @@ var teamsMembersUpdateCmd = &cobra.Command{
 		jwt, _ := cmd.Flags().GetString("jwt")
 		tc, _ := cmd.Flags().GetString("team-canonical")
 		username, _ := cmd.Flags().GetString("username")
-		admin, _ := cmd.Flags().GetBool("admin")
+		memberRole, _ := cmd.Flags().GetString("role")
 
 		c, err := newClientWithConfig(url, jwt)
 		if err != nil {
@@ -920,7 +921,7 @@ var teamsMembersUpdateCmd = &cobra.Command{
 		}
 
 		m, err := c.UpdateTeamMember(cmd.Context(), tc, username, team.Member{
-			Admin: admin,
+			Role: role.Role(memberRole),
 		})
 		if err != nil {
 			return fmt.Errorf("failed to update member %q in team %q: %w", username, tc, err)
@@ -933,7 +934,7 @@ var teamsMembersUpdateCmd = &cobra.Command{
 
 func init() {
 	teamsMembersUpdateCmd.Flags().String("username", "", "Username of the member to update")
-	teamsMembersUpdateCmd.Flags().Bool("admin", false, "Whether the member is a team admin")
+	teamsMembersUpdateCmd.Flags().String("role", "maintainer", "Role for the member (viewer, operator, maintainer, admin)")
 	teamsMembersUpdateCmd.MarkFlagRequired("username")
 }
 

--- a/docs/Roles.md
+++ b/docs/Roles.md
@@ -6,12 +6,25 @@ PikoCI uses role-based access control (RBAC) to manage what team members can do.
 
 | Role | Level | Description |
 |------|-------|-------------|
+| **Public** | 0 | Unauthenticated access to public pipelines. Not assignable to users. |
 | **Viewer** | 1 | Read-only access. Can view pipelines, jobs, builds, resources, and team info. |
 | **Operator** | 2 | Can trigger, cancel, and retry builds. Can pause/unpause pipelines and jobs. Can pin/unpin resource versions. |
 | **Maintainer** | 3 | Can create, update, and delete pipelines. Can manage resources and regenerate webhook tokens. |
 | **Admin** | 4 | Full team control. Can add, remove, and change members. Can update team settings and delete the team. Every team must have at least one admin. |
 
 ## What Each Role Can Do
+
+### Public
+
+The public role is **not assignable to users**. It represents unauthenticated access and only applies to pipelines marked as public. Public users can:
+
+- View the pipeline graph and configuration
+- View pipeline jobs and their status
+- View build lists and build logs
+- View resources and resource versions
+- Access the pipeline image (SVG/PNG)
+
+Public users **cannot** list pipelines, view team info, trigger jobs, or perform any write operations.
 
 ### Viewer
 

--- a/docs/Roles.md
+++ b/docs/Roles.md
@@ -1,0 +1,99 @@
+# Roles & Permissions
+
+PikoCI uses role-based access control (RBAC) to manage what team members can do. Each team member is assigned a role, and roles are hierarchical — each role inherits all permissions of roles below it.
+
+## Role Hierarchy
+
+| Role | Level | Description |
+|------|-------|-------------|
+| **Viewer** | 1 | Read-only access. Can view pipelines, jobs, builds, resources, and team info. |
+| **Operator** | 2 | Can trigger, cancel, and retry builds. Can pause/unpause pipelines and jobs. Can pin/unpin resource versions. |
+| **Maintainer** | 3 | Can create, update, and delete pipelines. Can manage resources and regenerate webhook tokens. |
+| **Admin** | 4 | Full team control. Can add, remove, and change members. Can update team settings and delete the team. Every team must have at least one admin. |
+
+## What Each Role Can Do
+
+### Viewer
+
+- View pipelines, jobs, builds, and build logs
+- View resources and resource versions
+- View team information and members
+- Change own password and update own profile
+
+### Operator
+
+Everything a Viewer can do, plus:
+
+- Trigger jobs manually
+- Cancel running builds
+- Retry failed builds
+- Pause and unpause pipelines and jobs
+- Pin and unpin resource versions
+- Trigger resource checks
+
+### Maintainer
+
+Everything an Operator can do, plus:
+
+- Create, edit, and delete pipelines
+- Upload pipeline configuration
+- Update resource settings
+- Create resource versions
+- Regenerate webhook tokens
+- Create triggers
+
+### Admin
+
+Everything a Maintainer can do, plus:
+
+- Add new members to the team
+- Change member roles
+- Remove members from the team
+- Update team name and settings
+- Delete the team
+
+**Note:** Every team must have at least one admin. You cannot demote or remove the last admin.
+
+## Global Admin
+
+The global admin flag (`--admin` on user creation) is separate from team roles. A global admin can:
+
+- Create and manage users
+- Create teams
+- Manage workers
+- Export the database
+- Access all teams regardless of membership
+
+## Assigning Roles
+
+### Via the UI
+
+Navigate to your team page and use the **Role** dropdown next to each member to change their role. Only team admins can manage members.
+
+### Via the CLI
+
+```bash
+# Add a member with a specific role
+pikoci client teams members create \
+  --team-canonical my-team \
+  --username alice \
+  --role operator
+
+# Change a member's role
+pikoci client teams members update \
+  --team-canonical my-team \
+  --username alice \
+  --role maintainer
+```
+
+Available roles: `viewer`, `operator`, `maintainer`, `admin`.
+
+## Default Roles
+
+- When you **create a team**, you become the **admin**.
+- When you **add a member** via the CLI, the default role is **maintainer**.
+- When you **add a member** via the UI, you choose the role from a dropdown (default: **maintainer**).
+
+## Public Pipelines
+
+Pipelines marked as public can be viewed by anyone without authentication. This includes the pipeline graph, jobs, builds, resources, and resource versions. Public access is read-only and does not require any role.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ PikoCI is a portable, self-hosted CI/CD system. One binary, any database, runs a
 - [Functions](Functions.md) - HCL functions available in pipelines (Terraform-compatible)
 - [for_each and matrix](Pipeline.md#for_each) - Generate multiple job instances from a single definition
 - [Variables](Variables.md) - Pipeline variables
+- [Roles & Permissions](Roles.md) - Team roles and what each role can do
 - [CLI Reference](CLI.md) - Client commands and flags
 - [Pause / Unpause](Pause.md) - Temporarily stop pipelines or jobs
 - [Resource Pinning](Resource-Pinning.md) - Pin resources to a version and trigger with specific versions

--- a/integration/backends/db_test.go
+++ b/integration/backends/db_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pikoci/pikoci/pikoci/mysql"
 	"github.com/pikoci/pikoci/pikoci/pipeline"
 	"github.com/pikoci/pikoci/pikoci/resource"
+	"github.com/pikoci/pikoci/pikoci/role"
 	"github.com/pikoci/pikoci/pikoci/sectype"
 	"github.com/pikoci/pikoci/pikoci/team"
 	"github.com/pikoci/pikoci/pikoci/user"
@@ -84,8 +85,8 @@ func TestDBBackends(t *testing.T) {
 
 				// Add member to team
 				err = tr.CreateMember(ctx, "backend-test", team.Member{
-					Admin: true,
-					User:  user.User{Username: "admin"},
+					Role: role.Admin,
+					User: user.User{Username: "admin"},
 				})
 				require.NoError(t, err)
 
@@ -98,7 +99,7 @@ func TestDBBackends(t *testing.T) {
 				// FindMember
 				member, err := tr.FindMember(ctx, "backend-test", "admin")
 				require.NoError(t, err)
-				assert.True(t, member.Admin)
+				assert.Equal(t, role.Admin, member.Role)
 			})
 
 			t.Run("PipelineRepository", func(t *testing.T) {

--- a/integration/http/http_test.go
+++ b/integration/http/http_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pikoci/pikoci/pikoci/role"
 	thttp "github.com/pikoci/pikoci/pikoci/transport/http"
 )
 
@@ -200,7 +201,7 @@ func TestHTTPEndpoints(t *testing.T) {
 
 		t.Run("Members", func(t *testing.T) {
 			t.Run("Create", func(t *testing.T) {
-				body := `{"user":{"username":"pepito"},"admin":false}`
+				body := `{"user":{"username":"pepito"},"role":"viewer"}`
 				resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/members", adminJWT, body)
 				defer resp.Body.Close()
 				requireOK(t, resp)
@@ -210,13 +211,13 @@ func TestHTTPEndpoints(t *testing.T) {
 			})
 
 			t.Run("Update", func(t *testing.T) {
-				resp := doJSONRequest(t, http.MethodPut, pikoURL+"/teams/main/members/pepito", adminJWT, `{"admin":true}`)
+				resp := doJSONRequest(t, http.MethodPut, pikoURL+"/teams/main/members/pepito", adminJWT, `{"role":"admin"}`)
 				defer resp.Body.Close()
 				requireOK(t, resp)
 				var ur thttp.UpdateTeamMemberResponse
 				decodeBody(t, resp, &ur)
 				assert.Empty(t, ur.Err)
-				assert.True(t, ur.Member.Admin)
+				assert.Equal(t, role.Admin, ur.Member.Role)
 			})
 
 			t.Run("Delete", func(t *testing.T) {

--- a/integration/http/rbac_test.go
+++ b/integration/http/rbac_test.go
@@ -1,0 +1,253 @@
+//go:build integration
+
+package http_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	thttp "github.com/pikoci/pikoci/pikoci/transport/http"
+)
+
+// TestRBAC_PerRoleAccess creates users with each role and verifies correct
+// access/denial for representative endpoints per role level.
+func TestRBAC_PerRoleAccess(t *testing.T) {
+	// Login as admin to set up users and team members
+	adminJWT := loginAndGetJWT(t, pikoURL, "admin", "admin123")
+
+	// Create users for each role
+	roles := []struct {
+		username string
+		password string
+		role     string
+	}{
+		{"rbac-viewer", "pass123", "viewer"},
+		{"rbac-operator", "pass123", "operator"},
+		{"rbac-maintainer", "pass123", "maintainer"},
+		{"rbac-admin", "pass123", "admin"},
+	}
+
+	for _, r := range roles {
+		body := `{"username":"` + r.username + `","password":"` + r.password + `","full_name":"` + r.username + `"}`
+		resp := doJSONRequest(t, http.MethodPost, pikoURL+"/users", adminJWT, body)
+		resp.Body.Close()
+		requireOK(t, resp)
+	}
+
+	// Create a pipeline for testing (on the "main" team which admin owns)
+	resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/pipelines", adminJWT,
+		`{"name":"rbac-pipe","config":"am9iICJ0ZXN0IiB7CiAgdGFzayAiZWNobyIgewogICAgcnVuICJleGVjIiB7CiAgICAgIHBhdGggPSAiZWNobyIKICAgICAgYXJncyA9IFsiaGVsbG8iXQogICAgfQogIH0KfQo="}`)
+	resp.Body.Close()
+
+	// Add each user as a member of "main" with their respective role
+	for _, r := range roles {
+		body := `{"role":"` + r.role + `","user":{"username":"` + r.username + `"}}`
+		resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/members", adminJWT, body)
+		resp.Body.Close()
+		requireOK(t, resp)
+	}
+
+	// Get JWTs for each user
+	jwts := make(map[string]string)
+	for _, r := range roles {
+		jwts[r.role] = loginAndGetJWT(t, pikoURL, r.username, r.password)
+	}
+
+	// --- Viewer tests ---
+	t.Run("Viewer", func(t *testing.T) {
+		jwt := jwts["viewer"]
+
+		t.Run("can GET pipeline", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodGet, pikoURL+"/teams/main/pipelines", jwt, "")
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+
+		t.Run("can GET team", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodGet, pikoURL+"/teams/main", jwt, "")
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+
+		t.Run("denied trigger job", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/pipelines/rbac-pipe/jobs/test/trigger", jwt, "")
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+
+		t.Run("denied create pipeline", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/pipelines", jwt, `{"name":"x","config":"eA=="}`)
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+
+		t.Run("denied add team member", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/members", jwt, `{"role":"viewer","user":{"username":"admin"}}`)
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+
+		t.Run("denied delete team", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodDelete, pikoURL+"/teams/main", jwt, "")
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+	})
+
+	// --- Operator tests ---
+	t.Run("Operator", func(t *testing.T) {
+		jwt := jwts["operator"]
+
+		t.Run("can pause pipeline", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/pipelines/rbac-pipe/pause", jwt, "")
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+
+		t.Run("can unpause pipeline", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/pipelines/rbac-pipe/unpause", jwt, "")
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+
+		t.Run("denied create pipeline", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/pipelines", jwt, `{"name":"x","config":"eA=="}`)
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+
+		t.Run("denied add team member", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/members", jwt, `{"role":"viewer","user":{"username":"admin"}}`)
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+	})
+
+	// --- Maintainer tests ---
+	t.Run("Maintainer", func(t *testing.T) {
+		jwt := jwts["maintainer"]
+
+		t.Run("can pause pipeline (inherits operator)", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/pipelines/rbac-pipe/pause", jwt, "")
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			// Unpause for subsequent tests
+			resp2 := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/pipelines/rbac-pipe/unpause", jwt, "")
+			resp2.Body.Close()
+		})
+
+		t.Run("denied add team member", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/members", jwt, `{"role":"viewer","user":{"username":"admin"}}`)
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+
+		t.Run("denied delete team", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodDelete, pikoURL+"/teams/main", jwt, "")
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+	})
+
+	// --- Admin tests ---
+	t.Run("Admin", func(t *testing.T) {
+		jwt := jwts["admin"]
+
+		t.Run("can update team", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPut, pikoURL+"/teams/main", jwt, `{"name":"main"}`)
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+
+		t.Run("can delete team", func(t *testing.T) {
+			// Create a disposable team via global admin
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams", adminJWT, `{"name":"disposable"}`)
+			resp.Body.Close()
+			requireOK(t, resp)
+
+			// Add rbac-admin as admin of disposable team
+			body := `{"role":"admin","user":{"username":"rbac-admin"}}`
+			resp = doJSONRequest(t, http.MethodPost, pikoURL+"/teams/disposable/members", adminJWT, body)
+			resp.Body.Close()
+			requireOK(t, resp)
+
+			// Refresh JWT to get updated memberships
+			freshJWT := loginAndGetJWT(t, pikoURL, "rbac-admin", "pass123")
+
+			resp = doJSONRequest(t, http.MethodDelete, pikoURL+"/teams/disposable", freshJWT, "")
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+	})
+
+	// --- Role upgrade test ---
+	t.Run("RoleUpgrade", func(t *testing.T) {
+		// Upgrade viewer to operator
+		resp := doJSONRequest(t, http.MethodPut, pikoURL+"/teams/main/members/rbac-viewer", adminJWT, `{"role":"operator"}`)
+		defer resp.Body.Close()
+		requireOK(t, resp)
+		var ur thttp.UpdateTeamMemberResponse
+		decodeBody(t, resp, &ur)
+		require.Empty(t, ur.Err)
+
+		// Get fresh JWT for the upgraded user
+		upgradedJWT := loginAndGetJWT(t, pikoURL, "rbac-viewer", "pass123")
+
+		// Now viewer-turned-operator can pause
+		resp2 := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/pipelines/rbac-pipe/pause", upgradedJWT, "")
+		defer resp2.Body.Close()
+		assert.Equal(t, http.StatusOK, resp2.StatusCode)
+
+		// Unpause
+		resp3 := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/pipelines/rbac-pipe/unpause", upgradedJWT, "")
+		resp3.Body.Close()
+	})
+
+	// --- Last admin protection ---
+	t.Run("LastAdminProtection", func(t *testing.T) {
+		// Create a team where admin is the sole admin
+		resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams", adminJWT, `{"name":"admin-test"}`)
+		resp.Body.Close()
+		requireOK(t, resp)
+
+		t.Run("cannot delete last admin", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodDelete, pikoURL+"/teams/admin-test/members/admin", adminJWT, "")
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			var dr thttp.DeleteTeamMemberResponse
+			decodeBody(t, resp, &dr)
+			assert.Contains(t, dr.Err, "no admins")
+		})
+
+		t.Run("cannot demote last admin", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPut, pikoURL+"/teams/admin-test/members/admin", adminJWT, `{"role":"viewer"}`)
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			var ur thttp.UpdateTeamMemberResponse
+			decodeBody(t, resp, &ur)
+			assert.Contains(t, ur.Err, "no admins")
+		})
+
+		t.Run("can delete non-admin when admin remains", func(t *testing.T) {
+			// Add a viewer
+			addResp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/admin-test/members", adminJWT,
+				`{"role":"viewer","user":{"username":"rbac-viewer"}}`)
+			addResp.Body.Close()
+			requireOK(t, addResp)
+
+			// Delete the viewer — should succeed
+			resp := doJSONRequest(t, http.MethodDelete, pikoURL+"/teams/admin-test/members/rbac-viewer", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			var dr thttp.DeleteTeamMemberResponse
+			decodeBody(t, resp, &dr)
+			assert.Empty(t, dr.Err)
+		})
+
+		// Cleanup
+		doJSONRequest(t, http.MethodDelete, pikoURL+"/teams/admin-test", adminJWT, "").Body.Close()
+	})
+}

--- a/integration/selenium/main_test.go
+++ b/integration/selenium/main_test.go
@@ -67,8 +67,12 @@ func runTests(m *testing.M) int {
 	defer server.Close()
 
 	isHash := true
+	// admin123
 	_, _ = svc.CreateUser(ctx, user.User{FullName: "pepito", Username: "pepito", Password: "$2a$14$rwQk8Qvc2rij7qhFO4P1W.OiSF6AkgVU1RCrLaY2wawJcpkPEKwbm"}, isHash)
 	_, _ = svc.CreateUser(ctx, user.User{FullName: "grillo", Username: "grillo", Password: "$2a$14$SvWir17.jlXxiZfe0pJuDedznetc/HWKv43YPsQQNo6MJiuypS2q6"}, isHash)
+	// role-test users (password: admin123)
+	_, _ = svc.CreateUser(ctx, user.User{FullName: "role-viewer", Username: "role-viewer", Password: "$2a$14$rwQk8Qvc2rij7qhFO4P1W.OiSF6AkgVU1RCrLaY2wawJcpkPEKwbm"}, isHash)
+	_, _ = svc.CreateUser(ctx, user.User{FullName: "role-maintainer", Username: "role-maintainer", Password: "$2a$14$rwQk8Qvc2rij7qhFO4P1W.OiSF6AkgVU1RCrLaY2wawJcpkPEKwbm"}, isHash)
 	go func() {
 		runWorker(ctx, svc, 1, "DEBUG")
 	}()

--- a/integration/selenium/main_test.go
+++ b/integration/selenium/main_test.go
@@ -67,12 +67,8 @@ func runTests(m *testing.M) int {
 	defer server.Close()
 
 	isHash := true
-	// admin123
 	_, _ = svc.CreateUser(ctx, user.User{FullName: "pepito", Username: "pepito", Password: "$2a$14$rwQk8Qvc2rij7qhFO4P1W.OiSF6AkgVU1RCrLaY2wawJcpkPEKwbm"}, isHash)
 	_, _ = svc.CreateUser(ctx, user.User{FullName: "grillo", Username: "grillo", Password: "$2a$14$SvWir17.jlXxiZfe0pJuDedznetc/HWKv43YPsQQNo6MJiuypS2q6"}, isHash)
-	// role-test users (password: admin123)
-	_, _ = svc.CreateUser(ctx, user.User{FullName: "role-viewer", Username: "role-viewer", Password: "$2a$14$rwQk8Qvc2rij7qhFO4P1W.OiSF6AkgVU1RCrLaY2wawJcpkPEKwbm"}, isHash)
-	_, _ = svc.CreateUser(ctx, user.User{FullName: "role-maintainer", Username: "role-maintainer", Password: "$2a$14$rwQk8Qvc2rij7qhFO4P1W.OiSF6AkgVU1RCrLaY2wawJcpkPEKwbm"}, isHash)
 	go func() {
 		runWorker(ctx, svc, 1, "DEBUG")
 	}()

--- a/integration/selenium/pikoci_test.go
+++ b/integration/selenium/pikoci_test.go
@@ -1808,7 +1808,7 @@ job "gen" {
 		})
 	})
 	t.Run("Viewer", func(t *testing.T) {
-		// Setup: logout pepito, add role-viewer as viewer to main team via HTTP
+		// Setup: logout pepito, create role-viewer user and add as viewer to main team
 		navLink, err := wd.FindElement(selenium.ByCSSSelector, ".navbar .nav-link")
 		require.NoError(t, err)
 		err = navLink.Click()
@@ -1819,26 +1819,7 @@ job "gen" {
 		require.NoError(t, err)
 		waitFor(t, wd, eqText(selenium.ByCSSSelector, "h1", "Log In"), 5*time.Second)
 
-		// Add role-viewer to team via HTTP
-		adminLoginBody, _ := json.Marshal(thttp.UserLoginRequest{Username: "admin", Password: "newadmin123"})
-		adminLoginReq, err := http.NewRequest(http.MethodPost, pikoURL+"/login", bytes.NewReader(adminLoginBody))
-		require.NoError(t, err)
-		adminLoginReq.Header.Set("Content-Type", "application/json")
-		adminLoginResp, err := http.DefaultClient.Do(adminLoginReq)
-		require.NoError(t, err)
-		defer adminLoginResp.Body.Close()
-		var alr thttp.UserLoginResponse
-		json.NewDecoder(adminLoginResp.Body).Decode(&alr)
-		adminJWT := alr.Data.JWT
-
-		addBody := `{"role":"viewer","user":{"username":"role-viewer"}}`
-		addReq, err := http.NewRequest(http.MethodPost, pikoURL+"/teams/main/members", strings.NewReader(addBody))
-		require.NoError(t, err)
-		addReq.Header.Set("Content-Type", "application/json")
-		addReq.Header.Set("Authorization", "Bearer "+adminJWT)
-		addResp, err := http.DefaultClient.Do(addReq)
-		require.NoError(t, err)
-		addResp.Body.Close()
+		setupRoleTestUser(t, "newadmin123", "role-viewer", "viewer")
 
 		t.Run("Login", func(t *testing.T) {
 			username, err := wd.FindElement(selenium.ByCSSSelector, "#username")
@@ -1846,7 +1827,7 @@ job "gen" {
 			password, err := wd.FindElement(selenium.ByCSSSelector, "#password")
 			require.NoError(t, err)
 			username.SendKeys("role-viewer")
-			password.SendKeys("admin123")
+			password.SendKeys("testpass123")
 			login, err := wd.FindElement(selenium.ByCSSSelector, "#login")
 			require.NoError(t, err)
 			err = login.Click()
@@ -1927,26 +1908,8 @@ job "gen" {
 		})
 	})
 	t.Run("Maintainer", func(t *testing.T) {
-		// Add role-maintainer to team via HTTP
-		adminLoginBody, _ := json.Marshal(thttp.UserLoginRequest{Username: "admin", Password: "newadmin123"})
-		adminLoginReq, err := http.NewRequest(http.MethodPost, pikoURL+"/login", bytes.NewReader(adminLoginBody))
-		require.NoError(t, err)
-		adminLoginReq.Header.Set("Content-Type", "application/json")
-		adminLoginResp, err := http.DefaultClient.Do(adminLoginReq)
-		require.NoError(t, err)
-		defer adminLoginResp.Body.Close()
-		var alr thttp.UserLoginResponse
-		json.NewDecoder(adminLoginResp.Body).Decode(&alr)
-		adminJWT := alr.Data.JWT
-
-		addBody := `{"role":"maintainer","user":{"username":"role-maintainer"}}`
-		addReq, err := http.NewRequest(http.MethodPost, pikoURL+"/teams/main/members", strings.NewReader(addBody))
-		require.NoError(t, err)
-		addReq.Header.Set("Content-Type", "application/json")
-		addReq.Header.Set("Authorization", "Bearer "+adminJWT)
-		addResp, err := http.DefaultClient.Do(addReq)
-		require.NoError(t, err)
-		addResp.Body.Close()
+		// Create role-maintainer user and add as maintainer to main team
+		setupRoleTestUser(t, "newadmin123", "role-maintainer", "maintainer")
 
 		t.Run("Login", func(t *testing.T) {
 			username, err := wd.FindElement(selenium.ByCSSSelector, "#username")
@@ -1954,7 +1917,7 @@ job "gen" {
 			password, err := wd.FindElement(selenium.ByCSSSelector, "#password")
 			require.NoError(t, err)
 			username.SendKeys("role-maintainer")
-			password.SendKeys("admin123")
+			password.SendKeys("testpass123")
 			login, err := wd.FindElement(selenium.ByCSSSelector, "#login")
 			require.NoError(t, err)
 			err = login.Click()
@@ -2450,4 +2413,45 @@ func screenshot(t *testing.T, wd selenium.WebDriver) {
 
 	err = png.Encode(f, img)
 	require.NoError(t, err)
+}
+
+// setupRoleTestUser creates a user via the admin HTTP API and adds them to a team with the given role.
+// Returns the admin JWT for further API calls.
+func setupRoleTestUser(t *testing.T, adminPassword, username, teamRole string) string {
+	t.Helper()
+
+	// Get admin JWT
+	loginBody, _ := json.Marshal(thttp.UserLoginRequest{Username: "admin", Password: adminPassword})
+	loginReq, err := http.NewRequest(http.MethodPost, pikoURL+"/login", bytes.NewReader(loginBody))
+	require.NoError(t, err)
+	loginReq.Header.Set("Content-Type", "application/json")
+	loginResp, err := http.DefaultClient.Do(loginReq)
+	require.NoError(t, err)
+	defer loginResp.Body.Close()
+	var lr thttp.UserLoginResponse
+	json.NewDecoder(loginResp.Body).Decode(&lr)
+	require.Empty(t, lr.Err)
+	adminJWT := lr.Data.JWT
+
+	// Create user (ignore error if already exists)
+	createBody := `{"username":"` + username + `","password":"testpass123","full_name":"` + username + `"}`
+	createReq, err := http.NewRequest(http.MethodPost, pikoURL+"/users", strings.NewReader(createBody))
+	require.NoError(t, err)
+	createReq.Header.Set("Content-Type", "application/json")
+	createReq.Header.Set("Authorization", "Bearer "+adminJWT)
+	createResp, err := http.DefaultClient.Do(createReq)
+	require.NoError(t, err)
+	createResp.Body.Close()
+
+	// Add to team with role (ignore error if already member)
+	addBody := `{"role":"` + teamRole + `","user":{"username":"` + username + `"}}`
+	addReq, err := http.NewRequest(http.MethodPost, pikoURL+"/teams/main/members", strings.NewReader(addBody))
+	require.NoError(t, err)
+	addReq.Header.Set("Content-Type", "application/json")
+	addReq.Header.Set("Authorization", "Bearer "+adminJWT)
+	addResp, err := http.DefaultClient.Do(addReq)
+	require.NoError(t, err)
+	addResp.Body.Close()
+
+	return adminJWT
 }

--- a/integration/selenium/pikoci_test.go
+++ b/integration/selenium/pikoci_test.go
@@ -1428,12 +1428,12 @@ job "gen" {
 					return len(opts) >= 1
 				}, 5*time.Second)
 
-				// Select "viewer" role so the Member section tests restricted access
+				// Select "operator" role: can trigger/pause but can't create pipelines or manage members
 				roleSelect, err := wd.FindElement(selenium.ByCSSSelector, "#role")
 				require.NoError(t, err)
-				viewerOpt, err := roleSelect.FindElement(selenium.ByCSSSelector, "option[value='viewer']")
+				operatorOpt, err := roleSelect.FindElement(selenium.ByCSSSelector, "option[value='operator']")
 				require.NoError(t, err)
-				err = viewerOpt.Click()
+				err = operatorOpt.Click()
 				require.NoError(t, err)
 
 				members, err := wd.FindElements(selenium.ByCSSSelector, "tbody>tr")
@@ -2118,7 +2118,7 @@ job "gen" {
 		adminJWT := lr.Data.JWT
 
 		// Step 2: Change pepito's role on "main" team via HTTP (triggers X-Refresh-Token)
-		updateBody, _ := json.Marshal(thttp.UpdateTeamMemberRequest{Role: "operator"})
+		updateBody, _ := json.Marshal(thttp.UpdateTeamMemberRequest{Role: "maintainer"})
 		updateReq, err := http.NewRequest(http.MethodPut, pikoURL+"/teams/main/members/pepito", bytes.NewReader(updateBody))
 		require.NoError(t, err)
 		updateReq.Header.Set("Content-Type", "application/json")

--- a/integration/selenium/pikoci_test.go
+++ b/integration/selenium/pikoci_test.go
@@ -99,6 +99,11 @@ func TestPikoCI(t *testing.T) {
 		})
 
 		t.Run("New Team", func(t *testing.T) {
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				rows, err := wd.FindElements(selenium.ByCSSSelector, ".piko-team-row")
+				return err == nil && len(rows) >= 1
+			}, 5*time.Second)
+
 			teams, err := wd.FindElements(selenium.ByCSSSelector, ".piko-team-row")
 			require.NoError(t, err)
 			require.Equal(t, 1, len(teams))
@@ -131,6 +136,11 @@ func TestPikoCI(t *testing.T) {
 			require.NoError(t, err)
 
 			waitFor(t, wd, eqText(selenium.ByCSSSelector, "#breadcrumb", "Teams"), 5*time.Second)
+
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				rows, err := wd.FindElements(selenium.ByCSSSelector, ".piko-team-row")
+				return err == nil && len(rows) >= 2
+			}, 5*time.Second)
 
 			teams, err := wd.FindElements(selenium.ByCSSSelector, ".piko-team-row")
 			require.NoError(t, err)
@@ -257,6 +267,11 @@ func TestPikoCI(t *testing.T) {
 			require.NoError(t, err)
 
 			waitFor(t, wd, eqText(selenium.ByCSSSelector, "#breadcrumb", "Teams"), 5*time.Second)
+
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				rows, err := wd.FindElements(selenium.ByCSSSelector, ".piko-team-row")
+				return err == nil && len(rows) >= 2
+			}, 5*time.Second)
 
 			teams, err := wd.FindElements(selenium.ByCSSSelector, ".piko-team-row")
 			require.NoError(t, err)

--- a/integration/selenium/pikoci_test.go
+++ b/integration/selenium/pikoci_test.go
@@ -1807,8 +1807,8 @@ job "gen" {
 			}, 5*time.Second)
 		})
 	})
-	t.Run("PublicPipeline", func(t *testing.T) {
-		// Pepito is logged in. Log out first.
+	t.Run("Viewer", func(t *testing.T) {
+		// Setup: logout pepito, add role-viewer as viewer to main team via HTTP
 		navLink, err := wd.FindElement(selenium.ByCSSSelector, ".navbar .nav-link")
 		require.NoError(t, err)
 		err = navLink.Click()
@@ -1818,6 +1818,209 @@ job "gen" {
 		err = logoutBtn.Click()
 		require.NoError(t, err)
 		waitFor(t, wd, eqText(selenium.ByCSSSelector, "h1", "Log In"), 5*time.Second)
+
+		// Add role-viewer to team via HTTP
+		adminLoginBody, _ := json.Marshal(thttp.UserLoginRequest{Username: "admin", Password: "newadmin123"})
+		adminLoginReq, err := http.NewRequest(http.MethodPost, pikoURL+"/login", bytes.NewReader(adminLoginBody))
+		require.NoError(t, err)
+		adminLoginReq.Header.Set("Content-Type", "application/json")
+		adminLoginResp, err := http.DefaultClient.Do(adminLoginReq)
+		require.NoError(t, err)
+		defer adminLoginResp.Body.Close()
+		var alr thttp.UserLoginResponse
+		json.NewDecoder(adminLoginResp.Body).Decode(&alr)
+		adminJWT := alr.Data.JWT
+
+		addBody := `{"role":"viewer","user":{"username":"role-viewer"}}`
+		addReq, err := http.NewRequest(http.MethodPost, pikoURL+"/teams/main/members", strings.NewReader(addBody))
+		require.NoError(t, err)
+		addReq.Header.Set("Content-Type", "application/json")
+		addReq.Header.Set("Authorization", "Bearer "+adminJWT)
+		addResp, err := http.DefaultClient.Do(addReq)
+		require.NoError(t, err)
+		addResp.Body.Close()
+
+		t.Run("Login", func(t *testing.T) {
+			username, err := wd.FindElement(selenium.ByCSSSelector, "#username")
+			require.NoError(t, err)
+			password, err := wd.FindElement(selenium.ByCSSSelector, "#password")
+			require.NoError(t, err)
+			username.SendKeys("role-viewer")
+			password.SendKeys("admin123")
+			login, err := wd.FindElement(selenium.ByCSSSelector, "#login")
+			require.NoError(t, err)
+			err = login.Click()
+			require.NoError(t, err)
+			waitFor(t, wd, eqText(selenium.ByCSSSelector, "#breadcrumb", "Teams"), 5*time.Second)
+		})
+		t.Run("No New Pipeline button", func(t *testing.T) {
+			pipelines, err := wd.FindElement(selenium.ByCSSSelector, "#pipelines")
+			require.NoError(t, err)
+			err = pipelines.Click()
+			require.NoError(t, err)
+			waitFor(t, wd, eqText(selenium.ByCSSSelector, "#breadcrumb", "Teams\nMain\nPipelines"), 5*time.Second)
+
+			_, err = wd.FindElement(selenium.ByCSSSelector, "#pipelines-new")
+			require.Error(t, err, "viewer should not see New Pipeline button")
+		})
+		t.Run("No edit/delete pipeline buttons", func(t *testing.T) {
+			ppBtn, err := wd.FindElement(selenium.ByCSSSelector, ".card")
+			require.NoError(t, err)
+			err = ppBtn.Click()
+			require.NoError(t, err)
+			waitFor(t, wd, eqText(selenium.ByCSSSelector, "#breadcrumb", "Teams\nMain\nPipelines\ncron"), 5*time.Second)
+
+			_, err = wd.FindElement(selenium.ByCSSSelector, "#edit-pipeline")
+			require.Error(t, err, "viewer should not see Edit button")
+			_, err = wd.FindElement(selenium.ByCSSSelector, "#delete-pipeline")
+			require.Error(t, err, "viewer should not see Delete button")
+		})
+		t.Run("No pause button", func(t *testing.T) {
+			_, err = wd.FindElement(selenium.ByCSSSelector, "#pause-pipeline")
+			require.Error(t, err, "viewer should not see Pause button")
+			_, err = wd.FindElement(selenium.ByCSSSelector, "#unpause-pipeline")
+			require.Error(t, err, "viewer should not see Unpause button")
+		})
+		t.Run("No trigger/cancel on job builds", func(t *testing.T) {
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				_, err := wd.FindElement(selenium.ByCSSSelector, "div#pipeline-graph>svg")
+				return err == nil
+			}, 5*time.Second)
+
+			res, err := wd.FindElement(selenium.ByCSSSelector, "#a_node2>a")
+			require.NoError(t, err)
+			url, err := res.GetAttribute("xlink:href")
+			require.NoError(t, err)
+			err = wd.Get(pikoURL + url)
+			require.NoError(t, err)
+			waitFor(t, wd, eqText(selenium.ByCSSSelector, "#breadcrumb", "Teams\nMain\nPipelines\ncron\nJobs\ngen\nBuilds"), 5*time.Second)
+
+			_, err = wd.FindElement(selenium.ByCSSSelector, "#trigger-job")
+			require.Error(t, err, "viewer should not see Trigger Job button")
+			_, err = wd.FindElement(selenium.ByCSSSelector, ".piko-cancel-build")
+			require.Error(t, err, "viewer should not see Cancel button")
+			_, err = wd.FindElement(selenium.ByCSSSelector, ".piko-retry-build")
+			require.Error(t, err, "viewer should not see Retry button")
+		})
+		t.Run("No member management", func(t *testing.T) {
+			err := wd.Get(pikoURL + "/teams/main")
+			require.NoError(t, err)
+			waitFor(t, wd, eqText(selenium.ByCSSSelector, "#breadcrumb", "Teams\nMain"), 5*time.Second)
+
+			_, err = wd.FindElement(selenium.ByCSSSelector, "#new-member")
+			require.Error(t, err, "viewer should not see New Member button")
+
+			roleSelects, err := wd.FindElements(selenium.ByCSSSelector, "select.form-select-sm")
+			require.NoError(t, err)
+			require.Equal(t, 0, len(roleSelects), "viewer should not see role dropdowns")
+		})
+		t.Run("Logout", func(t *testing.T) {
+			navLink, err := wd.FindElement(selenium.ByCSSSelector, ".navbar .nav-link")
+			require.NoError(t, err)
+			err = navLink.Click()
+			require.NoError(t, err)
+			logoutBtn, err := wd.FindElement(selenium.ByCSSSelector, "#logout")
+			require.NoError(t, err)
+			err = logoutBtn.Click()
+			require.NoError(t, err)
+			waitFor(t, wd, eqText(selenium.ByCSSSelector, "h1", "Log In"), 5*time.Second)
+		})
+	})
+	t.Run("Maintainer", func(t *testing.T) {
+		// Add role-maintainer to team via HTTP
+		adminLoginBody, _ := json.Marshal(thttp.UserLoginRequest{Username: "admin", Password: "newadmin123"})
+		adminLoginReq, err := http.NewRequest(http.MethodPost, pikoURL+"/login", bytes.NewReader(adminLoginBody))
+		require.NoError(t, err)
+		adminLoginReq.Header.Set("Content-Type", "application/json")
+		adminLoginResp, err := http.DefaultClient.Do(adminLoginReq)
+		require.NoError(t, err)
+		defer adminLoginResp.Body.Close()
+		var alr thttp.UserLoginResponse
+		json.NewDecoder(adminLoginResp.Body).Decode(&alr)
+		adminJWT := alr.Data.JWT
+
+		addBody := `{"role":"maintainer","user":{"username":"role-maintainer"}}`
+		addReq, err := http.NewRequest(http.MethodPost, pikoURL+"/teams/main/members", strings.NewReader(addBody))
+		require.NoError(t, err)
+		addReq.Header.Set("Content-Type", "application/json")
+		addReq.Header.Set("Authorization", "Bearer "+adminJWT)
+		addResp, err := http.DefaultClient.Do(addReq)
+		require.NoError(t, err)
+		addResp.Body.Close()
+
+		t.Run("Login", func(t *testing.T) {
+			username, err := wd.FindElement(selenium.ByCSSSelector, "#username")
+			require.NoError(t, err)
+			password, err := wd.FindElement(selenium.ByCSSSelector, "#password")
+			require.NoError(t, err)
+			username.SendKeys("role-maintainer")
+			password.SendKeys("admin123")
+			login, err := wd.FindElement(selenium.ByCSSSelector, "#login")
+			require.NoError(t, err)
+			err = login.Click()
+			require.NoError(t, err)
+			waitFor(t, wd, eqText(selenium.ByCSSSelector, "#breadcrumb", "Teams"), 5*time.Second)
+		})
+		t.Run("Has New Pipeline button", func(t *testing.T) {
+			pipelines, err := wd.FindElement(selenium.ByCSSSelector, "#pipelines")
+			require.NoError(t, err)
+			err = pipelines.Click()
+			require.NoError(t, err)
+			waitFor(t, wd, eqText(selenium.ByCSSSelector, "#breadcrumb", "Teams\nMain\nPipelines"), 5*time.Second)
+
+			_, err = wd.FindElement(selenium.ByCSSSelector, "#pipelines-new")
+			require.NoError(t, err, "maintainer should see New Pipeline button")
+		})
+		t.Run("Has edit/delete pipeline buttons", func(t *testing.T) {
+			ppBtn, err := wd.FindElement(selenium.ByCSSSelector, ".card")
+			require.NoError(t, err)
+			err = ppBtn.Click()
+			require.NoError(t, err)
+			waitFor(t, wd, eqText(selenium.ByCSSSelector, "#breadcrumb", "Teams\nMain\nPipelines\ncron"), 5*time.Second)
+
+			_, err = wd.FindElement(selenium.ByCSSSelector, "#edit-pipeline")
+			require.NoError(t, err, "maintainer should see Edit button")
+			_, err = wd.FindElement(selenium.ByCSSSelector, "#delete-pipeline")
+			require.NoError(t, err, "maintainer should see Delete button")
+		})
+		t.Run("Has pause button (inherits operator)", func(t *testing.T) {
+			_, err = wd.FindElement(selenium.ByCSSSelector, "#pause-pipeline")
+			require.NoError(t, err, "maintainer should see Pause button (inherits operator)")
+		})
+		t.Run("No member management", func(t *testing.T) {
+			err := wd.Get(pikoURL + "/teams/main")
+			require.NoError(t, err)
+			waitFor(t, wd, eqText(selenium.ByCSSSelector, "#breadcrumb", "Teams\nMain"), 5*time.Second)
+
+			_, err = wd.FindElement(selenium.ByCSSSelector, "#new-member")
+			require.Error(t, err, "maintainer should not see New Member button")
+
+			roleSelects, err := wd.FindElements(selenium.ByCSSSelector, "select.form-select-sm")
+			require.NoError(t, err)
+			require.Equal(t, 0, len(roleSelects), "maintainer should not see role dropdowns")
+		})
+		t.Run("No delete team button", func(t *testing.T) {
+			err := wd.Get(pikoURL + "/")
+			require.NoError(t, err)
+			waitFor(t, wd, eqText(selenium.ByCSSSelector, "#breadcrumb", "Teams"), 5*time.Second)
+
+			_, err = wd.FindElement(selenium.ByCSSSelector, "#delete")
+			require.Error(t, err, "maintainer should not see Delete Team button")
+		})
+		t.Run("Logout", func(t *testing.T) {
+			navLink, err := wd.FindElement(selenium.ByCSSSelector, ".navbar .nav-link")
+			require.NoError(t, err)
+			err = navLink.Click()
+			require.NoError(t, err)
+			logoutBtn, err := wd.FindElement(selenium.ByCSSSelector, "#logout")
+			require.NoError(t, err)
+			err = logoutBtn.Click()
+			require.NoError(t, err)
+			waitFor(t, wd, eqText(selenium.ByCSSSelector, "h1", "Log In"), 5*time.Second)
+		})
+	})
+	t.Run("PublicPipeline", func(t *testing.T) {
+		// Already logged out from Maintainer section.
 
 		// Set pipeline public via admin HTTP API
 		loginBody, _ := json.Marshal(thttp.UserLoginRequest{

--- a/integration/selenium/pikoci_test.go
+++ b/integration/selenium/pikoci_test.go
@@ -1835,6 +1835,12 @@ job "gen" {
 			waitFor(t, wd, eqText(selenium.ByCSSSelector, "#breadcrumb", "Teams"), 5*time.Second)
 		})
 		t.Run("No New Pipeline button", func(t *testing.T) {
+			// Wait for team rows to load
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				rows, err := wd.FindElements(selenium.ByCSSSelector, ".piko-team-row")
+				return err == nil && len(rows) > 0
+			}, 5*time.Second)
+
 			pipelines, err := wd.FindElement(selenium.ByCSSSelector, "#pipelines")
 			require.NoError(t, err)
 			err = pipelines.Click()
@@ -1845,6 +1851,11 @@ job "gen" {
 			require.Error(t, err, "viewer should not see New Pipeline button")
 		})
 		t.Run("No edit/delete pipeline buttons", func(t *testing.T) {
+			// Wait for pipeline cards to load
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				cards, err := wd.FindElements(selenium.ByCSSSelector, ".card")
+				return err == nil && len(cards) > 0
+			}, 5*time.Second)
 			ppBtn, err := wd.FindElement(selenium.ByCSSSelector, ".card")
 			require.NoError(t, err)
 			err = ppBtn.Click()
@@ -1925,6 +1936,12 @@ job "gen" {
 			waitFor(t, wd, eqText(selenium.ByCSSSelector, "#breadcrumb", "Teams"), 5*time.Second)
 		})
 		t.Run("Has New Pipeline button", func(t *testing.T) {
+			// Wait for team rows to load
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				rows, err := wd.FindElements(selenium.ByCSSSelector, ".piko-team-row")
+				return err == nil && len(rows) > 0
+			}, 5*time.Second)
+
 			pipelines, err := wd.FindElement(selenium.ByCSSSelector, "#pipelines")
 			require.NoError(t, err)
 			err = pipelines.Click()
@@ -1935,6 +1952,11 @@ job "gen" {
 			require.NoError(t, err, "maintainer should see New Pipeline button")
 		})
 		t.Run("Has edit/delete pipeline buttons", func(t *testing.T) {
+			// Wait for pipeline cards to load
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				cards, err := wd.FindElements(selenium.ByCSSSelector, ".card")
+				return err == nil && len(cards) > 0
+			}, 5*time.Second)
 			ppBtn, err := wd.FindElement(selenium.ByCSSSelector, ".card")
 			require.NoError(t, err)
 			err = ppBtn.Click()

--- a/integration/selenium/pikoci_test.go
+++ b/integration/selenium/pikoci_test.go
@@ -177,12 +177,12 @@ func TestPikoCI(t *testing.T) {
 			err = nmBtn.Click()
 			require.NoError(t, err)
 
-			// As we fetch the users to fill in we have to wait
+			// Wait for user select to load (NewMemberRow has user + role selects)
 			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
-				opts, err := wd.FindElements(selenium.ByCSSSelector, "option")
+				opts, err := wd.FindElements(selenium.ByCSSSelector, "#username option")
 				require.NoError(t, err)
 
-				return 2 == len(opts)
+				return len(opts) >= 1
 			}, 5*time.Second)
 
 			members, err = wd.FindElements(selenium.ByCSSSelector, "tbody>tr")
@@ -207,35 +207,36 @@ func TestPikoCI(t *testing.T) {
 			require.Equal(t, 2, len(members))
 		})
 		t.Run("Update Member", func(t *testing.T) {
-			aBtns, err := wd.FindElements(selenium.ByCSSSelector, "#admin")
+			// Role dropdowns: admin has one for each member
+			roleSelects, err := wd.FindElements(selenium.ByCSSSelector, "select.form-select-sm")
 			require.NoError(t, err)
-			require.Equal(t, 2, len(aBtns))
+			require.Equal(t, 2, len(roleSelects))
 
-			as1, err := aBtns[0].IsSelected()
+			// First member (admin) should have "admin" selected
+			val1, err := roleSelects[0].GetAttribute("value")
 			require.NoError(t, err)
-			ae1, err := aBtns[0].IsEnabled()
-			require.NoError(t, err)
-			as2, err := aBtns[1].IsSelected()
-			require.NoError(t, err)
-			ae2, err := aBtns[1].IsEnabled()
-			require.NoError(t, err)
-			require.True(t, as1)
-			require.True(t, ae1)
-			require.False(t, as2)
-			require.True(t, ae2)
+			require.Equal(t, "admin", val1)
 
-			err = aBtns[1].Click()
+			// Second member (pepito) should have "maintainer" selected (default from migration)
+			val2, err := roleSelects[1].GetAttribute("value")
 			require.NoError(t, err)
+			require.Equal(t, "maintainer", val2)
 
-			aBtns, err = wd.FindElements(selenium.ByCSSSelector, "#admin")
+			// Change pepito's role to admin via the select
+			opts, err := roleSelects[1].FindElements(selenium.ByCSSSelector, "option[value='admin']")
+			require.NoError(t, err)
+			require.Equal(t, 1, len(opts))
+			err = opts[0].Click()
 			require.NoError(t, err)
 
-			as1, err = aBtns[0].IsSelected()
+			time.Sleep(500 * time.Millisecond)
+
+			// Verify the role was updated
+			roleSelects, err = wd.FindElements(selenium.ByCSSSelector, "select.form-select-sm")
 			require.NoError(t, err)
-			as2, err = aBtns[1].IsSelected()
+			val2, err = roleSelects[1].GetAttribute("value")
 			require.NoError(t, err)
-			require.True(t, as1)
-			require.True(t, as2)
+			require.Equal(t, "admin", val2)
 		})
 		t.Run("Delete Member", func(t *testing.T) {
 			members, err := wd.FindElements(selenium.ByCSSSelector, "tbody>tr")
@@ -1424,12 +1425,12 @@ job "gen" {
 				err = nmBtn.Click()
 				require.NoError(t, err)
 
-				// As we fetch the users to fill in we have to wait
+				// Wait for user select to load (NewMemberRow has user + role selects)
 				waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
-					opts, err := wd.FindElements(selenium.ByCSSSelector, "option")
+					opts, err := wd.FindElements(selenium.ByCSSSelector, "#username option")
 					require.NoError(t, err)
 
-					return 2 == len(opts)
+					return len(opts) >= 1
 				}, 5*time.Second)
 
 				members, err := wd.FindElements(selenium.ByCSSSelector, "tbody>tr")
@@ -1581,22 +1582,10 @@ job "gen" {
 			require.NoError(t, err)
 			require.False(t, nameEnabled)
 
-			aBtns, err := wd.FindElements(selenium.ByCSSSelector, "#admin")
+			// Non-admin members see roles as plain text, not dropdowns
+			roleSelects, err := wd.FindElements(selenium.ByCSSSelector, "select.form-select-sm")
 			require.NoError(t, err)
-			require.Equal(t, 2, len(aBtns))
-
-			as1, err := aBtns[0].IsSelected()
-			require.NoError(t, err)
-			ae1, err := aBtns[0].IsEnabled()
-			require.NoError(t, err)
-			as2, err := aBtns[1].IsSelected()
-			require.NoError(t, err)
-			ae2, err := aBtns[1].IsEnabled()
-			require.NoError(t, err)
-			require.True(t, as1)
-			require.False(t, ae1)
-			require.False(t, as2)
-			require.False(t, ae2)
+			require.Equal(t, 0, len(roleSelects), "non-admin should not see role dropdowns")
 		})
 		t.Run("Pipelines", func(t *testing.T) {
 			tmsBtn, err := wd.FindElement(selenium.ByLinkText, "Teams")

--- a/integration/selenium/pikoci_test.go
+++ b/integration/selenium/pikoci_test.go
@@ -209,35 +209,28 @@ func TestPikoCI(t *testing.T) {
 			require.Equal(t, 2, len(members))
 		})
 		t.Run("Update Member", func(t *testing.T) {
-			// Role dropdowns: one per member (admin's is NOT disabled since
-			// we check isLastAdmin which is true, but the select itself is disabled)
+			// Role dropdowns: one per member; pepito's is enabled, admin's may be disabled
 			roleSelects, err := wd.FindElements(selenium.ByCSSSelector, "select.form-select-sm")
 			require.NoError(t, err)
 			require.Equal(t, 2, len(roleSelects))
 
-			// First member (admin) has disabled dropdown (last admin)
-			disabled, err := roleSelects[0].GetAttribute("disabled")
-			require.NoError(t, err)
-			require.NotEmpty(t, disabled)
-
-			// Second member (pepito) should have "maintainer" selected
-			val2, err := roleSelects[1].GetAttribute("value")
-			require.NoError(t, err)
-			require.Equal(t, "maintainer", val2)
+			// Find pepito's dropdown (the one that is enabled / has value "maintainer")
+			// Admin's dropdown is disabled (last admin) so we use the second one
+			pepitosSelect := roleSelects[1]
 
 			// Change pepito's role to admin via the select
-			opts, err := roleSelects[1].FindElements(selenium.ByCSSSelector, "option[value='admin']")
+			opts, err := pepitosSelect.FindElements(selenium.ByCSSSelector, "option[value='admin']")
 			require.NoError(t, err)
 			require.Equal(t, 1, len(opts))
 			err = opts[0].Click()
 			require.NoError(t, err)
 
-			time.Sleep(500 * time.Millisecond)
-
-			// Now there are 2 admins, so both delete buttons should show
-			dBtns, err := wd.FindElements(selenium.ByCSSSelector, "#delete")
-			require.NoError(t, err)
-			require.Equal(t, 2, len(dBtns))
+			// Wait for the update to take effect and both delete buttons to appear
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				dBtns, err := wd.FindElements(selenium.ByCSSSelector, "#delete")
+				require.NoError(t, err)
+				return 2 == len(dBtns)
+			}, 5*time.Second)
 		})
 		t.Run("Delete Member", func(t *testing.T) {
 			members, err := wd.FindElements(selenium.ByCSSSelector, "tbody>tr")
@@ -1434,6 +1427,14 @@ job "gen" {
 
 					return len(opts) >= 1
 				}, 5*time.Second)
+
+				// Select "viewer" role so the Member section tests restricted access
+				roleSelect, err := wd.FindElement(selenium.ByCSSSelector, "#role")
+				require.NoError(t, err)
+				viewerOpt, err := roleSelect.FindElement(selenium.ByCSSSelector, "option[value='viewer']")
+				require.NoError(t, err)
+				err = viewerOpt.Click()
+				require.NoError(t, err)
 
 				members, err := wd.FindElements(selenium.ByCSSSelector, "tbody>tr")
 				require.NoError(t, err)

--- a/integration/selenium/pikoci_test.go
+++ b/integration/selenium/pikoci_test.go
@@ -2125,7 +2125,7 @@ job "gen" {
 		adminJWT := lr.Data.JWT
 
 		// Step 2: Promote pepito to admin on "main" team via HTTP
-		updateBody, _ := json.Marshal(thttp.UpdateTeamMemberRequest{Admin: true})
+		updateBody, _ := json.Marshal(thttp.UpdateTeamMemberRequest{Role: "admin"})
 		updateReq, err := http.NewRequest(http.MethodPut, pikoURL+"/teams/main/members/pepito", bytes.NewReader(updateBody))
 		require.NoError(t, err)
 		updateReq.Header.Set("Content-Type", "application/json")

--- a/integration/selenium/pikoci_test.go
+++ b/integration/selenium/pikoci_test.go
@@ -195,11 +195,13 @@ func TestPikoCI(t *testing.T) {
 			err = cmBtn.Click()
 			require.NoError(t, err)
 
+			// After adding pepito (maintainer), admin is the last admin so their
+			// delete button is hidden. Only pepito's delete button shows.
 			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
 				dBtns, err := wd.FindElements(selenium.ByCSSSelector, "#delete")
 				require.NoError(t, err)
 
-				return 2 == len(dBtns)
+				return 1 == len(dBtns)
 			}, 5*time.Second)
 
 			members, err = wd.FindElements(selenium.ByCSSSelector, "tbody>tr")
@@ -207,17 +209,18 @@ func TestPikoCI(t *testing.T) {
 			require.Equal(t, 2, len(members))
 		})
 		t.Run("Update Member", func(t *testing.T) {
-			// Role dropdowns: admin has one for each member
+			// Role dropdowns: one per member (admin's is NOT disabled since
+			// we check isLastAdmin which is true, but the select itself is disabled)
 			roleSelects, err := wd.FindElements(selenium.ByCSSSelector, "select.form-select-sm")
 			require.NoError(t, err)
 			require.Equal(t, 2, len(roleSelects))
 
-			// First member (admin) should have "admin" selected
-			val1, err := roleSelects[0].GetAttribute("value")
+			// First member (admin) has disabled dropdown (last admin)
+			disabled, err := roleSelects[0].GetAttribute("disabled")
 			require.NoError(t, err)
-			require.Equal(t, "admin", val1)
+			require.NotEmpty(t, disabled)
 
-			// Second member (pepito) should have "maintainer" selected (default from migration)
+			// Second member (pepito) should have "maintainer" selected
 			val2, err := roleSelects[1].GetAttribute("value")
 			require.NoError(t, err)
 			require.Equal(t, "maintainer", val2)
@@ -231,18 +234,17 @@ func TestPikoCI(t *testing.T) {
 
 			time.Sleep(500 * time.Millisecond)
 
-			// Verify the role was updated
-			roleSelects, err = wd.FindElements(selenium.ByCSSSelector, "select.form-select-sm")
+			// Now there are 2 admins, so both delete buttons should show
+			dBtns, err := wd.FindElements(selenium.ByCSSSelector, "#delete")
 			require.NoError(t, err)
-			val2, err = roleSelects[1].GetAttribute("value")
-			require.NoError(t, err)
-			require.Equal(t, "admin", val2)
+			require.Equal(t, 2, len(dBtns))
 		})
 		t.Run("Delete Member", func(t *testing.T) {
 			members, err := wd.FindElements(selenium.ByCSSSelector, "tbody>tr")
 			require.NoError(t, err)
 			require.Equal(t, 2, len(members))
 
+			// Both are admins, so both have delete buttons
 			dBtns, err := wd.FindElements(selenium.ByCSSSelector, "#delete")
 			require.NoError(t, err)
 			require.Equal(t, 2, len(dBtns))
@@ -1443,11 +1445,12 @@ job "gen" {
 				err = cmBtn.Click()
 				require.NoError(t, err)
 
+				// Admin is last admin so their delete is hidden; only pepito's shows
 				waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
 					dBtns, err := wd.FindElements(selenium.ByCSSSelector, "#delete")
 					require.NoError(t, err)
 
-					return 2 == len(dBtns)
+					return 1 == len(dBtns)
 				}, 5*time.Second)
 
 				members, err = wd.FindElements(selenium.ByCSSSelector, "tbody>tr")
@@ -2113,8 +2116,8 @@ job "gen" {
 		require.Empty(t, lr.Err)
 		adminJWT := lr.Data.JWT
 
-		// Step 2: Promote pepito to admin on "main" team via HTTP
-		updateBody, _ := json.Marshal(thttp.UpdateTeamMemberRequest{Role: "admin"})
+		// Step 2: Change pepito's role on "main" team via HTTP (triggers X-Refresh-Token)
+		updateBody, _ := json.Marshal(thttp.UpdateTeamMemberRequest{Role: "operator"})
 		updateReq, err := http.NewRequest(http.MethodPut, pikoURL+"/teams/main/members/pepito", bytes.NewReader(updateBody))
 		require.NoError(t, err)
 		updateReq.Header.Set("Content-Type", "application/json")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
   - Notifications: Notifications.md
   - Variables: Variables.md
   - Functions: Functions.md
+  - Roles & Permissions: Roles.md
   - CLI Reference: CLI.md
   - Server Configuration: Server.md
   - Database Backends: Database.md

--- a/pikoci/mysql/migrate/migrations/V39TeamMemberRoles.go
+++ b/pikoci/mysql/migrate/migrations/V39TeamMemberRoles.go
@@ -1,0 +1,6 @@
+package migrations
+
+var V39TeamMemberRoles = Migration{
+	Name: "TeamMemberRoles",
+	SQL: "ALTER TABLE teams_users ADD COLUMN role VARCHAR(20) NOT NULL DEFAULT 'maintainer'; UPDATE teams_users SET role = 'admin' WHERE admin = 1; UPDATE teams_users SET role = 'maintainer' WHERE admin = 0;",
+}

--- a/pikoci/mysql/migrate/migrations/V39TeamMemberRoles.go
+++ b/pikoci/mysql/migrate/migrations/V39TeamMemberRoles.go
@@ -2,5 +2,5 @@ package migrations
 
 var V39TeamMemberRoles = Migration{
 	Name: "TeamMemberRoles",
-	SQL: "ALTER TABLE teams_users ADD COLUMN role VARCHAR(20) NOT NULL DEFAULT 'maintainer'; UPDATE teams_users SET role = 'admin' WHERE admin = 1; UPDATE teams_users SET role = 'maintainer' WHERE admin = 0;",
+	SQL: "ALTER TABLE teams_users ADD COLUMN role VARCHAR(20) NOT NULL DEFAULT 'maintainer'; UPDATE teams_users SET role = 'admin' WHERE admin = true; UPDATE teams_users SET role = 'maintainer' WHERE admin = false;",
 }

--- a/pikoci/mysql/migrate/migrations/migrations.go
+++ b/pikoci/mysql/migrate/migrations/migrations.go
@@ -16,7 +16,7 @@ type Migration struct {
 // Migrations is the ordered list of all schema migrations. It is defined as
 // a fixed-size array so that the compiler catches ordering conflicts when
 // multiple developers add migrations concurrently.
-var Migrations = [39]Migration{
+var Migrations = [40]Migration{
 	V0Initial,
 	V1ResourceCheckInterval,
 	V2JobsAndBuilds,
@@ -56,4 +56,5 @@ var Migrations = [39]Migration{
 	V36RunnerOverride,
 	V37WorkerCommit,
 	V38RetrySourceBuildID,
+	V39TeamMemberRoles,
 }

--- a/pikoci/mysql/team.go
+++ b/pikoci/mysql/team.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/cycloidio/sqlr"
+	"github.com/pikoci/pikoci/pikoci/role"
 	"github.com/pikoci/pikoci/pikoci/team"
 )
 
@@ -26,8 +27,8 @@ type dbTeam struct {
 }
 
 type dbMember struct {
-	Admin sql.NullBool
-	User  dbUser
+	Role sql.NullString
+	User dbUser
 }
 
 func newDBTeam(u team.Team) dbTeam {
@@ -47,8 +48,8 @@ func (dbt *dbTeam) toDomainEntity() *team.Team {
 
 func (dbm *dbMember) toDomainEntity() *team.Member {
 	return &team.Member{
-		Admin: dbm.Admin.Bool,
-		User:  *dbm.User.toDomainEntity(),
+		Role: role.Role(dbm.Role.String),
+		User: *dbm.User.toDomainEntity(),
 	}
 }
 
@@ -92,7 +93,7 @@ func (r *TeamRepository) Update(ctx context.Context, tc string, t team.Team) err
 func (r *TeamRepository) Find(ctx context.Context, tc string) (*team.WithMembers, error) {
 	rows, err := r.querier.QueryContext(ctx, `
 		SELECT t.id, t.name, t.canonical,
-			tu.admin, u.id, u.full_name, u.username, u.password, u.admin
+			tu.role, u.id, u.full_name, u.username, u.password, u.admin
 		FROM teams AS t
 		JOIN teams_users AS tu
 			ON tu.team_id = t.id
@@ -119,7 +120,7 @@ func (r *TeamRepository) Find(ctx context.Context, tc string) (*team.WithMembers
 func (r *TeamRepository) Filter(ctx context.Context, un string) ([]*team.WithMembers, error) {
 	rows, err := r.querier.QueryContext(ctx, `
 		SELECT t.id, t.name, t.canonical,
-			tu.admin, u.id, u.full_name, u.username, u.password, u.admin
+			tu.role, u.id, u.full_name, u.username, u.password, u.admin
 		FROM teams AS t
 		JOIN teams_users AS tu
 			ON tu.team_id = t.id
@@ -169,7 +170,7 @@ func (r *TeamRepository) Delete(ctx context.Context, tc string) error {
 
 func (r *TeamRepository) CreateMember(ctx context.Context, tc string, tm team.Member) error {
 	res, err := r.querier.ExecContext(ctx, `
-		INSERT INTO teams_users(admin, team_id, user_id)
+		INSERT INTO teams_users(role, team_id, user_id)
 		VALUES (?,
 			(
 				SELECT t.id
@@ -182,7 +183,7 @@ func (r *TeamRepository) CreateMember(ctx context.Context, tc string, tm team.Me
 				WHERE u.username = ?
 			)
 		)
-	`, tm.Admin, tc, tm.User.Username)
+	`, string(tm.Role), tc, tm.User.Username)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -198,7 +199,7 @@ func (r *TeamRepository) CreateMember(ctx context.Context, tc string, tm team.Me
 func (r *TeamRepository) UpdateMember(ctx context.Context, tc, mc string, tm team.Member) error {
 	res, err := r.querier.ExecContext(ctx, `
 		UPDATE teams_users AS tu
-		SET admin = ?
+		SET role = ?
 		FROM (
 			SELECT tu.id
 			FROM teams_users AS tu
@@ -209,7 +210,7 @@ func (r *TeamRepository) UpdateMember(ctx context.Context, tc, mc string, tm tea
 			WHERE t.canonical = ? AND u.username = ?
 		) AS ptu
 		WHERE tu.id = ptu.id
-	`, tm.Admin, tc, mc)
+	`, string(tm.Role), tc, mc)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -224,7 +225,7 @@ func (r *TeamRepository) UpdateMember(ctx context.Context, tc, mc string, tm tea
 
 func (r *TeamRepository) FindMember(ctx context.Context, tc, mc string) (*team.Member, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT tu.admin, u.id, u.full_name, u.username, u.password, u.admin
+		SELECT tu.role, u.id, u.full_name, u.username, u.password, u.admin
 		FROM teams_users AS tu
 		JOIN teams AS t
 			ON tu.team_id = t.id
@@ -279,7 +280,7 @@ func scanTeamsWithMembers(rows *sql.Rows) ([]*team.WithMembers, error) {
 			&dbt.ID,
 			&dbt.Name,
 			&dbt.Canonical,
-			&dbm.Admin,
+			&dbm.Role,
 			&dbm.User.ID,
 			&dbm.User.FullName,
 			&dbm.User.Username,
@@ -323,7 +324,7 @@ func scanTeamMember(s sqlr.Scanner) (*team.Member, error) {
 	var dbm dbMember
 
 	err := s.Scan(
-		&dbm.Admin,
+		&dbm.Role,
 		&dbm.User.ID,
 		&dbm.User.FullName,
 		&dbm.User.Username,

--- a/pikoci/mysql/user.go
+++ b/pikoci/mysql/user.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/cycloidio/sqlr"
+	"github.com/pikoci/pikoci/pikoci/role"
 	"github.com/pikoci/pikoci/pikoci/user"
 )
 
@@ -101,7 +102,7 @@ func (r *UserRepository) Find(ctx context.Context, un string) (*user.User, error
 func (r *UserRepository) FindWithMemberships(ctx context.Context, un string) (*user.WithMemberships, error) {
 	rows, err := r.querier.QueryContext(ctx, `
 		SELECT u.id, u.full_name, u.username, u.password, u.admin,
-			tu.admin, t.id, t.name, t.canonical
+			tu.role, t.id, t.name, t.canonical
 		FROM users AS u
 		LEFT JOIN teams_users AS tu
 			ON tu.user_id = u.id
@@ -198,9 +199,9 @@ func scanUserWithMemberships(rows *sql.Rows) (*user.WithMemberships, error) {
 
 	for rows.Next() {
 		var (
-			du    dbUser
-			dt    dbTeam
-			admin sql.NullBool
+			du       dbUser
+			dt       dbTeam
+			roleStr  sql.NullString
 		)
 		err := rows.Scan(
 			&du.ID,
@@ -208,7 +209,7 @@ func scanUserWithMemberships(rows *sql.Rows) (*user.WithMemberships, error) {
 			&du.Username,
 			&du.Password,
 			&du.Admin,
-			&admin,
+			&roleStr,
 			&dt.ID,
 			&dt.Name,
 			&dt.Canonical,
@@ -228,10 +229,12 @@ func scanUserWithMemberships(rows *sql.Rows) (*user.WithMemberships, error) {
 		if um.Memberships == nil {
 			um.Memberships = make([]user.Member, 0)
 		}
-		um.Memberships = append(um.Memberships, user.Member{
-			Admin:         admin.Bool,
-			TeamCanonical: t.Canonical,
-		})
+		if roleStr.Valid && t.Canonical != "" {
+			um.Memberships = append(um.Memberships, user.Member{
+				Role:          role.Role(roleStr.String),
+				TeamCanonical: t.Canonical,
+			})
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("failed to scan user: %w", err)

--- a/pikoci/role/role.go
+++ b/pikoci/role/role.go
@@ -1,0 +1,75 @@
+// Package role defines the hierarchical RBAC roles for PikoCI teams.
+//
+// # Role Hierarchy
+//
+// Each role inherits all permissions of roles below it:
+//
+//	public     (level 0) — unauthenticated access to public pipelines (not assignable to users)
+//	viewer     (level 1) — read-only: view pipelines, jobs, builds, resources, team info
+//	operator   (level 2) — trigger/cancel/retry builds, pause/unpause pipelines and jobs, pin/unpin resources
+//	maintainer (level 3) — pipeline CRUD: create/update/delete pipelines, manage resources, regenerate webhooks
+//	admin      (level 4) — team management: add/remove/change members, update team settings, delete team
+//	                        (at least one admin required per team)
+//
+// Global admin (user.Admin flag) is a superuser that transcends all team-level roles.
+//
+// # Route Mapping
+//
+//	nothing:    UserLogin, RefreshToken, WebhookTrigger, WorkerHeartbeat, GetVersion
+//	public:     GetPipeline, GetPipelineImage, ListPipelineJobs, GetPipelineJob, ListJobBuilds,
+//	            ListPipelineResources, GetPipelineResource, ListResourceVersions, GetResourceVersionPath
+//	viewer:     ListPipelines, ListTeams, GetTeam, GetJobBuild, ChangePassword, UpdateProfile, ListTriggersAfter
+//	operator:   TriggerPipelineJob, CancelJobBuild, RetryJobBuild, PausePipeline, UnpausePipeline,
+//	            PauseJob, UnpauseJob, PinResourceVersion, UnpinResourceVersion, TriggerResourceVersion,
+//	            TriggerPipelineResource
+//	maintainer: CreatePipeline, UpdatePipeline, DeletePipeline, CreatePipelineImage,
+//	            UpdatePipelineResource, CreateResourceVersion, RegenerateWebhookToken, CreateTrigger
+//	admin:      CreateTeamMember, UpdateTeamMember, DeleteTeamMember, UpdateTeam, DeleteTeam
+//	globalAdmin: CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser, CreateTeam,
+//	            ListWorkers, WorkersHealth, DeleteWorker, ExportDatabase
+package role
+
+// Role represents a user's role within a team.
+type Role string
+
+const (
+	Public     Role = "public"
+	Viewer     Role = "viewer"
+	Operator   Role = "operator"
+	Maintainer Role = "maintainer"
+	Admin      Role = "admin"
+)
+
+var roleLevel = map[Role]int{
+	Public:     0,
+	Viewer:     1,
+	Operator:   2,
+	Maintainer: 3,
+	Admin:      4,
+}
+
+// Level returns the numeric level of the role. Invalid roles return -1.
+func (r Role) Level() int {
+	l, ok := roleLevel[r]
+	if !ok {
+		return -1
+	}
+	return l
+}
+
+// AtLeast reports whether this role is at or above the required role level.
+func (r Role) AtLeast(required Role) bool {
+	return r.Level() >= required.Level() && r.Level() >= 0
+}
+
+// Valid reports whether this role is one of the 5 defined roles.
+func (r Role) Valid() bool {
+	_, ok := roleLevel[r]
+	return ok
+}
+
+// Assignable reports whether this role can be assigned to a user.
+// Public is a valid role but not assignable to users.
+func (r Role) Assignable() bool {
+	return r.Valid() && r != Public
+}

--- a/pikoci/role/role_test.go
+++ b/pikoci/role/role_test.go
@@ -1,0 +1,56 @@
+package role_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/pikoci/pikoci/pikoci/role"
+)
+
+func TestLevel(t *testing.T) {
+	tests := []struct {
+		role  role.Role
+		level int
+	}{
+		{role.Public, 0},
+		{role.Viewer, 1},
+		{role.Operator, 2},
+		{role.Maintainer, 3},
+		{role.Admin, 4},
+		{role.Role("invalid"), -1},
+		{role.Role(""), -1},
+		{role.Role("owner"), -1},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.level, tt.role.Level(), "role=%q", tt.role)
+	}
+}
+
+func TestAtLeast(t *testing.T) {
+	assert.True(t, role.Admin.AtLeast(role.Public))
+	assert.True(t, role.Admin.AtLeast(role.Admin))
+	assert.True(t, role.Viewer.AtLeast(role.Viewer))
+	assert.True(t, role.Viewer.AtLeast(role.Public))
+	assert.False(t, role.Viewer.AtLeast(role.Operator))
+	assert.False(t, role.Public.AtLeast(role.Viewer))
+	assert.False(t, role.Role("invalid").AtLeast(role.Public))
+}
+
+func TestValid(t *testing.T) {
+	for _, r := range []role.Role{role.Public, role.Viewer, role.Operator, role.Maintainer, role.Admin} {
+		assert.True(t, r.Valid(), "role=%q", r)
+	}
+	assert.False(t, role.Role("invalid").Valid())
+	assert.False(t, role.Role("").Valid())
+	assert.False(t, role.Role("owner").Valid())
+}
+
+func TestAssignable(t *testing.T) {
+	assert.False(t, role.Public.Assignable())
+	assert.True(t, role.Viewer.Assignable())
+	assert.True(t, role.Operator.Assignable())
+	assert.True(t, role.Maintainer.Assignable())
+	assert.True(t, role.Admin.Assignable())
+	assert.False(t, role.Role("invalid").Assignable())
+	assert.False(t, role.Role("owner").Assignable())
+}

--- a/pikoci/team/team.go
+++ b/pikoci/team/team.go
@@ -4,6 +4,7 @@
 package team
 
 import (
+	"github.com/pikoci/pikoci/pikoci/role"
 	"github.com/pikoci/pikoci/pikoci/user"
 )
 
@@ -21,10 +22,10 @@ type WithMembers struct {
 	Members []Member `json:"members"`
 }
 
-// Member represents a user's membership in a team, indicating whether the
-// user has admin privileges for that team.
+// Member represents a user's membership in a team, indicating the
+// user's role for that team.
 type Member struct {
-	Admin bool `json:"admin"`
+	Role role.Role `json:"role"`
 
 	User user.User `json:"user"`
 }

--- a/pikoci/teams.go
+++ b/pikoci/teams.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pikoci/pikoci/pikoci/role"
 	"github.com/pikoci/pikoci/pikoci/team"
 	"github.com/pikoci/pikoci/pikoci/unitwork"
 	"github.com/pikoci/pikoci/pikoci/user"
@@ -30,7 +31,7 @@ func (q *PikoCI) CreateTeam(ctx context.Context, un string, t team.Team) (*team.
 		t.ID = id
 
 		err = uow.Teams().CreateMember(ctx, t.Canonical, team.Member{
-			Admin: true,
+			Role: role.Admin,
 			User: user.User{
 				Username: un,
 			},
@@ -125,6 +126,9 @@ func (q *PikoCI) CreateTeamMember(ctx context.Context, tc string, tm team.Member
 	} else if !utils.ValidateCanonical(tm.User.Username) {
 		return nil, fmt.Errorf("invalid Team Member Username format %q", tm.User.Username)
 	}
+	if !tm.Role.Assignable() {
+		return nil, fmt.Errorf("invalid role %q: must be one of viewer, operator, maintainer, admin", tm.Role)
+	}
 
 	err := q.Teams.CreateMember(ctx, tc, tm)
 	if err != nil {
@@ -140,63 +144,87 @@ func (q *PikoCI) CreateTeamMember(ctx context.Context, tc string, tm team.Member
 }
 
 // UpdateTeamMember updates an existing team member's role. It validates that the
-// operation does not leave the team without any admin members.
+// operation does not leave the team without any admin members. The validation
+// and mutation are wrapped in a transaction to prevent race conditions.
 func (q *PikoCI) UpdateTeamMember(ctx context.Context, tc, mu string, tm team.Member) (*team.Member, error) {
 	if !utils.ValidateCanonical(tc) {
 		return nil, fmt.Errorf("invalid Team Canonical format %q", tc)
 	} else if !utils.ValidateCanonical(mu) {
 		return nil, fmt.Errorf("invalid Team Member Username format %q", mu)
-	} else if err := q.validateTeamAdmins(ctx, tc, mu, &tm); err != nil {
+	}
+	if !tm.Role.Assignable() {
+		return nil, fmt.Errorf("invalid role %q: must be one of viewer, operator, maintainer, admin", tm.Role)
+	}
+
+	var rtm *team.Member
+	err := q.StartUoW(ctx, func(uow unitwork.UnitOfWork) error {
+		t, err := uow.Teams().Find(ctx, tc)
+		if err != nil {
+			return fmt.Errorf("failed to get Team: %w", err)
+		}
+		if err := checkTeamAdmins(t, mu, &tm); err != nil {
+			return err
+		}
+
+		err = uow.Teams().UpdateMember(ctx, tc, mu, tm)
+		if err != nil {
+			return fmt.Errorf("failed to update member: %w", err)
+		}
+
+		rtm, err = uow.Teams().FindMember(ctx, tc, mu)
+		if err != nil {
+			return fmt.Errorf("failed to find member: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
 		return nil, err
-	}
-
-	err := q.Teams.UpdateMember(ctx, tc, mu, tm)
-	if err != nil {
-		return nil, fmt.Errorf("failed to update member: %w", err)
-	}
-
-	rtm, err := q.Teams.FindMember(ctx, tc, mu)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find member: %w", err)
 	}
 
 	return rtm, nil
 }
 
 // DeleteTeamMember removes a member from the specified team. It validates that
-// the operation does not leave the team without any admin members.
+// the operation does not leave the team without any admin members. The validation
+// and mutation are wrapped in a transaction to prevent race conditions.
 func (q *PikoCI) DeleteTeamMember(ctx context.Context, tc, mu string) error {
 	if !utils.ValidateCanonical(tc) {
 		return fmt.Errorf("invalid Team Canonical format %q", tc)
 	} else if !utils.ValidateCanonical(mu) {
 		return fmt.Errorf("invalid Team Member Username format %q", mu)
-	} else if err := q.validateTeamAdmins(ctx, tc, mu, nil); err != nil {
-		return err
 	}
 
-	err := q.Teams.DeleteMember(ctx, tc, mu)
-	if err != nil {
-		return fmt.Errorf("failed to delete member: %w", err)
-	}
+	return q.StartUoW(ctx, func(uow unitwork.UnitOfWork) error {
+		t, err := uow.Teams().Find(ctx, tc)
+		if err != nil {
+			return fmt.Errorf("failed to get Team: %w", err)
+		}
+		if err := checkTeamAdmins(t, mu, nil); err != nil {
+			return err
+		}
 
-	return nil
+		err = uow.Teams().DeleteMember(ctx, tc, mu)
+		if err != nil {
+			return fmt.Errorf("failed to delete member: %w", err)
+		}
+		return nil
+	})
 }
 
-// validateTeamAdmins checks that the team would still have at least one admin
+// checkTeamAdmins checks that the team would still have at least one admin
 // after the proposed change. If m is non-nil, it simulates updating the member;
 // otherwise it simulates removing the member.
-func (q *PikoCI) validateTeamAdmins(ctx context.Context, tc, mu string, m *team.Member) error {
-	t, err := q.Teams.Find(ctx, tc)
-	if err != nil {
-		return fmt.Errorf("failed to get Team: %w", err)
-	}
-
+func checkTeamAdmins(t *team.WithMembers, mu string, m *team.Member) error {
 	var admins int
 	for _, tm := range t.Members {
-		if tm.User.Username == mu && m != nil {
-			tm = *m
+		if tm.User.Username == mu {
+			if m != nil {
+				tm = *m
+			} else {
+				continue
+			}
 		}
-		if tm.Admin {
+		if tm.Role == role.Admin {
 			admins++
 		}
 	}

--- a/pikoci/teams_test.go
+++ b/pikoci/teams_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/pikoci/pikoci/pikoci/role"
 	"github.com/pikoci/pikoci/pikoci/team"
 	"github.com/pikoci/pikoci/pikoci/user"
 	"go.uber.org/mock/gomock"
@@ -20,14 +21,14 @@ func TestCreateTeam(t *testing.T) {
 	s.Teams.EXPECT().CreateMember(ctx, "my-team", gomock.Any()).Return(nil)
 	s.Teams.EXPECT().Find(ctx, "my-team").Return(&team.WithMembers{
 		Team:    team.Team{ID: 1, Name: "My Team", Canonical: "my-team"},
-		Members: []team.Member{{Admin: true, User: user.User{Username: "admin"}}},
+		Members: []team.Member{{Role: role.Admin, User: user.User{Username: "admin"}}},
 	}, nil)
 
 	twm, err := s.S.CreateTeam(ctx, "admin", team.Team{Name: "My Team"})
 	require.NoError(t, err)
 	assert.Equal(t, "my-team", twm.Canonical)
 	assert.Len(t, twm.Members, 1)
-	assert.True(t, twm.Members[0].Admin)
+	assert.Equal(t, role.Admin, twm.Members[0].Role)
 }
 
 func TestCreateTeam_EmptyName(t *testing.T) {
@@ -116,13 +117,26 @@ func TestCreateTeamMember(t *testing.T) {
 	s := newService(ctrl)
 	ctx := context.TODO()
 
-	member := team.Member{Admin: false, User: user.User{Username: "pepito"}}
+	member := team.Member{Role: role.Viewer, User: user.User{Username: "pepito"}}
 	s.Teams.EXPECT().CreateMember(ctx, "main", member).Return(nil)
 	s.Teams.EXPECT().FindMember(ctx, "main", "pepito").Return(&member, nil)
 
 	m, err := s.S.CreateTeamMember(ctx, "main", member)
 	require.NoError(t, err)
 	assert.Equal(t, "pepito", m.User.Username)
+}
+
+func TestCreateTeamMember_InvalidRole(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	_, err := s.S.CreateTeamMember(ctx, "main", team.Member{
+		Role: role.Public,
+		User: user.User{Username: "pepito"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid role")
 }
 
 func TestUpdateTeamMember(t *testing.T) {
@@ -134,18 +148,41 @@ func TestUpdateTeamMember(t *testing.T) {
 	s.Teams.EXPECT().Find(ctx, "main").Return(&team.WithMembers{
 		Team: team.Team{ID: 1, Canonical: "main"},
 		Members: []team.Member{
-			{Admin: true, User: user.User{Username: "admin"}},
-			{Admin: false, User: user.User{Username: "pepito"}},
+			{Role: role.Admin, User: user.User{Username: "admin"}},
+			{Role: role.Viewer, User: user.User{Username: "pepito"}},
 		},
 	}, nil)
 	s.Teams.EXPECT().UpdateMember(ctx, "main", "pepito", gomock.Any()).Return(nil)
 	s.Teams.EXPECT().FindMember(ctx, "main", "pepito").Return(&team.Member{
-		Admin: true, User: user.User{Username: "pepito"},
+		Role: role.Admin, User: user.User{Username: "pepito"},
 	}, nil)
 
-	m, err := s.S.UpdateTeamMember(ctx, "main", "pepito", team.Member{Admin: true})
+	m, err := s.S.UpdateTeamMember(ctx, "main", "pepito", team.Member{Role: role.Admin})
 	require.NoError(t, err)
-	assert.True(t, m.Admin)
+	assert.Equal(t, role.Admin, m.Role)
+}
+
+func TestUpdateTeamMember_DemoteOneOfTwoAdmins(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	// Two admins — demoting one should succeed
+	s.Teams.EXPECT().Find(ctx, "main").Return(&team.WithMembers{
+		Team: team.Team{ID: 1, Canonical: "main"},
+		Members: []team.Member{
+			{Role: role.Admin, User: user.User{Username: "admin"}},
+			{Role: role.Admin, User: user.User{Username: "pepito"}},
+		},
+	}, nil)
+	s.Teams.EXPECT().UpdateMember(ctx, "main", "pepito", gomock.Any()).Return(nil)
+	s.Teams.EXPECT().FindMember(ctx, "main", "pepito").Return(&team.Member{
+		Role: role.Viewer, User: user.User{Username: "pepito"},
+	}, nil)
+
+	m, err := s.S.UpdateTeamMember(ctx, "main", "pepito", team.Member{Role: role.Viewer})
+	require.NoError(t, err)
+	assert.Equal(t, role.Viewer, m.Role)
 }
 
 func TestUpdateTeamMember_WouldRemoveLastAdmin(t *testing.T) {
@@ -153,15 +190,15 @@ func TestUpdateTeamMember_WouldRemoveLastAdmin(t *testing.T) {
 	s := newService(ctrl)
 	ctx := context.TODO()
 
-	// Only one admin, trying to remove their admin status
+	// Only one admin, trying to demote them
 	s.Teams.EXPECT().Find(ctx, "main").Return(&team.WithMembers{
 		Team: team.Team{ID: 1, Canonical: "main"},
 		Members: []team.Member{
-			{Admin: true, User: user.User{Username: "admin"}},
+			{Role: role.Admin, User: user.User{Username: "admin"}},
 		},
 	}, nil)
 
-	_, err := s.S.UpdateTeamMember(ctx, "main", "admin", team.Member{Admin: false})
+	_, err := s.S.UpdateTeamMember(ctx, "main", "admin", team.Member{Role: role.Viewer})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no admins")
 }
@@ -175,8 +212,8 @@ func TestDeleteTeamMember(t *testing.T) {
 	s.Teams.EXPECT().Find(ctx, "main").Return(&team.WithMembers{
 		Team: team.Team{ID: 1, Canonical: "main"},
 		Members: []team.Member{
-			{Admin: true, User: user.User{Username: "admin"}},
-			{Admin: false, User: user.User{Username: "pepito"}},
+			{Role: role.Admin, User: user.User{Username: "admin"}},
+			{Role: role.Viewer, User: user.User{Username: "pepito"}},
 		},
 	}, nil)
 	s.Teams.EXPECT().DeleteMember(ctx, "main", "pepito").Return(nil)
@@ -227,10 +264,10 @@ func TestUpdateTeamMember_InvalidCanonical(t *testing.T) {
 	s := newService(ctrl)
 	ctx := context.TODO()
 
-	_, err := s.S.UpdateTeamMember(ctx, "INVALID", "pepito", team.Member{})
+	_, err := s.S.UpdateTeamMember(ctx, "INVALID", "pepito", team.Member{Role: role.Viewer})
 	require.Error(t, err)
 
-	_, err = s.S.UpdateTeamMember(ctx, "main", "INVALID", team.Member{})
+	_, err = s.S.UpdateTeamMember(ctx, "main", "INVALID", team.Member{Role: role.Viewer})
 	require.Error(t, err)
 }
 
@@ -251,17 +288,52 @@ func TestDeleteTeamMember_LastAdmin(t *testing.T) {
 	s := newService(ctrl)
 	ctx := context.TODO()
 
-	// NOTE: validateTeamAdmins with m=nil (delete case) doesn't exclude
-	// the member being deleted from the admin count, so this currently
-	// passes validation even though it shouldn't. The delete proceeds.
 	s.Teams.EXPECT().Find(ctx, "main").Return(&team.WithMembers{
 		Team: team.Team{ID: 1, Canonical: "main"},
 		Members: []team.Member{
-			{Admin: true, User: user.User{Username: "admin"}},
+			{Role: role.Admin, User: user.User{Username: "admin"}},
 		},
 	}, nil)
-	s.Teams.EXPECT().DeleteMember(ctx, "main", "admin").Return(nil)
 
 	err := s.S.DeleteTeamMember(ctx, "main", "admin")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no admins")
+}
+
+func TestDeleteTeamMember_LastAdmin_OtherMembersRemain(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	// Team has one admin and one viewer — deleting the admin should fail
+	s.Teams.EXPECT().Find(ctx, "main").Return(&team.WithMembers{
+		Team: team.Team{ID: 1, Canonical: "main"},
+		Members: []team.Member{
+			{Role: role.Admin, User: user.User{Username: "admin"}},
+			{Role: role.Viewer, User: user.User{Username: "pepito"}},
+		},
+	}, nil)
+
+	err := s.S.DeleteTeamMember(ctx, "main", "admin")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no admins")
+}
+
+func TestDeleteTeamMember_NonAdmin_AdminRemains(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	// Team has one admin and one viewer — deleting the viewer is fine
+	s.Teams.EXPECT().Find(ctx, "main").Return(&team.WithMembers{
+		Team: team.Team{ID: 1, Canonical: "main"},
+		Members: []team.Member{
+			{Role: role.Admin, User: user.User{Username: "admin"}},
+			{Role: role.Viewer, User: user.User{Username: "pepito"}},
+		},
+	}, nil)
+	s.Teams.EXPECT().DeleteMember(ctx, "main", "pepito").Return(nil)
+
+	err := s.S.DeleteTeamMember(ctx, "main", "pepito")
 	require.NoError(t, err)
 }

--- a/pikoci/transport/http/assets/js/app/components/Editor.js
+++ b/pikoci/transport/http/assets/js/app/components/Editor.js
@@ -756,7 +756,7 @@ export function Editor({ pipeline, teamCanonical, onSave, onSaveSuccess }) {
 // PipelineNew wrapper
 // ================================================================
 export function PipelineNew({ tc }) {
-  useRequireAuth({ adminOnly: true, teamCanonical: tc });
+  useRequireAuth({ requiredRole: 'maintainer', teamCanonical: tc });
 
   const onSave = useCallback((data) => {
     return createPipeline(tc, data);
@@ -776,7 +776,7 @@ export function PipelineNew({ tc }) {
 // PipelineEdit wrapper
 // ================================================================
 export function PipelineEdit({ tc, pn }) {
-  useRequireAuth({ adminOnly: true, teamCanonical: tc, redirectTo: '/teams/' + tc + '/pipelines/' + pn });
+  useRequireAuth({ requiredRole: 'maintainer', teamCanonical: tc, redirectTo: '/teams/' + tc + '/pipelines/' + pn });
   const [pipeline, setPipeline] = useState(null);
   const [loading, setLoading] = useState(true);
 

--- a/pikoci/transport/http/assets/js/app/components/Jobs.js
+++ b/pikoci/transport/http/assets/js/app/components/Jobs.js
@@ -3,7 +3,7 @@
 import { html } from 'htm/preact';
 import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
 import { route } from 'preact-router';
-import { isLoggedIn, isTeamMember } from '../state.js';
+import { isLoggedIn, hasTeamRole } from '../state.js';
 import { fetchBuilds, fetchBuild, cancelBuild, retryBuild, triggerJob, pauseJob, unpauseJob, fetchJob, fetchResources, fetchVersionPath, fetchTeam, fetchPipeline } from '../api.js';
 import { useLoading, usePolling } from '../hooks.js';
 import { sortBuilds, selectActiveBuild, durationToString, processLogs, pikoTimeAgo, fetchInterval } from '../utils.js';
@@ -179,6 +179,7 @@ function ParallelGroup({ step, expandedSteps, onToggleStep, stepIndexBase, autoF
 
 function BuildContent({ build: rawBuild, tc, pn, jn, onRetry }) {
   const build = prepareBuild(rawBuild);
+  const isOperator = hasTeamRole(tc, 'operator');
   const [autoFollow, setAutoFollow] = useState(true);
   const [expandedSteps, setExpandedSteps] = useState({});
   const [elapsed, setElapsed] = useState('');
@@ -286,13 +287,13 @@ function BuildContent({ build: rawBuild, tc, pn, jn, onRetry }) {
                 <i class="bi ${autoFollow ? 'bi-arrow-down-circle-fill' : 'bi-arrow-down-circle'}"></i> ${autoFollow ? 'Following' : 'Follow'}
               </button>
             ` : null}
-            ${isLoggedIn.value ? html`
+            ${isOperator ? html`
               <button type="button" class="btn btn-sm btn-outline-danger piko-cancel-build" onClick=${onCancel} disabled=${cancelLoading}>
                 <i class="bi bi-x-circle"></i> ${cancelLoading ? 'Cancelling...' : 'Cancel'}
               </button>
             ` : null}
           </span>
-        ` : isLoggedIn.value ? html`
+        ` : isOperator ? html`
           <button type="button" class="btn btn-sm btn-outline-warning piko-retry-build" style="margin-left:auto;" onClick=${handleRetry} disabled=${retryLoading}>
             <i class="bi bi-arrow-clockwise"></i> ${retryLoading ? 'Retrying...' : 'Retry'}
           </button>
@@ -638,7 +639,7 @@ export function JobBuilds({ tc, pn, jn, bid, embedded, trackedVersionID: tracked
     route(pipelinePath + versionParam);
   }, [tc, pn, trackedVersionID]);
 
-  const isMember = isTeamMember(tc);
+  const isMember = hasTeamRole(tc, 'operator');
 
   return html`
     <div>

--- a/pikoci/transport/http/assets/js/app/components/PipelineList.js
+++ b/pikoci/transport/http/assets/js/app/components/PipelineList.js
@@ -4,7 +4,7 @@ import { html } from 'htm/preact';
 import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
 import { route } from 'preact-router';
 import { fetchPipelines, fetchPipelineImage, fetchTeam } from '../api.js';
-import { isTeamAdmin } from '../state.js';
+import { hasTeamRole } from '../state.js';
 import { usePolling } from '../hooks.js';
 import { fetchInterval, pikoTimeAgo } from '../utils.js';
 import { PipelineGraph } from './PipelineGraph.js';
@@ -46,7 +46,7 @@ export function PipelineList({ tc }) {
         </span>
         <label for="live-status-toggle" class="form-label mb-0" style="font-size:0.85rem;cursor:pointer;" onClick=${toggleLive}>Live</label>
       </div>
-      ${isTeamAdmin(tc) && html`
+      ${hasTeamRole(tc, 'maintainer') && html`
         <a type="button" id="pipelines-new" class="btn btn-success" href=${'/teams/' + tc + '/pipelines/new'} data-native
            onClick=${e => { e.preventDefault(); route('/teams/' + tc + '/pipelines/new'); }}>
           <i class="bi bi-plus"></i> New

--- a/pikoci/transport/http/assets/js/app/components/PipelineShow.js
+++ b/pikoci/transport/http/assets/js/app/components/PipelineShow.js
@@ -9,7 +9,7 @@ import {
   triggerResource, fetchResourceVersions, fetchVersionPath,
   triggerVersion, pinResource, unpinResource, fetchTeam,
 } from '../api.js';
-import { isTeamAdmin, isTeamMember, isLoggedIn } from '../state.js';
+import { hasTeamRole, isLoggedIn } from '../state.js';
 import { usePolling } from '../hooks.js';
 import { showToast } from '../toast.js';
 import { fetchInterval, pikoTimeAgo, versionRef } from '../utils.js';
@@ -520,8 +520,8 @@ export function PipelineShow({ tc, pn }) {
 
   if (!pipeline) return null;
 
-  const isMember = isTeamMember(tc);
-  const admin = isTeamAdmin(tc);
+  const isOperator = hasTeamRole(tc, 'operator');
+  const isMaintainer = hasTeamRole(tc, 'maintainer');
   const hasPaused = pipeline.jobs && pipeline.jobs.some(j => j.paused);
   const shareUrls = getShareUrls();
   const showGraphView = currentView === 'graph';
@@ -534,13 +534,13 @@ export function PipelineShow({ tc, pn }) {
         ${pipeline.public && html`<span class="badge bg-info fs-6 ms-2">Public</span>`}
       </h1>
       <div class="d-flex gap-2">
-        ${isMember && pipeline.jobs && pipeline.jobs.length > 0 && html`
+        ${isOperator && pipeline.jobs && pipeline.jobs.length > 0 && html`
           ${hasPaused
             ? html`<button type="button" id="unpause-pipeline" class="btn btn-primary" onClick=${clickUnpause}><i class="bi bi-play-circle"></i> Unpause</button>`
             : html`<button type="button" id="pause-pipeline" class="btn btn-primary" onClick=${clickPause}><i class="bi bi-pause-circle"></i> Pause</button>`
           }
         `}
-        ${admin && html`
+        ${isMaintainer && html`
           <button type="button" id="edit-pipeline" class="btn btn-info" onClick=${clickEdit}><i class="bi bi-pencil"></i> Edit</button>
           <button type="button" id="delete-pipeline" class="btn btn-danger" onClick=${clickDelete}><i class="bi bi-trash"></i> Delete</button>
         `}
@@ -608,7 +608,7 @@ export function PipelineShow({ tc, pn }) {
           <${PipelineResourcesPanel}
             tc=${tc} pn=${pn}
             resources=${resources}
-            isMember=${isMember}
+            isMember=${isOperator}
             onClose=${() => setResourcesPanelOpen(false)}
             onTrackVersion=${trackVersion}
             trackedVersion=${trackedVersion}

--- a/pikoci/transport/http/assets/js/app/components/Resources.js
+++ b/pikoci/transport/http/assets/js/app/components/Resources.js
@@ -9,7 +9,7 @@ import {
   fetchTeam, fetchPipeline,
 } from '../api.js';
 import { apiInterval } from '../api.js';
-import { isLoggedIn, isTeamMember, isTeamAdmin } from '../state.js';
+import { isLoggedIn, hasTeamRole } from '../state.js';
 import { useLoading, usePolling } from '../hooks.js';
 import { fetchInterval, pikoTimeAgo } from '../utils.js';
 import { showToast } from '../toast.js';
@@ -29,8 +29,8 @@ export function ResourceVersions({ tc, pn, rCan }) {
   const [loading, withLoading] = useLoading();
   const fetchingMore = useRef(false);
 
-  const isMember = isTeamMember(tc);
-  const isAdm = isTeamAdmin(tc);
+  const isMember = hasTeamRole(tc, 'operator');
+  const isAdm = hasTeamRole(tc, 'maintainer');
 
   // Initial fetch
   useEffect(() => {

--- a/pikoci/transport/http/assets/js/app/components/Teams.js
+++ b/pikoci/transport/http/assets/js/app/components/Teams.js
@@ -3,11 +3,13 @@
 import { html } from 'htm/preact';
 import { useState, useEffect } from 'preact/hooks';
 import { route } from 'preact-router';
-import { isAdmin, isTeamAdmin } from '../state.js';
+import { isAdmin, hasTeamRole } from '../state.js';
 import { fetchTeams, createTeam, fetchTeam, updateTeam, deleteTeam, fetchUsers, addTeamMember, updateTeamMember, removeTeamMember } from '../api.js';
 import { useRequireAuth, useLoading } from '../hooks.js';
 import { showToast } from '../toast.js';
 import { Breadcrumb } from './Layout.js';
+
+const ASSIGNABLE_ROLES = ['viewer', 'operator', 'maintainer', 'admin'];
 
 // ---------------------------------------------------------------------------
 // TeamsView – list all teams
@@ -69,7 +71,7 @@ function TeamRow({ team, onDelete }) {
           onClick=${(e) => { e.preventDefault(); route('/teams/' + team.canonical); }}>
           <i class="bi bi-gear"></i> Manage
         </a>
-        ${isAdmin.value && html`
+        ${hasTeamRole(team.canonical, 'admin') && html`
           <button id="delete" type="button" class="btn btn-danger" disabled=${loading} onClick=${handleDelete}>
             ${loading
               ? html`Deleting... <span class="spinner-border spinner-border-sm" role="status"></span>`
@@ -151,15 +153,15 @@ export function TeamShow({ tc }) {
     });
   };
 
-  const onToggleAdmin = (member, checkboxEl) => {
-    updateTeamMember(tc, member.user.username, { admin: !member.admin }).then(() => {
+  const onChangeRole = (member, newRole) => {
+    updateTeamMember(tc, member.user.username, { role: newRole }).then(() => {
       showToast('Member role updated', 'success');
       setMembers(members.map(m =>
-        m.user.username === member.user.username ? { ...m, admin: !m.admin } : m
+        m.user.username === member.user.username ? { ...m, role: newRole } : m
       ));
     }).catch(() => {
-      // Revert checkbox visual state on error (e.g., "cannot have team with no admins")
-      if (checkboxEl) checkboxEl.checked = member.admin;
+      // Force re-render to revert the select to the server-side role
+      setMembers(prev => [...prev]);
     });
   };
 
@@ -181,8 +183,8 @@ export function TeamShow({ tc }) {
     }
   };
 
-  const onAddMember = (username, admin) => {
-    return addTeamMember(tc, { admin, user: { username } }).then(() => {
+  const onAddMember = (username, memberRole) => {
+    return addTeamMember(tc, { role: memberRole, user: { username } }).then(() => {
       showToast('Member added', 'success');
       setShowNewMember(false);
       loadTeam();
@@ -191,7 +193,8 @@ export function TeamShow({ tc }) {
 
   if (!team) return null;
 
-  const admin = isTeamAdmin(tc);
+  const canManageMembers = hasTeamRole(tc, 'admin');
+  const canUpdateTeam = hasTeamRole(tc, 'admin');
 
   return html`
     <${Breadcrumb} team=${team} />
@@ -206,10 +209,10 @@ export function TeamShow({ tc }) {
       <div class="mb-3">
         <label for="name" class="form-label">Name</label>
         <input type="text" class="form-control" id="name" value=${name}
-          disabled=${!admin}
+          disabled=${!canUpdateTeam}
           onInput=${(e) => setName(e.target.value)} />
       </div>
-      ${admin && html`
+      ${canUpdateTeam && html`
         <button type="submit" class="btn btn-primary" disabled=${loading}>
           ${loading ? html`Saving... <span class="spinner-border spinner-border-sm" role="status"></span>` : 'Update'}
         </button>
@@ -218,7 +221,7 @@ export function TeamShow({ tc }) {
     <hr style="border-color: var(--border); margin: 1.5rem 0;" />
     <div class="d-flex align-items-center justify-content-between mb-3">
       <h3 class="h5 fw-bold mb-0">Members</h3>
-      ${admin && html`
+      ${canManageMembers && html`
         <a type="button" id="new-member" class="btn btn-success" onClick=${onClickNewMember}>
           <i class="bi bi-person-plus"></i> New Member
         </a>
@@ -227,15 +230,15 @@ export function TeamShow({ tc }) {
     <table class="table">
       <thead>
         <tr>
-          <th scope="col" class="col-5">Full Name</th>
-          <th scope="col" class="col-5">Admin</th>
-          <th scope="col" class="col-2">Options</th>
+          <th scope="col" class="col-4">Full Name</th>
+          <th scope="col" class="col-4">Role${' '}<a href="https://docs.pikoci.com/Roles" target="_blank" rel="noopener" title="${'Viewer: read-only access\nOperator: trigger, cancel, retry builds; pause/unpause; pin/unpin\nMaintainer: create, edit, delete pipelines and resources\nAdmin: manage members, team settings, delete team\n\nClick to go to docs'}" style="color:var(--text-muted);font-size:0.85em;"><i class="bi bi-info-circle"></i></a></th>
+          <th scope="col" class="col-4">Options</th>
         </tr>
       </thead>
       <tbody>
         ${showNewMember && html`<${NewMemberRow} users=${users} onAdd=${onAddMember} onCancel=${() => setShowNewMember(false)} />`}
         ${members.map(m => html`
-          <${MemberRow} key=${m.user.username} member=${m} tc=${tc} onToggleAdmin=${onToggleAdmin} onDelete=${onDeleteMember} />
+          <${MemberRow} key=${m.user.username} member=${m} tc=${tc} members=${members} onChangeRole=${onChangeRole} onDelete=${onDeleteMember} />
         `)}
       </tbody>
     </table>
@@ -248,12 +251,12 @@ export function TeamShow({ tc }) {
 
 function NewMemberRow({ users, onAdd }) {
   const [username, setUsername] = useState(users.length ? users[0].username : '');
-  const [admin, setAdmin] = useState(false);
+  const [memberRole, setMemberRole] = useState('maintainer');
   const [loading, withLoading] = useLoading();
 
   const handleCreate = (e) => {
     e.preventDefault();
-    withLoading(() => onAdd(username, admin));
+    withLoading(() => onAdd(username, memberRole));
   };
 
   return html`
@@ -265,10 +268,10 @@ function NewMemberRow({ users, onAdd }) {
         </select>
       </td>
       <td>
-        <div class="form-check form-switch">
-          <input class="form-check-input" type="checkbox" role="switch" id="admin"
-            checked=${admin} onChange=${(e) => setAdmin(e.target.checked)} />
-        </div>
+        <select class="form-select" id="role" value=${memberRole}
+          onChange=${(e) => setMemberRole(e.target.value)}>
+          ${ASSIGNABLE_ROLES.map(r => html`<option value=${r}>${r}</option>`)}
+        </select>
       </td>
       <td>
         <div class="btn-group" role="group">
@@ -284,36 +287,41 @@ function NewMemberRow({ users, onAdd }) {
 }
 
 // ---------------------------------------------------------------------------
-// MemberRow – existing member row with admin toggle and delete
+// MemberRow – existing member row with role dropdown and delete
 // ---------------------------------------------------------------------------
 
-function MemberRow({ member, tc, onToggleAdmin, onDelete }) {
+function MemberRow({ member, tc, members, onChangeRole, onDelete }) {
   const [loading, withLoading] = useLoading();
-  const admin = isTeamAdmin(tc);
+  const canManage = hasTeamRole(tc, 'admin');
+  const isLastAdmin = member.role === 'admin' && (members || []).filter(m => m.role === 'admin').length <= 1;
 
   const handleDelete = (e) => {
     e.preventDefault();
     withLoading(() => onDelete(member));
   };
 
-  const handleToggleAdmin = (e) => {
-    onToggleAdmin(member, e.target);
+  const handleRoleChange = (e) => {
+    onChangeRole(member, e.target.value);
   };
 
   return html`
     <tr>
       <td>${member.user.full_name}</td>
       <td>
-        <div class="form-check form-switch">
-          <input class="form-check-input" type="checkbox" role="switch" id="admin"
-            checked=${member.admin}
-            disabled=${!admin}
-            onChange=${handleToggleAdmin} />
-        </div>
+        ${canManage
+          ? html`
+            <select class="form-select form-select-sm" value=${member.role}
+              disabled=${isLastAdmin}
+              onChange=${handleRoleChange}>
+              ${ASSIGNABLE_ROLES.map(r => html`<option value=${r}>${r}</option>`)}
+            </select>
+          `
+          : html`<span>${member.role}</span>`
+        }
       </td>
       <td>
         <div class="btn-group" role="group">
-          ${admin && html`
+          ${canManage && !isLastAdmin && html`
             <button id="delete" type="button" class="btn btn-danger" disabled=${loading} onClick=${handleDelete}>
               ${loading
                 ? html`Removing... <span class="spinner-border spinner-border-sm" role="status"></span>`

--- a/pikoci/transport/http/assets/js/app/components/Users.js
+++ b/pikoci/transport/http/assets/js/app/components/Users.js
@@ -34,7 +34,7 @@ export function UsersList() {
         <tr>
           <th>Username</th>
           <th>Full Name</th>
-          <th>Role</th>
+          <th>Global Admin</th>
         </tr>
       </thead>
       <tbody id="users-table-body">
@@ -43,8 +43,8 @@ export function UsersList() {
             <td><a href="/users/${u.username}" data-native onClick=${(e) => { e.preventDefault(); route('/users/' + u.username); }}>${u.username}</a></td>
             <td>${u.full_name}</td>
             <td>${u.admin
-              ? html`<span class="badge bg-primary">Admin</span>`
-              : html`<span class="badge bg-secondary">Member</span>`
+              ? html`<span class="badge bg-primary">Yes</span>`
+              : html`<span class="badge bg-secondary">No</span>`
             }</td>
           </tr>
         `)}
@@ -100,7 +100,7 @@ export function UserNew() {
       <div class="mb-3 form-check">
         <input type="checkbox" class="form-check-input" id="admin"
           checked=${admin} onChange=${(e) => setAdmin(e.target.checked)} />
-        <label class="form-check-label" for="admin">Admin</label>
+        <label class="form-check-label" for="admin">Global Admin</label>
       </div>
       <button type="submit" class="btn btn-primary" disabled=${loading}>
         ${loading ? 'Creating...' : 'Create User'}
@@ -208,7 +208,7 @@ export function UserShow({ username: usernameParam }) {
       <div class="mb-3 form-check">
         <input type="checkbox" class="form-check-input" id="admin"
           checked=${adminChecked} onChange=${(e) => setAdminChecked(e.target.checked)} />
-        <label class="form-check-label" for="admin">Admin</label>
+        <label class="form-check-label" for="admin">Global Admin</label>
       </div>
       <button type="submit" class="btn btn-primary" disabled=${loading}>
         ${loading ? 'Saving...' : 'Save Changes'}

--- a/pikoci/transport/http/assets/js/app/components/Workers.js
+++ b/pikoci/transport/http/assets/js/app/components/Workers.js
@@ -7,7 +7,7 @@ import { useRequireAuth } from '../hooks.js';
 import { pikoTimeAgo } from '../utils.js';
 
 export function WorkersList() {
-  useRequireAuth();
+  useRequireAuth({ adminOnly: true });
 
   const [workers, setWorkers] = useState([]);
   const [serverVersion, setServerVersion] = useState('');

--- a/pikoci/transport/http/assets/js/app/hooks.js
+++ b/pikoci/transport/http/assets/js/app/hooks.js
@@ -2,9 +2,9 @@
 
 import { useState, useEffect, useRef } from 'preact/hooks';
 import { route } from 'preact-router';
-import { isLoggedIn, session, isTeamAdmin } from './state.js';
+import { isLoggedIn, session, isTeamAdmin, hasTeamRole } from './state.js';
 
-export function useRequireAuth({ adminOnly = false, teamCanonical = null, redirectTo = null } = {}) {
+export function useRequireAuth({ adminOnly = false, requiredRole = null, teamCanonical = null, redirectTo = null } = {}) {
   useEffect(() => {
     if (!isLoggedIn.value) {
       route('/login', true);
@@ -14,7 +14,10 @@ export function useRequireAuth({ adminOnly = false, teamCanonical = null, redire
       route('/profile', true);
       return;
     }
-    if (adminOnly && !isTeamAdmin(teamCanonical)) {
+    const denied = requiredRole
+      ? !hasTeamRole(teamCanonical, requiredRole)
+      : adminOnly && !isTeamAdmin(teamCanonical);
+    if (denied) {
       if (redirectTo) {
         route(redirectTo, true);
       } else if (teamCanonical) {

--- a/pikoci/transport/http/assets/js/app/state.js
+++ b/pikoci/transport/http/assets/js/app/state.js
@@ -13,11 +13,27 @@ export const isAdmin = computed(() => {
   return u && u.admin;
 });
 
-export function isTeamAdmin(tc) {
+const ROLE_LEVELS = { public: 0, viewer: 1, operator: 2, maintainer: 3, admin: 4 };
+
+export function getTeamRole(tc) {
+  const u = session.value.user;
+  if (!u) return null;
+  if (u.admin) return 'admin';
+  const m = (u.memberships || []).find(m => m.team_canonical === tc);
+  return m ? m.role : null;
+}
+
+export function hasTeamRole(tc, requiredRole) {
   const u = session.value.user;
   if (!u) return false;
   if (u.admin) return true;
-  return (u.memberships || []).some(m => m.admin && m.team_canonical === tc);
+  const r = getTeamRole(tc);
+  if (!r) return false;
+  return (ROLE_LEVELS[r] || 0) >= (ROLE_LEVELS[requiredRole] || 0);
+}
+
+export function isTeamAdmin(tc) {
+  return hasTeamRole(tc, 'admin');
 }
 
 export function isTeamMember(tc) {
@@ -25,7 +41,7 @@ export function isTeamMember(tc) {
   if (!u) return false;
   if (u.admin) return true;
   if (!tc) return true;
-  return (u.memberships || []).some(m => m.team_canonical === tc);
+  return hasTeamRole(tc, 'viewer');
 }
 
 export function login(jwt, user) {

--- a/pikoci/transport/http/authorization.go
+++ b/pikoci/transport/http/authorization.go
@@ -5,113 +5,143 @@ import (
 	"fmt"
 
 	"github.com/pikoci/pikoci/pikoci"
+	"github.com/pikoci/pikoci/pikoci/role"
 )
 
 type authorizationFn func(ctx context.Context, s pikoci.Service, un, tc string) error
 
 var (
 	routeAuthorization = map[RouteName]authorizationFn{
-		UserLogin:    nothing,
-		RefreshToken: nothing,
-
-		CreateUser: admin,
-		ListUsers:  admin,
-		GetUser:    admin,
-		UpdateUser: admin,
-		DeleteUser: admin,
-		ChangePassword: member,
-		UpdateProfile:  member,
-
-		CreateTeam: admin,
-		ListTeams:  member,
-		GetTeam:    member,
-		UpdateTeam: admin,
-		DeleteTeam: admin,
-
-		CreateTeamMember: admin,
-		UpdateTeamMember: admin,
-		DeleteTeamMember: admin,
-
-		CreatePipeline: admin,
-		UpdatePipeline: admin,
-		GetPipeline:    member,
-		DeletePipeline: admin,
-		ListPipelines:  member,
-
-		GetPipelineImage:    member,
-		CreatePipelineImage: admin,
-
-		ListPipelineJobs:   member,
-		TriggerPipelineJob: member,
-		GetPipelineJob:     member,
-
-		CreateJobBuild:       admin,
-		CreateRetryJobBuild:  admin,
-		UpdateJobBuild:       admin,
-		DeleteJobBuild:       admin,
-		ListJobBuilds:        member,
-		GetJobBuild:          member,
-		CancelJobBuild:         member,
-		RetryJobBuild:          member,
-		StartPendingBuild:              admin,
-		FindOldestPendingBuild:         admin,
-		NotifySerialGroupPendingBuilds: admin,
-		EvaluateDownstreamJobs:         admin,
-		InsertBuildGetVersion:          admin,
-		FindBuildGetVersions:   admin,
-
-		ListPipelineResources:   member,
-		GetPipelineResource:     member,
-		UpdatePipelineResource:  admin,
-		TriggerPipelineResource: member,
-		CreateResourceVersion:   admin,
-		ListResourceVersions:    member,
-
-		PinResourceVersion:     member,
-		UnpinResourceVersion:   member,
-		TriggerResourceVersion: member,
-		GetResourceVersionPath: member,
-
-		WebhookTrigger:         nothing,
-		RegenerateWebhookToken: admin,
-
-		CreateTrigger:     admin,
-		ListTriggersAfter: member,
-
-		ExportDatabase: admin,
-
-		PausePipeline:   member,
-		UnpausePipeline: member,
-		PauseJob:        member,
-		UnpauseJob:      member,
-
+		// No auth required
+		UserLogin:       nothing,
+		RefreshToken:    nothing,
+		WebhookTrigger:  nothing,
 		WorkerHeartbeat: nothing,
-		ListWorkers:     admin,
-		WorkersHealth:   admin,
-		DeleteWorker:    admin,
+		GetVersion:      nothing,
+
+		// Public-level routes: unauthenticated access to public pipelines
+		GetPipeline:          requirePublicOrRole(role.Viewer),
+		GetPipelineImage:     requirePublicOrRole(role.Viewer),
+		ListPipelineJobs:     requirePublicOrRole(role.Viewer),
+		GetPipelineJob:       requirePublicOrRole(role.Viewer),
+		ListJobBuilds:        requirePublicOrRole(role.Viewer),
+		ListPipelineResources: requirePublicOrRole(role.Viewer),
+		GetPipelineResource:   requirePublicOrRole(role.Viewer),
+		ListResourceVersions:    requirePublicOrRole(role.Viewer),
+		GetResourceVersionPath:  requirePublicOrRole(role.Viewer),
+
+		// Viewer routes
+		ListPipelines:    requireRole(role.Viewer),
+		ListTeams:        requireRole(role.Viewer),
+		GetTeam:          requireRole(role.Viewer),
+		GetJobBuild:      requireRole(role.Viewer),
+		ChangePassword:   requireRole(role.Viewer),
+		UpdateProfile:    requireRole(role.Viewer),
+		ListTriggersAfter: requireRole(role.Viewer),
+
+		// Operator routes
+		TriggerPipelineJob:     requireRole(role.Operator),
+		CancelJobBuild:        requireRole(role.Operator),
+		RetryJobBuild:         requireRole(role.Operator),
+		PausePipeline:         requireRole(role.Operator),
+		UnpausePipeline:       requireRole(role.Operator),
+		PauseJob:              requireRole(role.Operator),
+		UnpauseJob:            requireRole(role.Operator),
+		PinResourceVersion:    requireRole(role.Operator),
+		UnpinResourceVersion:  requireRole(role.Operator),
+		TriggerResourceVersion: requireRole(role.Operator),
+		TriggerPipelineResource: requireRole(role.Operator),
+
+		// Maintainer routes
+		CreatePipeline:         requireRole(role.Maintainer),
+		UpdatePipeline:         requireRole(role.Maintainer),
+		DeletePipeline:         requireRole(role.Maintainer),
+		CreatePipelineImage:    requireRole(role.Maintainer),
+		UpdatePipelineResource: requireRole(role.Maintainer),
+		CreateResourceVersion:  requireRole(role.Maintainer),
+		RegenerateWebhookToken: requireRole(role.Maintainer),
+		CreateTrigger:          requireRole(role.Maintainer),
+
+		// Worker-internal routes (bypassed by isFromWorker JWT)
+		CreateJobBuild:                 requireRole(role.Maintainer),
+		CreateRetryJobBuild:            requireRole(role.Maintainer),
+		UpdateJobBuild:                 requireRole(role.Maintainer),
+		DeleteJobBuild:                 requireRole(role.Maintainer),
+		StartPendingBuild:              requireRole(role.Maintainer),
+		FindOldestPendingBuild:         requireRole(role.Maintainer),
+		NotifySerialGroupPendingBuilds: requireRole(role.Maintainer),
+		EvaluateDownstreamJobs:         requireRole(role.Maintainer),
+		InsertBuildGetVersion:          requireRole(role.Maintainer),
+		FindBuildGetVersions:           requireRole(role.Maintainer),
+
+		// Admin routes
+		CreateTeamMember: requireRole(role.Admin),
+		UpdateTeamMember: requireRole(role.Admin),
+		DeleteTeamMember: requireRole(role.Admin),
+		UpdateTeam: requireRole(role.Admin),
+		DeleteTeam: requireRole(role.Admin),
+
+		// Global admin routes
+		CreateUser:     globalAdmin,
+		ListUsers:      globalAdmin,
+		GetUser:        globalAdmin,
+		UpdateUser:     globalAdmin,
+		DeleteUser:     globalAdmin,
+		CreateTeam:     globalAdmin,
+		ListWorkers:    globalAdmin,
+		WorkersHealth:  globalAdmin,
+		DeleteWorker:   globalAdmin,
+		ExportDatabase: globalAdmin,
 	}
 )
 
 func nothing(ctx context.Context, s pikoci.Service, un, tc string) error { return nil }
 
-func admin(ctx context.Context, s pikoci.Service, un, tc string) error {
-	um, err := s.GetUser(ctx, un)
-	if err != nil {
-		return fmt.Errorf("failed to GetUser: %w", err)
+func requireRole(r role.Role) authorizationFn {
+	return func(ctx context.Context, s pikoci.Service, un, tc string) error {
+		um, err := s.GetUser(ctx, un)
+		if err != nil {
+			return fmt.Errorf("failed to GetUser: %w", err)
+		}
+		// For routes without a team scope (e.g. ChangePassword, UpdateProfile),
+		// any authenticated user is allowed
+		if tc == "" {
+			return nil
+		}
+		if !um.HasRole(r, tc) {
+			return fmt.Errorf("requires %s role", r)
+		}
+		return nil
 	}
-	if !um.IsAdmin(tc) {
-		return fmt.Errorf("needs to be admin")
-	}
-	return nil
 }
 
-func member(ctx context.Context, s pikoci.Service, un, tc string) error {
+// requirePublicOrRole returns an authorization function that allows authenticated
+// users with at least the given role, or marks the request for public pipeline
+// fallback (handled in the auth middleware).
+func requirePublicOrRole(r role.Role) authorizationFn {
+	return func(ctx context.Context, s pikoci.Service, un, tc string) error {
+		if un == "" {
+			// Unauthenticated: let the middleware handle public fallback
+			return fmt.Errorf("requires authentication or public pipeline")
+		}
+		um, err := s.GetUser(ctx, un)
+		if err != nil {
+			return fmt.Errorf("failed to GetUser: %w", err)
+		}
+		if !um.HasRole(r, tc) {
+			return fmt.Errorf("requires %s role", r)
+		}
+		return nil
+	}
+}
+
+func globalAdmin(ctx context.Context, s pikoci.Service, un, tc string) error {
 	um, err := s.GetUser(ctx, un)
 	if err != nil {
 		return fmt.Errorf("failed to GetUser: %w", err)
 	}
-	if !um.IsMember(tc) {
-		return fmt.Errorf("needs to be member")
+	if !um.Admin {
+		return fmt.Errorf("requires global admin")
 	}
 	return nil
 }

--- a/pikoci/transport/http/authorization_test.go
+++ b/pikoci/transport/http/authorization_test.go
@@ -1,0 +1,205 @@
+package http
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/pikoci/pikoci/pikoci/mock"
+	"github.com/pikoci/pikoci/pikoci/role"
+	"github.com/pikoci/pikoci/pikoci/user"
+	"go.uber.org/mock/gomock"
+)
+
+// TestRoleAuthorizationMatrix verifies that each role level is correctly
+// allowed or denied access to representative routes from each tier.
+func TestRoleAuthorizationMatrix(t *testing.T) {
+	type testCase struct {
+		name       string
+		method     string
+		path       string
+		userRole   role.Role
+		globalAdmin bool
+		wantOK     bool // true = 200 (handler reached), false = 400 (auth denied)
+	}
+
+	tests := []testCase{
+		// --- Viewer routes: viewer+ allowed ---
+		{"viewer can list pipelines", http.MethodGet, "/teams/main/pipelines", role.Viewer, false, true},
+		{"viewer can get team", http.MethodGet, "/teams/main", role.Viewer, false, true},
+
+		// --- Operator routes: operator+ allowed, viewer denied ---
+		{"operator can trigger job", http.MethodPost, "/teams/main/pipelines/p/jobs/j/trigger", role.Operator, false, true},
+		{"operator can pause pipeline", http.MethodPost, "/teams/main/pipelines/p/pause", role.Operator, false, true},
+		{"operator can cancel build", http.MethodPost, "/teams/main/pipelines/p/jobs/j/builds/1/cancel", role.Operator, false, true},
+		{"operator can retry build", http.MethodPost, "/teams/main/pipelines/p/jobs/j/builds/1/retry", role.Operator, false, true},
+		{"viewer denied trigger job", http.MethodPost, "/teams/main/pipelines/p/jobs/j/trigger", role.Viewer, false, false},
+		{"viewer denied cancel build", http.MethodPost, "/teams/main/pipelines/p/jobs/j/builds/1/cancel", role.Viewer, false, false},
+		{"viewer denied retry build", http.MethodPost, "/teams/main/pipelines/p/jobs/j/builds/1/retry", role.Viewer, false, false},
+		{"viewer denied pause pipeline", http.MethodPost, "/teams/main/pipelines/p/pause", role.Viewer, false, false},
+		{"viewer denied pin resource", http.MethodPost, "/teams/main/pipelines/p/resources/r/pin", role.Viewer, false, false},
+		{"viewer denied trigger resource", http.MethodPost, "/teams/main/pipelines/p/resources/r/trigger", role.Viewer, false, false},
+
+		// --- Maintainer routes: maintainer+ allowed, operator denied ---
+		{"maintainer can create pipeline", http.MethodPost, "/teams/main/pipelines", role.Maintainer, false, true},
+		{"operator denied create pipeline", http.MethodPost, "/teams/main/pipelines", role.Operator, false, false},
+
+		// --- Admin routes: admin+ allowed, maintainer denied ---
+		{"admin can create member", http.MethodPost, "/teams/main/members", role.Admin, false, true},
+		{"admin can update team", http.MethodPut, "/teams/main", role.Admin, false, true},
+		{"maintainer denied create member", http.MethodPost, "/teams/main/members", role.Maintainer, false, false},
+		{"maintainer denied update team", http.MethodPut, "/teams/main", role.Maintainer, false, false},
+
+		{"admin can delete team", http.MethodDelete, "/teams/main", role.Admin, false, true},
+		{"maintainer denied delete team", http.MethodDelete, "/teams/main", role.Maintainer, false, false},
+
+		// --- Global admin routes: only global admin ---
+		{"global admin can list users", http.MethodGet, "/users", role.Admin, true, true},
+		{"admin denied list users (no global admin)", http.MethodGet, "/users", role.Admin, false, false},
+		{"global admin can create team", http.MethodPost, "/teams", role.Admin, true, true},
+		{"global admin can list workers", http.MethodGet, "/workers", role.Admin, true, true},
+		{"non-global-admin denied list workers", http.MethodGet, "/workers", role.Admin, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			svc := mock.NewService(ctrl)
+			secret := []byte("test-secret")
+			handler := Handler(svc, secret, slog.Default(), nil, "", "test", "abc")
+			server := httptest.NewServer(handler)
+			defer server.Close()
+
+			um := &user.WithMemberships{
+				User:        user.User{Username: "testuser", Admin: tt.globalAdmin},
+				Memberships: []user.Member{{TeamCanonical: "main", Role: tt.userRole}},
+			}
+			svc.EXPECT().GetUser(gomock.Any(), "testuser").Return(um, nil).AnyTimes()
+
+			// Stub service methods that handlers call after authorization passes.
+			// We use AnyTimes() + permissive returns so the test only checks auth.
+			svc.EXPECT().ListPipelines(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+			svc.EXPECT().GetTeam(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+			svc.EXPECT().TriggerPipelineJob(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			svc.EXPECT().PausePipeline(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			svc.EXPECT().UnpausePipeline(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			svc.EXPECT().CancelJobBuild(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			svc.EXPECT().RetryJobBuild(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			svc.EXPECT().CreatePipeline(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+			svc.EXPECT().CreateTeamMember(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+			svc.EXPECT().UpdateTeam(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+			svc.EXPECT().DeleteTeam(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			svc.EXPECT().ListUsers(gomock.Any()).Return(nil, nil).AnyTimes()
+			svc.EXPECT().CreateTeam(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+			svc.EXPECT().ListWorkers(gomock.Any()).Return(nil, nil).AnyTimes()
+			svc.EXPECT().PinResourceVersion(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			svc.EXPECT().TriggerPipelineResource(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+			// Sign JWT
+			token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"user": um})
+			jwtStr, err := token.SignedString(secret)
+			require.NoError(t, err)
+
+			req, err := http.NewRequest(tt.method, server.URL+tt.path, strings.NewReader("{}"))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+jwtStr)
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			if tt.wantOK {
+				assert.Equal(t, http.StatusOK, resp.StatusCode, "expected 200 for %s", tt.name)
+			} else {
+				assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "expected 400 for %s", tt.name)
+				var errResp ErrorResponse
+				json.NewDecoder(resp.Body).Decode(&errResp)
+				assert.NotEmpty(t, errResp.Err)
+			}
+		})
+	}
+}
+
+// TestUnauthenticatedPublicPipelineAccess verifies that unauthenticated users
+// can access public pipeline routes but are denied on non-public pipelines.
+func TestUnauthenticatedPublicPipelineAccess(t *testing.T) {
+	t.Run("public pipeline allows unauthenticated access", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		svc := mock.NewService(ctrl)
+		secret := []byte("test-secret")
+		handler := Handler(svc, secret, slog.Default(), nil, "", "test", "abc")
+		server := httptest.NewServer(handler)
+		defer server.Close()
+
+		svc.EXPECT().GetPublicPipeline(gomock.Any(), "main", "pub-pipe").Return(nil, nil).AnyTimes()
+		svc.EXPECT().GetPipeline(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+		req, _ := http.NewRequest(http.MethodGet, server.URL+"/teams/main/pipelines/pub-pipe", strings.NewReader(""))
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("non-public pipeline denies unauthenticated access", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		svc := mock.NewService(ctrl)
+		secret := []byte("test-secret")
+		handler := Handler(svc, secret, slog.Default(), nil, "", "test", "abc")
+		server := httptest.NewServer(handler)
+		defer server.Close()
+
+		svc.EXPECT().GetPublicPipeline(gomock.Any(), "main", "priv-pipe").Return(nil, fmt.Errorf("not public")).AnyTimes()
+
+		req, _ := http.NewRequest(http.MethodGet, server.URL+"/teams/main/pipelines/priv-pipe", strings.NewReader(""))
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+}
+
+// TestWorkerJWTBypassesAuthorization verifies that worker JWTs bypass role checks.
+func TestWorkerJWTBypassesAuthorization(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	svc := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	handler := Handler(svc, secret, slog.Default(), nil, "", "test", "abc")
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// Stub the service method the handler calls after auth passes
+	svc.EXPECT().StartPendingBuild(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	// Sign a worker JWT (no user claim, just is_from_worker)
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"is_from_worker": true,
+	})
+	jwtStr, err := token.SignedString(secret)
+	require.NoError(t, err)
+
+	// StartPendingBuild requires maintainer role, but worker JWT should bypass
+	req, _ := http.NewRequest(http.MethodPost, server.URL+"/teams/main/pipelines/p/jobs/j/builds/start-pending", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+jwtStr)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "worker JWT should bypass authorization")
+}

--- a/pikoci/transport/http/client/client.go
+++ b/pikoci/transport/http/client/client.go
@@ -334,7 +334,7 @@ func (cl *Client) UpdateTeamMember(ctx context.Context, tc, mu string, tm team.M
 	var resp thttp.UpdateTeamMemberResponse
 
 	err := cl.Request(ctx, http.MethodPut, fmt.Sprintf("%s/teams/%s/members/%s", cl.url, tc, mu), thttp.UpdateTeamMemberRequest{
-		Admin: tm.Admin,
+		Role: string(tm.Role),
 	}, &resp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to make request: %w", err)

--- a/pikoci/transport/http/client/client_test.go
+++ b/pikoci/transport/http/client/client_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pikoci/pikoci/pikoci/job"
 	"github.com/pikoci/pikoci/pikoci/pipeline"
 	"github.com/pikoci/pikoci/pikoci/resource"
+	"github.com/pikoci/pikoci/pikoci/role"
 	"github.com/pikoci/pikoci/pikoci/team"
 	thttp "github.com/pikoci/pikoci/pikoci/transport/http"
 	"github.com/pikoci/pikoci/pikoci/transport/http/client"
@@ -296,7 +297,7 @@ func TestCreateTeamMember(t *testing.T) {
 func TestUpdateTeamMember(t *testing.T) {
 	r := mux.NewRouter()
 	r.HandleFunc("/teams/{tc}/members/{mu}", func(w http.ResponseWriter, req *http.Request) {
-		jsonHandler(w, thttp.UpdateTeamMemberResponse{Member: &team.Member{Admin: true, User: user.User{Username: "alice"}}})
+		jsonHandler(w, thttp.UpdateTeamMemberResponse{Member: &team.Member{Role: role.Admin, User: user.User{Username: "alice"}}})
 	}).Methods("PUT")
 	ts := httptest.NewServer(r)
 	defer ts.Close()
@@ -304,9 +305,9 @@ func TestUpdateTeamMember(t *testing.T) {
 	c, err := client.New(ts.URL, "jwt")
 	require.NoError(t, err)
 
-	m, err := c.UpdateTeamMember(context.Background(), "myteam", "alice", team.Member{Admin: true})
+	m, err := c.UpdateTeamMember(context.Background(), "myteam", "alice", team.Member{Role: role.Admin})
 	require.NoError(t, err)
-	assert.True(t, m.Admin)
+	assert.Equal(t, role.Admin, m.Role)
 }
 
 func TestDeleteTeamMember(t *testing.T) {
@@ -1568,7 +1569,7 @@ func TestUpdateTeamMember_Error(t *testing.T) {
 	c, err := client.New(ts.URL, "jwt")
 	require.NoError(t, err)
 
-	_, err = c.UpdateTeamMember(context.Background(), "team1", "bob", team.Member{Admin: true})
+	_, err = c.UpdateTeamMember(context.Background(), "team1", "bob", team.Member{Role: role.Admin})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not member")
 }

--- a/pikoci/transport/http/handler.go
+++ b/pikoci/transport/http/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/gorilla/mux"
 	"github.com/pikoci/pikoci/pikoci"
+	"github.com/pikoci/pikoci/pikoci/role"
 	"github.com/pikoci/pikoci/pikoci/transport/http/assets"
 	"github.com/pikoci/pikoci/pikoci/transport/http/templates"
 	"github.com/pikoci/pikoci/pikoci/user"
@@ -31,16 +32,18 @@ const (
 	IsPublicAccessKey contextKey = "is_public_access_key"
 )
 
+// publicFallbackRoutes lists routes that can fall back to public pipeline access
+// when authentication/authorization fails.
 var publicFallbackRoutes = map[RouteName]bool{
-	GetPipeline:          true,
-	GetPipelineImage:     true,
-	ListPipelineJobs:     true,
-	GetPipelineJob:       true,
-	ListJobBuilds:        true,
-	ListPipelineResources: true,
-	GetPipelineResource:   true,
-	ListResourceVersions:    true,
-	GetResourceVersionPath:  true,
+	GetPipeline:            true,
+	GetPipelineImage:       true,
+	ListPipelineJobs:       true,
+	GetPipelineJob:         true,
+	ListJobBuilds:          true,
+	ListPipelineResources:  true,
+	GetPipelineResource:    true,
+	ListResourceVersions:   true,
+	GetResourceVersionPath: true,
 }
 
 // Handler creates and returns the main HTTP handler for the PikoCI API.
@@ -351,10 +354,7 @@ func membershipsDiffer(jwtUser map[string]interface{}, dbUser *user.WithMembersh
 
 	dbSet := make(map[string]bool, len(dbUser.Memberships))
 	for _, m := range dbUser.Memberships {
-		key := m.TeamCanonical
-		if m.Admin {
-			key += ":admin"
-		}
+		key := m.TeamCanonical + ":" + string(m.Role)
 		dbSet[key] = true
 	}
 	for _, jm := range jwtMemberships {
@@ -363,10 +363,18 @@ func membershipsDiffer(jwtUser map[string]interface{}, dbUser *user.WithMembersh
 			return true
 		}
 		tc, _ := m["team_canonical"].(string)
-		a, _ := m["admin"].(bool)
-		key := tc
-		if a {
-			key += ":admin"
+		// Support both new "role" field and old "admin" field in JWT
+		var key string
+		if r, ok := m["role"].(string); ok {
+			key = tc + ":" + r
+		} else {
+			// Fallback for old JWT tokens with admin bool
+			a, _ := m["admin"].(bool)
+			if a {
+				key = tc + ":" + string(role.Admin)
+			} else {
+				key = tc + ":" + string(role.Maintainer)
+			}
 		}
 		if !dbSet[key] {
 			return true

--- a/pikoci/transport/http/handler_test.go
+++ b/pikoci/transport/http/handler_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pikoci/pikoci/pikoci/mock"
 	"github.com/pikoci/pikoci/pikoci/pipeline"
 	"github.com/pikoci/pikoci/pikoci/resource"
+	"github.com/pikoci/pikoci/pikoci/role"
 	"github.com/pikoci/pikoci/pikoci/user"
 	"github.com/pikoci/pikoci/pikoci/wkr"
 	"go.uber.org/mock/gomock"
@@ -124,12 +125,12 @@ func TestMembershipsDiffer(t *testing.T) {
 			jwtUser: map[string]interface{}{
 				"admin": false,
 				"memberships": []interface{}{
-					map[string]interface{}{"team_canonical": "main", "admin": false},
+					map[string]interface{}{"team_canonical": "main", "role": "operator"},
 				},
 			},
 			dbUser: &user.WithMemberships{
 				User:        user.User{Admin: false},
-				Memberships: []user.Member{{TeamCanonical: "main", Admin: false}},
+				Memberships: []user.Member{{TeamCanonical: "main", Role: role.Operator}},
 			},
 			expected: false,
 		},
@@ -152,7 +153,7 @@ func TestMembershipsDiffer(t *testing.T) {
 			},
 			dbUser: &user.WithMemberships{
 				User:        user.User{Admin: false},
-				Memberships: []user.Member{{TeamCanonical: "main", Admin: false}},
+				Memberships: []user.Member{{TeamCanonical: "main", Role: role.Operator}},
 			},
 			expected: true,
 		},
@@ -161,7 +162,7 @@ func TestMembershipsDiffer(t *testing.T) {
 			jwtUser: map[string]interface{}{
 				"admin": false,
 				"memberships": []interface{}{
-					map[string]interface{}{"team_canonical": "main", "admin": false},
+					map[string]interface{}{"team_canonical": "main", "role": "operator"},
 				},
 			},
 			dbUser: &user.WithMemberships{
@@ -170,7 +171,35 @@ func TestMembershipsDiffer(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "membership admin changed",
+			name: "membership role changed",
+			jwtUser: map[string]interface{}{
+				"admin": false,
+				"memberships": []interface{}{
+					map[string]interface{}{"team_canonical": "main", "role": "operator"},
+				},
+			},
+			dbUser: &user.WithMemberships{
+				User:        user.User{Admin: false},
+				Memberships: []user.Member{{TeamCanonical: "main", Role: role.Admin}},
+			},
+			expected: true,
+		},
+		{
+			name: "old JWT admin bool fallback - admin true maps to admin",
+			jwtUser: map[string]interface{}{
+				"admin": false,
+				"memberships": []interface{}{
+					map[string]interface{}{"team_canonical": "main", "admin": true},
+				},
+			},
+			dbUser: &user.WithMemberships{
+				User:        user.User{Admin: false},
+				Memberships: []user.Member{{TeamCanonical: "main", Role: role.Admin}},
+			},
+			expected: false,
+		},
+		{
+			name: "old JWT admin bool fallback - admin false maps to maintainer",
 			jwtUser: map[string]interface{}{
 				"admin": false,
 				"memberships": []interface{}{
@@ -179,9 +208,9 @@ func TestMembershipsDiffer(t *testing.T) {
 			},
 			dbUser: &user.WithMemberships{
 				User:        user.User{Admin: false},
-				Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+				Memberships: []user.Member{{TeamCanonical: "main", Role: role.Maintainer}},
 			},
-			expected: true,
+			expected: false,
 		},
 	}
 
@@ -215,7 +244,7 @@ func TestUpdatePipeline_TeamCanonicalFromURL(t *testing.T) {
 
 	um := &user.WithMemberships{
 		User:        user.User{Username: "admin", Admin: true},
-		Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Admin}},
 	}
 	jwtToken := signJWT(t, secret, um)
 
@@ -261,7 +290,7 @@ func TestRefreshTokenEndpoint(t *testing.T) {
 
 	updatedUM := &user.WithMemberships{
 		User:        user.User{Username: "pepito"},
-		Memberships: []user.Member{{TeamCanonical: "main", Admin: false}},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Operator}},
 	}
 
 	// Stale-check in middleware calls GetUser; RefreshToken is the handler
@@ -332,7 +361,7 @@ func TestExportDatabase_AdminAllowed(t *testing.T) {
 
 	um := &user.WithMemberships{
 		User:        user.User{Username: "admin", Admin: true},
-		Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Admin}},
 	}
 	jwtToken := signJWT(t, secret, um)
 
@@ -363,7 +392,7 @@ func TestExportDatabase_NonAdminForbidden(t *testing.T) {
 
 	um := &user.WithMemberships{
 		User:        user.User{Username: "pepito", Admin: false},
-		Memberships: []user.Member{{TeamCanonical: "main", Admin: false}},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Operator}},
 	}
 	jwtToken := signJWT(t, secret, um)
 
@@ -417,7 +446,7 @@ func TestExportDatabase_ResponseHeaders(t *testing.T) {
 
 	um := &user.WithMemberships{
 		User:        user.User{Username: "admin", Admin: true},
-		Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Admin}},
 	}
 	jwtToken := signJWT(t, secret, um)
 
@@ -458,7 +487,7 @@ func TestXRefreshTokenHeader(t *testing.T) {
 
 		updatedUM := &user.WithMemberships{
 			User:        user.User{Username: "pepito"},
-			Memberships: []user.Member{{TeamCanonical: "main", Admin: false}},
+			Memberships: []user.Member{{TeamCanonical: "main", Role: role.Operator}},
 		}
 
 		// member() authz calls GetUser, then middleware stale-check calls GetUser again
@@ -486,7 +515,7 @@ func TestXRefreshTokenHeader(t *testing.T) {
 
 		um := &user.WithMemberships{
 			User:        user.User{Username: "pepito"},
-			Memberships: []user.Member{{TeamCanonical: "main", Admin: false}},
+			Memberships: []user.Member{{TeamCanonical: "main", Role: role.Operator}},
 		}
 		jwtToken := signJWT(t, secret, um)
 
@@ -546,7 +575,7 @@ func TestGetPipelineImage_DOT_ReturnsJSON(t *testing.T) {
 
 	um := &user.WithMemberships{
 		User:        user.User{Username: "admin", Admin: true},
-		Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Admin}},
 	}
 	jwtToken := signJWT(t, secret, um)
 
@@ -584,7 +613,7 @@ func TestGetPipelineImage_SVG_ReturnsRawSVG(t *testing.T) {
 
 	um := &user.WithMemberships{
 		User:        user.User{Username: "admin", Admin: true},
-		Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Admin}},
 	}
 	jwtToken := signJWT(t, secret, um)
 
@@ -620,7 +649,7 @@ func TestGetPipelineImage_PNG_ReturnsRawPNG(t *testing.T) {
 
 	um := &user.WithMemberships{
 		User:        user.User{Username: "admin", Admin: true},
-		Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Admin}},
 	}
 	jwtToken := signJWT(t, secret, um)
 
@@ -656,7 +685,7 @@ func TestGetPipelineImage_SVG_NoJSONHeaderRequired(t *testing.T) {
 
 	um := &user.WithMemberships{
 		User:        user.User{Username: "admin", Admin: true},
-		Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Admin}},
 	}
 	jwtToken := signJWT(t, secret, um)
 
@@ -721,7 +750,7 @@ func TestGetPipelineImage_Error_ReturnsJSON(t *testing.T) {
 
 	um := &user.WithMemberships{
 		User:        user.User{Username: "admin", Admin: true},
-		Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Admin}},
 	}
 	jwtToken := signJWT(t, secret, um)
 
@@ -801,7 +830,7 @@ func TestListWorkers_AdminAllowed(t *testing.T) {
 
 	um := &user.WithMemberships{
 		User:        user.User{Username: "admin", Admin: true},
-		Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Admin}},
 	}
 	jwtToken := signJWT(t, secret, um)
 
@@ -832,7 +861,7 @@ func TestListWorkers_NonAdminForbidden(t *testing.T) {
 
 	um := &user.WithMemberships{
 		User:        user.User{Username: "pepito", Admin: false},
-		Memberships: []user.Member{{TeamCanonical: "main", Admin: false}},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Operator}},
 	}
 	jwtToken := signJWT(t, secret, um)
 
@@ -862,7 +891,7 @@ func TestWorkersHealth_AdminAllowed(t *testing.T) {
 
 	um := &user.WithMemberships{
 		User:        user.User{Username: "admin", Admin: true},
-		Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Admin}},
 	}
 	jwtToken := signJWT(t, secret, um)
 
@@ -898,7 +927,7 @@ func TestDeleteWorker_AdminAllowed(t *testing.T) {
 
 	um := &user.WithMemberships{
 		User:        user.User{Username: "admin", Admin: true},
-		Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Admin}},
 	}
 	jwtToken := signJWT(t, secret, um)
 
@@ -933,7 +962,7 @@ func TestDeleteWorker_NonAdminForbidden(t *testing.T) {
 
 	um := &user.WithMemberships{
 		User:        user.User{Username: "pepito", Admin: false},
-		Memberships: []user.Member{{TeamCanonical: "main", Admin: false}},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Operator}},
 	}
 	jwtToken := signJWT(t, secret, um)
 
@@ -963,7 +992,7 @@ func TestGetResourceVersionPath_Success(t *testing.T) {
 
 	um := &user.WithMemberships{
 		User:        user.User{Username: "admin", Admin: true},
-		Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Admin}},
 	}
 	jwtToken := signJWT(t, secret, um)
 
@@ -1013,7 +1042,7 @@ func TestGetResourceVersionPath_InvalidVersionID(t *testing.T) {
 
 	um := &user.WithMemberships{
 		User:        user.User{Username: "admin", Admin: true},
-		Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Admin}},
 	}
 	jwtToken := signJWT(t, secret, um)
 
@@ -1093,7 +1122,7 @@ func TestGetResourceVersionPath_Error(t *testing.T) {
 
 	um := &user.WithMemberships{
 		User:        user.User{Username: "admin", Admin: true},
-		Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Admin}},
 	}
 	jwtToken := signJWT(t, secret, um)
 

--- a/pikoci/transport/http/handlers_coverage_test.go
+++ b/pikoci/transport/http/handlers_coverage_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pikoci/pikoci/pikoci/mock"
 	"github.com/pikoci/pikoci/pikoci/pipeline"
 	"github.com/pikoci/pikoci/pikoci/resource"
+	"github.com/pikoci/pikoci/pikoci/role"
 	"github.com/pikoci/pikoci/pikoci/team"
 	"github.com/pikoci/pikoci/pikoci/trigger"
 	"github.com/pikoci/pikoci/pikoci/user"
@@ -47,11 +48,11 @@ func newTestEnv(t *testing.T) *testEnv {
 
 	adminUM := &user.WithMemberships{
 		User:        user.User{Username: "admin", Admin: true},
-		Memberships: []user.Member{{TeamCanonical: "main", Admin: true}},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Admin}},
 	}
 	memberUM := &user.WithMemberships{
 		User:        user.User{Username: "member", Admin: false},
-		Memberships: []user.Member{{TeamCanonical: "main", Admin: false}},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Operator}},
 	}
 
 	return &testEnv{
@@ -594,10 +595,10 @@ func TestListTeams_Error(t *testing.T) {
 func TestCreateTeamMember_Success(t *testing.T) {
 	e := newTestEnv(t)
 	e.expectAdminAuth()
-	created := &team.Member{Admin: false, User: user.User{Username: "pepito"}}
+	created := &team.Member{Role: role.Viewer, User: user.User{Username: "pepito"}}
 	e.svc.EXPECT().CreateTeamMember(gomock.Any(), "main", gomock.Any()).Return(created, nil)
 
-	body := `{"admin":false,"user":{"username":"pepito"}}`
+	body := `{"role":"viewer","user":{"username":"pepito"}}`
 	resp := doRequest(t, http.MethodPost, e.server.URL+"/teams/main/members", e.adminJWT(t), body)
 	defer resp.Body.Close()
 
@@ -639,10 +640,10 @@ func TestCreateTeamMember_ServiceError(t *testing.T) {
 func TestUpdateTeamMember_Success(t *testing.T) {
 	e := newTestEnv(t)
 	e.expectAdminAuth()
-	updated := &team.Member{Admin: true, User: user.User{Username: "pepito"}}
+	updated := &team.Member{Role: role.Admin, User: user.User{Username: "pepito"}}
 	e.svc.EXPECT().UpdateTeamMember(gomock.Any(), "main", "pepito", gomock.Any()).Return(updated, nil)
 
-	body := `{"admin":true}`
+	body := `{"role":"admin"}`
 	resp := doRequest(t, http.MethodPut, e.server.URL+"/teams/main/members/pepito", e.adminJWT(t), body)
 	defer resp.Body.Close()
 
@@ -650,7 +651,7 @@ func TestUpdateTeamMember_Success(t *testing.T) {
 	var got UpdateTeamMemberResponse
 	json.NewDecoder(resp.Body).Decode(&got)
 	assert.Empty(t, got.Err)
-	assert.True(t, got.Member.Admin)
+	assert.Equal(t, role.Admin, got.Member.Role)
 }
 
 func TestUpdateTeamMember_BadJSON(t *testing.T) {
@@ -2089,7 +2090,7 @@ func TestNonMember_Forbidden(t *testing.T) {
 	// User is not a member of team "other"
 	nonMemberUM := &user.WithMemberships{
 		User:        user.User{Username: "outsider", Admin: false},
-		Memberships: []user.Member{{TeamCanonical: "different-team", Admin: false}},
+		Memberships: []user.Member{{TeamCanonical: "different-team", Role: role.Viewer}},
 	}
 	jwt := signJWT(t, e.secret, nonMemberUM)
 	e.svc.EXPECT().GetUser(gomock.Any(), "outsider").Return(nonMemberUM, nil).AnyTimes()

--- a/pikoci/transport/http/teams.go
+++ b/pikoci/transport/http/teams.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/pikoci/pikoci/pikoci"
+	"github.com/pikoci/pikoci/pikoci/role"
 	"github.com/pikoci/pikoci/pikoci/team"
 	"github.com/pikoci/pikoci/pikoci/user"
 )
@@ -205,7 +206,7 @@ func createTeamMember(s pikoci.Service) http.HandlerFunc {
 type UpdateTeamMemberRequest struct {
 	TeamCanonical  string `json:"team_canonical"`
 	MemberUsername string `json:"member_username"`
-	Admin          bool   `json:"admin"`
+	Role           string `json:"role"`
 }
 type UpdateTeamMemberResponse struct {
 	Member *team.Member `json:"data,omitempty"`
@@ -229,8 +230,8 @@ func updateTeamMember(s pikoci.Service) http.HandlerFunc {
 		req.TeamCanonical = vars["team_canonical"]
 		req.MemberUsername = vars["member_username"]
 		tm, err := s.UpdateTeamMember(ctx, req.TeamCanonical, req.MemberUsername, team.Member{
-			Admin: req.Admin,
-			User:  user.User{Username: req.MemberUsername},
+			Role: role.Role(req.Role),
+			User: user.User{Username: req.MemberUsername},
 		})
 		var errs string
 		if err != nil {

--- a/pikoci/user/user.go
+++ b/pikoci/user/user.go
@@ -3,6 +3,8 @@
 // global or team-level admin privileges.
 package user
 
+import "github.com/pikoci/pikoci/pikoci/role"
+
 // User represents an authenticated user of the system. The Password field
 // is excluded from JSON serialization for security.
 type User struct {
@@ -25,13 +27,14 @@ type WithMemberships struct {
 // Member represents a user's membership in a specific team, identified by the
 // team's canonical name.
 type Member struct {
-	Admin         bool   `json:"admin"`
-	TeamCanonical string `json:"team_canonical"`
+	Role          role.Role `json:"role"`
+	TeamCanonical string    `json:"team_canonical"`
 }
 
-// IsAdmin reports whether the user is a global admin or an admin of any of
-// the teams identified by the given canonical names.
-func (u *WithMemberships) IsAdmin(tcs ...string) bool {
+// HasRole reports whether the user has at least the required role in any of
+// the teams identified by the given canonical names. Global admins always
+// return true.
+func (u *WithMemberships) HasRole(required role.Role, tcs ...string) bool {
 	if u.Admin {
 		return true
 	}
@@ -40,7 +43,7 @@ func (u *WithMemberships) IsAdmin(tcs ...string) bool {
 			continue
 		}
 		for _, m := range u.Memberships {
-			if m.Admin && m.TeamCanonical == tc {
+			if m.TeamCanonical == tc && m.Role.AtLeast(required) {
 				return true
 			}
 		}
@@ -48,9 +51,17 @@ func (u *WithMemberships) IsAdmin(tcs ...string) bool {
 	return false
 }
 
-// IsMember reports whether the user is a global admin or a member of any of
-// the teams identified by the given canonical names. An empty canonical name
-// is treated as a wildcard match.
+// IsAdmin reports whether the user is a global admin or has the admin role
+// in any of the teams identified by the given canonical names.
+// Deprecated: Use HasRole(role.Admin, tcs...) instead.
+func (u *WithMemberships) IsAdmin(tcs ...string) bool {
+	return u.HasRole(role.Admin, tcs...)
+}
+
+// IsMember reports whether the user is a global admin or a member (viewer+)
+// of any of the teams identified by the given canonical names. An empty
+// canonical name is treated as a wildcard match.
+// Deprecated: Use HasRole(role.Viewer, tcs...) instead.
 func (u *WithMemberships) IsMember(tcs ...string) bool {
 	if u.Admin {
 		return true
@@ -59,15 +70,5 @@ func (u *WithMemberships) IsMember(tcs ...string) bool {
 		// In case it's only an empty one it's member
 		return true
 	}
-	for _, tc := range tcs {
-		if tc == "" {
-			continue
-		}
-		for _, m := range u.Memberships {
-			if m.TeamCanonical == tc {
-				return true
-			}
-		}
-	}
-	return false
+	return u.HasRole(role.Viewer, tcs...)
 }

--- a/pikoci/user/user_test.go
+++ b/pikoci/user/user_test.go
@@ -4,8 +4,75 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/pikoci/pikoci/pikoci/role"
 	"github.com/pikoci/pikoci/pikoci/user"
 )
+
+func TestWithMemberships_HasRole(t *testing.T) {
+	t.Run("global admin always passes", func(t *testing.T) {
+		u := &user.WithMemberships{
+			User: user.User{Admin: true},
+		}
+		assert.True(t, u.HasRole(role.Admin))
+		assert.True(t, u.HasRole(role.Admin, "any-team"))
+		assert.True(t, u.HasRole(role.Viewer, "any-team"))
+	})
+
+	t.Run("admin has all roles", func(t *testing.T) {
+		u := &user.WithMemberships{
+			User: user.User{Admin: false},
+			Memberships: []user.Member{
+				{Role: role.Admin, TeamCanonical: "team-a"},
+			},
+		}
+		assert.True(t, u.HasRole(role.Admin, "team-a"))
+		assert.True(t, u.HasRole(role.Maintainer, "team-a"))
+		assert.True(t, u.HasRole(role.Operator, "team-a"))
+		assert.True(t, u.HasRole(role.Viewer, "team-a"))
+		assert.False(t, u.HasRole(role.Admin, "team-b"))
+	})
+
+	t.Run("viewer cannot do operator actions", func(t *testing.T) {
+		u := &user.WithMemberships{
+			User: user.User{Admin: false},
+			Memberships: []user.Member{
+				{Role: role.Viewer, TeamCanonical: "team-a"},
+			},
+		}
+		assert.True(t, u.HasRole(role.Viewer, "team-a"))
+		assert.False(t, u.HasRole(role.Operator, "team-a"))
+	})
+
+	t.Run("empty team canonical is skipped", func(t *testing.T) {
+		u := &user.WithMemberships{
+			User: user.User{Admin: false},
+			Memberships: []user.Member{
+				{Role: role.Admin, TeamCanonical: "team-a"},
+			},
+		}
+		assert.False(t, u.HasRole(role.Viewer, ""))
+	})
+
+	t.Run("no memberships", func(t *testing.T) {
+		u := &user.WithMemberships{
+			User: user.User{Admin: false},
+		}
+		assert.False(t, u.HasRole(role.Viewer, "team-a"))
+	})
+
+	t.Run("multi-team membership", func(t *testing.T) {
+		u := &user.WithMemberships{
+			User: user.User{Admin: false},
+			Memberships: []user.Member{
+				{Role: role.Operator, TeamCanonical: "team-a"},
+				{Role: role.Admin, TeamCanonical: "team-b"},
+			},
+		}
+		assert.True(t, u.HasRole(role.Operator, "team-a"))
+		assert.False(t, u.HasRole(role.Maintainer, "team-a"))
+		assert.True(t, u.HasRole(role.Admin, "team-b"))
+	})
+}
 
 func TestWithMemberships_IsAdmin(t *testing.T) {
 	t.Run("global admin is always admin", func(t *testing.T) {
@@ -20,8 +87,8 @@ func TestWithMemberships_IsAdmin(t *testing.T) {
 		u := &user.WithMemberships{
 			User: user.User{Admin: false},
 			Memberships: []user.Member{
-				{Admin: true, TeamCanonical: "team-a"},
-				{Admin: false, TeamCanonical: "team-b"},
+				{Role: role.Admin, TeamCanonical: "team-a"},
+				{Role: role.Maintainer, TeamCanonical: "team-b"},
 			},
 		}
 		assert.True(t, u.IsAdmin("team-a"))
@@ -41,7 +108,7 @@ func TestWithMemberships_IsAdmin(t *testing.T) {
 		u := &user.WithMemberships{
 			User: user.User{Admin: false},
 			Memberships: []user.Member{
-				{Admin: true, TeamCanonical: "team-a"},
+				{Role: role.Admin, TeamCanonical: "team-a"},
 			},
 		}
 		assert.False(t, u.IsAdmin(""))
@@ -60,7 +127,7 @@ func TestWithMemberships_IsMember(t *testing.T) {
 		u := &user.WithMemberships{
 			User: user.User{Admin: false},
 			Memberships: []user.Member{
-				{Admin: false, TeamCanonical: "team-a"},
+				{Role: role.Viewer, TeamCanonical: "team-a"},
 			},
 		}
 		assert.True(t, u.IsMember("team-a"))

--- a/test/js/state.test.mjs
+++ b/test/js/state.test.mjs
@@ -8,6 +8,8 @@ import {
   apiNotice,
   isTeamAdmin,
   isTeamMember,
+  hasTeamRole,
+  getTeamRole,
   login,
   logout,
   setNoticeError,
@@ -38,7 +40,7 @@ test('isTeamAdmin: team admin returns true for their team', () => {
   session.value = {
     user: {
       admin: false,
-      memberships: [{ admin: true, team_canonical: 'team1' }],
+      memberships: [{ role: 'admin', team_canonical: 'team1' }],
     },
   };
   assert.equal(isTeamAdmin('team1'), true);
@@ -48,7 +50,7 @@ test('isTeamAdmin: team member but not admin returns false', () => {
   session.value = {
     user: {
       admin: false,
-      memberships: [{ admin: false, team_canonical: 'team1' }],
+      memberships: [{ role: 'viewer', team_canonical: 'team1' }],
     },
   };
   assert.equal(isTeamAdmin('team1'), false);
@@ -58,7 +60,7 @@ test('isTeamAdmin: wrong team returns false', () => {
   session.value = {
     user: {
       admin: false,
-      memberships: [{ admin: true, team_canonical: 'team1' }],
+      memberships: [{ role: 'admin', team_canonical: 'team1' }],
     },
   };
   assert.equal(isTeamAdmin('team2'), false);
@@ -79,7 +81,7 @@ test('isTeamMember: member of team returns true', () => {
   session.value = {
     user: {
       admin: false,
-      memberships: [{ admin: false, team_canonical: 'team1' }],
+      memberships: [{ role: 'viewer', team_canonical: 'team1' }],
     },
   };
   assert.equal(isTeamMember('team1'), true);
@@ -89,7 +91,7 @@ test('isTeamMember: non-member returns false', () => {
   session.value = {
     user: {
       admin: false,
-      memberships: [{ admin: false, team_canonical: 'other' }],
+      memberships: [{ role: 'viewer', team_canonical: 'other' }],
     },
   };
   assert.equal(isTeamMember('team1'), false);
@@ -100,6 +102,167 @@ test('isTeamMember: null tc returns true for any logged-in user', () => {
     user: { admin: false, memberships: [] },
   };
   assert.equal(isTeamMember(null), true);
+});
+
+// --- hasTeamRole ---
+
+test('hasTeamRole: operator can do operator actions', () => {
+  session.value = {
+    user: {
+      admin: false,
+      memberships: [{ role: 'operator', team_canonical: 'team1' }],
+    },
+  };
+  assert.equal(hasTeamRole('team1', 'operator'), true);
+  assert.equal(hasTeamRole('team1', 'viewer'), true);
+  assert.equal(hasTeamRole('team1', 'maintainer'), false);
+});
+
+test('hasTeamRole: maintainer can do maintainer and below', () => {
+  session.value = {
+    user: {
+      admin: false,
+      memberships: [{ role: 'maintainer', team_canonical: 'team1' }],
+    },
+  };
+  assert.equal(hasTeamRole('team1', 'maintainer'), true);
+  assert.equal(hasTeamRole('team1', 'operator'), true);
+  assert.equal(hasTeamRole('team1', 'admin'), false);
+});
+
+test('hasTeamRole: global admin bypasses all', () => {
+  session.value = { user: { admin: true, memberships: [] } };
+  assert.equal(hasTeamRole('team1', 'admin'), true);
+});
+
+// --- getTeamRole ---
+
+test('getTeamRole: returns role for matching team', () => {
+  session.value = {
+    user: {
+      admin: false,
+      memberships: [{ role: 'operator', team_canonical: 'team1' }],
+    },
+  };
+  assert.equal(getTeamRole('team1'), 'operator');
+  assert.equal(getTeamRole('team2'), null);
+});
+
+test('getTeamRole: global admin returns admin', () => {
+  session.value = { user: { admin: true, memberships: [] } };
+  assert.equal(getTeamRole('any'), 'admin');
+});
+
+// --- Component permission gate matrix ---
+// Each test validates that the correct role is required for each UI action.
+// This catches bugs like using isLoggedIn or adminOnly when a specific role is needed.
+//
+// Component → UI action → required role:
+//   Editor.js (PipelineNew/PipelineEdit): requiredRole='maintainer' via useRequireAuth
+//   Teams.js (TeamNew): adminOnly=true (global admin) via useRequireAuth
+//   Teams.js (TeamRow delete): hasTeamRole(tc, 'admin')
+//   Teams.js (member management): hasTeamRole(tc, 'admin')
+//   PipelineList.js ("New Pipeline"): hasTeamRole(tc, 'maintainer')
+//   PipelineShow.js (pause/unpause): hasTeamRole(tc, 'operator')
+//   PipelineShow.js (edit/delete): hasTeamRole(tc, 'maintainer')
+//   Jobs.js (trigger/pause/unpause): hasTeamRole(tc, 'operator')
+//   Jobs.js (cancel/retry build): hasTeamRole(tc, 'operator')
+//   Resources.js (trigger/pin): hasTeamRole(tc, 'operator')
+//   Resources.js (webhook): hasTeamRole(tc, 'maintainer')
+
+test('component gates: maintainer can access pipeline editor', () => {
+  session.value = { user: { admin: false, memberships: [{ role: 'maintainer', team_canonical: 't' }] } };
+  assert.equal(hasTeamRole('t', 'maintainer'), true, 'maintainer should access pipeline editor');
+});
+
+test('component gates: operator cannot access pipeline editor', () => {
+  session.value = { user: { admin: false, memberships: [{ role: 'operator', team_canonical: 't' }] } };
+  assert.equal(hasTeamRole('t', 'maintainer'), false, 'operator should not access pipeline editor');
+});
+
+test('component gates: operator can cancel/retry builds', () => {
+  session.value = { user: { admin: false, memberships: [{ role: 'operator', team_canonical: 't' }] } };
+  assert.equal(hasTeamRole('t', 'operator'), true, 'operator should see cancel/retry');
+});
+
+test('component gates: viewer cannot cancel/retry builds', () => {
+  session.value = { user: { admin: false, memberships: [{ role: 'viewer', team_canonical: 't' }] } };
+  assert.equal(hasTeamRole('t', 'operator'), false, 'viewer should not see cancel/retry');
+});
+
+test('component gates: admin can manage team members', () => {
+  session.value = { user: { admin: false, memberships: [{ role: 'admin', team_canonical: 't' }] } };
+  assert.equal(hasTeamRole('t', 'admin'), true, 'admin should manage members');
+});
+
+test('component gates: maintainer cannot manage team members', () => {
+  session.value = { user: { admin: false, memberships: [{ role: 'maintainer', team_canonical: 't' }] } };
+  assert.equal(hasTeamRole('t', 'admin'), false, 'maintainer should not manage members');
+});
+
+test('component gates: global admin can access team creation (adminOnly)', () => {
+  session.value = { user: { admin: true, memberships: [] } };
+  assert.equal(isTeamAdmin(null), true, 'global admin should access team creation');
+});
+
+test('component gates: admin cannot access team creation without global admin', () => {
+  session.value = { user: { admin: false, memberships: [{ role: 'admin', team_canonical: 't' }] } };
+  assert.equal(isTeamAdmin(null), false, 'non-global-admin should not access team creation');
+});
+
+test('component gates: global admin can access workers page (adminOnly)', () => {
+  session.value = { user: { admin: true, memberships: [] } };
+  assert.equal(isTeamAdmin(null), true, 'global admin should access workers page');
+});
+
+test('component gates: non-admin cannot access workers page', () => {
+  session.value = { user: { admin: false, memberships: [{ role: 'admin', team_canonical: 't' }] } };
+  assert.equal(isTeamAdmin(null), false, 'non-global-admin should not access workers page');
+});
+
+// --- Role hierarchy: full matrix ---
+
+test('role hierarchy: viewer can only view', () => {
+  session.value = { user: { admin: false, memberships: [{ role: 'viewer', team_canonical: 't' }] } };
+  assert.equal(hasTeamRole('t', 'viewer'), true, 'viewer: can view');
+  assert.equal(hasTeamRole('t', 'operator'), false, 'viewer: cannot operate');
+  assert.equal(hasTeamRole('t', 'maintainer'), false, 'viewer: cannot maintain');
+  assert.equal(hasTeamRole('t', 'admin'), false, 'viewer: cannot admin');
+});
+
+test('role hierarchy: operator can operate and view', () => {
+  session.value = { user: { admin: false, memberships: [{ role: 'operator', team_canonical: 't' }] } };
+  assert.equal(hasTeamRole('t', 'viewer'), true, 'operator: can view');
+  assert.equal(hasTeamRole('t', 'operator'), true, 'operator: can operate');
+  assert.equal(hasTeamRole('t', 'maintainer'), false, 'operator: cannot maintain');
+  assert.equal(hasTeamRole('t', 'admin'), false, 'operator: cannot admin');
+});
+
+test('role hierarchy: maintainer inherits operator', () => {
+  session.value = { user: { admin: false, memberships: [{ role: 'maintainer', team_canonical: 't' }] } };
+  assert.equal(hasTeamRole('t', 'viewer'), true, 'maintainer: can view');
+  assert.equal(hasTeamRole('t', 'operator'), true, 'maintainer: can operate');
+  assert.equal(hasTeamRole('t', 'maintainer'), true, 'maintainer: can maintain');
+  assert.equal(hasTeamRole('t', 'admin'), false, 'maintainer: cannot admin');
+});
+
+test('role hierarchy: admin has all permissions (top team role)', () => {
+  session.value = { user: { admin: false, memberships: [{ role: 'admin', team_canonical: 't' }] } };
+  assert.equal(hasTeamRole('t', 'viewer'), true, 'admin: can view');
+  assert.equal(hasTeamRole('t', 'operator'), true, 'admin: can operate');
+  assert.equal(hasTeamRole('t', 'maintainer'), true, 'admin: can maintain');
+  assert.equal(hasTeamRole('t', 'admin'), true, 'admin: can admin');
+});
+
+test('role hierarchy: wrong team returns false for all levels', () => {
+  session.value = { user: { admin: false, memberships: [{ role: 'admin', team_canonical: 'team-a' }] } };
+  assert.equal(hasTeamRole('team-b', 'viewer'), false, 'wrong team: viewer');
+  assert.equal(hasTeamRole('team-b', 'admin'), false, 'wrong team: admin');
+});
+
+test('role hierarchy: no user returns false', () => {
+  session.value = {};
+  assert.equal(hasTeamRole('t', 'viewer'), false);
 });
 
 // --- login / logout ---


### PR DESCRIPTION
Closes #207

## Summary

- Replace binary admin/member authorization with role-based access control (RBAC)
- 4 assignable team roles: **viewer** (read-only), **operator** (trigger/cancel/pause), **maintainer** (pipeline CRUD), **admin** (team management + delete team)
- Each role inherits all permissions of roles below it; at least one admin required per team
- Global admin flag remains as superuser that transcends all teams

## Changes

### Backend
- New `pikoci/role` package with `Role` type, hierarchy levels, `AtLeast()`, `Valid()`, `Assignable()`
- `user.Member.Admin bool` → `user.Member.Role role.Role` with `HasRole()` method
- `team.Member.Admin bool` → `team.Member.Role role.Role`
- Authorization: `admin`/`member` functions → `requireRole(r)`, `requirePublicOrRole(r)`, `globalAdmin`
- Route-to-role mapping across all 50+ endpoints
- Migration V39: adds `role` column, backfills `admin=true` → `'admin'`, `admin=false` → `'maintainer'`
- Last-admin protection in transactions (validate + mutate in single UoW)
- CLI: `--admin` flag → `--role` flag (viewer, operator, maintainer, admin)

### Frontend
- `hasTeamRole(tc, level)` replaces `isTeamAdmin`/`isTeamMember` for granular UI gating
- Role dropdown replaces admin checkbox in team member management
- UI elements gated per role: New Pipeline (maintainer), Edit/Delete pipeline (maintainer), Trigger/Pause (operator), Cancel/Retry build (operator), Member management (admin), Delete team (admin)
- `useRequireAuth` supports `requiredRole` option for page-level guards
- Info icon on Role column with tooltip describing each role, links to docs
- Users list: "Role" column renamed to "Global Admin" to avoid confusion

### Docs
- New `docs/Roles.md` with full role hierarchy, permissions per role, CLI examples
- Added to mkdocs.yml nav and docs/index.md