### PR TITLE
feat: add build report export (#531)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Version pinning at build creation**: Downstream builds snapshot triggered resource versions at creation time, matching Concourse CI behavior.
 - **Audit log**: Append-only team audit trail with 16 event types, filterable UI/CLI/API, cursor-based pagination. Read+ access ([#532](https://github.com/PikoCI/pikoci/issues/532)).
 - **Secrets masking in build logs**: Secret values replaced with `***` in stdout/stderr. Real-time and stored output. Skips values < 3 chars ([#147](https://github.com/PikoCI/pikoci/issues/147)).
+- **Build report export**: JSON report for any build containing status, steps, logs, approvals, and version data. Available via API (`GET .../builds/{bn}/report`), CLI (`builds report`), and UI Export button. Read+ access ([#531](https://github.com/PikoCI/pikoci/issues/531)).
 
 ### Fixed
 

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -990,6 +990,7 @@ func init() {
 	buildsCmd.AddCommand(buildsRetryCmd)
 	buildsCmd.AddCommand(buildsApproveCmd)
 	buildsCmd.AddCommand(buildsRejectCmd)
+	buildsCmd.AddCommand(buildsReportCmd)
 }
 
 var buildsListCmd = &cobra.Command{
@@ -1213,6 +1214,52 @@ func init() {
 	buildsRejectCmd.Flags().String("message", "", "Rejection reason (required)")
 	buildsRejectCmd.MarkFlagRequired("build-number")
 	buildsRejectCmd.MarkFlagRequired("message")
+}
+
+var buildsReportCmd = &cobra.Command{
+	Use:   "report",
+	Short: "Exports a Build report as JSON",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		tc, _ := cmd.Flags().GetString("team-canonical")
+		pn, _ := cmd.Flags().GetString("pipeline-name")
+		pn = utils.Canonicalize(pn)
+		jn, _ := cmd.Flags().GetString("job-name")
+		bn, _ := cmd.Flags().GetString("build-number")
+		output, _ := cmd.Flags().GetString("output")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		report, err := c.GetBuildReport(cmd.Context(), tc, pn, jn, bn)
+		if err != nil {
+			return fmt.Errorf("failed to get build report %q: %w", bn, err)
+		}
+
+		data, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal report: %w", err)
+		}
+
+		if output != "" {
+			if err := os.WriteFile(output, data, 0644); err != nil {
+				return fmt.Errorf("failed to write report to %q: %w", output, err)
+			}
+			fmt.Printf("Report written to %s\n", output)
+		} else {
+			fmt.Println(string(data))
+		}
+		return nil
+	},
+}
+
+func init() {
+	buildsReportCmd.Flags().String("build-number", "", "Number of the Build")
+	buildsReportCmd.Flags().String("output", "", "Output file path (default: stdout)")
+	buildsReportCmd.MarkFlagRequired("build-number")
 }
 
 // resources

--- a/cmd/client_test.go
+++ b/cmd/client_test.go
@@ -27,7 +27,7 @@ func TestCommandTree(t *testing.T) {
 		{usersCmd, "users", []string{"create", "list", "update", "delete", "change-password"}},
 		{teamsCmd, "teams", []string{"create", "list", "get", "update", "delete", "members"}},
 		{teamsMembersCmd, "members", []string{"create", "update", "delete"}},
-		{buildsCmd, "builds", []string{"list", "get", "delete", "cancel", "retry", "approve", "reject"}},
+		{buildsCmd, "builds", []string{"list", "get", "delete", "cancel", "retry", "approve", "reject", "report"}},
 		{resourcesCmd, "resources", []string{"get", "trigger", "versions", "webhook-regenerate"}},
 		{triggersCmd, "triggers", []string{"create", "list"}},
 	}
@@ -63,6 +63,7 @@ func TestRequiredFlags(t *testing.T) {
 		{"builds delete", buildsDeleteCmd, []string{"build-number"}},
 		{"builds cancel", buildsCancelCmd, []string{"build-number"}},
 		{"builds retry", buildsRetryCmd, []string{"build-number"}},
+		{"builds report", buildsReportCmd, []string{"build-number"}},
 		{"resources get", resourcesGetCmd, []string{"resource-canonical"}},
 		{"resources trigger", resourcesTriggerCmd, []string{"resource-canonical"}},
 		{"resources versions", resourcesVersionsCmd, []string{"resource-canonical"}},

--- a/integration/http/http_test.go
+++ b/integration/http/http_test.go
@@ -555,6 +555,33 @@ func TestHTTPEndpoints(t *testing.T) {
 			decodeBody(t, resp, &rr)
 			assert.Empty(t, rr.Err)
 		})
+
+		t.Run("Report", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodGet, pikoURL+"/teams/main/pipelines/test-pipe/jobs/test-job/builds/1/report", adminJWT, "")
+			defer resp.Body.Close()
+			requireOK(t, resp)
+			assert.Contains(t, resp.Header.Get("Content-Disposition"), "attachment")
+			assert.Contains(t, resp.Header.Get("Content-Disposition"), "build-report-1.json")
+			var rr thttp.GetBuildReportResponse
+			decodeBody(t, resp, &rr)
+			assert.Empty(t, rr.Err)
+			require.NotNil(t, rr.Report)
+			assert.Equal(t, "1", rr.Report.ReportVersion)
+			assert.Equal(t, "main", rr.Report.Team)
+			assert.Equal(t, "test-pipe", rr.Report.Pipeline)
+			assert.Equal(t, "test-job", rr.Report.Job)
+			assert.Equal(t, "1", rr.Report.Build.Number)
+			assert.NotEmpty(t, rr.Report.Build.Status)
+			assert.NotNil(t, rr.Report.Approvals)
+			assert.NotNil(t, rr.Report.Steps)
+			assert.NotNil(t, rr.Report.JobLogs)
+		})
+
+		t.Run("Report_Unauthenticated", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodGet, pikoURL+"/teams/main/pipelines/test-pipe/jobs/test-job/builds/1/report", "", "")
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
 	})
 
 	// ---- Workers ----

--- a/pikoci/build/build.go
+++ b/pikoci/build/build.go
@@ -79,6 +79,34 @@ type Build struct {
 	OnUpdate func() `json:"-"`
 }
 
+// BuildReport is a structured JSON report containing all runtime data for a build.
+// It wraps the build data with team/pipeline/job context and a generation timestamp.
+type BuildReport struct {
+	ReportVersion   string                            `json:"report_version"`
+	GeneratedAt     time.Time                         `json:"generated_at"`
+	Team            string                            `json:"team"`
+	Pipeline        string                            `json:"pipeline"`
+	Job             string                            `json:"job"`
+	Build           BuildReportData                   `json:"build"`
+	Approvals       []Approval                        `json:"approvals"`
+	Steps           []Step                            `json:"steps"`
+	JobLogs         []Step                            `json:"job_logs"`
+}
+
+// BuildReportData contains the build-specific fields for the report.
+type BuildReportData struct {
+	Number            string                            `json:"number"`
+	Status            string                            `json:"status"`
+	Error             string                            `json:"error"`
+	StartedAt         time.Time                         `json:"started_at"`
+	Duration          time.Duration                     `json:"duration"`
+	VersionID         uint32                            `json:"version_id"`
+	ResourceCanonical string                            `json:"resource_canonical"`
+	VersionMetadata   map[string]interface{}            `json:"version_metadata"`
+	PinnedVersions    map[string]map[string]interface{} `json:"pinned_versions"`
+	RetryOf           string                            `json:"retry_of"`
+}
+
 // Step represents an individual step within a build, such as a get, put, or task
 // operation. Each step tracks its own logs, duration, and completion status.
 type Step struct {

--- a/pikoci/builds.go
+++ b/pikoci/builds.go
@@ -154,6 +154,57 @@ func (q *PikoCI) GetJobBuild(ctx context.Context, tc, pc, jn string, buildNumber
 	return b, nil
 }
 
+// GetBuildReport generates a structured JSON report for a build.
+func (q *PikoCI) GetBuildReport(ctx context.Context, tc, pc, jn, buildNumber string) (*build.BuildReport, error) {
+	b, err := q.GetJobBuild(ctx, tc, pc, jn, buildNumber)
+	if err != nil {
+		return nil, fmt.Errorf("failed to GetJobBuild: %w", err)
+	}
+
+	retryOf := ""
+	if b.RetrySourceBuildID > 0 {
+		rb, err := q.Builds.FindByID(ctx, b.RetrySourceBuildID)
+		if err == nil && rb != nil {
+			retryOf = rb.BuildNumber
+		}
+	}
+
+	report := &build.BuildReport{
+		ReportVersion: "1",
+		GeneratedAt:   time.Now().UTC(),
+		Team:          tc,
+		Pipeline:      pc,
+		Job:           jn,
+		Build: build.BuildReportData{
+			Number:            b.BuildNumber,
+			Status:            b.Status.String(),
+			Error:             b.Error,
+			StartedAt:         b.StartedAt,
+			Duration:          b.Duration,
+			VersionID:         b.VersionID,
+			ResourceCanonical: b.ResourceCanonical,
+			VersionMetadata:   b.VersionMetadata,
+			PinnedVersions:    b.PinnedVersions,
+			RetryOf:           retryOf,
+		},
+		Approvals: b.Approvals,
+		Steps:     b.Steps,
+		JobLogs:   b.Job,
+	}
+
+	if report.Approvals == nil {
+		report.Approvals = []build.Approval{}
+	}
+	if report.Steps == nil {
+		report.Steps = []build.Step{}
+	}
+	if report.JobLogs == nil {
+		report.JobLogs = []build.Step{}
+	}
+
+	return report, nil
+}
+
 // CancelJobBuild cancels a running or pending build and notifies the next
 // pending build in the queue so it can potentially start.
 func (q *PikoCI) CancelJobBuild(ctx context.Context, tc, pc, jn string, buildNumber string) error {

--- a/pikoci/builds_test.go
+++ b/pikoci/builds_test.go
@@ -385,6 +385,56 @@ func TestInsertBuildGetVersion(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestGetBuildReport(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	expected := &build.Build{
+		ID:          5,
+		BuildNumber: "3",
+		Status:      build.Succeeded,
+		Steps:       []build.Step{{Type: "task", Name: "deploy", Status: build.Succeeded}},
+		Job:         []build.Step{{Type: "job", Name: "summary", Status: build.Succeeded}},
+		Approvals:   []build.Approval{{Username: "alice", Action: "approved"}},
+	}
+	s.Builds.EXPECT().Find(ctx, "main", "my-pipeline", "my-job", "3").Return(expected, nil)
+	s.Builds.EXPECT().FindApprovals(ctx, uint32(5)).Return(expected.Approvals, nil)
+	s.Builds.EXPECT().FindGetVersions(ctx, uint32(5)).Return(nil, nil)
+
+	report, err := s.S.GetBuildReport(ctx, "main", "my-pipeline", "my-job", "3")
+	require.NoError(t, err)
+	assert.Equal(t, "1", report.ReportVersion)
+	assert.Equal(t, "main", report.Team)
+	assert.Equal(t, "my-pipeline", report.Pipeline)
+	assert.Equal(t, "my-job", report.Job)
+	assert.Equal(t, "3", report.Build.Number)
+	assert.Equal(t, "succeeded", report.Build.Status)
+	assert.Len(t, report.Steps, 1)
+	assert.Len(t, report.JobLogs, 1)
+	assert.Len(t, report.Approvals, 1)
+}
+
+func TestGetBuildReport_InvalidCanonical(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	_, err := s.S.GetBuildReport(ctx, "INVALID", "my-pipeline", "my-job", "1")
+	require.Error(t, err)
+}
+
+func TestGetBuildReport_NotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Builds.EXPECT().Find(ctx, "main", "my-pipeline", "my-job", "99").Return(nil, assert.AnError)
+
+	_, err := s.S.GetBuildReport(ctx, "main", "my-pipeline", "my-job", "99")
+	require.Error(t, err)
+}
+
 func TestReEnqueuePendingBuilds_NoPipelines(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := newService(ctrl)

--- a/pikoci/mock/service.go
+++ b/pikoci/mock/service.go
@@ -401,6 +401,21 @@ func (mr *ServiceMockRecorder) FindOldestPendingBuild(ctx, tc, pn, jn any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindOldestPendingBuild", reflect.TypeOf((*Service)(nil).FindOldestPendingBuild), ctx, tc, pn, jn)
 }
 
+// GetBuildReport mocks base method.
+func (m *Service) GetBuildReport(ctx context.Context, tc, pn, jn, buildNumber string) (*build.BuildReport, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBuildReport", ctx, tc, pn, jn, buildNumber)
+	ret0, _ := ret[0].(*build.BuildReport)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBuildReport indicates an expected call of GetBuildReport.
+func (mr *ServiceMockRecorder) GetBuildReport(ctx, tc, pn, jn, buildNumber any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBuildReport", reflect.TypeOf((*Service)(nil).GetBuildReport), ctx, tc, pn, jn, buildNumber)
+}
+
 // GetJobBuild mocks base method.
 func (m *Service) GetJobBuild(ctx context.Context, tc, pn, jn, buildNumber string) (*build.Build, error) {
 	m.ctrl.T.Helper()

--- a/pikoci/service.go
+++ b/pikoci/service.go
@@ -169,6 +169,9 @@ type Service interface {
 	// CancelJobBuild cancels a running or pending build and notifies the next
 	// pending build in the queue.
 	CancelJobBuild(ctx context.Context, tc, pn, jn string, buildNumber string) error
+	// GetBuildReport generates a structured JSON report for a build containing
+	// all runtime data including approvals, versions, and step logs.
+	GetBuildReport(ctx context.Context, tc, pn, jn, buildNumber string) (*build.BuildReport, error)
 	// RetryJobBuild creates a retry of a completed build and enqueues it for execution.
 	RetryJobBuild(ctx context.Context, tc, pn, jn, buildNumber string) error
 	// FindBuildGetVersions returns the resource version IDs fetched during get

--- a/pikoci/transport/http/assets/js/app/api.js
+++ b/pikoci/transport/http/assets/js/app/api.js
@@ -140,6 +140,8 @@ export const approveBuild = (tc, pn, jn, bid, message) =>
   api('/teams/' + tc + '/pipelines/' + pn + '/jobs/' + jn + '/builds/' + bid + '/approve', { method: 'POST', body: JSON.stringify({ message }) });
 export const rejectBuild = (tc, pn, jn, bid, message) =>
   api('/teams/' + tc + '/pipelines/' + pn + '/jobs/' + jn + '/builds/' + bid + '/reject', { method: 'POST', body: JSON.stringify({ message }) });
+export const fetchBuildReport = (tc, pn, jn, bid) =>
+  api('/teams/' + tc + '/pipelines/' + pn + '/jobs/' + jn + '/builds/' + bid + '/report');
 
 // --- Resources ---
 export const fetchResources = (tc, pn) => api('/teams/' + tc + '/pipelines/' + pn + '/resources').then(r => r.data);

--- a/pikoci/transport/http/assets/js/app/components/Jobs.js
+++ b/pikoci/transport/http/assets/js/app/components/Jobs.js
@@ -4,7 +4,7 @@ import { html } from 'htm/preact';
 import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
 import { route } from 'preact-router';
 import { isLoggedIn, hasTeamRole, session } from '../state.js';
-import { fetchBuilds, fetchBuild, cancelBuild, retryBuild, approveBuild, rejectBuild, triggerJob, pauseJob, unpauseJob, fetchJob, fetchResources, fetchResourceVersions, fetchVersionPath, fetchTeam, fetchPipeline } from '../api.js';
+import { fetchBuilds, fetchBuild, cancelBuild, retryBuild, approveBuild, rejectBuild, fetchBuildReport, triggerJob, pauseJob, unpauseJob, fetchJob, fetchResources, fetchResourceVersions, fetchVersionPath, fetchTeam, fetchPipeline } from '../api.js';
 import { useLoading, usePolling } from '../hooks.js';
 import { sortBuilds, selectActiveBuild, durationToString, processLogs, pikoTimeAgo, fetchInterval } from '../utils.js';
 import { showToast } from '../toast.js';
@@ -239,6 +239,7 @@ function BuildContent({ build: rawBuild, tc, pn, jn, job: jobData, onRetry }) {
     ? { ...rawBuild, approvals: fullBuild.approvals, version_metadata: fullBuild.version_metadata, pinned_versions: fullBuild.pinned_versions }
     : (fullBuild || rawBuild);
   const build = prepareBuild(mergedBuild);
+  const isReader = hasTeamRole(tc, 'read');
   const isOperator = hasTeamRole(tc, 'write');
   const [autoFollow, setAutoFollow] = useState(true);
   const [expandedSteps, setExpandedSteps] = useState({});
@@ -249,6 +250,7 @@ function BuildContent({ build: rawBuild, tc, pn, jn, job: jobData, onRetry }) {
   const [retryLoading, withRetryLoading] = useLoading();
   const [approveMsg, setApproveMsg] = useState('');
   const [rejectMsg, setRejectMsg] = useState('');
+  const [exportLoading, withExportLoading] = useLoading();
   const [approveLoading, withApproveLoading] = useLoading();
   const [rejectLoading, withRejectLoading] = useLoading();
   const initializedRef = useRef(false);
@@ -335,6 +337,19 @@ function BuildContent({ build: rawBuild, tc, pn, jn, job: jobData, onRetry }) {
     });
   }, [tc, pn, jn, build.build_number, withRetryLoading, onRetry]);
 
+  const onExport = useCallback(async () => {
+    await withExportLoading(async () => {
+      const resp = await fetchBuildReport(tc, pn, jn, build.build_number);
+      const blob = new Blob([JSON.stringify(resp.data, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'build-report-' + build.build_number + '.json';
+      a.click();
+      URL.revokeObjectURL(url);
+    });
+  }, [tc, pn, jn, build.build_number, withExportLoading]);
+
   const toggleFollowBtn = useCallback(() => {
     setAutoFollow(prev => !prev);
   }, []);
@@ -412,7 +427,7 @@ function BuildContent({ build: rawBuild, tc, pn, jn, job: jobData, onRetry }) {
                 }}>
                   <input type="text" class="form-control" placeholder="Optional message"
                     value=${approveMsg} onInput=${(e) => setApproveMsg(e.target.value)} />
-                  <button type="submit" class="btn btn-success" disabled=${approveLoading}>
+                  <button type="submit" class="btn btn-success" title="Approve build" disabled=${approveLoading}>
                     <i class="bi bi-check-circle"></i> ${approveLoading ? 'Approving...' : 'Approve'}
                   </button>
                 </form>
@@ -429,7 +444,7 @@ function BuildContent({ build: rawBuild, tc, pn, jn, job: jobData, onRetry }) {
                 }}>
                   <input type="text" class="form-control" placeholder="Reason (required)"
                     value=${rejectMsg} onInput=${(e) => setRejectMsg(e.target.value)} />
-                  <button type="submit" class="btn btn-danger" disabled=${rejectLoading || !rejectMsg}>
+                  <button type="submit" class="btn btn-danger" title="Reject build" disabled=${rejectLoading || !rejectMsg}>
                     <i class="bi bi-x-circle"></i> ${rejectLoading ? 'Rejecting...' : 'Reject'}
                   </button>
                 </form>
@@ -460,16 +475,25 @@ function BuildContent({ build: rawBuild, tc, pn, jn, job: jobData, onRetry }) {
               </button>
             ` : null}
             ${isOperator ? html`
-              <button type="button" class="btn btn-sm btn-outline-danger piko-cancel-build" onClick=${onCancel} disabled=${cancelLoading}>
+              <button type="button" class="btn btn-sm btn-outline-danger piko-cancel-build" title="Cancel build" onClick=${onCancel} disabled=${cancelLoading}>
                 <i class="bi bi-x-circle"></i> ${cancelLoading ? 'Cancelling...' : 'Cancel'}
               </button>
             ` : null}
           </span>
-        ` : isOperator && !isWaitingApproval ? html`
-          <button type="button" class="btn btn-sm btn-outline-warning piko-retry-build" style="margin-left:auto;" onClick=${handleRetry} disabled=${retryLoading}>
-            <i class="bi bi-arrow-clockwise"></i> ${retryLoading ? 'Retrying...' : 'Retry'}
-          </button>
-        ` : null}
+        ` : html`
+          <span style="margin-left:auto;display:flex;gap:6px;align-items:center;">
+            ${isOperator && !isWaitingApproval ? html`
+              <button type="button" class="btn btn-sm btn-outline-warning piko-retry-build" title="Retry build" onClick=${handleRetry} disabled=${retryLoading}>
+                <i class="bi bi-arrow-clockwise"></i> ${retryLoading ? 'Retrying...' : 'Retry'}
+              </button>
+            ` : null}
+            ${isReader ? html`
+              <button type="button" class="btn btn-sm btn-outline-secondary" title="Export build report" onClick=${onExport} disabled=${exportLoading}>
+                <i class="bi bi-download"></i> ${exportLoading ? 'Exporting...' : 'Export'}
+              </button>
+            ` : null}
+          </span>
+        `}
       </div>
       ${steps.map((s, i) => {
         if (s.type === 'in_parallel') {
@@ -821,14 +845,14 @@ export function JobBuilds({ tc, pn, jn, bid, embedded, trackedVersionID: tracked
         <div class="d-flex gap-2">
           ${isMember ? html`
             ${job && job.paused ? html`
-              <button type="button" id="unpause-job" class="btn btn-primary" onClick=${onUnpause} disabled=${unpauseLoading}>
+              <button type="button" id="unpause-job" class="btn btn-primary" title="Unpause job" onClick=${onUnpause} disabled=${unpauseLoading}>
                 <i class="bi bi-play-circle"></i> ${unpauseLoading ? 'Unpausing...' : 'Unpause Job'}
               </button>
             ` : html`
-              <button type="button" id="trigger-job" class="btn btn-warning" onClick=${onTrigger} disabled=${triggerLoading}>
+              <button type="button" id="trigger-job" class="btn btn-warning" title="Trigger job" onClick=${onTrigger} disabled=${triggerLoading}>
                 <i class="bi bi-play-circle"></i> ${triggerLoading ? 'Triggering...' : 'Trigger Job'}
               </button>
-              <button type="button" id="pause-job" class="btn btn-primary" onClick=${onPause} disabled=${pauseLoading}>
+              <button type="button" id="pause-job" class="btn btn-primary" title="Pause job" onClick=${onPause} disabled=${pauseLoading}>
                 <i class="bi bi-pause-circle"></i> ${pauseLoading ? 'Pausing...' : 'Pause Job'}
               </button>
             `}

--- a/pikoci/transport/http/authorization.go
+++ b/pikoci/transport/http/authorization.go
@@ -37,6 +37,7 @@ var (
 		ListTeams:        requireRole(role.Read),
 		GetTeam:          requireRole(role.Read),
 		GetJobBuild:      requireRole(role.Read),
+		GetBuildReport:   requireRole(role.Read),
 		ChangePassword:   requireRole(role.Read),
 		UpdateProfile:    requireRole(role.Read),
 		ListTriggersAfter: requireRole(role.Read),

--- a/pikoci/transport/http/authorization_test.go
+++ b/pikoci/transport/http/authorization_test.go
@@ -39,6 +39,7 @@ func TestRoleAuthorizationMatrix(t *testing.T) {
 		{"viewer can list pipelines", http.MethodGet, "/teams/main/pipelines", role.Read, false, true},
 		{"viewer can get team", http.MethodGet, "/teams/main", role.Read, false, true},
 		{"viewer can list audit log", http.MethodGet, "/teams/main/audit", role.Read, false, true},
+		{"viewer can get build report", http.MethodGet, "/teams/main/pipelines/p/jobs/j/builds/1/report", role.Read, false, true},
 
 		// --- Operator routes: operator+ allowed, viewer denied ---
 		{"operator can trigger job", http.MethodPost, "/teams/main/pipelines/p/jobs/j/trigger", role.Write, false, true},
@@ -115,6 +116,7 @@ func TestRoleAuthorizationMatrix(t *testing.T) {
 		svc.EXPECT().ListAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, false, nil).AnyTimes()
 			svc.EXPECT().ApproveBuild(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			svc.EXPECT().RejectBuild(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			svc.EXPECT().GetBuildReport(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
 			// Sign JWT
 			token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"user": um})

--- a/pikoci/transport/http/builds.go
+++ b/pikoci/transport/http/builds.go
@@ -225,6 +225,32 @@ func getJobBuild(s pikoci.Service) http.HandlerFunc {
 	}
 }
 
+type GetBuildReportResponse struct {
+	Report *build.BuildReport `json:"data,omitempty"`
+	Err    string             `json:"error,omitempty"`
+}
+
+func (r GetBuildReportResponse) Error() string { return r.Err }
+
+func getBuildReport(s pikoci.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var ctx = r.Context()
+		vars := mux.Vars(r)
+		tc := vars["team_canonical"]
+		pc := vars["pipeline_canonical"]
+		jn := vars["job_name"]
+		bn := vars["build_number"]
+		report, err := s.GetBuildReport(ctx, tc, pc, jn, bn)
+		var errs string
+		if err != nil {
+			errs = err.Error()
+		} else {
+			w.Header().Set("Content-Disposition", "attachment; filename=build-report-"+bn+".json")
+		}
+		encodeResponse(GetBuildReportResponse{Report: report, Err: errs}, w)
+	}
+}
+
 type CancelJobBuildResponse struct {
 	Err string `json:"error,omitempty"`
 }

--- a/pikoci/transport/http/client/client.go
+++ b/pikoci/transport/http/client/client.go
@@ -757,6 +757,22 @@ func (cl *Client) GetJobBuild(ctx context.Context, tc, pn, jn string, buildNumbe
 	return resp.Build, nil
 }
 
+// GetBuildReport retrieves a structured JSON report for a build.
+func (cl *Client) GetBuildReport(ctx context.Context, tc, pn, jn string, buildNumber string) (*build.BuildReport, error) {
+	var resp thttp.GetBuildReportResponse
+
+	err := cl.Request(ctx, http.MethodGet, fmt.Sprintf("%s/teams/%s/pipelines/%s/jobs/%s/builds/%s/report", cl.url, tc, pn, jn, buildNumber), nil, &resp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make request: %w", err)
+	}
+
+	if resp.Err != "" {
+		return nil, fmt.Errorf("error from request: %s", resp.Err)
+	}
+
+	return resp.Report, nil
+}
+
 // CancelJobBuild cancels a running build.
 func (cl *Client) CancelJobBuild(ctx context.Context, tc, pn, jn string, buildNumber string) error {
 	var resp thttp.CancelJobBuildResponse

--- a/pikoci/transport/http/handler.go
+++ b/pikoci/transport/http/handler.go
@@ -284,6 +284,7 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, 
 	api.Methods(http.MethodPut).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/builds/{build_number}").Name(UpdateJobBuild.String()).Handler(updateJobBuild(s))
 	api.Methods(http.MethodDelete).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/builds/{build_number}").Name(DeleteJobBuild.String()).Handler(deleteJobBuild(s))
 	api.Methods(http.MethodGet).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/builds/{build_number}").Name(GetJobBuild.String()).Handler(getJobBuild(s))
+	api.Methods(http.MethodGet).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/builds/{build_number}/report").Name(GetBuildReport.String()).Handler(getBuildReport(s))
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/builds/{build_number}/cancel").Name(CancelJobBuild.String()).Handler(cancelJobBuild(s))
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/builds/{build_number}/retry").Name(RetryJobBuild.String()).Handler(retryJobBuild(s))
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/builds/{build_number}/approve").Name(ApproveBuild.String()).Handler(approveBuild(s))

--- a/pikoci/transport/http/handler_test.go
+++ b/pikoci/transport/http/handler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/pikoci/pikoci/pikoci/build"
 	"github.com/pikoci/pikoci/pikoci/mock"
 	"github.com/pikoci/pikoci/pikoci/pipeline"
 	"github.com/pikoci/pikoci/pikoci/resource"
@@ -773,6 +774,116 @@ func TestGetPipelineImage_Error_ReturnsJSON(t *testing.T) {
 	assert.NotEmpty(t, result.Err)
 }
 
+
+func TestGetBuildReport_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	handler := Handler(s, secret, logger, nil, "", "test", "abc1234")
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	um := &user.WithMemberships{
+		User:        user.User{Username: "admin", Admin: true},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Admin}},
+	}
+	jwtToken := signJWT(t, secret, um)
+
+	report := &build.BuildReport{
+		ReportVersion: "1",
+		Team:          "main",
+		Pipeline:      "my-pipeline",
+		Job:           "my-job",
+		Build:         build.BuildReportData{Number: "1", Status: "succeeded"},
+		Approvals:     []build.Approval{},
+		Steps:         []build.Step{{Type: "task", Name: "echo", Status: build.Succeeded}},
+		JobLogs:       []build.Step{},
+	}
+	s.EXPECT().GetUser(gomock.Any(), "admin").Return(um, nil).AnyTimes()
+	s.EXPECT().GetBuildReport(gomock.Any(), "main", "my-pipeline", "my-job", "1").Return(report, nil)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams/main/pipelines/my-pipeline/jobs/my-job/builds/1/report", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+jwtToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Disposition"), "attachment")
+	assert.Contains(t, resp.Header.Get("Content-Disposition"), "build-report-1.json")
+
+	var result GetBuildReportResponse
+	json.NewDecoder(resp.Body).Decode(&result)
+	assert.Empty(t, result.Err)
+	require.NotNil(t, result.Report)
+	assert.Equal(t, "1", result.Report.ReportVersion)
+	assert.Equal(t, "main", result.Report.Team)
+	assert.Equal(t, "1", result.Report.Build.Number)
+	assert.Len(t, result.Report.Steps, 1)
+}
+
+func TestGetBuildReport_Error_NoContentDisposition(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	handler := Handler(s, secret, logger, nil, "", "test", "abc1234")
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	um := &user.WithMemberships{
+		User:        user.User{Username: "admin", Admin: true},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Admin}},
+	}
+	jwtToken := signJWT(t, secret, um)
+
+	s.EXPECT().GetUser(gomock.Any(), "admin").Return(um, nil).AnyTimes()
+	s.EXPECT().GetBuildReport(gomock.Any(), "main", "my-pipeline", "my-job", "99").Return(nil, assert.AnError)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams/main/pipelines/my-pipeline/jobs/my-job/builds/99/report", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+jwtToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Empty(t, resp.Header.Get("Content-Disposition"), "error responses should not have Content-Disposition")
+
+	var result GetBuildReportResponse
+	json.NewDecoder(resp.Body).Decode(&result)
+	assert.NotEmpty(t, result.Err)
+	assert.Nil(t, result.Report)
+}
+
+func TestGetBuildReport_UnauthenticatedDenied(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	handler := Handler(s, secret, logger, nil, "", "test", "abc1234")
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams/main/pipelines/my-pipeline/jobs/my-job/builds/1/report", nil)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
 
 func TestWorkerHeartbeat_WithWorkerToken(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/pikoci/transport/http/route_names.go
+++ b/pikoci/transport/http/route_names.go
@@ -164,6 +164,9 @@ const (
 	// ListAuditLog is the route for listing audit log entries for a team.
 	ListAuditLog
 
+	// GetBuildReport is the route for exporting a build report as JSON.
+	GetBuildReport
+
 	// ApproveBuild is the route for approving a build waiting for approval.
 	ApproveBuild
 	// RejectBuild is the route for rejecting a build waiting for approval.

--- a/pikoci/transport/http/route_names_string.go
+++ b/pikoci/transport/http/route_names_string.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _RouteNameName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_joblist_pipeline_jobsget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobslist_pipeline_resourcesget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionget_resource_version_pathwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_workercreate_api_tokenlist_api_tokensdelete_api_tokenlist_audit_logapprove_buildreject_build"
+const _RouteNameName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_joblist_pipeline_jobsget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobslist_pipeline_resourcesget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionget_resource_version_pathwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_workercreate_api_tokenlist_api_tokensdelete_api_tokenlist_audit_logget_build_reportapprove_buildreject_build"
 
-var _RouteNameIndex = [...]uint16{0, 10, 23, 34, 44, 52, 63, 74, 89, 103, 114, 124, 132, 143, 154, 172, 190, 208, 223, 238, 250, 265, 279, 297, 318, 338, 356, 372, 388, 410, 426, 442, 457, 481, 504, 517, 533, 548, 567, 592, 626, 650, 673, 694, 718, 743, 766, 788, 808, 830, 854, 879, 894, 918, 932, 951, 966, 980, 996, 1005, 1016, 1027, 1043, 1055, 1069, 1082, 1098, 1113, 1129, 1143, 1156, 1168}
+var _RouteNameIndex = [...]uint16{0, 10, 23, 34, 44, 52, 63, 74, 89, 103, 114, 124, 132, 143, 154, 172, 190, 208, 223, 238, 250, 265, 279, 297, 318, 338, 356, 372, 388, 410, 426, 442, 457, 481, 504, 517, 533, 548, 567, 592, 626, 650, 673, 694, 718, 743, 766, 788, 808, 830, 854, 879, 894, 918, 932, 951, 966, 980, 996, 1005, 1016, 1027, 1043, 1055, 1069, 1082, 1098, 1113, 1129, 1143, 1159, 1172, 1184}
 
-const _RouteNameLowerName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_joblist_pipeline_jobsget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobslist_pipeline_resourcesget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionget_resource_version_pathwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_workercreate_api_tokenlist_api_tokensdelete_api_tokenlist_audit_logapprove_buildreject_build"
+const _RouteNameLowerName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_joblist_pipeline_jobsget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobslist_pipeline_resourcesget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionget_resource_version_pathwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_workercreate_api_tokenlist_api_tokensdelete_api_tokenlist_audit_logget_build_reportapprove_buildreject_build"
 
 func (i RouteName) String() string {
 	if i < 0 || i >= RouteName(len(_RouteNameIndex)-1) {
@@ -93,11 +93,12 @@ func _RouteNameNoOp() {
 	_ = x[ListApiTokens-(66)]
 	_ = x[DeleteApiToken-(67)]
 	_ = x[ListAuditLog-(68)]
-	_ = x[ApproveBuild-(69)]
-	_ = x[RejectBuild-(70)]
+	_ = x[GetBuildReport-(69)]
+	_ = x[ApproveBuild-(70)]
+	_ = x[RejectBuild-(71)]
 }
 
-var _RouteNameValues = []RouteName{UserLogin, RefreshToken, CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser, ChangePassword, UpdateProfile, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, ListPipelineJobs, GetPipelineJob, CreateJobBuild, CreateRetryJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, InsertBuildGetVersion, FindBuildGetVersions, GetJobBuild, CancelJobBuild, RetryJobBuild, StartPendingBuild, FindOldestPendingBuild, NotifySerialGroupPendingBuilds, EvaluateDownstreamJobs, ListPipelineResources, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions, PinResourceVersion, UnpinResourceVersion, TriggerResourceVersion, GetResourceVersionPath, WebhookTrigger, RegenerateWebhookToken, CreateTrigger, ListTriggersAfter, ExportDatabase, PausePipeline, UnpausePipeline, PauseJob, UnpauseJob, GetVersion, WorkerHeartbeat, ListWorkers, WorkersHealth, DeleteWorker, CreateApiToken, ListApiTokens, DeleteApiToken, ListAuditLog, ApproveBuild, RejectBuild}
+var _RouteNameValues = []RouteName{UserLogin, RefreshToken, CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser, ChangePassword, UpdateProfile, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, ListPipelineJobs, GetPipelineJob, CreateJobBuild, CreateRetryJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, InsertBuildGetVersion, FindBuildGetVersions, GetJobBuild, CancelJobBuild, RetryJobBuild, StartPendingBuild, FindOldestPendingBuild, NotifySerialGroupPendingBuilds, EvaluateDownstreamJobs, ListPipelineResources, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions, PinResourceVersion, UnpinResourceVersion, TriggerResourceVersion, GetResourceVersionPath, WebhookTrigger, RegenerateWebhookToken, CreateTrigger, ListTriggersAfter, ExportDatabase, PausePipeline, UnpausePipeline, PauseJob, UnpauseJob, GetVersion, WorkerHeartbeat, ListWorkers, WorkersHealth, DeleteWorker, CreateApiToken, ListApiTokens, DeleteApiToken, ListAuditLog, GetBuildReport, ApproveBuild, RejectBuild}
 
 var _RouteNameNameToValueMap = map[string]RouteName{
 	_RouteNameName[0:10]:           UserLogin,
@@ -238,10 +239,12 @@ var _RouteNameNameToValueMap = map[string]RouteName{
 	_RouteNameLowerName[1113:1129]: DeleteApiToken,
 	_RouteNameName[1129:1143]:      ListAuditLog,
 	_RouteNameLowerName[1129:1143]: ListAuditLog,
-	_RouteNameName[1143:1156]:      ApproveBuild,
-	_RouteNameLowerName[1143:1156]: ApproveBuild,
-	_RouteNameName[1156:1168]:      RejectBuild,
-	_RouteNameLowerName[1156:1168]: RejectBuild,
+	_RouteNameName[1143:1159]:      GetBuildReport,
+	_RouteNameLowerName[1143:1159]: GetBuildReport,
+	_RouteNameName[1159:1172]:      ApproveBuild,
+	_RouteNameLowerName[1159:1172]: ApproveBuild,
+	_RouteNameName[1172:1184]:      RejectBuild,
+	_RouteNameLowerName[1172:1184]: RejectBuild,
 }
 
 var _RouteNameNames = []string{
@@ -314,8 +317,9 @@ var _RouteNameNames = []string{
 	_RouteNameName[1098:1113],
 	_RouteNameName[1113:1129],
 	_RouteNameName[1129:1143],
-	_RouteNameName[1143:1156],
-	_RouteNameName[1156:1168],
+	_RouteNameName[1143:1159],
+	_RouteNameName[1159:1172],
+	_RouteNameName[1172:1184],
 }
 
 // RouteNameString retrieves an enum value from the enum constants string name.


### PR DESCRIPTION
## Summary

- Add JSON build report export with full audit trail: status, steps, logs, approvals, version data
- API: `GET /teams/{tc}/pipelines/{pc}/jobs/{jn}/builds/{bn}/report` with `Content-Disposition: attachment` header
- CLI: `pikoci client builds report --build-number N [--output file.json]`
- UI: Export button on build detail page (Read+ users only)
- All buttons in Jobs.js now have `title` attributes for accessibility

Closes #531