### PR TITLE
feat: mask secret values in build logs (#147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Secrets masking in build logs**: Resolved secret values are automatically replaced with `***` in command stdout/stderr as a safety net against accidental leaks. Masking applies to real-time partial log streaming and final stored output. Values shorter than 3 characters are skipped to avoid false positives, and longer secrets are masked before shorter substrings to prevent partial masking ([#147](https://github.com/PikoCI/pikoci/issues/147)).
+
 ### Fixed
 
 - `GracefulStop()` hanging indefinitely after SIGQUIT when workers reconnect during drain, leaving the server alive but not accepting connections (502 from reverse proxy) (#572).

--- a/integration/backends/secrets_test.go
+++ b/integration/backends/secrets_test.go
@@ -165,8 +165,10 @@ job "deploy" {
 		}
 
 		require.NotNil(t, taskStep, "task step 'use-secrets' should exist in build steps")
-		assert.True(t, strings.Contains(taskStep.Logs, "db_username=admin"), "logs should contain db_username=admin, got: %s", taskStep.Logs)
-		assert.True(t, strings.Contains(taskStep.Logs, "db_password=s3cret"), "logs should contain db_password=s3cret, got: %s", taskStep.Logs)
+		assert.True(t, strings.Contains(taskStep.Logs, "db_username=***"), "logs should mask db_username value, got: %s", taskStep.Logs)
+		assert.True(t, strings.Contains(taskStep.Logs, "db_password=***"), "logs should mask db_password value, got: %s", taskStep.Logs)
+		assert.False(t, strings.Contains(taskStep.Logs, "admin"), "logs should not contain raw secret 'admin', got: %s", taskStep.Logs)
+		assert.False(t, strings.Contains(taskStep.Logs, "s3cret"), "logs should not contain raw secret 's3cret', got: %s", taskStep.Logs)
 	})
 
 	t.Run("SecretBackedVariableWithFileSource", func(t *testing.T) {
@@ -262,8 +264,10 @@ job "deploy" {
 			}
 		}
 		require.NotNil(t, taskStep, "task step 'use-file-secrets' should exist in build steps")
-		assert.True(t, strings.Contains(taskStep.Logs, "api_key=abc123"), "logs should contain api_key=abc123, got: %s", taskStep.Logs)
-		assert.True(t, strings.Contains(taskStep.Logs, "api_secret=xyz789"), "logs should contain api_secret=xyz789, got: %s", taskStep.Logs)
+		assert.True(t, strings.Contains(taskStep.Logs, "api_key=***"), "logs should mask api_key value, got: %s", taskStep.Logs)
+		assert.True(t, strings.Contains(taskStep.Logs, "api_secret=***"), "logs should mask api_secret value, got: %s", taskStep.Logs)
+		assert.False(t, strings.Contains(taskStep.Logs, "abc123"), "logs should not contain raw secret 'abc123', got: %s", taskStep.Logs)
+		assert.False(t, strings.Contains(taskStep.Logs, "xyz789"), "logs should not contain raw secret 'xyz789', got: %s", taskStep.Logs)
 	})
 
 	t.Run("SecretBackedVariableWithFileSourceEnvFormat", func(t *testing.T) {
@@ -376,10 +380,12 @@ job "deploy" {
 			}
 		}
 		require.NotNil(t, taskStep, "task step 'use-env-secrets' should exist in build steps")
-		assert.True(t, strings.Contains(taskStep.Logs, "db_host=db.example.com"), "logs should contain db_host=db.example.com, got: %s", taskStep.Logs)
-		assert.True(t, strings.Contains(taskStep.Logs, "db_password=s3cret"), "logs should contain db_password=s3cret, got: %s", taskStep.Logs)
-		assert.True(t, strings.Contains(taskStep.Logs, "db_user=admin"), "logs should contain db_user=admin (quotes stripped), got: %s", taskStep.Logs)
-		assert.True(t, strings.Contains(taskStep.Logs, "db_conn=host=db;port=5432"), "logs should contain db_conn=host=db;port=5432 (value with = sign), got: %s", taskStep.Logs)
+		assert.True(t, strings.Contains(taskStep.Logs, "db_host=***"), "logs should mask db_host value, got: %s", taskStep.Logs)
+		assert.True(t, strings.Contains(taskStep.Logs, "db_password=***"), "logs should mask db_password value, got: %s", taskStep.Logs)
+		assert.True(t, strings.Contains(taskStep.Logs, "db_user=***"), "logs should mask db_user value, got: %s", taskStep.Logs)
+		assert.True(t, strings.Contains(taskStep.Logs, "db_conn=***"), "logs should mask db_conn value, got: %s", taskStep.Logs)
+		assert.False(t, strings.Contains(taskStep.Logs, "db.example.com"), "logs should not contain raw secret 'db.example.com', got: %s", taskStep.Logs)
+		assert.False(t, strings.Contains(taskStep.Logs, "s3cret"), "logs should not contain raw secret 's3cret', got: %s", taskStep.Logs)
 	})
 
 	cancel()

--- a/worker/service.go
+++ b/worker/service.go
@@ -1683,6 +1683,8 @@ func (w *Worker) runAutoNotifications(ctx context.Context, m workitem.Body, b *b
 		return
 	}
 
+	secretVals := secretValuesFromResolved(resolved)
+
 	// Map build status to event name
 	var event string
 	switch b.Status {
@@ -1750,7 +1752,7 @@ func (w *Worker) runAutoNotifications(ctx context.Context, m workitem.Body, b *b
 				Message: n.Message,
 			},
 		}
-		w.runNotifyStep(ctx, m, b, cwd, pp, *ps.Notify, ps, nil, secretValuesFromResolved(resolved), resolved)
+		w.runNotifyStep(ctx, m, b, cwd, pp, *ps.Notify, ps, nil, secretVals, resolved)
 	}
 }
 

