### PR TITLE
feat: add secret chaining for variable path/key expressions (#248)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Secret chaining**: Secret-backed variables can now reference other variables in their `path` and `key` fields (e.g., `path = var.key_path`). Dependencies are resolved automatically in topological order with cycle detection and a max depth of 10 levels. Secret type config values that contain secret placeholders are also resolved in dependency order ([#248](https://github.com/PikoCI/pikoci/issues/248)).
 - **Approval gates**: `approve` HCL block on jobs creates a human approval gate. Purple "Waiting for Approval" status, approve/reject UI+CLI+API (Maintain+), configurable count, notifications, version pinning, audit events ([#152](https://github.com/PikoCI/pikoci/issues/152)).
 - **Version pinning at build creation**: Downstream builds snapshot triggered resource versions at creation time, matching Concourse CI behavior.
 - **Audit log**: Append-only team audit trail with 16 event types, filterable UI/CLI/API, cursor-based pagination. Read+ access ([#532](https://github.com/PikoCI/pikoci/issues/532)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Secret chaining**: Secret-backed variables can now reference other variables in their `path` and `key` fields (e.g., `path = var.key_path`). Dependencies are resolved automatically in topological order with cycle detection and a max depth of 10 levels. Secret type config values that contain secret placeholders are also resolved in dependency order ([#248](https://github.com/PikoCI/pikoci/issues/248)).
+- **Secret chaining**: Secret `path`/`key` fields and `secret_type` config can now reference other variables, resolved in dependency order with cycle detection ([#248](https://github.com/PikoCI/pikoci/issues/248)).
 - **Approval gates**: `approve` HCL block on jobs creates a human approval gate. Purple "Waiting for Approval" status, approve/reject UI+CLI+API (Maintain+), configurable count, notifications, version pinning, audit events ([#152](https://github.com/PikoCI/pikoci/issues/152)).
 - **Version pinning at build creation**: Downstream builds snapshot triggered resource versions at creation time, matching Concourse CI behavior.
 - **Audit log**: Append-only team audit trail with 16 event types, filterable UI/CLI/API, cursor-based pagination. Read+ access ([#532](https://github.com/PikoCI/pikoci/issues/532)).

--- a/docs/Secret-Types.md
+++ b/docs/Secret-Types.md
@@ -102,7 +102,40 @@ job "deploy" {
 
 Secret-backed variables are resolved lazily at runtime — every resource check, get, task, or put execution fetches the latest secret value. This means rotated secrets are picked up automatically without pipeline updates.
 
-For more details on secret-backed variables, including precedence rules and override behavior, see [Variables](Variables.md).
+### Config chaining
+
+Secret type config fields can reference secret-backed variables. This enables patterns like reading a vault address from a `.env` file, then using it to connect to vault:
+
+```hcl
+variable "vault_addr" {
+  type = string
+  secret "env" {
+    key = "VAULT_ADDR"
+  }
+}
+
+variable "vault_token" {
+  type = string  # provided via vars file
+}
+
+secret_type "my-vault" {
+  source  = "pikoci://vault"
+  address = var.vault_addr    # resolved from .env before vault secrets are fetched
+  token   = var.vault_token
+}
+
+variable "db_pass" {
+  type = string
+  secret "my-vault" {
+    path = "secret/data/db"
+    key  = "password"
+  }
+}
+```
+
+Dependencies between secrets are resolved automatically in the correct order.
+
+For more details on secret-backed variables, including precedence rules, override behavior, and secret chaining, see [Variables](Variables.md).
 
 ## Built-in: vault
 

--- a/docs/Variables.md
+++ b/docs/Variables.md
@@ -117,6 +117,56 @@ This lets you override secrets with plaintext for local development:
 }
 ```
 
+### Secret chaining
+
+The `path` and `key` fields in a `secret` block can reference other variables using `var.<name>` or string interpolation `${var.<name>}`. This enables patterns where one secret's location is itself stored in another secret:
+
+```hcl
+# Step 1: Read the key file path from a .env file
+variable "key_path" {
+  type = string
+  secret "env" {
+    key = "GITHUB_APP_KEY_FILE"
+  }
+}
+
+# Step 2: Read the key content from the file at that path
+variable "key_content" {
+  type = string
+  secret "file" {
+    path = var.key_path
+    key  = "content"
+  }
+}
+
+# String interpolation also works
+variable "nested_secret" {
+  type = string
+  secret "file" {
+    path = "${var.key_path}/subdir"
+    key  = "content"
+  }
+}
+
+# Key chaining — the key name itself comes from another variable
+variable "key_name" {
+  type = string
+  secret "env" {
+    key = "SECRET_KEY_NAME"
+  }
+}
+
+variable "dynamic_secret" {
+  type = string
+  secret "vault" {
+    path = "secret/data/app"
+    key  = var.key_name
+  }
+}
+```
+
+Dependencies are resolved automatically in the correct order — you don't need to worry about declaration order. Circular dependencies are detected with a clear error message. The maximum chain depth is 10 levels.
+
 ### Full example
 
 ```hcl

--- a/pikoci/helper.go
+++ b/pikoci/helper.go
@@ -932,14 +932,27 @@ func ReadPipeline(ctx context.Context, rpp []byte, vars map[string]interface{}) 
 	funcs := hclFunctions()
 	ectx := pipeline.TypeEvalContext()
 	ectx.Functions = funcs
-	var pvars pipeline.Variables
+	// Use VariablesBasic to avoid decoding secret block internals (which may
+	// contain expressions like path = var.x that aren't resolvable yet).
+	var pvars pipeline.VariablesBasic
 	err := hclsimple.Decode("pipeline.hcl", rpp, ectx, &pvars)
 	if err != nil {
 		return nil, fmt.Errorf("failed to Decode Pipeline config: %w", err)
 	}
 
+	// Pass 1: Build ecvars with defaults and temporary placeholders for secret vars.
+	// Secret block details (type, path, key) are extracted from AST below.
 	ecvars := make(map[string]cty.Value)
 	secretVars := make(map[string]pipeline.VariableSecret)
+
+	// Parse secret blocks from AST with TypeEvalContext (no var.* yet).
+	// For literal path/key this resolves correctly; for expressions referencing
+	// var.*, per-attribute fallback produces empty strings — pass 2 re-evaluates.
+	preSecrets, err := pipeline.ParseSecretBlocksFromASTLenient(rpp, ectx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse secret blocks: %w", err)
+	}
+
 	for _, v := range pvars.Variables {
 		switch v.Type {
 		case "string":
@@ -949,11 +962,11 @@ func ReadPipeline(ctx context.Context, rpp []byte, vars map[string]interface{}) 
 					return nil, fmt.Errorf("variable %q configured with invalid type type, expected 'string'", v.Name)
 				}
 				ecvars[v.Name] = cty.StringVal(s)
-			} else if v.Secret != nil {
+			} else if sv, ok := preSecrets[v.Name]; ok {
 				placeholder := fmt.Sprintf("__pikoci_secret:%s:%s:%s__",
-					v.Secret.Type, v.Secret.Path, v.Secret.Key)
+					sv.Type, sv.Path, sv.Key)
 				ecvars[v.Name] = cty.StringVal(placeholder)
-				secretVars[v.Name] = *v.Secret
+				secretVars[v.Name] = sv
 			} else {
 				a, ok := v.Default.(*hcl.Attribute)
 				if !ok {
@@ -1009,6 +1022,30 @@ func ReadPipeline(ctx context.Context, rpp []byte, vars map[string]interface{}) 
 			}
 		}
 	}
+
+	// Pass 2: Re-evaluate secret block path/key as HCL expressions against the
+	// fully-populated eval context, so they can reference other variables.
+	if len(secretVars) > 0 {
+		varEctx := &hcl.EvalContext{
+			Variables: map[string]cty.Value{
+				"var": cty.ObjectVal(ecvars),
+			},
+			Functions: funcs,
+		}
+		resolvedSecrets, err := pipeline.ParseSecretBlocksFromAST(rpp, varEctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to evaluate secret expressions: %w", err)
+		}
+		for varName := range secretVars {
+			if sv, ok := resolvedSecrets[varName]; ok {
+				secretVars[varName] = sv
+				placeholder := fmt.Sprintf("__pikoci_secret:%s:%s:%s__",
+					sv.Type, sv.Path, sv.Key)
+				ecvars[varName] = cty.StringVal(placeholder)
+			}
+		}
+	}
+
 	ectx = &hcl.EvalContext{
 		Variables: map[string]cty.Value{
 			"var": cty.ObjectVal(ecvars),

--- a/pikoci/pipeline/pipeline.go
+++ b/pikoci/pipeline/pipeline.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsimple"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pikoci/pikoci/pikoci/builtin"
 	"github.com/pikoci/pikoci/pikoci/job"
 	"github.com/pikoci/pikoci/pikoci/notification"
@@ -78,6 +79,23 @@ type Variable struct {
 	Type    string          `json:"type" hcl:"type"`
 	Default interface{}     `json:"default" hcl:"default,optional"`
 	Secret  *VariableSecret `json:"secret,omitempty" hcl:"secret,block"`
+}
+
+// VariablesBasic is like Variables but does NOT decode secret block internals.
+// This is needed because secret blocks may contain expressions (path = var.x)
+// that reference variables not yet in the eval context during initial parsing.
+type VariablesBasic struct {
+	Variables []VariableBasic `hcl:"variable,block"`
+	Remain    hcl.Body        `hcl:",remain"`
+}
+
+// VariableBasic is like Variable but without secret block decoding.
+// Secret blocks go into Remain and are parsed separately from the AST.
+type VariableBasic struct {
+	Name    string      `hcl:"name,label"`
+	Type    string      `hcl:"type"`
+	Default interface{} `hcl:"default,optional"`
+	Remain  hcl.Body    `hcl:",remain"`
 }
 
 // VariableSecret references a secret value for a pipeline variable. The Type
@@ -284,18 +302,99 @@ func convertHCLService(hs hclServiceRaw) service.Service {
 	return s
 }
 
-// hclVariableRaw is a minimal struct for parsing variable blocks from raw HCL.
-type hclVariableRaw struct {
-	Name   string          `hcl:"name,label"`
-	Type   string          `hcl:"type"`
-	Secret *VariableSecret `hcl:"secret,block"`
-	Remain hcl.Body        `hcl:",remain"`
+// hclPipelineVariables is a minimal struct for parsing only variable blocks from raw HCL.
+// Uses VariableBasic (no secret block decoding) so path = var.x doesn't fail.
+type hclPipelineVariables struct {
+	Variables []VariableBasic `hcl:"variable,block"`
+	Remain    hcl.Body        `hcl:",remain"`
 }
 
-// hclPipelineVariables is a minimal struct for parsing only variable blocks from raw HCL.
-type hclPipelineVariables struct {
-	Variables []hclVariableRaw `hcl:"variable,block"`
-	Remain    hcl.Body         `hcl:",remain"`
+// ParseSecretBlocksFromASTLenient is like ParseSecretBlocksFromAST but uses
+// per-attribute fallback: if a path/key expression fails to evaluate (e.g.,
+// because it references var.* not yet in scope), the field is left empty
+// instead of returning an error. This is used for pass 1 bootstrapping.
+func ParseSecretBlocksFromASTLenient(raw []byte, ectx *hcl.EvalContext) (map[string]VariableSecret, error) {
+	file, diags := hclsyntax.ParseConfig(raw, "pipeline.hcl", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("failed to parse pipeline HCL: %s", diags.Error())
+	}
+
+	result := make(map[string]VariableSecret)
+	for _, block := range file.Body.(*hclsyntax.Body).Blocks {
+		if block.Type != "variable" || len(block.Labels) == 0 {
+			continue
+		}
+		varName := block.Labels[0]
+		for _, sub := range block.Body.Blocks {
+			if sub.Type != "secret" || len(sub.Labels) == 0 {
+				continue
+			}
+			sv := VariableSecret{Type: sub.Labels[0]}
+			if attr, exists := sub.Body.Attributes["path"]; exists {
+				if val, vd := attr.Expr.Value(ectx); !vd.HasErrors() && val.Type() == cty.String {
+					sv.Path = val.AsString()
+				}
+			}
+			if attr, exists := sub.Body.Attributes["key"]; exists {
+				if val, vd := attr.Expr.Value(ectx); !vd.HasErrors() && val.Type() == cty.String {
+					sv.Key = val.AsString()
+				}
+			}
+			result[varName] = sv
+			break
+		}
+	}
+	return result, nil
+}
+
+// ParseSecretBlocksFromAST extracts secret block information from raw HCL using
+// AST traversal. This is needed because secret block path/key may contain
+// variable expressions (e.g., path = var.x) that can't be decoded via struct
+// tags when var.* isn't in the eval context. The ectx must be non-nil and
+// should contain the full var.* namespace for expression evaluation.
+func ParseSecretBlocksFromAST(raw []byte, ectx *hcl.EvalContext) (map[string]VariableSecret, error) {
+	file, diags := hclsyntax.ParseConfig(raw, "pipeline.hcl", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("failed to parse pipeline HCL: %s", diags.Error())
+	}
+
+	result := make(map[string]VariableSecret)
+	for _, block := range file.Body.(*hclsyntax.Body).Blocks {
+		if block.Type != "variable" || len(block.Labels) == 0 {
+			continue
+		}
+		varName := block.Labels[0]
+		for _, sub := range block.Body.Blocks {
+			if sub.Type != "secret" || len(sub.Labels) == 0 {
+				continue
+			}
+			sv := VariableSecret{Type: sub.Labels[0]}
+
+			if attr, exists := sub.Body.Attributes["path"]; exists {
+				val, vdiags := attr.Expr.Value(ectx)
+				if vdiags.HasErrors() {
+					return nil, fmt.Errorf("failed to evaluate secret path for variable %q: %s", varName, vdiags.Error())
+				}
+				if val.Type() != cty.String {
+					return nil, fmt.Errorf("secret path for variable %q must be a string, got %s", varName, val.Type().FriendlyName())
+				}
+				sv.Path = val.AsString()
+			}
+			if attr, exists := sub.Body.Attributes["key"]; exists {
+				val, vdiags := attr.Expr.Value(ectx)
+				if vdiags.HasErrors() {
+					return nil, fmt.Errorf("failed to evaluate secret key for variable %q: %s", varName, vdiags.Error())
+				}
+				if val.Type() != cty.String {
+					return nil, fmt.Errorf("secret key for variable %q must be a string, got %s", varName, val.Type().FriendlyName())
+				}
+				sv.Key = val.AsString()
+			}
+			result[varName] = sv
+			break
+		}
+	}
+	return result, nil
 }
 
 // ParseSecretVarsFromRaw parses secret-backed variable declarations from raw pipeline HCL.
@@ -305,21 +404,23 @@ func ParseSecretVarsFromRaw(raw []byte, vars map[string]interface{}) (map[string
 		return nil, nil
 	}
 
-	ectx := TypeEvalContext()
-
-	var pv hclPipelineVariables
-	err := hclsimple.Decode("pipeline.hcl", raw, ectx, &pv)
+	// Build eval context with all variable defaults/placeholders so that
+	// path/key expressions like `path = var.x` can be resolved.
+	varEctx, err := buildVarEvalContextWithOverrides(raw, vars)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse variables from raw HCL: %w", err)
+		return nil, fmt.Errorf("failed to build eval context for secret parsing: %w", err)
 	}
 
-	secretVars := make(map[string]VariableSecret)
-	for _, v := range pv.Variables {
-		if v.Secret != nil {
-			// Only include if not overridden by vars file
-			if _, overridden := vars[v.Name]; !overridden {
-				secretVars[v.Name] = *v.Secret
-			}
+	// Parse secret blocks from AST using the full eval context.
+	secretVars, err := ParseSecretBlocksFromAST(raw, varEctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Exclude variables overridden by vars file
+	for varName := range secretVars {
+		if _, overridden := vars[varName]; overridden {
+			delete(secretVars, varName)
 		}
 	}
 
@@ -335,16 +436,29 @@ func ParseSecretVarsFromRaw(raw []byte, vars map[string]interface{}) (map[string
 func buildVarEvalContext(raw []byte) (*hcl.EvalContext, error) {
 	typeCtx := TypeEvalContext()
 
-	var pvars Variables
-	if err := hclsimple.Decode("pipeline.hcl", raw, typeCtx, &pvars); err != nil {
+	// Use hclPipelineVariables (which doesn't decode secret internals) so
+	// that secret blocks with path = var.x don't cause decode failures.
+	var pv hclPipelineVariables
+	if err := hclsimple.Decode("pipeline.hcl", raw, typeCtx, &pv); err != nil {
 		return nil, fmt.Errorf("failed to parse variables: %w", err)
 	}
 
+	// Detect secret blocks from AST using the lenient parser. Expression
+	// evaluation uses TypeEvalContext (no var.*), so expressions referencing
+	// var.* fall back to empty strings — the exact path/key are not needed
+	// for the eval context, only that the variable produces a string placeholder.
+	secretBlocks, err := ParseSecretBlocksFromASTLenient(raw, typeCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Now parse default values for non-secret variables
 	ecvars := make(map[string]cty.Value)
-	for _, v := range pvars.Variables {
-		if v.Secret != nil {
+	for _, v := range pv.Variables {
+		if _, isSecret := secretBlocks[v.Name]; isSecret {
+			sv := secretBlocks[v.Name]
 			placeholder := fmt.Sprintf("__pikoci_secret:%s:%s:%s__",
-				v.Secret.Type, v.Secret.Path, v.Secret.Key)
+				sv.Type, sv.Path, sv.Key)
 			ecvars[v.Name] = cty.StringVal(placeholder)
 			continue
 		}
@@ -360,8 +474,8 @@ func buildVarEvalContext(raw []byte) (*hcl.EvalContext, error) {
 			}
 			continue
 		}
-		ctyv, diags := a.Expr.Value(typeCtx)
-		if diags.HasErrors() {
+		ctyv, evalDiags := a.Expr.Value(typeCtx)
+		if evalDiags.HasErrors() {
 			switch v.Type {
 			case "number":
 				ecvars[v.Name] = cty.NumberIntVal(0)
@@ -384,4 +498,38 @@ func buildVarEvalContext(raw []byte) (*hcl.EvalContext, error) {
 			"var": cty.ObjectVal(ecvars),
 		},
 	}, nil
+}
+
+// buildVarEvalContextWithOverrides is like buildVarEvalContext but applies
+// vars file overrides, so that overridden variables resolve to their override
+// value instead of a secret placeholder.
+func buildVarEvalContextWithOverrides(raw []byte, vars map[string]interface{}) (*hcl.EvalContext, error) {
+	ectx, err := buildVarEvalContext(raw)
+	if err != nil {
+		return nil, err
+	}
+	if len(vars) == 0 {
+		return ectx, nil
+	}
+
+	// Extract the current var object and override with provided values
+	varObj := ectx.Variables["var"]
+	ecvars := varObj.AsValueMap()
+	if ecvars == nil {
+		ecvars = make(map[string]cty.Value)
+	}
+	for k, v := range vars {
+		switch val := v.(type) {
+		case string:
+			ecvars[k] = cty.StringVal(val)
+		case float64:
+			ecvars[k] = cty.NumberFloatVal(val)
+		case bool:
+			ecvars[k] = cty.BoolVal(val)
+		default:
+			return nil, fmt.Errorf("unsupported override type %T for variable %q", v, k)
+		}
+	}
+	ectx.Variables["var"] = cty.ObjectVal(ecvars)
+	return ectx, nil
 }

--- a/pikoci/pipeline/pipeline_test.go
+++ b/pikoci/pipeline/pipeline_test.go
@@ -541,6 +541,251 @@ variable "db_pass" {
 	})
 }
 
+func TestParseSecretVarsFromRaw_SecretChaining(t *testing.T) {
+	t.Run("path references variable with default", func(t *testing.T) {
+		raw := []byte(`
+variable "base_path" {
+  type    = string
+  default = "/etc/secrets"
+}
+
+variable "key_content" {
+  type = string
+  secret "file" {
+    path = var.base_path
+    key  = "content"
+  }
+}
+`)
+		secretVars, err := pipeline.ParseSecretVarsFromRaw(raw, nil)
+		require.NoError(t, err)
+		require.Len(t, secretVars, 1)
+
+		kc, ok := secretVars["key_content"]
+		require.True(t, ok)
+		assert.Equal(t, "file", kc.Type)
+		assert.Equal(t, "/etc/secrets", kc.Path)
+		assert.Equal(t, "content", kc.Key)
+	})
+
+	t.Run("path references secret-backed variable contains placeholder", func(t *testing.T) {
+		raw := []byte(`
+variable "key_path" {
+  type = string
+  secret "env" {
+    key = "KEY_FILE"
+  }
+}
+
+variable "key_content" {
+  type = string
+  secret "file" {
+    path = var.key_path
+    key  = "content"
+  }
+}
+`)
+		secretVars, err := pipeline.ParseSecretVarsFromRaw(raw, nil)
+		require.NoError(t, err)
+		require.Len(t, secretVars, 2)
+
+		kc, ok := secretVars["key_content"]
+		require.True(t, ok)
+		assert.Equal(t, "file", kc.Type)
+		assert.Contains(t, kc.Path, "__pikoci_secret:env::KEY_FILE__")
+		assert.Equal(t, "content", kc.Key)
+	})
+
+	t.Run("path with string interpolation", func(t *testing.T) {
+		raw := []byte(`
+variable "key_path" {
+  type = string
+  secret "env" {
+    key = "KEY_DIR"
+  }
+}
+
+variable "key_content" {
+  type = string
+  secret "file" {
+    path = "${var.key_path}/subdir"
+    key  = "content"
+  }
+}
+`)
+		secretVars, err := pipeline.ParseSecretVarsFromRaw(raw, nil)
+		require.NoError(t, err)
+
+		kc, ok := secretVars["key_content"]
+		require.True(t, ok)
+		assert.Equal(t, "__pikoci_secret:env::KEY_DIR__/subdir", kc.Path)
+	})
+
+	t.Run("key references secret-backed variable", func(t *testing.T) {
+		raw := []byte(`
+variable "key_name" {
+  type = string
+  secret "env" {
+    key = "SECRET_KEY_NAME"
+  }
+}
+
+variable "value" {
+  type = string
+  secret "vault" {
+    path = "secret/data/app"
+    key  = var.key_name
+  }
+}
+`)
+		secretVars, err := pipeline.ParseSecretVarsFromRaw(raw, nil)
+		require.NoError(t, err)
+
+		v, ok := secretVars["value"]
+		require.True(t, ok)
+		assert.Equal(t, "vault", v.Type)
+		assert.Equal(t, "secret/data/app", v.Path)
+		assert.Contains(t, v.Key, "__pikoci_secret:env::SECRET_KEY_NAME__")
+	})
+
+	t.Run("no path just key works as before", func(t *testing.T) {
+		raw := []byte(`
+variable "api_key" {
+  type = string
+  secret "env" {
+    key = "API_KEY"
+  }
+}
+`)
+		secretVars, err := pipeline.ParseSecretVarsFromRaw(raw, nil)
+		require.NoError(t, err)
+		require.Len(t, secretVars, 1)
+
+		ak, ok := secretVars["api_key"]
+		require.True(t, ok)
+		assert.Equal(t, "env", ak.Type)
+		assert.Equal(t, "", ak.Path)
+		assert.Equal(t, "API_KEY", ak.Key)
+	})
+
+	t.Run("dependent declared before dependency still works", func(t *testing.T) {
+		raw := []byte(`
+variable "key_content" {
+  type = string
+  secret "file" {
+    path = var.key_path
+    key  = "content"
+  }
+}
+
+variable "key_path" {
+  type = string
+  secret "env" {
+    key = "KEY_FILE"
+  }
+}
+`)
+		secretVars, err := pipeline.ParseSecretVarsFromRaw(raw, nil)
+		require.NoError(t, err)
+		require.Len(t, secretVars, 2)
+
+		kc, ok := secretVars["key_content"]
+		require.True(t, ok)
+		assert.Contains(t, kc.Path, "__pikoci_secret:env::KEY_FILE__")
+	})
+
+	t.Run("path references undefined variable returns error", func(t *testing.T) {
+		raw := []byte(`
+variable "key_content" {
+  type = string
+  secret "file" {
+    path = var.nonexistent
+    key  = "content"
+  }
+}
+`)
+		_, err := pipeline.ParseSecretVarsFromRaw(raw, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to evaluate secret path")
+	})
+
+	t.Run("path references number variable returns type error", func(t *testing.T) {
+		raw := []byte(`
+variable "some_number" {
+  type    = number
+  default = 42
+}
+
+variable "key_content" {
+  type = string
+  secret "file" {
+    path = var.some_number
+    key  = "content"
+  }
+}
+`)
+		_, err := pipeline.ParseSecretVarsFromRaw(raw, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be a string")
+	})
+
+	t.Run("override in vars breaks chain", func(t *testing.T) {
+		raw := []byte(`
+variable "key_path" {
+  type = string
+  secret "env" {
+    key = "KEY_FILE"
+  }
+}
+
+variable "key_content" {
+  type = string
+  secret "file" {
+    path = var.key_path
+    key  = "content"
+  }
+}
+`)
+		// Override key_path — it's no longer secret-backed, so key_content's
+		// path resolves to the override value directly (no placeholder).
+		vars := map[string]interface{}{
+			"key_path": "/override/path",
+		}
+		secretVars, err := pipeline.ParseSecretVarsFromRaw(raw, vars)
+		require.NoError(t, err)
+		require.Len(t, secretVars, 1)
+
+		// key_path is excluded (overridden)
+		_, ok := secretVars["key_path"]
+		assert.False(t, ok)
+
+		// key_content's path resolves to the override value
+		kc, ok := secretVars["key_content"]
+		require.True(t, ok)
+		assert.Equal(t, "/override/path", kc.Path)
+	})
+
+	t.Run("literal path still works unchanged", func(t *testing.T) {
+		raw := []byte(`
+variable "db_pass" {
+  type = string
+  secret "vault" {
+    path = "secret/data/db"
+    key  = "password"
+  }
+}
+`)
+		secretVars, err := pipeline.ParseSecretVarsFromRaw(raw, nil)
+		require.NoError(t, err)
+		require.Len(t, secretVars, 1)
+
+		dp, ok := secretVars["db_pass"]
+		require.True(t, ok)
+		assert.Equal(t, "secret/data/db", dp.Path)
+		assert.Equal(t, "password", dp.Key)
+	})
+}
+
 func TestTypeEvalContext(t *testing.T) {
 	ectx := pipeline.TypeEvalContext()
 	require.NotNil(t, ectx)

--- a/worker/secret_deps.go
+++ b/worker/secret_deps.go
@@ -1,0 +1,177 @@
+package worker
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/pikoci/pikoci/pikoci/pipeline"
+)
+
+const maxSecretChainDepth = 10
+
+// secretDepGraph represents a dependency graph between secret-backed variables.
+type secretDepGraph struct {
+	// deps maps variable name → set of variable names it depends on
+	deps map[string]map[string]bool
+	// all variable names that are part of the graph
+	vars map[string]bool
+}
+
+// buildSecretDependencyGraph builds a dependency graph for secret-backed variables.
+// It scans each variable's path, key, and associated secret_type config for
+// placeholders that reference other secret variables.
+func buildSecretDependencyGraph(secretVars map[string]pipeline.VariableSecret, pp *pipeline.Pipeline) *secretDepGraph {
+	// Build reverse index: placeholder → variable name
+	placeholderToVar := make(map[string]string)
+	for varName, sv := range secretVars {
+		placeholder := fmt.Sprintf("__pikoci_secret:%s:%s:%s__", sv.Type, sv.Path, sv.Key)
+		placeholderToVar[placeholder] = varName
+	}
+
+	g := &secretDepGraph{
+		deps: make(map[string]map[string]bool),
+		vars: make(map[string]bool),
+	}
+
+	for varName, sv := range secretVars {
+		g.vars[varName] = true
+		g.deps[varName] = make(map[string]bool)
+
+		// Scan path and key for placeholders
+		scanForDeps(g, varName, sv.Path, placeholderToVar)
+		scanForDeps(g, varName, sv.Key, placeholderToVar)
+
+		// Scan associated secret_type config
+		st, ok := pp.SecretType(sv.Type)
+		if ok {
+			for _, configVal := range st.Config {
+				scanForDeps(g, varName, configVal, placeholderToVar)
+			}
+		}
+	}
+
+	return g
+}
+
+// scanForDeps finds all placeholders in s and adds dependency edges from varName
+// to the variable that owns each placeholder.
+func scanForDeps(g *secretDepGraph, varName, s string, placeholderToVar map[string]string) {
+	for placeholder, depVar := range placeholderToVar {
+		if strings.Contains(s, placeholder) {
+			g.deps[varName][depVar] = true
+		}
+	}
+}
+
+// sortedKeys returns sorted keys from a map for deterministic iteration.
+func sortedKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// detectCycle returns a cycle path if one exists, or nil.
+// Iteration order is deterministic (sorted) for reproducible error messages.
+func (g *secretDepGraph) detectCycle() []string {
+	visited := make(map[string]int) // 0=unvisited, 1=in-stack, 2=done
+	var path []string
+
+	var dfs func(node string) []string
+	dfs = func(node string) []string {
+		visited[node] = 1
+		path = append(path, node)
+		for _, dep := range sortedKeys(g.deps[node]) {
+			if visited[dep] == 1 {
+				// Found cycle — extract cycle from path
+				cycleStart := -1
+				for i, n := range path {
+					if n == dep {
+						cycleStart = i
+						break
+					}
+				}
+				cycle := make([]string, len(path[cycleStart:]))
+				copy(cycle, path[cycleStart:])
+				cycle = append(cycle, dep)
+				return cycle
+			}
+			if visited[dep] == 0 {
+				if cycle := dfs(dep); cycle != nil {
+					return cycle
+				}
+			}
+		}
+		path = path[:len(path)-1]
+		visited[node] = 2
+		return nil
+	}
+
+	for _, v := range sortedKeys(g.vars) {
+		if visited[v] == 0 {
+			if cycle := dfs(v); cycle != nil {
+				return cycle
+			}
+		}
+	}
+	return nil
+}
+
+// topologicalSort returns variables grouped into layers. Layer 0 has no
+// dependencies, layer 1 depends only on layer 0, etc. Returns an error
+// if a cycle exists or chain depth exceeds maxSecretChainDepth.
+func (g *secretDepGraph) topologicalSort() ([][]string, error) {
+	// Check for cycles
+	if cycle := g.detectCycle(); cycle != nil {
+		return nil, fmt.Errorf("circular secret dependency: %s", strings.Join(cycle, " -> "))
+	}
+
+	remaining := make(map[string]map[string]bool)
+	for v, deps := range g.deps {
+		remaining[v] = make(map[string]bool)
+		for d := range deps {
+			remaining[v][d] = true
+		}
+	}
+
+	var layers [][]string
+	resolved := make(map[string]bool)
+
+	for len(remaining) > 0 {
+		if len(layers) >= maxSecretChainDepth {
+			return nil, fmt.Errorf("secret dependency chain too deep (max %d levels)", maxSecretChainDepth)
+		}
+
+		// Find all vars with no unresolved deps
+		var layer []string
+		for v, deps := range remaining {
+			allResolved := true
+			for d := range deps {
+				if !resolved[d] {
+					allResolved = false
+					break
+				}
+			}
+			if allResolved {
+				layer = append(layer, v)
+			}
+		}
+
+		if len(layer) == 0 {
+			// Should not happen if cycle detection works, but guard anyway
+			return nil, fmt.Errorf("internal error: no progress in topological sort")
+		}
+
+		sort.Strings(layer)
+		layers = append(layers, layer)
+		for _, v := range layer {
+			resolved[v] = true
+			delete(remaining, v)
+		}
+	}
+
+	return layers, nil
+}

--- a/worker/secret_deps_test.go
+++ b/worker/secret_deps_test.go
@@ -1,0 +1,233 @@
+package worker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/pikoci/pikoci/pikoci/pipeline"
+	"github.com/pikoci/pikoci/pikoci/sectype"
+)
+
+func TestBuildSecretDependencyGraph(t *testing.T) {
+	t.Run("no dependencies", func(t *testing.T) {
+		secretVars := map[string]pipeline.VariableSecret{
+			"a": {Type: "env", Key: "A"},
+			"b": {Type: "env", Key: "B"},
+		}
+		pp := &pipeline.Pipeline{}
+
+		g := buildSecretDependencyGraph(secretVars, pp)
+
+		// No variable depends on any other
+		for _, deps := range g.deps {
+			assert.Empty(t, deps)
+		}
+	})
+
+	t.Run("linear chain A depends on B", func(t *testing.T) {
+		secretVars := map[string]pipeline.VariableSecret{
+			"b": {Type: "env", Key: "B_KEY"},
+			"a": {Type: "file", Path: "__pikoci_secret:env::B_KEY__", Key: "content"},
+		}
+		pp := &pipeline.Pipeline{}
+
+		g := buildSecretDependencyGraph(secretVars, pp)
+
+		assert.True(t, g.deps["a"]["b"])
+		assert.Empty(t, g.deps["b"])
+	})
+
+	t.Run("diamond dependency", func(t *testing.T) {
+		secretVars := map[string]pipeline.VariableSecret{
+			"c": {Type: "env", Key: "C_KEY"},
+			"b": {Type: "env", Key: "B_KEY"},
+			"a": {
+				Type: "vault",
+				Path: "__pikoci_secret:env::B_KEY__",
+				Key:  "__pikoci_secret:env::C_KEY__",
+			},
+		}
+		pp := &pipeline.Pipeline{}
+
+		g := buildSecretDependencyGraph(secretVars, pp)
+
+		assert.True(t, g.deps["a"]["b"])
+		assert.True(t, g.deps["a"]["c"])
+		assert.Empty(t, g.deps["b"])
+		assert.Empty(t, g.deps["c"])
+	})
+
+	t.Run("secret_type config dependency", func(t *testing.T) {
+		secretVars := map[string]pipeline.VariableSecret{
+			"vault_addr": {Type: "env", Key: "VAULT_ADDR"},
+			"db_pass":    {Type: "vault", Path: "secret/data/db", Key: "password"},
+		}
+		pp := &pipeline.Pipeline{
+			SecretTypes: []sectype.SecretType{
+				{
+					Name:   "vault",
+					Config: map[string]string{"address": "__pikoci_secret:env::VAULT_ADDR__"},
+				},
+			},
+		}
+
+		g := buildSecretDependencyGraph(secretVars, pp)
+
+		// db_pass depends on vault_addr via secret_type config
+		assert.True(t, g.deps["db_pass"]["vault_addr"])
+		assert.Empty(t, g.deps["vault_addr"])
+	})
+}
+
+func TestSecretDepGraph_DetectCycle(t *testing.T) {
+	t.Run("no cycle", func(t *testing.T) {
+		g := &secretDepGraph{
+			vars: map[string]bool{"a": true, "b": true},
+			deps: map[string]map[string]bool{
+				"a": {"b": true},
+				"b": {},
+			},
+		}
+		assert.Nil(t, g.detectCycle())
+	})
+
+	t.Run("circular two vars", func(t *testing.T) {
+		g := &secretDepGraph{
+			vars: map[string]bool{"a": true, "b": true},
+			deps: map[string]map[string]bool{
+				"a": {"b": true},
+				"b": {"a": true},
+			},
+		}
+		cycle := g.detectCycle()
+		require.NotNil(t, cycle)
+		// Deterministic: sorted iteration starts at "a", follows a -> b -> a
+		assert.Equal(t, []string{"a", "b", "a"}, cycle)
+	})
+
+	t.Run("self-referential", func(t *testing.T) {
+		g := &secretDepGraph{
+			vars: map[string]bool{"a": true},
+			deps: map[string]map[string]bool{
+				"a": {"a": true},
+			},
+		}
+		cycle := g.detectCycle()
+		require.NotNil(t, cycle)
+		assert.Equal(t, []string{"a", "a"}, cycle)
+	})
+
+	t.Run("circular three vars", func(t *testing.T) {
+		g := &secretDepGraph{
+			vars: map[string]bool{"a": true, "b": true, "c": true},
+			deps: map[string]map[string]bool{
+				"a": {"b": true},
+				"b": {"c": true},
+				"c": {"a": true},
+			},
+		}
+		cycle := g.detectCycle()
+		require.NotNil(t, cycle)
+		assert.Equal(t, []string{"a", "b", "c", "a"}, cycle)
+	})
+}
+
+func TestSecretDepGraph_TopologicalSort(t *testing.T) {
+	t.Run("no dependencies single layer", func(t *testing.T) {
+		g := &secretDepGraph{
+			vars: map[string]bool{"a": true, "b": true, "c": true},
+			deps: map[string]map[string]bool{
+				"a": {},
+				"b": {},
+				"c": {},
+			},
+		}
+		layers, err := g.topologicalSort()
+		require.NoError(t, err)
+		require.Len(t, layers, 1)
+		assert.Equal(t, []string{"a", "b", "c"}, layers[0])
+	})
+
+	t.Run("linear chain", func(t *testing.T) {
+		g := &secretDepGraph{
+			vars: map[string]bool{"a": true, "b": true, "c": true},
+			deps: map[string]map[string]bool{
+				"a": {"b": true},
+				"b": {"c": true},
+				"c": {},
+			},
+		}
+		layers, err := g.topologicalSort()
+		require.NoError(t, err)
+		require.Len(t, layers, 3)
+		assert.Equal(t, []string{"c"}, layers[0])
+		assert.Equal(t, []string{"b"}, layers[1])
+		assert.Equal(t, []string{"a"}, layers[2])
+	})
+
+	t.Run("diamond", func(t *testing.T) {
+		g := &secretDepGraph{
+			vars: map[string]bool{"a": true, "b": true, "c": true},
+			deps: map[string]map[string]bool{
+				"a": {"b": true, "c": true},
+				"b": {},
+				"c": {},
+			},
+		}
+		layers, err := g.topologicalSort()
+		require.NoError(t, err)
+		require.Len(t, layers, 2)
+		assert.Equal(t, []string{"b", "c"}, layers[0])
+		assert.Equal(t, []string{"a"}, layers[1])
+	})
+
+	t.Run("mixed deps and no deps", func(t *testing.T) {
+		g := &secretDepGraph{
+			vars: map[string]bool{"a": true, "b": true, "c": true, "d": true},
+			deps: map[string]map[string]bool{
+				"a": {"b": true},
+				"b": {},
+				"c": {},
+				"d": {},
+			},
+		}
+		layers, err := g.topologicalSort()
+		require.NoError(t, err)
+		require.Len(t, layers, 2)
+		assert.Equal(t, []string{"b", "c", "d"}, layers[0])
+		assert.Equal(t, []string{"a"}, layers[1])
+	})
+
+	t.Run("circular returns error", func(t *testing.T) {
+		g := &secretDepGraph{
+			vars: map[string]bool{"a": true, "b": true},
+			deps: map[string]map[string]bool{
+				"a": {"b": true},
+				"b": {"a": true},
+			},
+		}
+		_, err := g.topologicalSort()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "circular secret dependency")
+	})
+
+	t.Run("max depth exceeded", func(t *testing.T) {
+		// Build a chain of 11 levels
+		vars := make(map[string]bool)
+		deps := make(map[string]map[string]bool)
+		for i := 0; i <= 10; i++ {
+			name := string(rune('a' + i))
+			vars[name] = true
+			deps[name] = make(map[string]bool)
+			if i > 0 {
+				prev := string(rune('a' + i - 1))
+				deps[name][prev] = true
+			}
+		}
+		g := &secretDepGraph{vars: vars, deps: deps}
+		_, err := g.topologicalSort()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "secret dependency chain too deep")
+	})
+}

--- a/worker/service.go
+++ b/worker/service.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pikoci/pikoci/pikoci/resource"
 	"github.com/pikoci/pikoci/pikoci/restype"
 	"github.com/pikoci/pikoci/pikoci/runner"
+	"github.com/pikoci/pikoci/pikoci/sectype"
 	"github.com/pikoci/pikoci/pikoci/service"
 	"github.com/pikoci/pikoci/pikoci/utils"
 	"github.com/pikoci/pikoci/pikoci/wkr"
@@ -3072,8 +3073,9 @@ func (w *Worker) stopServices(m workitem.Body, b *build.Build, cwd string, pp *p
 }
 
 // resolveSecretVars resolves all secret-backed variable placeholders by fetching
-// the actual secret values from the configured secret types. Variables sharing
-// the same secret type and path are batched into a single fetch call.
+// the actual secret values from the configured secret types. Variables are
+// resolved in dependency order: if a variable's path/key references another
+// secret variable's placeholder, the dependency is resolved first.
 func (w *Worker) resolveSecretVars(ctx context.Context, cwd string, pp *pipeline.Pipeline) (map[string]string, error) {
 	if len(pp.SecretVars) == 0 {
 		return nil, nil
@@ -3082,31 +3084,120 @@ func (w *Worker) resolveSecretVars(ctx context.Context, cwd string, pp *pipeline
 		return nil, nil
 	}
 
-	// Group variables by (type, path) to avoid duplicate fetches.
-	type fetchKey struct{ typ, path string }
-	groups := make(map[fetchKey][]string) // fetchKey -> []varName
-	for varName, sv := range pp.SecretVars {
-		k := fetchKey{sv.Type, sv.Path}
-		groups[k] = append(groups[k], varName)
+	// Build dependency graph and topological sort
+	graph := buildSecretDependencyGraph(pp.SecretVars, pp)
+
+	layers, err := graph.topologicalSort()
+	if err != nil {
+		return nil, err
 	}
 
+	w.logger.Debug("secret dependency resolution", "layers", len(layers), "vars", len(pp.SecretVars))
+	for i, layer := range layers {
+		w.logger.Debug("secret resolution layer", "layer", i, "vars", layer)
+	}
+
+	// Make a mutable copy of secret vars so we can substitute resolved
+	// placeholders into path/key without mutating the original pipeline.
+	workingVars := make(map[string]pipeline.VariableSecret, len(pp.SecretVars))
+	for k, v := range pp.SecretVars {
+		workingVars[k] = v
+	}
+
+	// Track resolved placeholder → value
 	resolved := make(map[string]string)
-	for k, varNames := range groups {
-		secrets, err := w.fetchSecrets(ctx, cwd, pp, map[string]string{k.typ: k.path})
-		if err != nil {
-			return nil, fmt.Errorf("failed to resolve secrets from %q at %q: %w", k.typ, k.path, err)
-		}
-		for _, varName := range varNames {
-			sv := pp.SecretVars[varName]
-			placeholder := fmt.Sprintf("__pikoci_secret:%s:%s:%s__", sv.Type, sv.Path, sv.Key)
-			val, ok := secrets["secret_"+sv.Key]
-			if !ok {
-				return nil, fmt.Errorf("secret for variable %q: key %q not found in response", varName, sv.Key)
+
+	for _, layer := range layers {
+		// Substitute resolved placeholders into this layer's path/key values
+		for _, varName := range layer {
+			sv := workingVars[varName]
+			for placeholder, val := range resolved {
+				sv.Path = strings.ReplaceAll(sv.Path, placeholder, val)
+				sv.Key = strings.ReplaceAll(sv.Key, placeholder, val)
 			}
-			resolved[placeholder] = val
+			workingVars[varName] = sv
+		}
+
+		// Build a pipeline copy with resolved secret_type configs for this layer
+		layerPP := pp
+		if len(resolved) > 0 {
+			layerPP = w.pipelineWithResolvedConfigs(pp, resolved)
+		}
+
+		// Group by (type, resolved_path) for batching
+		type fetchKey struct{ typ, path string }
+		groups := make(map[fetchKey][]string)
+		for _, varName := range layer {
+			sv := workingVars[varName]
+			k := fetchKey{sv.Type, sv.Path}
+			groups[k] = append(groups[k], varName)
+		}
+
+		for k, varNames := range groups {
+			secrets, err := w.fetchSecrets(ctx, cwd, layerPP, map[string]string{k.typ: k.path})
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve secrets from %q at %q: %w", k.typ, k.path, err)
+			}
+			for _, varName := range varNames {
+				sv := workingVars[varName]
+				// Use the original (pre-resolution) path/key for the placeholder
+				origSV := pp.SecretVars[varName]
+				placeholder := fmt.Sprintf("__pikoci_secret:%s:%s:%s__", origSV.Type, origSV.Path, origSV.Key)
+				val, ok := secrets["secret_"+sv.Key]
+				if !ok {
+					return nil, fmt.Errorf("secret for variable %q: key %q not found in response", varName, sv.Key)
+				}
+				resolved[placeholder] = val
+			}
 		}
 	}
+
 	return resolved, nil
+}
+
+// pipelineWithResolvedConfigs creates a shallow copy of the pipeline with
+// secret_type configs that have had placeholders substituted. The original
+// pipeline is not modified.
+func (w *Worker) pipelineWithResolvedConfigs(pp *pipeline.Pipeline, resolved map[string]string) *pipeline.Pipeline {
+	// Check if any config values contain placeholders
+	needsCopy := false
+	for _, st := range pp.SecretTypes {
+		for _, v := range st.Config {
+			for placeholder := range resolved {
+				if strings.Contains(v, placeholder) {
+					needsCopy = true
+					break
+				}
+			}
+			if needsCopy {
+				break
+			}
+		}
+		if needsCopy {
+			break
+		}
+	}
+	if !needsCopy {
+		return pp
+	}
+
+	// Shallow copy of pipeline, deep copy of SecretTypes
+	ppCopy := *pp
+	ppCopy.SecretTypes = make([]sectype.SecretType, len(pp.SecretTypes))
+	for i, st := range pp.SecretTypes {
+		stCopy := st
+		if len(st.Config) > 0 {
+			stCopy.Config = make(map[string]string, len(st.Config))
+			for k, v := range st.Config {
+				for placeholder, val := range resolved {
+					v = strings.ReplaceAll(v, placeholder, val)
+				}
+				stCopy.Config[k] = v
+			}
+		}
+		ppCopy.SecretTypes[i] = stCopy
+	}
+	return &ppCopy
 }
 
 // replaceSecretPlaceholders replaces secret placeholder strings in a params map


### PR DESCRIPTION
## Summary

Secret-backed variables can now reference other variables in their `path` and `key` fields, enabling patterns like reading a file path from `.env` then fetching the file at that path, or reading a vault address from `.env` then fetching secrets from that vault.

- **Parse-time**: two-pass HCL evaluation — pass 1 builds eval context with defaults/placeholders, pass 2 re-evaluates secret block `path`/`key` as expressions against the full context
- **Runtime**: dependency graph with topological sort resolves secrets in layer order, substituting resolved values into subsequent layers' path/key and secret_type configs
- **Cycle detection** with clear error messages and max chain depth of 10
- **24 new tests** covering parse-time expressions, dependency graph, cycle detection, topological sort, and error paths

Closes #248