--- a/worker/service.go
+++ b/worker/service.go
@@ -1072,7 +1072,7 @@ func (w *Worker) runGetStep(ctx context.Context, m workitem.Body, b *build.Build
 		}
 
 		var attemptOut string
-		attemptOut, d, err = w.runRunner(runCtx, ru, cwd, rc, onPartialLog)
+		attemptOut, d, err = w.runRunner(runCtx, ru, cwd, rc, nil, onPartialLog)
 		out += attemptOut
 
 		if cancel != nil {
@@ -1265,7 +1265,7 @@ func (w *Worker) runTaskStep(ctx context.Context, m workitem.Body, b *build.Buil
 		}
 
 		var attemptOut string
-		attemptOut, d, err = w.runRunner(runCtx, ru, cwd, t.Run, onPartialLog)
+		attemptOut, d, err = w.runRunner(runCtx, ru, cwd, t.Run, nil, onPartialLog)
 		out += attemptOut
 
 		if cancel != nil {
@@ -1431,7 +1431,7 @@ func (w *Worker) runPutStep(ctx context.Context, m workitem.Body, b *build.Build
 		}
 
 		var attemptOut string
-		attemptOut, d, err = w.runRunner(runCtx, ru, cwd, rc, onPartialLog)
+		attemptOut, d, err = w.runRunner(runCtx, ru, cwd, rc, nil, onPartialLog)
 		out += attemptOut
 
 		if cancel != nil {
@@ -1638,7 +1638,7 @@ func (w *Worker) runNotifyStep(ctx context.Context, m workitem.Body, b *build.Bu
 		}
 
 		var attemptOut string
-		attemptOut, d, err = w.runRunner(runCtx, ru, cwd, rc, onPartialLog)
+		attemptOut, d, err = w.runRunner(runCtx, ru, cwd, rc, nil, onPartialLog)
 		out += attemptOut
 
 		if cancel != nil {
@@ -1868,7 +1868,7 @@ func (w *Worker) runHooks(ctx context.Context, m workitem.Body, b *build.Build, 
 			}
 
 			var runErr error
-			out, d, runErr = w.runRunner(ctx, ru, cwd, rc, onPartialLog)
+			out, d, runErr = w.runRunner(ctx, ru, cwd, rc, nil, onPartialLog)
 			hookStatus := build.Succeeded
 			if runErr != nil {
 				hookStatus = build.Failed
@@ -1979,7 +1979,7 @@ func (w *Worker) processResourceCheck(ctx context.Context, m workitem.Body, cwd 
 	replaceSecretPlaceholdersInSlice(rc.Args, resolved)
 
 	checkWarnStr := formatParamWarnings(checkWarnings)
-	out, _, err := w.runRunner(ctx, ru, cwd, rc)
+	out, _, err := w.runRunner(ctx, ru, cwd, rc, nil)
 	if err != nil {
 		r.Logs = checkWarnStr + out
 		if nerr := w.pikoci.UpdatePipelineResource(ctx, m.TeamCanonical, m.PipelineCanonical, r.Canonical, r); nerr != nil {
@@ -2330,7 +2330,7 @@ func prepareShellRunner(ru *runner.Runner, rc *utils.RunnerCommand, cwd string) 
 	return nil
 }
 
-func (w *Worker) runRunner(ctx context.Context, ru runner.Runner, cwd string, rc utils.RunnerCommand, onPartialLog ...func(string)) (string, time.Duration, error) {
+func (w *Worker) runRunner(ctx context.Context, ru runner.Runner, cwd string, rc utils.RunnerCommand, secretVals []string, onPartialLog ...func(string)) (string, time.Duration, error) {
 	if ru.Name == "shell" {
 		if err := prepareShellRunner(&ru, &rc, cwd); err != nil {
 			return err.Error(), 0, err
@@ -2433,7 +2433,7 @@ func (w *Worker) runRunner(ctx context.Context, ru runner.Runner, cwd string, rc
 					if ctx.Err() != nil {
 						return
 					}
-					partialCb(sw.String())
+					partialCb(maskSecrets(sw.String(), secretVals))
 				case <-ctx.Done():
 					return
 				case <-done:
@@ -2467,6 +2467,7 @@ func (w *Worker) runRunner(ctx context.Context, ru runner.Runner, cwd string, rc
 			out += n + "\n"
 		}
 	}
+	out = maskSecrets(out, secretVals)
 	w.logger.Debug("finished running command", "out", out)
 
 	return out, duration, err
@@ -2515,7 +2516,7 @@ func (w *Worker) fetchSecrets(ctx context.Context, cwd string, pp *pipeline.Pipe
 			rc.Params[k] = v
 		}
 
-		out, _, err := w.runRunner(ctx, ru, cwd, rc)
+		out, _, err := w.runRunner(ctx, ru, cwd, rc, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch secret from %q at %q: %s\n%w", stName, path, out, err)
 		}
@@ -2606,7 +2607,7 @@ func (w *Worker) startServices(ctx context.Context, m workitem.Body, b *build.Bu
 			w.updateBuild(ctx, m, *b)
 		}
 
-		out, d, err := w.runRunner(ctx, ru, cwd, rc, onPartialLog)
+		out, d, err := w.runRunner(ctx, ru, cwd, rc, nil, onPartialLog)
 		out = svcWarnStr + out
 		if err != nil {
 			b.Steps[stepIdx] = build.Step{Type: "service", Name: ss.Name + ":start", Logs: out, Duration: d, Status: build.Failed}
@@ -2958,7 +2959,7 @@ func (w *Worker) waitForServices(ctx context.Context, m workitem.Body, b *build.
 				default:
 				}
 
-				lastOut, _, lastErr = w.runRunner(ctx, ru, cwd, runCmd)
+				lastOut, _, lastErr = w.runRunner(ctx, ru, cwd, runCmd, nil)
 				if lastErr == nil {
 					results <- readyResult{
 						name: svcName,
@@ -3035,7 +3036,7 @@ func (w *Worker) stopServices(m workitem.Body, b *build.Build, cwd string, pp *p
 			w.updateBuild(stopCtx, m, *b)
 		}
 
-		out, d, err := w.runRunner(stopCtx, ru, cwd, rc, onPartialLog)
+		out, d, err := w.runRunner(stopCtx, ru, cwd, rc, nil, onPartialLog)
 		out = stopWarnStr + out
 		stepStatus := build.Succeeded
 		if err != nil {

--- a/worker/service.go
+++ b/worker/service.go
@@ -2340,7 +2340,7 @@ func prepareShellRunner(ru *runner.Runner, rc *utils.RunnerCommand, cwd string) 
 func (w *Worker) runRunner(ctx context.Context, ru runner.Runner, cwd string, rc utils.RunnerCommand, secretVals []string, onPartialLog ...func(string)) (string, time.Duration, error) {
 	if ru.Name == "shell" {
 		if err := prepareShellRunner(&ru, &rc, cwd); err != nil {
-			return err.Error(), 0, err
+			return maskSecrets(err.Error(), secretVals), 0, err
 		}
 	}
 
@@ -2422,7 +2422,7 @@ func (w *Worker) runRunner(ctx context.Context, ru runner.Runner, cwd string, rc
 
 	start := time.Now()
 	if err := cmd.Start(); err != nil {
-		out := err.Error()
+		out := maskSecrets(err.Error(), secretVals)
 		return out, time.Since(start), err
 	}
 

--- a/worker/service.go
+++ b/worker/service.go
@@ -708,6 +708,8 @@ func (w *Worker) runPlan(ctx context.Context, m workitem.Body, b *build.Build, c
 		return true, nil, nil
 	}
 
+	secretVals := secretValuesFromResolved(resolved)
+
 	// exportedVars accumulates key-value pairs exported by get and task steps
 	// so that subsequent steps can consume them as environment variables.
 	exportedVars := make(map[string]string)
@@ -733,35 +735,35 @@ func (w *Worker) runPlan(ctx context.Context, m workitem.Body, b *build.Build, c
 			if ps.Get == nil {
 				continue
 			}
-			if w.runGetStep(ctx, m, b, cwd, pp, *ps.Get, ps, resolvedVersions, exportedVars, resolved) {
+			if w.runGetStep(ctx, m, b, cwd, pp, *ps.Get, ps, resolvedVersions, exportedVars, secretVals, resolved) {
 				return true, resolved, exportedVars
 			}
 		case job.StepTypeTask:
 			if ps.Task == nil {
 				continue
 			}
-			if w.runTaskStep(ctx, m, b, cwd, pp, *ps.Task, ps, exportedVars, resolved) {
+			if w.runTaskStep(ctx, m, b, cwd, pp, *ps.Task, ps, exportedVars, secretVals, resolved) {
 				return true, resolved, exportedVars
 			}
 		case job.StepTypePut:
 			if ps.Put == nil {
 				continue
 			}
-			if w.runPutStep(ctx, m, b, cwd, pp, *ps.Put, ps, exportedVars, resolved) {
+			if w.runPutStep(ctx, m, b, cwd, pp, *ps.Put, ps, exportedVars, secretVals, resolved) {
 				return true, resolved, exportedVars
 			}
 		case job.StepTypeNotify:
 			if ps.Notify == nil {
 				continue
 			}
-			if w.runNotifyStep(ctx, m, b, cwd, pp, *ps.Notify, ps, exportedVars, resolved) {
+			if w.runNotifyStep(ctx, m, b, cwd, pp, *ps.Notify, ps, exportedVars, secretVals, resolved) {
 				return true, resolved, exportedVars
 			}
 		case job.StepTypeInParallel:
 			if ps.InParallel == nil {
 				continue
 			}
-			if w.runInParallelStep(ctx, m, b, cwd, pp, *ps.InParallel, ps, resolvedVersions, exportedVars, resolved) {
+			if w.runInParallelStep(ctx, m, b, cwd, pp, *ps.InParallel, ps, resolvedVersions, exportedVars, secretVals, resolved) {
 				return true, resolved, exportedVars
 			}
 		}
@@ -775,7 +777,7 @@ func (w *Worker) runInParallelStep(
 	ctx context.Context, m workitem.Body, b *build.Build,
 	cwd string, pp *pipeline.Pipeline, ip job.InParallelStep,
 	ps job.PlanStep, resolvedVersions map[string]uint32,
-	exportedVars map[string]string, resolved map[string]string,
+	exportedVars map[string]string, secretVals []string, resolved map[string]string,
 ) bool {
 	start := time.Now()
 
@@ -902,19 +904,19 @@ func (w *Worker) runInParallelStep(
 			switch ps.Type {
 			case job.StepTypeGet:
 				if ps.Get != nil {
-					failed = w.runGetStep(parallelCtx, m, localBuild, cwd, pp, *ps.Get, ps, resolvedVersions, localVars, resolved)
+					failed = w.runGetStep(parallelCtx, m, localBuild, cwd, pp, *ps.Get, ps, resolvedVersions, localVars, secretVals, resolved)
 				}
 			case job.StepTypeTask:
 				if ps.Task != nil {
-					failed = w.runTaskStep(parallelCtx, m, localBuild, cwd, pp, *ps.Task, ps, localVars, resolved)
+					failed = w.runTaskStep(parallelCtx, m, localBuild, cwd, pp, *ps.Task, ps, localVars, secretVals, resolved)
 				}
 			case job.StepTypePut:
 				if ps.Put != nil {
-					failed = w.runPutStep(parallelCtx, m, localBuild, cwd, pp, *ps.Put, ps, localVars, resolved)
+					failed = w.runPutStep(parallelCtx, m, localBuild, cwd, pp, *ps.Put, ps, localVars, secretVals, resolved)
 				}
 			case job.StepTypeNotify:
 				if ps.Notify != nil {
-					failed = w.runNotifyStep(parallelCtx, m, localBuild, cwd, pp, *ps.Notify, ps, localVars, resolved)
+					failed = w.runNotifyStep(parallelCtx, m, localBuild, cwd, pp, *ps.Notify, ps, localVars, secretVals, resolved)
 				}
 			}
 
@@ -975,7 +977,7 @@ func (w *Worker) runInParallelStep(
 
 // runGetStep runs a single get step (resource pull).
 // Returns true if the step failed.
-func (w *Worker) runGetStep(ctx context.Context, m workitem.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, g job.GetStep, ps job.PlanStep, resolvedVersions map[string]uint32, exportedVars map[string]string, resolved ...map[string]string) bool {
+func (w *Worker) runGetStep(ctx context.Context, m workitem.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, g job.GetStep, ps job.PlanStep, resolvedVersions map[string]uint32, exportedVars map[string]string, secretVals []string, resolved ...map[string]string) bool {
 	var secretResolved map[string]string
 	if len(resolved) > 0 {
 		secretResolved = resolved[0]
@@ -1072,7 +1074,7 @@ func (w *Worker) runGetStep(ctx context.Context, m workitem.Body, b *build.Build
 		}
 
 		var attemptOut string
-		attemptOut, d, err = w.runRunner(runCtx, ru, cwd, rc, nil, onPartialLog)
+		attemptOut, d, err = w.runRunner(runCtx, ru, cwd, rc, secretVals, onPartialLog)
 		out += attemptOut
 
 		if cancel != nil {
@@ -1185,7 +1187,7 @@ func (w *Worker) runGetStepLocal(ctx context.Context, m workitem.Body, b *build.
 
 // runTaskStep runs a single task step.
 // Returns true if the step failed.
-func (w *Worker) runTaskStep(ctx context.Context, m workitem.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, t job.TaskStep, ps job.PlanStep, exportedVars map[string]string, resolved ...map[string]string) bool {
+func (w *Worker) runTaskStep(ctx context.Context, m workitem.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, t job.TaskStep, ps job.PlanStep, exportedVars map[string]string, secretVals []string, resolved ...map[string]string) bool {
 	var secretResolved map[string]string
 	if len(resolved) > 0 {
 		secretResolved = resolved[0]
@@ -1265,7 +1267,7 @@ func (w *Worker) runTaskStep(ctx context.Context, m workitem.Body, b *build.Buil
 		}
 
 		var attemptOut string
-		attemptOut, d, err = w.runRunner(runCtx, ru, cwd, t.Run, nil, onPartialLog)
+		attemptOut, d, err = w.runRunner(runCtx, ru, cwd, t.Run, secretVals, onPartialLog)
 		out += attemptOut
 
 		if cancel != nil {
@@ -1324,7 +1326,7 @@ func (w *Worker) runTaskStep(ctx context.Context, m workitem.Body, b *build.Buil
 
 // runPutStep runs a single put step (resource push).
 // Returns true if the step failed.
-func (w *Worker) runPutStep(ctx context.Context, m workitem.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, p job.PutStep, ps job.PlanStep, exportedVars map[string]string, resolved ...map[string]string) bool {
+func (w *Worker) runPutStep(ctx context.Context, m workitem.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, p job.PutStep, ps job.PlanStep, exportedVars map[string]string, secretVals []string, resolved ...map[string]string) bool {
 	if w.LocalMode {
 		rCan := utils.ResourceCanonical(p.Type, p.Name)
 		logMsg := fmt.Sprintf("skipping put step (local execution): %s", rCan)
@@ -1431,7 +1433,7 @@ func (w *Worker) runPutStep(ctx context.Context, m workitem.Body, b *build.Build
 		}
 
 		var attemptOut string
-		attemptOut, d, err = w.runRunner(runCtx, ru, cwd, rc, nil, onPartialLog)
+		attemptOut, d, err = w.runRunner(runCtx, ru, cwd, rc, secretVals, onPartialLog)
 		out += attemptOut
 
 		if cancel != nil {
@@ -1524,7 +1526,7 @@ func (w *Worker) implicitGetAfterPut(ctx context.Context, m workitem.Body, b *bu
 
 // runNotifyStep runs a single notify step (fire-and-forget notification).
 // Returns true if the step failed.
-func (w *Worker) runNotifyStep(ctx context.Context, m workitem.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, n job.NotifyStep, ps job.PlanStep, exportedVars map[string]string, resolved ...map[string]string) bool {
+func (w *Worker) runNotifyStep(ctx context.Context, m workitem.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, n job.NotifyStep, ps job.PlanStep, exportedVars map[string]string, secretVals []string, resolved ...map[string]string) bool {
 	if w.LocalMode {
 		nCan := utils.NotificationCanonical(n.Type, n.Name)
 		logMsg := fmt.Sprintf("skipping notify step (local execution): %s", nCan)
@@ -1638,7 +1640,7 @@ func (w *Worker) runNotifyStep(ctx context.Context, m workitem.Body, b *build.Bu
 		}
 
 		var attemptOut string
-		attemptOut, d, err = w.runRunner(runCtx, ru, cwd, rc, nil, onPartialLog)
+		attemptOut, d, err = w.runRunner(runCtx, ru, cwd, rc, secretVals, onPartialLog)
 		out += attemptOut
 
 		if cancel != nil {
@@ -1747,7 +1749,7 @@ func (w *Worker) runAutoNotifications(ctx context.Context, m workitem.Body, b *b
 				Message: n.Message,
 			},
 		}
-		w.runNotifyStep(ctx, m, b, cwd, pp, *ps.Notify, ps, nil, resolved)
+		w.runNotifyStep(ctx, m, b, cwd, pp, *ps.Notify, ps, nil, secretValuesFromResolved(resolved), resolved)
 	}
 }
 
@@ -1816,6 +1818,7 @@ func (w *Worker) buildPullParams(ctx context.Context, m workitem.Body, b *build.
 // runHooks runs a list of hooks (on_success, on_failure, on_cancel, ensure) and appends
 // the results as build steps.
 func (w *Worker) runHooks(ctx context.Context, m workitem.Body, b *build.Build, steps *[]build.Step, cwd string, pp *pipeline.Pipeline, stepName string, hooks []job.HookStep, hookType string, resolved map[string]string, exportedVars map[string]string, buildStatus ...string) {
+	secretVals := secretValuesFromResolved(resolved)
 	for i, h := range hooks {
 		// Compute step name early so we can use it for the running step
 		name := hookType
@@ -1868,7 +1871,7 @@ func (w *Worker) runHooks(ctx context.Context, m workitem.Body, b *build.Build, 
 			}
 
 			var runErr error
-			out, d, runErr = w.runRunner(ctx, ru, cwd, rc, nil, onPartialLog)
+			out, d, runErr = w.runRunner(ctx, ru, cwd, rc, secretVals, onPartialLog)
 			hookStatus := build.Succeeded
 			if runErr != nil {
 				hookStatus = build.Failed
@@ -1886,7 +1889,7 @@ func (w *Worker) runHooks(ctx context.Context, m workitem.Body, b *build.Build, 
 				Type: job.StepTypePut,
 				Put:  h.Put,
 			}
-			w.runPutStep(ctx, m, b, cwd, pp, *h.Put, ps, nil, resolved)
+			w.runPutStep(ctx, m, b, cwd, pp, *h.Put, ps, nil, secretVals, resolved)
 			continue
 		case job.StepTypeNotify:
 			if h.Notify == nil {
@@ -1896,7 +1899,7 @@ func (w *Worker) runHooks(ctx context.Context, m workitem.Body, b *build.Build, 
 				Type:   job.StepTypeNotify,
 				Notify: h.Notify,
 			}
-			w.runNotifyStep(ctx, m, b, cwd, pp, *h.Notify, ps, exportedVars, resolved)
+			w.runNotifyStep(ctx, m, b, cwd, pp, *h.Notify, ps, exportedVars, secretVals, resolved)
 			continue
 		default:
 			continue

--- a/worker/service.go
+++ b/worker/service.go
@@ -3109,6 +3109,40 @@ func replaceSecretPlaceholdersInSlice(ss []string, resolved map[string]string) {
 	}
 }
 
+// secretValuesFromResolved extracts unique non-empty secret values from a
+// resolved placeholder map, sorted longest-first so longer secrets are
+// masked before shorter substrings. Values shorter than 3 characters are
+// skipped to avoid false positives.
+func secretValuesFromResolved(resolved map[string]string) []string {
+	seen := make(map[string]struct{}, len(resolved))
+	var vals []string
+	for _, v := range resolved {
+		if v == "" || len(v) < 3 {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		vals = append(vals, v)
+	}
+	if len(vals) == 0 {
+		return nil
+	}
+	sort.Slice(vals, func(i, j int) bool {
+		return len(vals[i]) > len(vals[j])
+	})
+	return vals
+}
+
+// maskSecrets replaces all secret values in s with "***".
+func maskSecrets(s string, secretValues []string) string {
+	for _, v := range secretValues {
+		s = strings.ReplaceAll(s, v, "***")
+	}
+	return s
+}
+
 // parseEnvFormat parses KEY=VALUE lines (e.g. .env files) into a map.
 // Comment lines (#), blank lines, and lines without a valid variable name are ignored.
 // Values optionally wrapped in single or double quotes are stripped.

--- a/worker/service.go
+++ b/worker/service.go
@@ -695,9 +695,10 @@ func (w *Worker) checkVersionAvailability(ctx context.Context, m workitem.Body, 
 func (w *Worker) runPlan(ctx context.Context, m workitem.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, j *job.Job, resolvedVersions map[string]uint32) (bool, map[string]string, map[string]string) {
 	// Track all started services so we can stop them at the end.
 	var allStartedServices []job.ServiceStep
+	var secretVals []string
 	defer func() {
 		if len(allStartedServices) > 0 {
-			w.stopServices(m, b, cwd, pp, allStartedServices)
+			w.stopServices(m, b, cwd, pp, allStartedServices, secretVals)
 		}
 	}()
 
@@ -708,7 +709,7 @@ func (w *Worker) runPlan(ctx context.Context, m workitem.Body, b *build.Build, c
 		return true, nil, nil
 	}
 
-	secretVals := secretValuesFromResolved(resolved)
+	secretVals = secretValuesFromResolved(resolved)
 
 	// exportedVars accumulates key-value pairs exported by get and task steps
 	// so that subsequent steps can consume them as environment variables.
@@ -723,12 +724,12 @@ func (w *Worker) runPlan(ctx context.Context, m workitem.Body, b *build.Build, c
 			}
 			// Collect consecutive service steps and start them as a batch
 			batch := []job.ServiceStep{*ps.Service}
-			startedServices := w.startServices(ctx, m, b, cwd, pp, batch)
+			startedServices := w.startServices(ctx, m, b, cwd, pp, batch, secretVals)
 			allStartedServices = append(allStartedServices, startedServices...)
 			if len(startedServices) != len(batch) {
 				return true, resolved, exportedVars
 			}
-			if !w.waitForServices(ctx, m, b, cwd, pp, startedServices) {
+			if !w.waitForServices(ctx, m, b, cwd, pp, startedServices, secretVals) {
 				return true, resolved, exportedVars
 			}
 		case job.StepTypeGet:
@@ -1980,9 +1981,10 @@ func (w *Worker) processResourceCheck(ctx context.Context, m workitem.Body, cwd 
 
 	replaceSecretPlaceholders(rc.Params, resolved)
 	replaceSecretPlaceholdersInSlice(rc.Args, resolved)
+	secretVals := secretValuesFromResolved(resolved)
 
 	checkWarnStr := formatParamWarnings(checkWarnings)
-	out, _, err := w.runRunner(ctx, ru, cwd, rc, nil)
+	out, _, err := w.runRunner(ctx, ru, cwd, rc, secretVals)
 	if err != nil {
 		r.Logs = checkWarnStr + out
 		if nerr := w.pikoci.UpdatePipelineResource(ctx, m.TeamCanonical, m.PipelineCanonical, r.Canonical, r); nerr != nil {
@@ -2572,7 +2574,7 @@ func (w *Worker) fetchSecrets(ctx context.Context, cwd string, pp *pipeline.Pipe
 }
 
 // startServices starts all service steps and returns the successfully started service steps.
-func (w *Worker) startServices(ctx context.Context, m workitem.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, serviceSteps []job.ServiceStep) []job.ServiceStep {
+func (w *Worker) startServices(ctx context.Context, m workitem.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, serviceSteps []job.ServiceStep, secretVals []string) []job.ServiceStep {
 	var started []job.ServiceStep
 	for _, ss := range serviceSteps {
 		svc, ok := pp.Service(ss.Name)
@@ -2610,7 +2612,7 @@ func (w *Worker) startServices(ctx context.Context, m workitem.Body, b *build.Bu
 			w.updateBuild(ctx, m, *b)
 		}
 
-		out, d, err := w.runRunner(ctx, ru, cwd, rc, nil, onPartialLog)
+		out, d, err := w.runRunner(ctx, ru, cwd, rc, secretVals, onPartialLog)
 		out = svcWarnStr + out
 		if err != nil {
 			b.Steps[stepIdx] = build.Step{Type: "service", Name: ss.Name + ":start", Logs: out, Duration: d, Status: build.Failed}
@@ -2853,7 +2855,7 @@ func (w *Worker) serviceParams(b *build.Build, m workitem.Body, cmdParams map[st
 
 // waitForServices runs ready_check for all started services that have one.
 // Returns false if any ready_check times out.
-func (w *Worker) waitForServices(ctx context.Context, m workitem.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, startedServices []job.ServiceStep) bool {
+func (w *Worker) waitForServices(ctx context.Context, m workitem.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, startedServices []job.ServiceStep, secretVals []string) bool {
 	type readyResult struct {
 		name string
 		out  string
@@ -2962,7 +2964,7 @@ func (w *Worker) waitForServices(ctx context.Context, m workitem.Body, b *build.
 				default:
 				}
 
-				lastOut, _, lastErr = w.runRunner(ctx, ru, cwd, runCmd, nil)
+				lastOut, _, lastErr = w.runRunner(ctx, ru, cwd, runCmd, secretVals)
 				if lastErr == nil {
 					results <- readyResult{
 						name: svcName,
@@ -3004,7 +3006,7 @@ func (w *Worker) waitForServices(ctx context.Context, m workitem.Body, b *build.
 
 // stopServices stops all started services unconditionally.
 // Uses a fresh context to ensure cleanup runs even if the parent context is cancelled.
-func (w *Worker) stopServices(m workitem.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, startedServices []job.ServiceStep) {
+func (w *Worker) stopServices(m workitem.Body, b *build.Build, cwd string, pp *pipeline.Pipeline, startedServices []job.ServiceStep, secretVals []string) {
 	stopCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -3039,7 +3041,7 @@ func (w *Worker) stopServices(m workitem.Body, b *build.Build, cwd string, pp *p
 			w.updateBuild(stopCtx, m, *b)
 		}
 
-		out, d, err := w.runRunner(stopCtx, ru, cwd, rc, nil, onPartialLog)
+		out, d, err := w.runRunner(stopCtx, ru, cwd, rc, secretVals, onPartialLog)
 		out = stopWarnStr + out
 		stepStatus := build.Succeeded
 		if err != nil {

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -2332,6 +2332,124 @@ func TestReplaceSecretPlaceholders_NoResolved(t *testing.T) {
 	assert.Equal(t, "literal-value", params["param_token"])
 }
 
+func TestSecretValuesFromResolved(t *testing.T) {
+	tests := []struct {
+		name     string
+		resolved map[string]string
+		want     []string
+	}{
+		{
+			name:     "nil map",
+			resolved: nil,
+			want:     nil,
+		},
+		{
+			name:     "empty map",
+			resolved: map[string]string{},
+			want:     nil,
+		},
+		{
+			name: "skips empty values",
+			resolved: map[string]string{
+				"__pikoci_secret:vault:path:key__": "",
+			},
+			want: nil,
+		},
+		{
+			name: "skips short values under 3 chars",
+			resolved: map[string]string{
+				"__pikoci_secret:vault:path:a__": "ab",
+				"__pikoci_secret:vault:path:b__": "x",
+			},
+			want: nil,
+		},
+		{
+			name: "extracts and deduplicates",
+			resolved: map[string]string{
+				"__pikoci_secret:vault:path:token__":    "s3cret-token",
+				"__pikoci_secret:vault:path:token2__":   "s3cret-token",
+				"__pikoci_secret:vault:path:password__": "hunter2",
+			},
+			want: []string{"s3cret-token", "hunter2"},
+		},
+		{
+			name: "sorts longest first",
+			resolved: map[string]string{
+				"__pikoci_secret:vault:path:short__": "abc",
+				"__pikoci_secret:vault:path:long__":  "abcdefghij",
+				"__pikoci_secret:vault:path:mid__":   "abcdef",
+			},
+			want: []string{"abcdefghij", "abcdef", "abc"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := secretValuesFromResolved(tt.resolved)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMaskSecrets(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		vals  []string
+		want  string
+	}{
+		{
+			name:  "nil vals is no-op",
+			input: "hello world",
+			vals:  nil,
+			want:  "hello world",
+		},
+		{
+			name:  "empty vals is no-op",
+			input: "hello world",
+			vals:  []string{},
+			want:  "hello world",
+		},
+		{
+			name:  "masks single value",
+			input: "token is s3cret-token here",
+			vals:  []string{"s3cret-token"},
+			want:  "token is *** here",
+		},
+		{
+			name:  "masks multiple occurrences",
+			input: "s3cret-token and s3cret-token again",
+			vals:  []string{"s3cret-token"},
+			want:  "*** and *** again",
+		},
+		{
+			name:  "masks multiple different values",
+			input: "user=admin pass=hunter2",
+			vals:  []string{"admin", "hunter2"},
+			want:  "user=*** pass=***",
+		},
+		{
+			name:  "longest first prevents partial masking",
+			input: "the value is supersecret",
+			vals:  []string{"supersecret", "secret"},
+			want:  "the value is ***",
+		},
+		{
+			name:  "no match leaves string unchanged",
+			input: "nothing to see here",
+			vals:  []string{"s3cret-token"},
+			want:  "nothing to see here",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := maskSecrets(tt.input, tt.vals)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestProcessResourceCheck_WithSecretVars(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	w, svc := newTestWorker(ctrl)

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -2435,6 +2435,18 @@ func TestMaskSecrets(t *testing.T) {
 			want:  "the value is ***",
 		},
 		{
+			name:  "masks multi-line secret",
+			input: "begin\nline1\nline2\nend",
+			vals:  []string{"line1\nline2"},
+			want:  "begin\n***\nend",
+		},
+		{
+			name:  "regex-special chars in secret treated literally",
+			input: "price is $100.00 (USD)",
+			vals:  []string{"$100.00 (USD)"},
+			want:  "price is ***",
+		},
+		{
 			name:  "no match leaves string unchanged",
 			input: "nothing to see here",
 			vals:  []string{"s3cret-token"},
@@ -3050,11 +3062,10 @@ func TestRunRunner_MasksSecretInPartialLog(t *testing.T) {
 	assert.Contains(t, out, "***")
 	assert.NotContains(t, out, "my-s3cret-token")
 	// At least one partial log should have been emitted (sleep 3 > 2s ticker)
-	if len(partialLogs) > 0 {
-		for _, pl := range partialLogs {
-			assert.NotContains(t, pl, "my-s3cret-token", "partial log should be masked")
-			assert.Contains(t, pl, "***", "partial log should contain masked value")
-		}
+	require.NotEmpty(t, partialLogs, "expected at least one partial log from 3s sleep with 2s ticker")
+	for _, pl := range partialLogs {
+		assert.NotContains(t, pl, "my-s3cret-token", "partial log should be masked")
+		assert.Contains(t, pl, "***", "partial log should contain masked value")
 	}
 }
 

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -3022,6 +3022,42 @@ func TestRunRunner_MasksSecretInOutput(t *testing.T) {
 	assert.NotContains(t, out, "my-s3cret-token")
 }
 
+func TestRunRunner_MasksSecretInPartialLog(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	cwd := t.TempDir()
+
+	ru := runner.Runner{
+		Name: "exec",
+		Run:  utils.RunCommand{Path: "$path", Args: []string{"$args"}},
+	}
+	rc := utils.RunnerCommand{
+		Runner: "exec",
+		Args:   []string{"-ec", `echo "my-s3cret-token"; sleep 3`},
+		Params: map[string]string{"path": "/bin/sh"},
+	}
+
+	var partialLogs []string
+	onPartial := func(partial string) {
+		partialLogs = append(partialLogs, partial)
+	}
+
+	secretVals := []string{"my-s3cret-token"}
+	out, _, err := w.runRunner(ctx, ru, cwd, rc, secretVals, onPartial)
+	require.NoError(t, err)
+	assert.Contains(t, out, "***")
+	assert.NotContains(t, out, "my-s3cret-token")
+	// At least one partial log should have been emitted (sleep 3 > 2s ticker)
+	if len(partialLogs) > 0 {
+		for _, pl := range partialLogs {
+			assert.NotContains(t, pl, "my-s3cret-token", "partial log should be masked")
+			assert.Contains(t, pl, "***", "partial log should contain masked value")
+		}
+	}
+}
+
 func TestRunRunner_NilSecretVals_NoMasking(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	w, _ := newTestWorker(ctrl)

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -2700,7 +2700,7 @@ func TestRunRunner_ShellVariablesNotDestroyed(t *testing.T) {
 		Params: map[string]string{"path": "/bin/sh"},
 	}
 
-	out, _, err := w.runRunner(ctx, ru, cwd, rc)
+	out, _, err := w.runRunner(ctx, ru, cwd, rc, nil)
 	require.NoError(t, err)
 	assert.Contains(t, out, "hello_from_shell", "shell variable should survive and be echoed")
 }
@@ -2724,7 +2724,7 @@ func TestRunRunner_AwkPositionalArgsWork(t *testing.T) {
 		Params: map[string]string{"path": "/bin/sh"},
 	}
 
-	out, _, err := w.runRunner(ctx, ru, cwd, rc)
+	out, _, err := w.runRunner(ctx, ru, cwd, rc, nil)
 	require.NoError(t, err)
 	assert.Contains(t, out, "foo", "awk $1 should extract first field")
 	assert.NotContains(t, out, "bar", "awk $1 should not include second field")
@@ -2752,7 +2752,7 @@ func TestRunRunner_ParamVarsExpandedByShell(t *testing.T) {
 		},
 	}
 
-	out, _, err := w.runRunner(ctx, ru, cwd, rc)
+	out, _, err := w.runRunner(ctx, ru, cwd, rc, nil)
 	require.NoError(t, err)
 	assert.Contains(t, out, "url=https://example.com", "param_url should be expanded by shell from env")
 }
@@ -2796,7 +2796,7 @@ func TestRunRunner_EnvPlaceholder(t *testing.T) {
 	// The -e flags come before the -ec arg. Since /bin/sh doesn't understand
 	// -e KEY=VALUE as positional args, the command will fail. But we can verify
 	// the behavior via the isRunnerInternalParam function directly.
-	w.runRunner(ctx, ru, cwd, rc)
+	w.runRunner(ctx, ru, cwd, rc, nil)
 }
 
 func TestIsRunnerInternalParam(t *testing.T) {
@@ -2900,7 +2900,7 @@ func TestRunRunner_EnvPlaceholder_RemapsPIKOCIOutput(t *testing.T) {
 		},
 	}
 
-	out, _, _ := w.runRunner(ctx, ru, cwd, rc)
+	out, _, _ := w.runRunner(ctx, ru, cwd, rc, nil)
 
 	// The output should contain the remapped PIKOCI_OUTPUT path
 	assert.Contains(t, out, "PIKOCI_OUTPUT=/workdir/.pikoci-output-12345",
@@ -2947,7 +2947,7 @@ func TestRunRunner_EnvPlaceholder_DockerTemplate(t *testing.T) {
 		},
 	}
 
-	out, _, err := w.runRunner(ctx, ru, cwd, rc)
+	out, _, err := w.runRunner(ctx, ru, cwd, rc, nil)
 	require.NoError(t, err)
 
 	// Verify volume mount expanded
@@ -2990,12 +2990,58 @@ func TestRunRunner_EnvPlaceholder_PIKOCIOutputNoWorkdir(t *testing.T) {
 		},
 	}
 
-	out, _, _ := w.runRunner(ctx, ru, cwd, rc)
+	out, _, _ := w.runRunner(ctx, ru, cwd, rc, nil)
 
 	// Without -w, the original host path should be used
 	assert.Contains(t, out, "PIKOCI_OUTPUT="+hostPath,
 		"PIKOCI_OUTPUT should use original host path when no -w flag")
 	assert.Contains(t, out, "GET_REPO_REF=abc123")
+}
+
+func TestRunRunner_MasksSecretInOutput(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	cwd := t.TempDir()
+
+	ru := runner.Runner{
+		Name: "exec",
+		Run:  utils.RunCommand{Path: "$path", Args: []string{"$args"}},
+	}
+	rc := utils.RunnerCommand{
+		Runner: "exec",
+		Args:   []string{"-ec", `echo "my-s3cret-token"`},
+		Params: map[string]string{"path": "/bin/sh"},
+	}
+
+	secretVals := []string{"my-s3cret-token"}
+	out, _, err := w.runRunner(ctx, ru, cwd, rc, secretVals)
+	require.NoError(t, err)
+	assert.Contains(t, out, "***")
+	assert.NotContains(t, out, "my-s3cret-token")
+}
+
+func TestRunRunner_NilSecretVals_NoMasking(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, _ := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	cwd := t.TempDir()
+
+	ru := runner.Runner{
+		Name: "exec",
+		Run:  utils.RunCommand{Path: "$path", Args: []string{"$args"}},
+	}
+	rc := utils.RunnerCommand{
+		Runner: "exec",
+		Args:   []string{"-ec", `echo "visible-output"`},
+		Params: map[string]string{"path": "/bin/sh"},
+	}
+
+	out, _, err := w.runRunner(ctx, ru, cwd, rc, nil)
+	require.NoError(t, err)
+	assert.Contains(t, out, "visible-output")
 }
 
 func TestProcessResourceCheck_RawSecretFormat(t *testing.T) {
@@ -4695,7 +4741,7 @@ func TestRunRunner_ShellCmdMode(t *testing.T) {
 		Params: map[string]string{"cmd": "echo shell_works"},
 	}
 
-	out, _, err := w.runRunner(ctx, ru, cwd, rc)
+	out, _, err := w.runRunner(ctx, ru, cwd, rc, nil)
 	require.NoError(t, err)
 	assert.Contains(t, out, "shell_works")
 }
@@ -4719,7 +4765,7 @@ func TestRunRunner_ShellFileMode(t *testing.T) {
 		Params: map[string]string{"file": "hello.sh"},
 	}
 
-	out, _, err := w.runRunner(ctx, ru, cwd, rc)
+	out, _, err := w.runRunner(ctx, ru, cwd, rc, nil)
 	require.NoError(t, err)
 	assert.Contains(t, out, "file_works")
 }


### PR DESCRIPTION
## Summary

Automatically replace resolved secret values with `***` in build logs (stdout/stderr) as a safety net against accidental leaks.

- Add `secretValuesFromResolved` and `maskSecrets` helper functions (dedup, skip short/empty, longest-first ordering)
- Add `secretVals []string` parameter to `runRunner`, applying masking at partial log streaming, final output, and early error returns
- Thread `secretVals` from `runPlan` through all step functions (`runGetStep`, `runTaskStep`, `runPutStep`, `runNotifyStep`, `runInParallelStep`), hooks, services (`startServices`, `waitForServices`, `stopServices`), and `processResourceCheck`
- `fetchSecrets` intentionally passes `nil` to avoid corrupting parsed secret output

## Changelog

### Added
- Secrets masking in build logs: resolved secret values are automatically replaced with `***` in command stdout/stderr
- Masking applies to real-time partial log streaming and final stored output
- Values shorter than 3 characters are skipped to avoid false positives
- Longer secrets are masked before shorter substrings to prevent partial masking

Closes #147