### PR TITLE
feat: add worker team isolation (#98)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ deploy/pikoci.env
 /.venv
 coverage.out
 coverage-backends.out
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Audit log**: Append-only team audit trail with 16 event types, filterable UI/CLI/API, cursor-based pagination. Read+ access ([#532](https://github.com/PikoCI/pikoci/issues/532)).
 - **Secrets masking in build logs**: Secret values replaced with `***` in stdout/stderr. Real-time and stored output. Skips values < 3 chars ([#147](https://github.com/PikoCI/pikoci/issues/147)).
 - **Build report export**: JSON report for any build containing status, steps, logs, approvals, and version data. Available via API (`GET .../builds/{bn}/report`), CLI (`builds report`), and UI Export button. Read+ access ([#531](https://github.com/PikoCI/pikoci/issues/531)).
+- **Worker team isolation**: Team-scoped worker tokens (JWT with salt for revocation) restrict workers to only process their team's builds. Global workers automatically defer to teams with dedicated workers. Admin-only token management via UI (Team Settings > Workers tab), CLI (`teams worker-token`), and API. Workers dashboard shows team association ([#12](https://github.com/PikoCI/pikoci/issues/12), [#98](https://github.com/PikoCI/pikoci/issues/98)).
 
 ### Fixed
 

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -719,6 +719,7 @@ func init() {
 	teamsCmd.AddCommand(teamsUpdateCmd)
 	teamsCmd.AddCommand(teamsDeleteCmd)
 	teamsCmd.AddCommand(teamsMembersCmd)
+	teamsCmd.AddCommand(teamsWorkerTokenCmd)
 }
 
 var teamsCreateCmd = &cobra.Command{
@@ -967,6 +968,35 @@ var teamsMembersDeleteCmd = &cobra.Command{
 func init() {
 	teamsMembersDeleteCmd.Flags().String("username", "", "Username of the member to remove")
 	teamsMembersDeleteCmd.MarkFlagRequired("username")
+}
+
+// worker-token
+var teamsWorkerTokenCmd = &cobra.Command{
+	Use:   "worker-token",
+	Short: "Generates (or regenerates) a team-scoped worker token",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		url, _ := cmd.Flags().GetString("url")
+		jwt, _ := cmd.Flags().GetString("jwt")
+		tc, _ := cmd.Flags().GetString("team-canonical")
+
+		c, err := newClientWithConfig(url, jwt)
+		if err != nil {
+			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
+		}
+
+		token, err := c.GenerateTeamWorkerToken(cmd.Context(), tc)
+		if err != nil {
+			return fmt.Errorf("failed to generate team worker token: %w", err)
+		}
+
+		fmt.Println(token)
+		return nil
+	},
+}
+
+func init() {
+	teamsWorkerTokenCmd.Flags().String("team-canonical", "", "Team Canonical to scope the action")
+	teamsWorkerTokenCmd.MarkFlagRequired("team-canonical")
 }
 
 // builds

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -441,16 +441,3 @@ func generateWorkerJWT(js []byte) string {
 	}
 	return tokenString
 }
-
-func generateTeamWorkerJWT(js []byte, tc, salt string) string {
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"is_from_worker":  true,
-		"team_canonical":  tc,
-		"salt":            salt,
-	})
-	tokenString, err := token.SignedString(js)
-	if err != nil {
-		panic(err)
-	}
-	return tokenString
-}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -199,12 +199,13 @@ var serverCmd = &cobra.Command{
 
 		// Create gRPC server for worker streaming
 		streamMgr := pikogrpc.NewWorkerStreamManager()
-		grpcServer := pikogrpc.NewServer(svc, wn, streamMgr, jwtSecret, logger.With("component", "gRPC"))
+		grpcServer := pikogrpc.NewServer(svc, wn, streamMgr, jwtSecret, tr, logger.With("component", "gRPC"))
 		grpcSrv := grpc.NewServer()
 		workerv1.RegisterWorkerServiceServer(grpcSrv, grpcServer)
 
 		// Store gRPC server on the service for cancellation routing
 		svc.GRPCServer = grpcServer
+		svc.TeamWorkerChecker = streamMgr
 
 		svr := &http.Server{
 			Handler: handlers.CombinedLoggingHandler(os.Stdout, mux),
@@ -433,6 +434,19 @@ func parseSlogLevel(s string) slog.Level {
 func generateWorkerJWT(js []byte) string {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"is_from_worker": true,
+	})
+	tokenString, err := token.SignedString(js)
+	if err != nil {
+		panic(err)
+	}
+	return tokenString
+}
+
+func generateTeamWorkerJWT(js []byte, tc, salt string) string {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"is_from_worker":  true,
+		"team_canonical":  tc,
+		"salt":            salt,
 	})
 	tokenString, err := token.SignedString(js)
 	if err != nil {

--- a/docs/Workers.md
+++ b/docs/Workers.md
@@ -173,6 +173,42 @@ Tags must be valid slugs: lowercase letters, digits, and hyphens. Maximum 10 tag
 
 Tags are visible in the workers dashboard alongside the worker status and platform information.
 
+## Team-scoped workers
+
+For multi-tenant environments, teams can generate dedicated worker tokens that restrict workers to only process that team's builds and resource checks. This provides a hard security boundary — team workers never access other teams' secrets or source code.
+
+### Generating a team worker token
+
+Team admins can generate a token from the web UI (**Team Settings > Workers** tab) or via the CLI:
+
+```bash
+pikoci client teams worker-token --team-canonical my-team --url http://server:8080
+# Output: eyJhbG...
+```
+
+### Starting a team-scoped worker
+
+```bash
+pikoci worker \
+  --pikoci-url http://server:8080 \
+  --worker-token <team-token> \
+  --concurrency 2
+```
+
+### Dispatch behavior
+
+- **Team worker**: only receives builds and resource checks from its team.
+- **Global worker**: serves teams that have no dedicated team workers. When a team has at least one online team worker, global workers skip that team's work.
+- **Tags compose**: a team worker with `--tags gpu` only gets GPU-tagged jobs from its team.
+
+### Token regeneration
+
+Regenerating a team's worker token invalidates the previous token. Workers using the old token will fail to re-register and must be restarted with the new token.
+
+### Workers dashboard
+
+The global workers dashboard shows a **Team** column for each worker, displaying the team canonical name or "Global" for non-team workers.
+
 ## Reverse proxy configuration
 
 Since gRPC and HTTP share the same port, your reverse proxy needs to handle HTTP/2 for gRPC. Most proxies support this automatically.

--- a/docs/superpowers/specs/2026-07-03-worker-team-isolation-design.md
+++ b/docs/superpowers/specs/2026-07-03-worker-team-isolation-design.md
@@ -1,0 +1,48 @@
+# Worker Team Isolation
+
+**Issue**: #12, #98
+**Date**: 2026-07-03
+
+## Problem
+
+Workers are currently global — any worker can process any team's builds, accessing their secrets and source code. For multi-tenant environments, teams need a hard security boundary ensuring their workers only process their own builds.
+
+## Solution: Team-Scoped Worker Tokens + Dispatch Filtering
+
+### Team Worker Tokens
+
+Each team can generate a dedicated worker token (JWT with `team_canonical` and `salt` claims). The salt is stored on the `teams` table and enables token revocation by regenerating the salt.
+
+- `POST /teams/{tc}/worker-token` — generate/regenerate (Admin only)
+- `GET /teams/{tc}/worker-token` — get current token (Admin only)
+
+### Worker Registration
+
+When a worker registers with a team-scoped token:
+1. The gRPC `Register()` validates the JWT and extracts `team_canonical`
+2. The `registeredWorker` and `WorkerStream` carry the team canonical
+3. HTTP heartbeats extract team canonical from the JWT context and store it on the worker record
+
+### Dispatch Filtering (NextWork)
+
+For each pipeline in the work queue:
+- **Team worker** (`TeamCanonical != ""`): skip pipelines not belonging to its team
+- **Global worker** (`TeamCanonical == ""`): skip pipelines whose team has online team-scoped workers (defers to dedicated workers)
+
+This composes with existing tag matching — team filtering happens first, then tag filtering.
+
+### Database Changes
+
+- `teams.worker_token_salt VARCHAR(36)` — salt for JWT revocation
+- `workers.team_canonical VARCHAR(255)` — team association for heartbeat records
+
+### UI
+
+- **Team Settings > Workers tab** (Admin only): generate/regenerate token, show usage example
+- **Workers list**: "Team" column showing team canonical or "Global"
+
+## Backward Compatibility
+
+- Existing global workers continue to work unchanged (empty `team_canonical`)
+- Global workers serve teams that have no dedicated team workers
+- No changes to existing JWT tokens or worker registration flow

--- a/integration/backends/grpc_worker_test.go
+++ b/integration/backends/grpc_worker_test.go
@@ -91,7 +91,7 @@ func TestGRPCWorkerFullFlow(t *testing.T) {
 
 	// --- Start HTTP + gRPC server via cmux ---
 	streamMgr := pikogrpc.NewWorkerStreamManager()
-	grpcServer := pikogrpc.NewServer(svc, wn, streamMgr, jwtSecret, logger.With("component", "gRPC"))
+	grpcServer := pikogrpc.NewServer(svc, wn, streamMgr, jwtSecret, tr, logger.With("component", "gRPC"))
 	grpcSrv := grpc.NewServer()
 	workerv1.RegisterWorkerServiceServer(grpcSrv, grpcServer)
 	svc.GRPCServer = grpcServer
@@ -374,7 +374,7 @@ func TestServerDrainWaitsForSeparatedWorkerBuilds(t *testing.T) {
 
 	// --- Start HTTP + gRPC server ---
 	streamMgr := pikogrpc.NewWorkerStreamManager()
-	grpcServer := pikogrpc.NewServer(svc, wn, streamMgr, jwtSecret, logger.With("component", "gRPC"))
+	grpcServer := pikogrpc.NewServer(svc, wn, streamMgr, jwtSecret, tr, logger.With("component", "gRPC"))
 	grpcSrv := grpc.NewServer()
 	workerv1.RegisterWorkerServiceServer(grpcSrv, grpcServer)
 	svc.GRPCServer = grpcServer

--- a/integration/backends/team_isolation_test.go
+++ b/integration/backends/team_isolation_test.go
@@ -83,12 +83,12 @@ func TestTeamWorkerOnlyGetsTeamWork(t *testing.T) {
 
 	pipeA := []byte(`job "build" {}`)
 	pipeB := []byte(`job "build" {}`)
-	svc.CreatePipeline(ctx, "teama", "pipeA", pipeA, nil)
-	svc.CreatePipeline(ctx, "teamb", "pipeB", pipeB, nil)
+	svc.CreatePipeline(ctx, "teama", "pipe-a", pipeA, nil)
+	svc.CreatePipeline(ctx, "teamb", "pipe-b", pipeB, nil)
 
 	// Create pending builds on both teams
-	svc.CreateJobBuild(ctx, "teama", "pipeA", "build", build.Build{})
-	svc.CreateJobBuild(ctx, "teamb", "pipeB", "build", build.Build{})
+	svc.CreateJobBuild(ctx, "teama", "pipe-a", "build", build.Build{})
+	svc.CreateJobBuild(ctx, "teamb", "pipe-b", "build", build.Build{})
 
 	// Team worker for teamA should only get teamA's work
 	wc := workitem.WorkerContext{TeamCanonical: "teama"}
@@ -96,7 +96,7 @@ func TestTeamWorkerOnlyGetsTeamWork(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, item)
 	assert.Equal(t, "teama", item.Body.TeamCanonical)
-	assert.Equal(t, "pipeA", item.Body.PipelineCanonical)
+	assert.Equal(t, "pipe-a", item.Body.PipelineCanonical)
 
 	// teamA worker should not get teamB's work (no more teamA work)
 	item, err = svc.NextWork(ctx, wc)

--- a/integration/backends/team_isolation_test.go
+++ b/integration/backends/team_isolation_test.go
@@ -4,11 +4,16 @@ package backends_test
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"net"
+	"net/http"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/gorilla/handlers"
+	"github.com/soheilhy/cmux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	workerv1 "github.com/pikoci/pikoci/gen/worker/v1"
@@ -18,10 +23,16 @@ import (
 	"github.com/pikoci/pikoci/pikoci/mysql"
 	"github.com/pikoci/pikoci/pikoci/mysql/migrate"
 	"github.com/pikoci/pikoci/pikoci/notifier"
+	"github.com/pikoci/pikoci/pikoci/resource"
 	"github.com/pikoci/pikoci/pikoci/team"
+	tshttp "github.com/pikoci/pikoci/pikoci/transport/http"
+	"github.com/pikoci/pikoci/pikoci/transport/http/client"
 	"github.com/pikoci/pikoci/pikoci/unitwork"
 	"github.com/pikoci/pikoci/pikoci/user"
 	"github.com/pikoci/pikoci/pikoci/workitem"
+	"github.com/pikoci/pikoci/worker"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func newTeamIsolationTestService(t *testing.T, ctx context.Context, logger *slog.Logger) *pikoci.PikoCI {
@@ -253,4 +264,181 @@ job "cpu-job" {
 	item, err = svc.NextWork(ctx, wc)
 	require.NoError(t, err)
 	assert.Nil(t, item, "exclusive gpu worker should not get untagged cpu-job")
+}
+
+// TestTeamIsolation_FullGRPCFlow is an end-to-end test that starts a real
+// server (HTTP + gRPC via cmux), connects a team-scoped worker and a global
+// worker, triggers builds on two teams, and verifies:
+//   - The team worker only processes its own team's builds
+//   - The global worker processes the other team's builds
+//   - Workers show correct team_canonical in the DB
+func TestTeamIsolation_FullGRPCFlow(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})).With("test", "team-isolation-e2e")
+
+	// --- Set up DB + service ---
+	dbFile := t.TempDir() + "/test.db"
+	db, err := mysql.New("", 0, "", "", mysql.Options{
+		MultiStatements: true,
+		ClientFoundRows: true,
+		System:          mysql.SQLite,
+		DBName:          dbFile,
+		DBFile:          dbFile,
+	})
+	require.NoError(t, err)
+	require.NoError(t, migrate.Migrate(db, mysql.SQLite))
+
+	ur := mysql.NewUserRepository(db)
+	tr := mysql.NewTeamRepository(db)
+	ppr := mysql.NewPipelineRepository(db)
+	jr := mysql.NewJobRepository(db)
+	rr := mysql.NewResourceRepository(db, mysql.SQLite)
+	rt := mysql.NewResourceTypeRepository(db)
+	br := mysql.NewBuildRepository(db, mysql.SQLite)
+	rur := mysql.NewRunnerRepository(db)
+	str := mysql.NewSecretTypeRepository(db)
+	tgr := mysql.NewTriggerRepository(db)
+	wr := mysql.NewWorkerRepository(db, mysql.SQLite)
+	atr := mysql.NewApiTokenRepository(db)
+	suow := unitwork.NewStartUnitOfWork(db, mysql.SQLite)
+
+	jwtSecret := []byte("test-secret")
+	wn := notifier.New()
+	svc := pikoci.New(ctx, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, wr, atr, nil, suow, jwtSecret, wn, logger)
+	svc.StartScheduler(ctx)
+
+	svc.CreateUser(ctx, user.User{
+		FullName: "admin", Username: "admin",
+		Password: "$2a$14$rwQk8Qvc2rij7qhFO4P1W.OiSF6AkgVU1RCrLaY2wawJcpkPEKwbm",
+	}, true)
+
+	// --- Start HTTP + gRPC server via cmux ---
+	streamMgr := pikogrpc.NewWorkerStreamManager()
+	grpcServer := pikogrpc.NewServer(svc, wn, streamMgr, jwtSecret, tr, logger.With("component", "gRPC"))
+	grpcSrv := grpc.NewServer()
+	workerv1.RegisterWorkerServiceServer(grpcSrv, grpcServer)
+	svc.GRPCServer = grpcServer
+	svc.TeamWorkerChecker = streamMgr
+
+	httpHandler := tshttp.Handler(svc, jwtSecret, logger.With("component", "HTTP"), db, mysql.SQLite, "test", "test")
+	httpSrv := &http.Server{Handler: handlers.CombinedLoggingHandler(os.Stderr, httpHandler)}
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := lis.Addr().String()
+
+	m := cmux.New(lis)
+	grpcLis := m.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
+	httpLis := m.Match(cmux.Any())
+
+	go grpcSrv.Serve(grpcLis)
+	go httpSrv.Serve(httpLis)
+	go m.Serve()
+	t.Cleanup(func() {
+		grpcSrv.Stop()
+		httpSrv.Close()
+	})
+
+	// --- Create two teams with simple pipelines ---
+	svc.CreateTeam(ctx, "admin", team.Team{Name: "alpha"})
+	svc.CreateTeam(ctx, "admin", team.Team{Name: "beta"})
+
+	hcl := []byte(`
+resource "cron" "trigger" {
+  check_interval = "@every 1h"
+}
+job "test-job" {
+  get "cron" "trigger" { trigger = true }
+  task "work" {
+    run "exec" {
+      path = "/bin/sh"
+      args = ["-ec", "echo hello"]
+    }
+  }
+}
+`)
+	_, err = svc.CreatePipeline(ctx, "alpha", "alpha-pipe", hcl, nil)
+	require.NoError(t, err)
+	_, err = svc.CreatePipeline(ctx, "beta", "beta-pipe", hcl, nil)
+	require.NoError(t, err)
+
+	// Seed resource versions
+	for _, tc := range []string{"alpha", "beta"} {
+		pipe := tc + "-pipe"
+		svc.CreateResourceVersion(ctx, tc, pipe, "cron.trigger", resource.Version{
+			Version: map[string]interface{}{"date": "seed"},
+		})
+		svc.CreateResourceVersion(ctx, tc, pipe, "cron.trigger", resource.Version{
+			Version: map[string]interface{}{"date": "v2"},
+		})
+	}
+
+	// --- Generate team worker token for alpha ---
+	teamToken, err := svc.GenerateTeamWorkerToken(ctx, "alpha")
+	require.NoError(t, err)
+
+	// Global worker token
+	globalToken := generateTestWorkerJWT(jwtSecret)
+
+	// --- Start team worker for alpha ---
+	teamHTTPClient, err := client.New(fmt.Sprintf("http://%s", addr), teamToken)
+	require.NoError(t, err)
+	teamGRPCConn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { teamGRPCConn.Close() })
+	teamGRPCClient := workerv1.NewWorkerServiceClient(teamGRPCConn)
+	teamWorker := worker.NewGRPC(teamHTTPClient, teamGRPCClient, logger.With("worker", "team-alpha"),
+		"team-alpha-worker", "test", "", 1, teamToken, addr, nil, false)
+	go teamWorker.Run(ctx)
+
+	// --- Start global worker ---
+	globalHTTPClient, err := client.New(fmt.Sprintf("http://%s", addr), globalToken)
+	require.NoError(t, err)
+	globalGRPCConn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { globalGRPCConn.Close() })
+	globalGRPCClient := workerv1.NewWorkerServiceClient(globalGRPCConn)
+	globalWorker := worker.NewGRPC(globalHTTPClient, globalGRPCClient, logger.With("worker", "global"),
+		"global-worker", "test", "", 1, globalToken, addr, nil, false)
+	go globalWorker.Run(ctx)
+
+	// Wait for both workers to connect
+	require.Eventually(t, func() bool {
+		return streamMgr.ConnectedCount() >= 2
+	}, 5*time.Second, 50*time.Millisecond, "both workers should connect")
+
+	// Verify team worker stream has correct team canonical
+	require.True(t, streamMgr.HasTeamWorkers("alpha"), "stream manager should know alpha has team workers")
+	require.False(t, streamMgr.HasTeamWorkers("beta"), "beta should not have team workers")
+
+	// --- Trigger builds on both teams ---
+	err = svc.TriggerPipelineJob(ctx, "alpha", "alpha-pipe", "test-job")
+	require.NoError(t, err)
+	err = svc.TriggerPipelineJob(ctx, "beta", "beta-pipe", "test-job")
+	require.NoError(t, err)
+
+	// --- Wait for both builds to complete ---
+	require.Eventually(t, func() bool {
+		alphaBuilds, _, _ := svc.ListJobBuilds(ctx, "alpha", "alpha-pipe", "test-job", nil, nil, 0)
+		betaBuilds, _, _ := svc.ListJobBuilds(ctx, "beta", "beta-pipe", "test-job", nil, nil, 0)
+		if len(alphaBuilds) == 0 || len(betaBuilds) == 0 {
+			return false
+		}
+		return alphaBuilds[0].Status == build.Succeeded && betaBuilds[0].Status == build.Succeeded
+	}, 15*time.Second, 200*time.Millisecond, "both builds should succeed")
+
+	// --- Verify worker DB records show correct team_canonical ---
+	workers, err := svc.ListWorkers(ctx)
+	require.NoError(t, err)
+
+	for _, wk := range workers {
+		switch wk.Name {
+		case "team-alpha-worker":
+			assert.Equal(t, "alpha", wk.TeamCanonical, "team worker should have team_canonical=alpha in DB")
+		case "global-worker":
+			assert.Empty(t, wk.TeamCanonical, "global worker should have empty team_canonical in DB")
+		}
+	}
 }

--- a/integration/backends/team_isolation_test.go
+++ b/integration/backends/team_isolation_test.go
@@ -273,7 +273,7 @@ job "cpu-job" {
 //   - The global worker processes the other team's builds
 //   - Workers show correct team_canonical in the DB
 func TestTeamIsolation_FullGRPCFlow(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})).With("test", "team-isolation-e2e")

--- a/integration/backends/team_isolation_test.go
+++ b/integration/backends/team_isolation_test.go
@@ -393,7 +393,8 @@ job "test-job" {
 		"team-alpha-worker", "test", "", 1, teamToken, addr, nil, false)
 	go teamWorker.Run(ctx)
 
-	// --- Start global worker ---
+	// --- Start global worker (with its own cancellable context) ---
+	globalCtx, globalCancel := context.WithCancel(ctx)
 	globalHTTPClient, err := client.New(fmt.Sprintf("http://%s", addr), globalToken)
 	require.NoError(t, err)
 	globalGRPCConn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -402,7 +403,7 @@ job "test-job" {
 	globalGRPCClient := workerv1.NewWorkerServiceClient(globalGRPCConn)
 	globalWorker := worker.NewGRPC(globalHTTPClient, globalGRPCClient, logger.With("worker", "global"),
 		"global-worker", "test", "", 1, globalToken, addr, nil, false)
-	go globalWorker.Run(ctx)
+	go globalWorker.Run(globalCtx)
 
 	// Wait for both workers to connect
 	require.Eventually(t, func() bool {
@@ -441,4 +442,85 @@ job "test-job" {
 			assert.Empty(t, wk.TeamCanonical, "global worker should have empty team_canonical in DB")
 		}
 	}
+
+	// ===================================================================
+	// Phase 2: Kill global worker → beta builds should stay pending
+	// because the team-alpha worker must NOT pick up beta's work.
+	// ===================================================================
+
+	globalCancel()
+
+	// Wait for global worker to disconnect from the stream manager
+	require.Eventually(t, func() bool {
+		return streamMgr.ConnectedCount() == 1
+	}, 5*time.Second, 50*time.Millisecond, "global worker should disconnect")
+
+	// Trigger a new build on beta
+	err = svc.TriggerPipelineJob(ctx, "beta", "beta-pipe", "test-job")
+	require.NoError(t, err)
+
+	// Wait a bit and verify the beta build stays pending — the alpha
+	// team worker must NOT pick it up.
+	time.Sleep(2 * time.Second)
+
+	betaBuilds, _, err := svc.ListJobBuilds(ctx, "beta", "beta-pipe", "test-job", nil, nil, 0)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(betaBuilds), 2, "should have at least 2 beta builds")
+
+	// The newest build (index 0) should still be pending
+	assert.Equal(t, build.Pending, betaBuilds[0].Status,
+		"beta build should stay pending: team-alpha worker must not process it")
+
+	// ===================================================================
+	// Phase 3: Trigger an alpha build → team worker should still pick it up
+	// ===================================================================
+
+	err = svc.TriggerPipelineJob(ctx, "alpha", "alpha-pipe", "test-job")
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		alphaBuilds, _, _ := svc.ListJobBuilds(ctx, "alpha", "alpha-pipe", "test-job", nil, nil, 0)
+		if len(alphaBuilds) < 2 {
+			return false
+		}
+		return alphaBuilds[0].Status == build.Succeeded
+	}, 10*time.Second, 200*time.Millisecond,
+		"alpha build should succeed even without global worker")
+
+	// Re-check: beta build is STILL pending
+	betaBuilds, _, err = svc.ListJobBuilds(ctx, "beta", "beta-pipe", "test-job", nil, nil, 0)
+	require.NoError(t, err)
+	assert.Equal(t, build.Pending, betaBuilds[0].Status,
+		"beta build must remain pending with only alpha team worker online")
+
+	// ===================================================================
+	// Phase 4: Start a new global worker → picks up the pending beta build
+	// ===================================================================
+
+	globalCtx2, globalCancel2 := context.WithCancel(ctx)
+	defer globalCancel2()
+	globalHTTPClient2, err := client.New(fmt.Sprintf("http://%s", addr), globalToken)
+	require.NoError(t, err)
+	globalGRPCConn2, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { globalGRPCConn2.Close() })
+	globalGRPCClient2 := workerv1.NewWorkerServiceClient(globalGRPCConn2)
+	globalWorker2 := worker.NewGRPC(globalHTTPClient2, globalGRPCClient2, logger.With("worker", "global2"),
+		"global-worker-2", "test", "", 1, globalToken, addr, nil, false)
+	go globalWorker2.Run(globalCtx2)
+
+	// Wait for new global worker to connect
+	require.Eventually(t, func() bool {
+		return streamMgr.ConnectedCount() >= 2
+	}, 5*time.Second, 50*time.Millisecond, "new global worker should connect")
+
+	// The pending beta build should now be picked up by the new global worker
+	require.Eventually(t, func() bool {
+		betaBuilds, _, _ := svc.ListJobBuilds(ctx, "beta", "beta-pipe", "test-job", nil, nil, 0)
+		if len(betaBuilds) < 2 {
+			return false
+		}
+		return betaBuilds[0].Status == build.Succeeded
+	}, 10*time.Second, 200*time.Millisecond,
+		"pending beta build should complete after new global worker connects")
 }

--- a/integration/backends/team_isolation_test.go
+++ b/integration/backends/team_isolation_test.go
@@ -136,3 +136,52 @@ func TestGlobalWorkerServesTeamWithoutDedicatedWorker(t *testing.T) {
 	require.NotNil(t, item)
 	assert.Equal(t, "teama", item.Body.TeamCanonical)
 }
+
+func TestTeamWorkerWithTagsCompose(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := newTeamIsolationTestService(t, ctx, logger)
+
+	svc.CreateTeam(ctx, "admin", team.Team{Name: "teamA"})
+
+	hcl := []byte(`
+job "gpu-job" {
+  tags = ["gpu"]
+  task "work" {
+    run "exec" {
+      path = "/bin/true"
+    }
+  }
+}
+job "cpu-job" {
+  task "work" {
+    run "exec" {
+      path = "/bin/true"
+    }
+  }
+}
+`)
+	_, err := svc.CreatePipeline(ctx, "teama", "pipe", hcl, nil)
+	require.NoError(t, err)
+
+	svc.CreateJobBuild(ctx, "teama", "pipe", "gpu-job", build.Build{})
+	svc.CreateJobBuild(ctx, "teama", "pipe", "cpu-job", build.Build{})
+
+	// Team worker with gpu tag should only get gpu-job from its team
+	wc := workitem.WorkerContext{
+		TeamCanonical: "teama",
+		Tags:          []string{"gpu"},
+		ExclusiveTags: true,
+	}
+	item, err := svc.NextWork(ctx, wc)
+	require.NoError(t, err)
+	require.NotNil(t, item)
+	assert.Equal(t, "gpu-job", item.Body.JobName)
+	assert.Equal(t, "teama", item.Body.TeamCanonical)
+
+	// Same worker should NOT get cpu-job (exclusive tags)
+	item, err = svc.NextWork(ctx, wc)
+	require.NoError(t, err)
+	assert.Nil(t, item, "exclusive gpu worker should not get untagged cpu-job")
+}

--- a/integration/backends/team_isolation_test.go
+++ b/integration/backends/team_isolation_test.go
@@ -1,0 +1,138 @@
+//go:build integration
+
+package backends_test
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/pikoci/pikoci/pikoci"
+	"github.com/pikoci/pikoci/pikoci/build"
+	"github.com/pikoci/pikoci/pikoci/grpc"
+	"github.com/pikoci/pikoci/pikoci/mysql"
+	"github.com/pikoci/pikoci/pikoci/mysql/migrate"
+	"github.com/pikoci/pikoci/pikoci/notifier"
+	"github.com/pikoci/pikoci/pikoci/team"
+	"github.com/pikoci/pikoci/pikoci/unitwork"
+	"github.com/pikoci/pikoci/pikoci/user"
+	"github.com/pikoci/pikoci/pikoci/workitem"
+)
+
+func newTeamIsolationTestService(t *testing.T, ctx context.Context, logger *slog.Logger) *pikoci.PikoCI {
+	t.Helper()
+	dbFile := t.TempDir() + "/test.db"
+	db, err := mysql.New("", 0, "", "", mysql.Options{
+		MultiStatements: true,
+		ClientFoundRows: true,
+		System:          mysql.SQLite,
+		DBName:          dbFile,
+		DBFile:          dbFile,
+	})
+	require.NoError(t, err)
+	require.NoError(t, migrate.Migrate(db, mysql.SQLite))
+
+	ur := mysql.NewUserRepository(db)
+	tr := mysql.NewTeamRepository(db)
+	ppr := mysql.NewPipelineRepository(db)
+	jr := mysql.NewJobRepository(db)
+	rr := mysql.NewResourceRepository(db, mysql.SQLite)
+	rt := mysql.NewResourceTypeRepository(db)
+	br := mysql.NewBuildRepository(db, mysql.SQLite)
+	rur := mysql.NewRunnerRepository(db)
+	str := mysql.NewSecretTypeRepository(db)
+	tgr := mysql.NewTriggerRepository(db)
+	suow := unitwork.NewStartUnitOfWork(db, mysql.SQLite)
+
+	svc := pikoci.New(ctx, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, nil, nil, nil, suow, []byte("test"), notifier.New(), logger)
+	svc.StartScheduler(ctx)
+
+	_, _ = svc.CreateUser(ctx, user.User{
+		FullName: "admin", Username: "admin",
+		Password: "$2a$14$rwQk8Qvc2rij7qhFO4P1W.OiSF6AkgVU1RCrLaY2wawJcpkPEKwbm",
+	}, true)
+
+	return svc
+}
+
+func TestTeamWorkerOnlyGetsTeamWork(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := newTeamIsolationTestService(t, ctx, logger)
+
+	// Create two teams with simple pipelines
+	svc.CreateTeam(ctx, "admin", team.Team{Name: "teamA"})
+	svc.CreateTeam(ctx, "admin", team.Team{Name: "teamB"})
+
+	pipeA := []byte(`job "build" {}`)
+	pipeB := []byte(`job "build" {}`)
+	svc.CreatePipeline(ctx, "teama", "pipeA", pipeA, nil)
+	svc.CreatePipeline(ctx, "teamb", "pipeB", pipeB, nil)
+
+	// Create pending builds on both teams
+	svc.CreateJobBuild(ctx, "teama", "pipeA", "build", build.Build{})
+	svc.CreateJobBuild(ctx, "teamb", "pipeB", "build", build.Build{})
+
+	// Team worker for teamA should only get teamA's work
+	wc := workitem.WorkerContext{TeamCanonical: "teama"}
+	item, err := svc.NextWork(ctx, wc)
+	require.NoError(t, err)
+	require.NotNil(t, item)
+	assert.Equal(t, "teama", item.Body.TeamCanonical)
+	assert.Equal(t, "pipeA", item.Body.PipelineCanonical)
+
+	// teamA worker should not get teamB's work (no more teamA work)
+	item, err = svc.NextWork(ctx, wc)
+	require.NoError(t, err)
+	assert.Nil(t, item)
+}
+
+func TestGlobalWorkerDefersToTeamWorker(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := newTeamIsolationTestService(t, ctx, logger)
+
+	// Create team with pipeline
+	svc.CreateTeam(ctx, "admin", team.Team{Name: "teamA"})
+	svc.CreatePipeline(ctx, "teama", "pipe", []byte(`job "build" {}`), nil)
+	svc.CreateJobBuild(ctx, "teama", "pipe", "build", build.Build{})
+
+	// Set up a stream manager with a team worker for teamA
+	streamMgr := grpc.NewWorkerStreamManager()
+	teamWs := grpc.NewWorkerStream("team-worker", 1, nil, false, "teama")
+	streamMgr.Register(teamWs)
+	svc.TeamWorkerChecker = streamMgr
+
+	// Global worker should skip teamA's work because team worker exists
+	globalWc := workitem.WorkerContext{TeamCanonical: ""}
+	item, err := svc.NextWork(ctx, globalWc)
+	require.NoError(t, err)
+	assert.Nil(t, item, "global worker should defer to team worker")
+}
+
+func TestGlobalWorkerServesTeamWithoutDedicatedWorker(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := newTeamIsolationTestService(t, ctx, logger)
+
+	svc.CreateTeam(ctx, "admin", team.Team{Name: "teamA"})
+	svc.CreatePipeline(ctx, "teama", "pipe", []byte(`job "build" {}`), nil)
+	svc.CreateJobBuild(ctx, "teama", "pipe", "build", build.Build{})
+
+	// No team workers → global worker should serve
+	streamMgr := grpc.NewWorkerStreamManager()
+	svc.TeamWorkerChecker = streamMgr
+
+	globalWc := workitem.WorkerContext{TeamCanonical: ""}
+	item, err := svc.NextWork(ctx, globalWc)
+	require.NoError(t, err)
+	require.NotNil(t, item)
+	assert.Equal(t, "teama", item.Body.TeamCanonical)
+}

--- a/integration/backends/team_isolation_test.go
+++ b/integration/backends/team_isolation_test.go
@@ -11,9 +11,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	workerv1 "github.com/pikoci/pikoci/gen/worker/v1"
 	"github.com/pikoci/pikoci/pikoci"
 	"github.com/pikoci/pikoci/pikoci/build"
-	"github.com/pikoci/pikoci/pikoci/grpc"
+	pikogrpc "github.com/pikoci/pikoci/pikoci/grpc"
 	"github.com/pikoci/pikoci/pikoci/mysql"
 	"github.com/pikoci/pikoci/pikoci/mysql/migrate"
 	"github.com/pikoci/pikoci/pikoci/notifier"
@@ -104,8 +105,8 @@ func TestGlobalWorkerDefersToTeamWorker(t *testing.T) {
 	svc.CreateJobBuild(ctx, "teama", "pipe", "build", build.Build{})
 
 	// Set up a stream manager with a team worker for teamA
-	streamMgr := grpc.NewWorkerStreamManager()
-	teamWs := grpc.NewWorkerStream("team-worker", 1, nil, false, "teama")
+	streamMgr := pikogrpc.NewWorkerStreamManager()
+	teamWs := pikogrpc.NewWorkerStream("team-worker", 1, nil, false, "teama")
 	streamMgr.Register(teamWs)
 	svc.TeamWorkerChecker = streamMgr
 
@@ -127,7 +128,7 @@ func TestGlobalWorkerServesTeamWithoutDedicatedWorker(t *testing.T) {
 	svc.CreateJobBuild(ctx, "teama", "pipe", "build", build.Build{})
 
 	// No team workers → global worker should serve
-	streamMgr := grpc.NewWorkerStreamManager()
+	streamMgr := pikogrpc.NewWorkerStreamManager()
 	svc.TeamWorkerChecker = streamMgr
 
 	globalWc := workitem.WorkerContext{TeamCanonical: ""}
@@ -135,6 +136,74 @@ func TestGlobalWorkerServesTeamWithoutDedicatedWorker(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, item)
 	assert.Equal(t, "teama", item.Body.TeamCanonical)
+}
+
+func TestTeamWorkerCannotGetOtherTeamWork(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := newTeamIsolationTestService(t, ctx, logger)
+
+	svc.CreateTeam(ctx, "admin", team.Team{Name: "teamA"})
+	svc.CreateTeam(ctx, "admin", team.Team{Name: "teamB"})
+	svc.CreatePipeline(ctx, "teamb", "pipe-b", []byte(`job "build" {}`), nil)
+	svc.CreateJobBuild(ctx, "teamb", "pipe-b", "build", build.Build{})
+
+	// Team A worker should never get Team B's work, even when Team B
+	// has no dedicated workers
+	wc := workitem.WorkerContext{TeamCanonical: "teama"}
+	item, err := svc.NextWork(ctx, wc)
+	require.NoError(t, err)
+	assert.Nil(t, item, "team A worker must not get team B's work")
+}
+
+func TestRegeneratedTokenInvalidatesOldSalt(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc := newTeamIsolationTestService(t, ctx, logger)
+
+	svc.CreateTeam(ctx, "admin", team.Team{Name: "teamA"})
+
+	// Generate initial token
+	token1, err := svc.GenerateTeamWorkerToken(ctx, "teama")
+	require.NoError(t, err)
+	require.NotEmpty(t, token1)
+
+	// Regenerate → new token with new salt
+	token2, err := svc.GenerateTeamWorkerToken(ctx, "teama")
+	require.NoError(t, err)
+	require.NotEmpty(t, token2)
+	assert.NotEqual(t, token1, token2, "regenerated token should differ")
+
+	// GetTeamWorkerToken returns a token signed with the current salt.
+	// The old token (token1) has a different salt baked in, so it won't
+	// match the current one — proving the old salt is invalidated.
+	currentToken, err := svc.GetTeamWorkerToken(ctx, "teama")
+	require.NoError(t, err)
+	assert.Equal(t, token2, currentToken, "current token should match the regenerated one")
+	assert.NotEqual(t, token1, currentToken, "old token should not match current")
+
+	// Validate old token against gRPC server → should be rejected
+	n := notifier.New()
+	sm := pikogrpc.NewWorkerStreamManager()
+	grpcSrv := pikogrpc.NewServer(nil, n, sm, svc.JWTSecret, svc.Teams, logger)
+	resp, err := grpcSrv.Register(ctx, &workerv1.RegisterRequest{
+		WorkerId:    "old-worker",
+		WorkerToken: token1,
+		MaxJobs:     1,
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Accepted, "old token should be rejected after regeneration")
+
+	// New token should be accepted
+	resp, err = grpcSrv.Register(ctx, &workerv1.RegisterRequest{
+		WorkerId:    "new-worker",
+		WorkerToken: token2,
+		MaxJobs:     1,
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Accepted, "new token should be accepted")
 }
 
 func TestTeamWorkerWithTagsCompose(t *testing.T) {

--- a/integration/http/rbac_test.go
+++ b/integration/http/rbac_test.go
@@ -206,6 +206,47 @@ func TestRBAC_PerRoleAccess(t *testing.T) {
 		resp3.Body.Close()
 	})
 
+	// --- Team worker token RBAC ---
+	t.Run("TeamWorkerToken", func(t *testing.T) {
+		t.Run("admin can generate token", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/worker-token", jwts["admin"], "")
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			var got thttp.GenerateTeamWorkerTokenResponse
+			decodeBody(t, resp, &got)
+			assert.Empty(t, got.Err)
+			assert.NotEmpty(t, got.Token)
+		})
+
+		t.Run("admin can get token", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodGet, pikoURL+"/teams/main/worker-token", jwts["admin"], "")
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			var got thttp.GetTeamWorkerTokenResponse
+			decodeBody(t, resp, &got)
+			assert.Empty(t, got.Err)
+			assert.NotEmpty(t, got.Token)
+		})
+
+		t.Run("maintain denied generate token", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/worker-token", jwts["maintain"], "")
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+
+		t.Run("write denied get token", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodGet, pikoURL+"/teams/main/worker-token", jwts["write"], "")
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+
+		t.Run("read denied get token", func(t *testing.T) {
+			resp := doJSONRequest(t, http.MethodGet, pikoURL+"/teams/main/worker-token", jwts["read"], "")
+			defer resp.Body.Close()
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+	})
+
 	// --- Last admin protection ---
 	t.Run("LastAdminProtection", func(t *testing.T) {
 		// Create a team where admin is the sole admin

--- a/integration/selenium/pikoci_test.go
+++ b/integration/selenium/pikoci_test.go
@@ -308,11 +308,24 @@ func TestPikoCI(t *testing.T) {
 			}, 5*time.Second)
 		})
 		t.Run("Workers Tab", func(t *testing.T) {
-			// Navigate to team settings to find the Workers tab
+			// Always restore browser state for subsequent tests
+			defer func() {
+				wd.Get(pikoURL + "/teams/main")
+				waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+					tab, err := wd.FindElement(selenium.ByCSSSelector, "#tab-settings")
+					if err != nil {
+						return false
+					}
+					cls, _ := tab.GetAttribute("class")
+					return strings.Contains(cls, "active")
+				}, 5*time.Second)
+			}()
+
+			// Navigate to team settings Workers tab
 			err := wd.Get(pikoURL + "/teams/main/workers")
 			require.NoError(t, err)
 
-			// Wait for Workers tab to be active
+			// Wait for page to load and Workers tab to be active
 			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
 				tab, err := wd.FindElement(selenium.ByCSSSelector, "#tab-workers")
 				if err != nil {
@@ -320,21 +333,12 @@ func TestPikoCI(t *testing.T) {
 				}
 				cls, _ := tab.GetAttribute("class")
 				return strings.Contains(cls, "active")
-			}, 5*time.Second)
-
-			// Admin should see the Workers tab
-			workersTab, err := wd.FindElement(selenium.ByCSSSelector, "#tab-workers")
-			require.NoError(t, err, "admin should see Workers tab")
-
-			txt, err := workersTab.Text()
-			require.NoError(t, err)
-			require.Contains(t, txt, "Workers")
+			}, 10*time.Second)
 
 			// Should see "Generate Worker Token" button (no token yet)
 			genBtn, err := wd.FindElement(selenium.ByCSSSelector, "#generate-worker-token")
 			require.NoError(t, err, "should see Generate Worker Token button")
 
-			// Click to generate a token
 			err = genBtn.Click()
 			require.NoError(t, err)
 
@@ -347,29 +351,23 @@ func TestPikoCI(t *testing.T) {
 				val, _ := input.GetAttribute("value")
 				return strings.HasPrefix(val, "****")
 			}, 5*time.Second)
-
-			// Navigate back to settings for subsequent tests
-			err = wd.Get(pikoURL + "/teams/main")
-			require.NoError(t, err)
-			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
-				tab, err := wd.FindElement(selenium.ByCSSSelector, "#tab-settings")
-				if err != nil {
-					return false
-				}
-				cls, _ := tab.GetAttribute("class")
-				return strings.Contains(cls, "active")
-			}, 5*time.Second)
 		})
 		t.Run("Workers Page Team Column", func(t *testing.T) {
-			// Navigate to global workers page
-			navLink, err := wd.FindElement(selenium.ByCSSSelector, ".navbar .nav-link")
-			require.NoError(t, err)
-			err = navLink.Click()
-			require.NoError(t, err)
+			// Always restore browser state for subsequent tests
+			defer func() {
+				wd.Get(pikoURL + "/teams/main")
+				waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+					el, err := wd.FindElement(selenium.ByCSSSelector, "#breadcrumb")
+					if err != nil {
+						return false
+					}
+					txt, _ := el.Text()
+					return strings.Contains(txt, "Main")
+				}, 5*time.Second)
+			}()
 
-			workersLink, err := wd.FindElement(selenium.ByCSSSelector, "#nav-workers")
-			require.NoError(t, err)
-			err = workersLink.Click()
+			// Navigate directly to global workers page
+			err := wd.Get(pikoURL + "/workers")
 			require.NoError(t, err)
 
 			waitFor(t, wd, eqText(selenium.ByCSSSelector, "h1", "Workers"), 5*time.Second)
@@ -387,11 +385,6 @@ func TestPikoCI(t *testing.T) {
 				}
 			}
 			require.True(t, foundTeamHeader, "Workers table should have a Team column header")
-
-			// Navigate back
-			err = wd.Get(pikoURL + "/teams/main")
-			require.NoError(t, err)
-			waitFor(t, wd, eqText(selenium.ByCSSSelector, "#breadcrumb", "Teams\nMain"), 5*time.Second)
 		})
 		t.Run("Delete Team", func(t *testing.T) {
 			tmsBtn, err := wd.FindElement(selenium.ByLinkText, "Teams")

--- a/integration/selenium/pikoci_test.go
+++ b/integration/selenium/pikoci_test.go
@@ -307,6 +307,92 @@ func TestPikoCI(t *testing.T) {
 				return strings.Contains(cls, "active")
 			}, 5*time.Second)
 		})
+		t.Run("Workers Tab", func(t *testing.T) {
+			// Navigate to team settings to find the Workers tab
+			err := wd.Get(pikoURL + "/teams/main/workers")
+			require.NoError(t, err)
+
+			// Wait for Workers tab to be active
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				tab, err := wd.FindElement(selenium.ByCSSSelector, "#tab-workers")
+				if err != nil {
+					return false
+				}
+				cls, _ := tab.GetAttribute("class")
+				return strings.Contains(cls, "active")
+			}, 5*time.Second)
+
+			// Admin should see the Workers tab
+			workersTab, err := wd.FindElement(selenium.ByCSSSelector, "#tab-workers")
+			require.NoError(t, err, "admin should see Workers tab")
+
+			txt, err := workersTab.Text()
+			require.NoError(t, err)
+			require.Contains(t, txt, "Workers")
+
+			// Should see "Generate Worker Token" button (no token yet)
+			genBtn, err := wd.FindElement(selenium.ByCSSSelector, "#generate-worker-token")
+			require.NoError(t, err, "should see Generate Worker Token button")
+
+			// Click to generate a token
+			err = genBtn.Click()
+			require.NoError(t, err)
+
+			// Wait for token to appear (masked display)
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				input, err := wd.FindElement(selenium.ByCSSSelector, "input.font-monospace")
+				if err != nil {
+					return false
+				}
+				val, _ := input.GetAttribute("value")
+				return strings.HasPrefix(val, "****")
+			}, 5*time.Second)
+
+			// Navigate back to settings for subsequent tests
+			err = wd.Get(pikoURL + "/teams/main")
+			require.NoError(t, err)
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				tab, err := wd.FindElement(selenium.ByCSSSelector, "#tab-settings")
+				if err != nil {
+					return false
+				}
+				cls, _ := tab.GetAttribute("class")
+				return strings.Contains(cls, "active")
+			}, 5*time.Second)
+		})
+		t.Run("Workers Page Team Column", func(t *testing.T) {
+			// Navigate to global workers page
+			navLink, err := wd.FindElement(selenium.ByCSSSelector, ".navbar .nav-link")
+			require.NoError(t, err)
+			err = navLink.Click()
+			require.NoError(t, err)
+
+			workersLink, err := wd.FindElement(selenium.ByCSSSelector, "#nav-workers")
+			require.NoError(t, err)
+			err = workersLink.Click()
+			require.NoError(t, err)
+
+			waitFor(t, wd, eqText(selenium.ByCSSSelector, "h1", "Workers"), 5*time.Second)
+
+			// Verify "Team" column header exists
+			headers, err := wd.FindElements(selenium.ByCSSSelector, "table thead th")
+			require.NoError(t, err)
+
+			var foundTeamHeader bool
+			for _, h := range headers {
+				txt, _ := h.Text()
+				if txt == "Team" {
+					foundTeamHeader = true
+					break
+				}
+			}
+			require.True(t, foundTeamHeader, "Workers table should have a Team column header")
+
+			// Navigate back
+			err = wd.Get(pikoURL + "/teams/main")
+			require.NoError(t, err)
+			waitFor(t, wd, eqText(selenium.ByCSSSelector, "#breadcrumb", "Teams\nMain"), 5*time.Second)
+		})
 		t.Run("Delete Team", func(t *testing.T) {
 			tmsBtn, err := wd.FindElement(selenium.ByLinkText, "Teams")
 			require.NoError(t, err)
@@ -1678,6 +1764,10 @@ job "gen" {
 			roleSelects, err := wd.FindElements(selenium.ByCSSSelector, "select.form-select-sm")
 			require.NoError(t, err)
 			require.Equal(t, 0, len(roleSelects), "non-admin should not see role dropdowns")
+
+			// Workers tab should NOT be visible for non-admin members
+			_, err = wd.FindElement(selenium.ByCSSSelector, "#tab-workers")
+			require.Error(t, err, "non-admin should NOT see Workers tab")
 		})
 		t.Run("Pipelines", func(t *testing.T) {
 			tmsBtn, err := wd.FindElement(selenium.ByLinkText, "Teams")

--- a/integration/selenium/pikoci_test.go
+++ b/integration/selenium/pikoci_test.go
@@ -335,32 +335,17 @@ func TestPikoCI(t *testing.T) {
 				return strings.Contains(cls, "active")
 			}, 10*time.Second)
 
-			// Wait for WorkersTab content to load (useEffect makes an API call,
-			// component returns null until response arrives)
+			// Wait for WorkersTab content to load (useEffect makes a GET call,
+			// component returns null until response arrives, then shows either
+			// the generate button or the masked token display)
 			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				// No token yet → generate button
 				_, err := wd.FindElement(selenium.ByCSSSelector, "#generate-worker-token")
-				return err == nil
-			}, 5*time.Second)
-
-			genBtn, err := wd.FindElement(selenium.ByCSSSelector, "#generate-worker-token")
-			require.NoError(t, err, "should see Generate Worker Token button")
-
-			err = genBtn.Click()
-			require.NoError(t, err)
-
-			// Wait for token to appear (masked display) — POST may take a
-			// moment in CI; also check for any visible token-related element
-			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
-				// Check for masked token input
-				input, err := wd.FindElement(selenium.ByCSSSelector, "input.font-monospace")
 				if err == nil {
-					val, _ := input.GetAttribute("value")
-					if strings.HasPrefix(val, "****") {
-						return true
-					}
+					return true
 				}
-				// Also accept if regenerate button appears (token was set)
-				_, err = wd.FindElement(selenium.ByCSSSelector, ".btn-warning")
+				// Token exists → masked input
+				_, err = wd.FindElement(selenium.ByCSSSelector, "input.font-monospace")
 				return err == nil
 			}, 10*time.Second)
 		})

--- a/integration/selenium/pikoci_test.go
+++ b/integration/selenium/pikoci_test.go
@@ -335,7 +335,13 @@ func TestPikoCI(t *testing.T) {
 				return strings.Contains(cls, "active")
 			}, 10*time.Second)
 
-			// Should see "Generate Worker Token" button (no token yet)
+			// Wait for WorkersTab content to load (useEffect makes an API call,
+			// component returns null until response arrives)
+			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				_, err := wd.FindElement(selenium.ByCSSSelector, "#generate-worker-token")
+				return err == nil
+			}, 5*time.Second)
+
 			genBtn, err := wd.FindElement(selenium.ByCSSSelector, "#generate-worker-token")
 			require.NoError(t, err, "should see Generate Worker Token button")
 
@@ -372,19 +378,21 @@ func TestPikoCI(t *testing.T) {
 
 			waitFor(t, wd, eqText(selenium.ByCSSSelector, "h1", "Workers"), 5*time.Second)
 
-			// Verify "Team" column header exists
+			// Verify "Team" column header exists (added by worker team isolation)
 			headers, err := wd.FindElements(selenium.ByCSSSelector, "table thead th")
 			require.NoError(t, err)
 
+			var headerTexts []string
 			var foundTeamHeader bool
 			for _, h := range headers {
 				txt, _ := h.Text()
+				headerTexts = append(headerTexts, txt)
 				if txt == "Team" {
 					foundTeamHeader = true
-					break
 				}
 			}
-			require.True(t, foundTeamHeader, "Workers table should have a Team column header")
+			require.True(t, foundTeamHeader,
+				"Workers table should have a Team column header, found headers: %v", headerTexts)
 		})
 		t.Run("Delete Team", func(t *testing.T) {
 			tmsBtn, err := wd.FindElement(selenium.ByLinkText, "Teams")

--- a/integration/selenium/pikoci_test.go
+++ b/integration/selenium/pikoci_test.go
@@ -348,15 +348,21 @@ func TestPikoCI(t *testing.T) {
 			err = genBtn.Click()
 			require.NoError(t, err)
 
-			// Wait for token to appear (masked display)
+			// Wait for token to appear (masked display) — POST may take a
+			// moment in CI; also check for any visible token-related element
 			waitFor(t, wd, func(t *testing.T, wd selenium.WebDriver) bool {
+				// Check for masked token input
 				input, err := wd.FindElement(selenium.ByCSSSelector, "input.font-monospace")
-				if err != nil {
-					return false
+				if err == nil {
+					val, _ := input.GetAttribute("value")
+					if strings.HasPrefix(val, "****") {
+						return true
+					}
 				}
-				val, _ := input.GetAttribute("value")
-				return strings.HasPrefix(val, "****")
-			}, 5*time.Second)
+				// Also accept if regenerate button appears (token was set)
+				_, err = wd.FindElement(selenium.ByCSSSelector, ".btn-warning")
+				return err == nil
+			}, 10*time.Second)
 		})
 		t.Run("Workers Page Team Column", func(t *testing.T) {
 			// Always restore browser state for subsequent tests
@@ -387,7 +393,7 @@ func TestPikoCI(t *testing.T) {
 			for _, h := range headers {
 				txt, _ := h.Text()
 				headerTexts = append(headerTexts, txt)
-				if txt == "Team" {
+				if strings.EqualFold(txt, "Team") {
 					foundTeamHeader = true
 				}
 			}

--- a/pikoci/grpc/server.go
+++ b/pikoci/grpc/server.go
@@ -24,15 +24,21 @@ type WorkDispatcher interface {
 	NextWork(ctx context.Context, wc workitem.WorkerContext) (*workitem.Item, error)
 }
 
+// TeamSaltLookup provides team worker token salt for JWT validation.
+type TeamSaltLookup interface {
+	FindWorkerTokenSalt(ctx context.Context, tc string) (string, error)
+}
+
 // Server implements the WorkerService gRPC server.
 type Server struct {
 	workerv1.UnimplementedWorkerServiceServer
 
-	svc       WorkDispatcher
-	notifier  *notifier.WorkNotifier
-	streams   *WorkerStreamManager
-	jwtSecret []byte
-	logger    *slog.Logger
+	svc            WorkDispatcher
+	notifier       *notifier.WorkNotifier
+	streams        *WorkerStreamManager
+	jwtSecret      []byte
+	teamSaltLookup TeamSaltLookup
+	logger         *slog.Logger
 
 	// registeredWorkers stores registration info from Register calls.
 	// Entries expire after 30 seconds if Execute is not called.
@@ -44,16 +50,18 @@ type registeredWorker struct {
 	maxJobs       int32
 	tags          []string
 	exclusiveTags bool
-	registeredAt    time.Time
+	teamCanonical string
+	registeredAt  time.Time
 }
 
 // NewServer creates a new gRPC WorkerService server.
-func NewServer(svc WorkDispatcher, n *notifier.WorkNotifier, sm *WorkerStreamManager, jwtSecret []byte, l *slog.Logger) *Server {
+func NewServer(svc WorkDispatcher, n *notifier.WorkNotifier, sm *WorkerStreamManager, jwtSecret []byte, tsl TeamSaltLookup, l *slog.Logger) *Server {
 	return &Server{
 		svc:               svc,
 		notifier:          n,
 		streams:           sm,
 		jwtSecret:         jwtSecret,
+		teamSaltLookup:    tsl,
 		logger:            l,
 		registeredWorkers: make(map[string]*registeredWorker),
 	}
@@ -67,21 +75,23 @@ func (s *Server) Streams() *WorkerStreamManager {
 // Register validates a worker's JWT token and stores the worker's max_jobs
 // capacity for use when the Execute stream opens.
 func (s *Server) Register(ctx context.Context, req *workerv1.RegisterRequest) (*workerv1.RegisterResponse, error) {
-	if err := s.validateWorkerToken(req.WorkerToken); err != nil {
+	teamCanonical, err := s.validateWorkerToken(ctx, req.WorkerToken)
+	if err != nil {
 		return &workerv1.RegisterResponse{
 			Accepted: false,
 			Message:  "invalid worker token",
 		}, nil
 	}
 
-	s.logger.Info("worker registered via gRPC", "worker_id", req.WorkerId, "max_jobs", req.MaxJobs)
+	s.logger.Info("worker registered via gRPC", "worker_id", req.WorkerId, "max_jobs", req.MaxJobs, "team", teamCanonical)
 
 	s.registeredMu.Lock()
 	s.registeredWorkers[req.WorkerId] = &registeredWorker{
 		maxJobs:       req.MaxJobs,
 		tags:          req.Tags,
 		exclusiveTags: req.ExclusiveTags,
-		registeredAt:    time.Now(),
+		teamCanonical: teamCanonical,
+		registeredAt:  time.Now(),
 	}
 	s.registeredMu.Unlock()
 
@@ -134,7 +144,7 @@ func (s *Server) Execute(stream workerv1.WorkerService_ExecuteServer) error {
 	if maxJobs <= 0 {
 		maxJobs = 1
 	}
-	ws := NewWorkerStream(workerID, maxJobs, rw.tags, rw.exclusiveTags)
+	ws := NewWorkerStream(workerID, maxJobs, rw.tags, rw.exclusiveTags, rw.teamCanonical)
 	s.streams.Register(ws)
 	defer s.streams.Unregister(workerID)
 
@@ -222,6 +232,7 @@ func (s *Server) tryDispatch(ctx context.Context, ws *WorkerStream) {
 	wc := workitem.WorkerContext{
 		Tags:          ws.Tags,
 		ExclusiveTags: ws.ExclusiveTags,
+		TeamCanonical: ws.TeamCanonical,
 	}
 	for ws.HasCapacity() {
 		item, err := s.svc.NextWork(ctx, wc)
@@ -340,25 +351,53 @@ func (s *Server) CancelBuild(buildID string, reason string) error {
 	return s.streams.SendToWorker(ws.WorkerID, msg)
 }
 
-// validateWorkerToken validates a JWT worker token.
-func (s *Server) validateWorkerToken(tokenStr string) error {
+// validateWorkerToken validates a JWT worker token and returns the team
+// canonical if the token is team-scoped, or empty string for global workers.
+func (s *Server) validateWorkerToken(ctx context.Context, tokenStr string) (string, error) {
 	token, err := jwt.Parse(tokenStr, func(token *jwt.Token) (interface{}, error) {
 		return s.jwtSecret, nil
 	}, jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}))
 	if err != nil {
-		return fmt.Errorf("invalid token: %w", err)
+		return "", fmt.Errorf("invalid token: %w", err)
 	}
 
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok {
-		return fmt.Errorf("invalid claims")
+		return "", fmt.Errorf("invalid claims")
 	}
 
 	isFromWorker, _ := claims["is_from_worker"].(bool)
 	if !isFromWorker {
-		return fmt.Errorf("token is not a worker token")
+		return "", fmt.Errorf("token is not a worker token")
 	}
 
-	return nil
+	// Check for team-scoped token
+	tc, _ := claims["team_canonical"].(string)
+	if tc == "" {
+		return "", nil // global worker
+	}
+
+	// Verify salt against DB
+	salt, _ := claims["salt"].(string)
+	if salt == "" {
+		return "", fmt.Errorf("team token missing salt claim")
+	}
+
+	if s.teamSaltLookup == nil {
+		return "", fmt.Errorf("team salt lookup not configured")
+	}
+
+	dbSalt, err := s.teamSaltLookup.FindWorkerTokenSalt(ctx, tc)
+	if err != nil {
+		return "", fmt.Errorf("failed to look up team salt: %w", err)
+	}
+	if dbSalt == "" {
+		return "", fmt.Errorf("team worker token has been revoked")
+	}
+	if dbSalt != salt {
+		return "", fmt.Errorf("team worker token salt mismatch")
+	}
+
+	return tc, nil
 }
 

--- a/pikoci/grpc/server_test.go
+++ b/pikoci/grpc/server_test.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net"
 	"os"
@@ -65,9 +66,13 @@ func TestServer_ValidateWorkerToken(t *testing.T) {
 // fakeTeamSaltLookup implements TeamSaltLookup for testing.
 type fakeTeamSaltLookup struct {
 	salts map[string]string
+	err   error
 }
 
 func (f *fakeTeamSaltLookup) FindWorkerTokenSalt(ctx context.Context, tc string) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
 	return f.salts[tc], nil
 }
 
@@ -126,6 +131,90 @@ func TestServer_ValidateWorkerToken_TeamScoped(t *testing.T) {
 	tc, err = s.validateWorkerToken(ctx, globalToken)
 	assert.NoError(t, err)
 	assert.Empty(t, tc)
+}
+
+func TestServer_ValidateWorkerToken_NilSaltLookup_TeamToken(t *testing.T) {
+	ctx := context.TODO()
+	secret := []byte("test-secret")
+	// Server with nil teamSaltLookup (embedded mode)
+	s := NewServer(nil, notifier.New(), NewWorkerStreamManager(), secret, nil, testLogger)
+
+	teamToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"is_from_worker": true,
+		"team_canonical": "teamA",
+		"salt":           "some-salt",
+	})
+	tokenStr, _ := teamToken.SignedString(secret)
+	_, err := s.validateWorkerToken(ctx, tokenStr)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "team salt lookup not configured")
+}
+
+func TestServer_ValidateWorkerToken_SaltLookupDBError(t *testing.T) {
+	ctx := context.TODO()
+	secret := []byte("test-secret")
+	tsl := &fakeTeamSaltLookup{err: fmt.Errorf("connection refused")}
+	s := NewServer(nil, notifier.New(), NewWorkerStreamManager(), secret, tsl, testLogger)
+
+	teamToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"is_from_worker": true,
+		"team_canonical": "teamA",
+		"salt":           "some-salt",
+	})
+	tokenStr, _ := teamToken.SignedString(secret)
+	_, err := s.validateWorkerToken(ctx, tokenStr)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to look up team salt")
+}
+
+func TestServer_Register_TeamScoped(t *testing.T) {
+	secret := []byte("test-secret")
+	salt := "test-salt"
+	tsl := &fakeTeamSaltLookup{salts: map[string]string{"teamA": salt}}
+	s := NewServer(nil, notifier.New(), NewWorkerStreamManager(), secret, tsl, testLogger)
+
+	teamToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"is_from_worker": true,
+		"team_canonical": "teamA",
+		"salt":           salt,
+	})
+	tokenStr, _ := teamToken.SignedString(secret)
+
+	resp, err := s.Register(context.TODO(), &workerv1.RegisterRequest{
+		WorkerId:    "tw1",
+		WorkerToken: tokenStr,
+		MaxJobs:     2,
+		Tags:        []string{"gpu"},
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Accepted)
+
+	// Verify teamCanonical is stored in registeredWorker
+	s.registeredMu.Lock()
+	rw, ok := s.registeredWorkers["tw1"]
+	s.registeredMu.Unlock()
+	assert.True(t, ok)
+	assert.Equal(t, "teamA", rw.teamCanonical)
+	assert.Equal(t, int32(2), rw.maxJobs)
+}
+
+func TestServer_TryDispatch_PropagatesTeamCanonical(t *testing.T) {
+	var capturedWC workitem.WorkerContext
+	dispatcher := &fakeDispatcher{
+		nextWorkFn: func(ctx context.Context, wc workitem.WorkerContext) (*workitem.Item, error) {
+			capturedWC = wc
+			return nil, nil
+		},
+	}
+
+	s := NewServer(dispatcher, notifier.New(), NewWorkerStreamManager(), nil, nil, testLogger)
+	ws := NewWorkerStream("w1", 2, []string{"gpu"}, true, "teamA")
+
+	s.tryDispatch(context.Background(), ws)
+
+	assert.Equal(t, "teamA", capturedWC.TeamCanonical)
+	assert.Equal(t, []string{"gpu"}, capturedWC.Tags)
+	assert.True(t, capturedWC.ExclusiveTags)
 }
 
 func TestServer_Register_ValidToken(t *testing.T) {

--- a/pikoci/grpc/server_test.go
+++ b/pikoci/grpc/server_test.go
@@ -31,38 +31,106 @@ func validWorkerToken(secret []byte) string {
 // --- Unit tests ---
 
 func TestServer_ValidateWorkerToken(t *testing.T) {
+	ctx := context.TODO()
 	secret := []byte("test-secret")
-	s := NewServer(nil, notifier.New(), NewWorkerStreamManager(), secret, testLogger)
+	s := NewServer(nil, notifier.New(), NewWorkerStreamManager(), secret, nil, testLogger)
 
-	// Valid worker token
-	err := s.validateWorkerToken(validWorkerToken(secret))
+	// Valid global worker token
+	tc, err := s.validateWorkerToken(ctx, validWorkerToken(secret))
 	assert.NoError(t, err)
+	assert.Empty(t, tc)
 
 	// Non-worker token (user token, missing is_from_worker)
 	token2 := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"user": map[string]interface{}{"username": "test"},
 	})
 	tokenStr2, _ := token2.SignedString(secret)
-	err = s.validateWorkerToken(tokenStr2)
+	_, err = s.validateWorkerToken(ctx, tokenStr2)
 	assert.Error(t, err)
 
 	// Invalid token string
-	err = s.validateWorkerToken("invalid-token")
+	_, err = s.validateWorkerToken(ctx, "invalid-token")
 	assert.Error(t, err)
 
 	// Wrong signing secret
 	wrongSecret := []byte("wrong-secret")
-	err = s.validateWorkerToken(validWorkerToken(wrongSecret))
+	_, err = s.validateWorkerToken(ctx, validWorkerToken(wrongSecret))
 	assert.Error(t, err)
 
 	// Empty token
-	err = s.validateWorkerToken("")
+	_, err = s.validateWorkerToken(ctx, "")
 	assert.Error(t, err)
+}
+
+// fakeTeamSaltLookup implements TeamSaltLookup for testing.
+type fakeTeamSaltLookup struct {
+	salts map[string]string
+}
+
+func (f *fakeTeamSaltLookup) FindWorkerTokenSalt(ctx context.Context, tc string) (string, error) {
+	return f.salts[tc], nil
+}
+
+func TestServer_ValidateWorkerToken_TeamScoped(t *testing.T) {
+	ctx := context.TODO()
+	secret := []byte("test-secret")
+	salt := "test-salt-uuid"
+
+	tsl := &fakeTeamSaltLookup{salts: map[string]string{"teamA": salt}}
+	s := NewServer(nil, notifier.New(), NewWorkerStreamManager(), secret, tsl, testLogger)
+
+	// Valid team token with correct salt
+	teamToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"is_from_worker": true,
+		"team_canonical": "teamA",
+		"salt":           salt,
+	})
+	tokenStr, _ := teamToken.SignedString(secret)
+	tc, err := s.validateWorkerToken(ctx, tokenStr)
+	assert.NoError(t, err)
+	assert.Equal(t, "teamA", tc)
+
+	// Team token with wrong salt
+	badSaltToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"is_from_worker": true,
+		"team_canonical": "teamA",
+		"salt":           "wrong-salt",
+	})
+	tokenStr, _ = badSaltToken.SignedString(secret)
+	_, err = s.validateWorkerToken(ctx, tokenStr)
+	assert.Error(t, err)
+
+	// Team token with empty salt in DB (token revoked)
+	tsl2 := &fakeTeamSaltLookup{salts: map[string]string{"teamB": ""}}
+	s2 := NewServer(nil, notifier.New(), NewWorkerStreamManager(), secret, tsl2, testLogger)
+	revokedToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"is_from_worker": true,
+		"team_canonical": "teamB",
+		"salt":           "old-salt",
+	})
+	tokenStr, _ = revokedToken.SignedString(secret)
+	_, err = s2.validateWorkerToken(ctx, tokenStr)
+	assert.Error(t, err)
+
+	// Team token missing salt claim
+	noSaltToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"is_from_worker": true,
+		"team_canonical": "teamA",
+	})
+	tokenStr, _ = noSaltToken.SignedString(secret)
+	_, err = s.validateWorkerToken(ctx, tokenStr)
+	assert.Error(t, err)
+
+	// Global token (no team claim) → accepted, returns empty team canonical
+	globalToken := validWorkerToken(secret)
+	tc, err = s.validateWorkerToken(ctx, globalToken)
+	assert.NoError(t, err)
+	assert.Empty(t, tc)
 }
 
 func TestServer_Register_ValidToken(t *testing.T) {
 	secret := []byte("test-secret")
-	s := NewServer(nil, notifier.New(), NewWorkerStreamManager(), secret, testLogger)
+	s := NewServer(nil, notifier.New(), NewWorkerStreamManager(), secret, nil, testLogger)
 
 	resp, err := s.Register(context.TODO(), &workerv1.RegisterRequest{
 		WorkerId:    "w1",
@@ -82,7 +150,7 @@ func TestServer_Register_ValidToken(t *testing.T) {
 
 func TestServer_Register_InvalidToken(t *testing.T) {
 	secret := []byte("test-secret")
-	s := NewServer(nil, notifier.New(), NewWorkerStreamManager(), secret, testLogger)
+	s := NewServer(nil, notifier.New(), NewWorkerStreamManager(), secret, nil, testLogger)
 
 	resp, err := s.Register(context.TODO(), &workerv1.RegisterRequest{
 		WorkerId:    "w2",
@@ -101,7 +169,7 @@ func TestServer_Register_InvalidToken(t *testing.T) {
 
 func TestServer_Register_ConsumedByExecute(t *testing.T) {
 	secret := []byte("test-secret")
-	s := NewServer(nil, notifier.New(), NewWorkerStreamManager(), secret, testLogger)
+	s := NewServer(nil, notifier.New(), NewWorkerStreamManager(), secret, nil, testLogger)
 
 	// Register stores entry
 	s.Register(context.TODO(), &workerv1.RegisterRequest{
@@ -129,14 +197,14 @@ func TestServer_Register_ConsumedByExecute(t *testing.T) {
 }
 
 func TestServer_CancelBuild(t *testing.T) {
-	s := NewServer(nil, notifier.New(), NewWorkerStreamManager(), nil, testLogger)
+	s := NewServer(nil, notifier.New(), NewWorkerStreamManager(), nil, nil, testLogger)
 
 	// No worker has the build
 	err := s.CancelBuild("b1", "user cancelled")
 	assert.Error(t, err)
 
 	// Register a worker with the build
-	ws := NewWorkerStream("w1", 2, nil, false)
+	ws := NewWorkerStream("w1", 2, nil, false, "")
 	ws.AddBuild("b1")
 	s.streams.Register(ws)
 
@@ -152,8 +220,8 @@ func TestServer_CancelBuild(t *testing.T) {
 }
 
 func TestServer_SendWorkItem(t *testing.T) {
-	s := NewServer(nil, notifier.New(), NewWorkerStreamManager(), nil, testLogger)
-	ws := NewWorkerStream("w1", 2, nil, false)
+	s := NewServer(nil, notifier.New(), NewWorkerStreamManager(), nil, nil, testLogger)
+	ws := NewWorkerStream("w1", 2, nil, false, "")
 
 	item := &workitem.Item{
 		Type: "job",
@@ -185,8 +253,8 @@ func TestServer_SendWorkItem(t *testing.T) {
 }
 
 func TestServer_SendWorkItem_ResourceCheck(t *testing.T) {
-	s := NewServer(nil, notifier.New(), NewWorkerStreamManager(), nil, testLogger)
-	ws := NewWorkerStream("w1", 2, nil, false)
+	s := NewServer(nil, notifier.New(), NewWorkerStreamManager(), nil, nil, testLogger)
+	ws := NewWorkerStream("w1", 2, nil, false, "")
 
 	item := &workitem.Item{
 		Type: "check",
@@ -228,8 +296,8 @@ func TestServer_TryDispatch_FillsCapacity(t *testing.T) {
 		},
 	}
 
-	s := NewServer(dispatcher, notifier.New(), NewWorkerStreamManager(), nil, testLogger)
-	ws := NewWorkerStream("w1", 3, nil, false)
+	s := NewServer(dispatcher, notifier.New(), NewWorkerStreamManager(), nil, nil, testLogger)
+	ws := NewWorkerStream("w1", 3, nil, false, "")
 
 	s.tryDispatch(context.Background(), ws)
 
@@ -239,8 +307,8 @@ func TestServer_TryDispatch_FillsCapacity(t *testing.T) {
 
 func TestServer_HandleJobResult_NotifiesAndRemovesBuild(t *testing.T) {
 	n := notifier.New()
-	s := NewServer(nil, n, NewWorkerStreamManager(), nil, testLogger)
-	ws := NewWorkerStream("w1", 2, nil, false)
+	s := NewServer(nil, n, NewWorkerStreamManager(), nil, nil, testLogger)
+	ws := NewWorkerStream("w1", 2, nil, false, "")
 	ws.AddBuild("b1")
 
 	// Set up a waiter before the notification
@@ -270,7 +338,7 @@ func TestServer_HandleJobResult_NotifiesAndRemovesBuild(t *testing.T) {
 func startTestServer(t *testing.T, svc WorkDispatcher, n *notifier.WorkNotifier, secret []byte) (workerv1.WorkerServiceClient, *Server, func()) {
 	t.Helper()
 	sm := NewWorkerStreamManager()
-	srv := NewServer(svc, n, sm, secret, testLogger)
+	srv := NewServer(svc, n, sm, secret, nil, testLogger)
 	grpcSrv := grpc.NewServer()
 	workerv1.RegisterWorkerServiceServer(grpcSrv, srv)
 

--- a/pikoci/grpc/streams.go
+++ b/pikoci/grpc/streams.go
@@ -15,6 +15,7 @@ type WorkerStream struct {
 	MaxJobs       int32
 	Tags          []string
 	ExclusiveTags bool
+	TeamCanonical string
 	Send          chan *workerv1.ServerMessage
 	Done          chan struct{}
 
@@ -23,12 +24,13 @@ type WorkerStream struct {
 }
 
 // NewWorkerStream creates a WorkerStream for the given worker.
-func NewWorkerStream(workerID string, maxJobs int32, tags []string, exclusiveTags bool) *WorkerStream {
+func NewWorkerStream(workerID string, maxJobs int32, tags []string, exclusiveTags bool, teamCanonical string) *WorkerStream {
 	return &WorkerStream{
 		WorkerID:      workerID,
 		MaxJobs:       maxJobs,
 		Tags:          tags,
 		ExclusiveTags: exclusiveTags,
+		TeamCanonical: teamCanonical,
 		Send:          make(chan *workerv1.ServerMessage, 16),
 		Done:          make(chan struct{}),
 		runningBuilds: make(map[string]struct{}),
@@ -156,4 +158,16 @@ func (m *WorkerStreamManager) ConnectedCount() int {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return len(m.streams)
+}
+
+// HasTeamWorkers returns true if any connected worker is scoped to the given team.
+func (m *WorkerStreamManager) HasTeamWorkers(tc string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, ws := range m.streams {
+		if ws.TeamCanonical == tc {
+			return true
+		}
+	}
+	return false
 }

--- a/pikoci/grpc/streams_test.go
+++ b/pikoci/grpc/streams_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestWorkerStream_BuildTracking(t *testing.T) {
-	ws := NewWorkerStream("w1", 2, nil, false)
+	ws := NewWorkerStream("w1", 2, nil, false, "")
 
 	assert.True(t, ws.HasCapacity())
 	assert.Equal(t, 0, ws.RunningCount())
@@ -33,7 +33,7 @@ func TestWorkerStream_BuildTracking(t *testing.T) {
 func TestWorkerStreamManager_RegisterUnregister(t *testing.T) {
 	m := NewWorkerStreamManager()
 
-	ws := NewWorkerStream("w1", 2, nil, false)
+	ws := NewWorkerStream("w1", 2, nil, false, "")
 	m.Register(ws)
 	assert.Equal(t, 1, m.ConnectedCount())
 	assert.Equal(t, ws, m.Get("w1"))
@@ -46,10 +46,10 @@ func TestWorkerStreamManager_RegisterUnregister(t *testing.T) {
 func TestWorkerStreamManager_RegisterReplacesOld(t *testing.T) {
 	m := NewWorkerStreamManager()
 
-	old := NewWorkerStream("w1", 2, nil, false)
+	old := NewWorkerStream("w1", 2, nil, false, "")
 	m.Register(old)
 
-	newWs := NewWorkerStream("w1", 3, nil, false)
+	newWs := NewWorkerStream("w1", 3, nil, false, "")
 	m.Register(newWs)
 
 	// Old stream's Done should be closed
@@ -71,7 +71,7 @@ func TestWorkerStreamManager_SendToWorker(t *testing.T) {
 	err := m.SendToWorker("w1", &workerv1.ServerMessage{})
 	require.Error(t, err)
 
-	ws := NewWorkerStream("w1", 2, nil, false)
+	ws := NewWorkerStream("w1", 2, nil, false, "")
 	m.Register(ws)
 
 	msg := &workerv1.ServerMessage{
@@ -91,17 +91,36 @@ func TestWorkerStreamManager_FindIdleWorker(t *testing.T) {
 
 	assert.Nil(t, m.FindIdleWorker())
 
-	ws1 := NewWorkerStream("w1", 1, nil, false)
+	ws1 := NewWorkerStream("w1", 1, nil, false, "")
 	ws1.AddBuild("b1") // at capacity
 	m.Register(ws1)
 
 	assert.Nil(t, m.FindIdleWorker())
 
-	ws2 := NewWorkerStream("w2", 2, nil, false)
+	ws2 := NewWorkerStream("w2", 2, nil, false, "")
 	m.Register(ws2)
 
 	idle := m.FindIdleWorker()
 	assert.Equal(t, ws2, idle)
+}
+
+func TestWorkerStreamManager_HasTeamWorkers(t *testing.T) {
+	m := NewWorkerStreamManager()
+
+	assert.False(t, m.HasTeamWorkers("teamA"))
+
+	ws1 := NewWorkerStream("w1", 1, nil, false, "teamA")
+	m.Register(ws1)
+	assert.True(t, m.HasTeamWorkers("teamA"))
+	assert.False(t, m.HasTeamWorkers("teamB"))
+
+	ws2 := NewWorkerStream("w2", 1, nil, false, "")
+	m.Register(ws2)
+	assert.True(t, m.HasTeamWorkers("teamA"))
+	assert.False(t, m.HasTeamWorkers("teamB"))
+
+	m.Unregister("w1")
+	assert.False(t, m.HasTeamWorkers("teamA"))
 }
 
 func TestWorkerStreamManager_WorkerForBuild(t *testing.T) {
@@ -109,11 +128,11 @@ func TestWorkerStreamManager_WorkerForBuild(t *testing.T) {
 
 	assert.Nil(t, m.WorkerForBuild("b1"))
 
-	ws1 := NewWorkerStream("w1", 2, nil, false)
+	ws1 := NewWorkerStream("w1", 2, nil, false, "")
 	ws1.AddBuild("b1")
 	m.Register(ws1)
 
-	ws2 := NewWorkerStream("w2", 2, nil, false)
+	ws2 := NewWorkerStream("w2", 2, nil, false, "")
 	ws2.AddBuild("b2")
 	m.Register(ws2)
 

--- a/pikoci/mock/service.go
+++ b/pikoci/mock/service.go
@@ -401,6 +401,21 @@ func (mr *ServiceMockRecorder) FindOldestPendingBuild(ctx, tc, pn, jn any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindOldestPendingBuild", reflect.TypeOf((*Service)(nil).FindOldestPendingBuild), ctx, tc, pn, jn)
 }
 
+// GenerateTeamWorkerToken mocks base method.
+func (m *Service) GenerateTeamWorkerToken(ctx context.Context, tc string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GenerateTeamWorkerToken", ctx, tc)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GenerateTeamWorkerToken indicates an expected call of GenerateTeamWorkerToken.
+func (mr *ServiceMockRecorder) GenerateTeamWorkerToken(ctx, tc any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateTeamWorkerToken", reflect.TypeOf((*Service)(nil).GenerateTeamWorkerToken), ctx, tc)
+}
+
 // GetBuildReport mocks base method.
 func (m *Service) GetBuildReport(ctx context.Context, tc, pn, jn, buildNumber string) (*build.BuildReport, error) {
 	m.ctrl.T.Helper()
@@ -594,6 +609,21 @@ func (m *Service) GetTeam(ctx context.Context, tc string) (*team.WithMembers, er
 func (mr *ServiceMockRecorder) GetTeam(ctx, tc any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeam", reflect.TypeOf((*Service)(nil).GetTeam), ctx, tc)
+}
+
+// GetTeamWorkerToken mocks base method.
+func (m *Service) GetTeamWorkerToken(ctx context.Context, tc string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTeamWorkerToken", ctx, tc)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTeamWorkerToken indicates an expected call of GetTeamWorkerToken.
+func (mr *ServiceMockRecorder) GetTeamWorkerToken(ctx, tc any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamWorkerToken", reflect.TypeOf((*Service)(nil).GetTeamWorkerToken), ctx, tc)
 }
 
 // GetUser mocks base method.

--- a/pikoci/mock/team_repository.go
+++ b/pikoci/mock/team_repository.go
@@ -143,6 +143,21 @@ func (mr *TeamRepositoryMockRecorder) FindMember(ctx, tc, mc any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindMember", reflect.TypeOf((*TeamRepository)(nil).FindMember), ctx, tc, mc)
 }
 
+// FindWorkerTokenSalt mocks base method.
+func (m *TeamRepository) FindWorkerTokenSalt(ctx context.Context, tc string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindWorkerTokenSalt", ctx, tc)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindWorkerTokenSalt indicates an expected call of FindWorkerTokenSalt.
+func (mr *TeamRepositoryMockRecorder) FindWorkerTokenSalt(ctx, tc any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindWorkerTokenSalt", reflect.TypeOf((*TeamRepository)(nil).FindWorkerTokenSalt), ctx, tc)
+}
+
 // Update mocks base method.
 func (m *TeamRepository) Update(ctx context.Context, tc string, t team.Team) error {
 	m.ctrl.T.Helper()
@@ -169,4 +184,18 @@ func (m *TeamRepository) UpdateMember(ctx context.Context, tc, mc string, tm tea
 func (mr *TeamRepositoryMockRecorder) UpdateMember(ctx, tc, mc, tm any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMember", reflect.TypeOf((*TeamRepository)(nil).UpdateMember), ctx, tc, mc, tm)
+}
+
+// UpdateWorkerTokenSalt mocks base method.
+func (m *TeamRepository) UpdateWorkerTokenSalt(ctx context.Context, tc, salt string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateWorkerTokenSalt", ctx, tc, salt)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateWorkerTokenSalt indicates an expected call of UpdateWorkerTokenSalt.
+func (mr *TeamRepositoryMockRecorder) UpdateWorkerTokenSalt(ctx, tc, salt any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkerTokenSalt", reflect.TypeOf((*TeamRepository)(nil).UpdateWorkerTokenSalt), ctx, tc, salt)
 }

--- a/pikoci/mysql/migrate/migrations/V45TeamWorkerIsolation.go
+++ b/pikoci/mysql/migrate/migrations/V45TeamWorkerIsolation.go
@@ -1,0 +1,7 @@
+package migrations
+
+var V45TeamWorkerIsolation = Migration{
+	Name: "TeamWorkerIsolation",
+	SQL: `ALTER TABLE teams ADD COLUMN worker_token_salt VARCHAR(36) NOT NULL DEFAULT '';
+ALTER TABLE workers ADD COLUMN team_canonical VARCHAR(255) NOT NULL DEFAULT '';`,
+}

--- a/pikoci/mysql/migrate/migrations/migrations.go
+++ b/pikoci/mysql/migrate/migrations/migrations.go
@@ -16,7 +16,7 @@ type Migration struct {
 // Migrations is the ordered list of all schema migrations. It is defined as
 // a fixed-size array so that the compiler catches ordering conflicts when
 // multiple developers add migrations concurrently.
-var Migrations = [45]Migration{
+var Migrations = [46]Migration{
 	V0Initial,
 	V1ResourceCheckInterval,
 	V2JobsAndBuilds,
@@ -62,4 +62,5 @@ var Migrations = [45]Migration{
 	V42RenameRoles,
 	V43BuildApprovals,
 	V44JobApproveColumns,
+	V45TeamWorkerIsolation,
 }

--- a/pikoci/mysql/team.go
+++ b/pikoci/mysql/team.go
@@ -268,6 +268,27 @@ func (r *TeamRepository) DeleteMember(ctx context.Context, tc, mc string) error 
 	return nil
 }
 
+func (r *TeamRepository) FindWorkerTokenSalt(ctx context.Context, tc string) (string, error) {
+	var salt sql.NullString
+	err := r.querier.QueryRowContext(ctx, `
+		SELECT worker_token_salt FROM teams WHERE canonical = ?
+	`, tc).Scan(&salt)
+	if err != nil {
+		return "", fmt.Errorf("failed to find worker token salt: %w", err)
+	}
+	return salt.String, nil
+}
+
+func (r *TeamRepository) UpdateWorkerTokenSalt(ctx context.Context, tc, salt string) error {
+	res, err := r.querier.ExecContext(ctx, `
+		UPDATE teams SET worker_token_salt = ? WHERE canonical = ?
+	`, salt, tc)
+	if err != nil {
+		return fmt.Errorf("failed to update worker token salt: %w", err)
+	}
+	return isEntityFound(res)
+}
+
 func scanTeamsWithMembers(rows *sql.Rows) ([]*team.WithMembers, error) {
 	var ts []*team.WithMembers
 

--- a/pikoci/mysql/worker.go
+++ b/pikoci/mysql/worker.go
@@ -31,8 +31,8 @@ func (r *WorkerRepository) Upsert(ctx context.Context, w wkr.Worker) error {
 	var q string
 	switch r.system {
 	case MySQL:
-		q = "INSERT INTO workers (name, hostname, os, arch, go_version, version, `commit`, concurrency, tags, exclusive_tags, started_at, last_ping_at)" +
-			" VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)" +
+		q = "INSERT INTO workers (name, hostname, os, arch, go_version, version, `commit`, concurrency, tags, exclusive_tags, team_canonical, started_at, last_ping_at)" +
+			" VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)" +
 			" ON DUPLICATE KEY UPDATE" +
 			" hostname = VALUES(hostname)," +
 			" os = VALUES(os)," +
@@ -43,12 +43,13 @@ func (r *WorkerRepository) Upsert(ctx context.Context, w wkr.Worker) error {
 			" concurrency = VALUES(concurrency)," +
 			" tags = VALUES(tags)," +
 			" exclusive_tags = VALUES(exclusive_tags)," +
+			" team_canonical = VALUES(team_canonical)," +
 			" started_at = VALUES(started_at)," +
 			" last_ping_at = VALUES(last_ping_at)"
 	default:
 		// SQLite, mem, PostgreSQL
-		q = "INSERT INTO workers (name, hostname, os, arch, go_version, version, `commit`, concurrency, tags, exclusive_tags, started_at, last_ping_at)" +
-			" VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)" +
+		q = "INSERT INTO workers (name, hostname, os, arch, go_version, version, `commit`, concurrency, tags, exclusive_tags, team_canonical, started_at, last_ping_at)" +
+			" VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)" +
 			" ON CONFLICT(name) DO UPDATE SET" +
 			" hostname = excluded.hostname," +
 			" os = excluded.os," +
@@ -59,13 +60,14 @@ func (r *WorkerRepository) Upsert(ctx context.Context, w wkr.Worker) error {
 			" concurrency = excluded.concurrency," +
 			" tags = excluded.tags," +
 			" exclusive_tags = excluded.exclusive_tags," +
+			" team_canonical = excluded.team_canonical," +
 			" started_at = excluded.started_at," +
 			" last_ping_at = excluded.last_ping_at"
 	}
 
 	_, err := r.querier.ExecContext(ctx, q,
 		w.Name, w.Hostname, w.OS, w.Arch, w.GoVersion, w.Version, w.Commit,
-		w.Concurrency, tagsStr, w.ExclusiveTags, w.StartedAt, w.LastPingAt,
+		w.Concurrency, tagsStr, w.ExclusiveTags, w.TeamCanonical, w.StartedAt, w.LastPingAt,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to upsert worker: %w", err)
@@ -75,7 +77,7 @@ func (r *WorkerRepository) Upsert(ctx context.Context, w wkr.Worker) error {
 
 func (r *WorkerRepository) Filter(ctx context.Context) ([]*wkr.Worker, error) {
 	rows, err := r.querier.QueryContext(ctx,
-		"SELECT id, name, hostname, os, arch, go_version, version, `commit`, concurrency, tags, exclusive_tags, started_at, last_ping_at"+
+		"SELECT id, name, hostname, os, arch, go_version, version, `commit`, concurrency, tags, exclusive_tags, team_canonical, started_at, last_ping_at"+
 			" FROM workers ORDER BY name ASC")
 	if err != nil {
 		return nil, fmt.Errorf("failed to query workers: %w", err)
@@ -97,10 +99,11 @@ func (r *WorkerRepository) Filter(ctx context.Context) ([]*wkr.Worker, error) {
 			concurrency   sql.NullInt64
 			tagsStr       sql.NullString
 			exclusiveTags sql.NullBool
+			teamCanonical sql.NullString
 			startedAt     sql.NullTime
 			lastPingAt    sql.NullTime
 		)
-		if err := rows.Scan(&id, &name, &hostname, &os, &arch, &goVersion, &version, &commit, &concurrency, &tagsStr, &exclusiveTags, &startedAt, &lastPingAt); err != nil {
+		if err := rows.Scan(&id, &name, &hostname, &os, &arch, &goVersion, &version, &commit, &concurrency, &tagsStr, &exclusiveTags, &teamCanonical, &startedAt, &lastPingAt); err != nil {
 			return nil, fmt.Errorf("failed to scan worker: %w", err)
 		}
 		var tags []string
@@ -119,6 +122,7 @@ func (r *WorkerRepository) Filter(ctx context.Context) ([]*wkr.Worker, error) {
 			Concurrency:   int(concurrency.Int64),
 			Tags:          tags,
 			ExclusiveTags: exclusiveTags.Bool,
+			TeamCanonical: teamCanonical.String,
 			StartedAt:     startedAt.Time,
 			LastPingAt:    lastPingAt.Time,
 		}

--- a/pikoci/service.go
+++ b/pikoci/service.go
@@ -310,6 +310,13 @@ type PikoCI struct {
 		CancelBuild(buildID string, reason string) error
 	}
 
+	// TeamWorkerChecker reports whether a team has online team-scoped workers.
+	// Used by NextWork to let global workers defer to team workers.
+	// Nil means no team workers exist (e.g. embedded worker mode).
+	TeamWorkerChecker interface {
+		HasTeamWorkers(tc string) bool
+	}
+
 	scheduler *scheduler.Scheduler
 	logger    *slog.Logger
 }

--- a/pikoci/service.go
+++ b/pikoci/service.go
@@ -261,6 +261,13 @@ type Service interface {
 	// ListAuditLog returns audit log entries for the given team matching the
 	// filter options. The boolean return value indicates whether more results exist.
 	ListAuditLog(ctx context.Context, tc string, opts auditlog.FilterOpts) ([]*auditlog.Entry, bool, error)
+
+	// GenerateTeamWorkerToken generates (or regenerates) a team-scoped worker
+	// token by creating a new salt, storing it, and signing a JWT.
+	GenerateTeamWorkerToken(ctx context.Context, tc string) (string, error)
+	// GetTeamWorkerToken returns the current team worker token, or empty string
+	// if none has been generated.
+	GetTeamWorkerToken(ctx context.Context, tc string) (string, error)
 }
 
 // PikoCI is the primary implementation of the Service interface. It coordinates

--- a/pikoci/team/repository.go
+++ b/pikoci/team/repository.go
@@ -25,4 +25,9 @@ type Repository interface {
 	FindMember(ctx context.Context, tc, mc string) (*Member, error)
 	// DeleteMember removes a member from a team.
 	DeleteMember(ctx context.Context, tc, mc string) error
+
+	// FindWorkerTokenSalt returns the worker token salt for a team.
+	FindWorkerTokenSalt(ctx context.Context, tc string) (string, error)
+	// UpdateWorkerTokenSalt sets the worker token salt for a team.
+	UpdateWorkerTokenSalt(ctx context.Context, tc, salt string) error
 }

--- a/pikoci/team/team.go
+++ b/pikoci/team/team.go
@@ -10,9 +10,10 @@ import (
 
 // Team represents a group of users that owns pipelines and resources.
 type Team struct {
-	ID        uint32 `json:"id"`
-	Name      string `json:"name"`
-	Canonical string `json:"canonical"`
+	ID              uint32 `json:"id"`
+	Name            string `json:"name"`
+	Canonical       string `json:"canonical"`
+	WorkerTokenSalt string `json:"-"`
 }
 
 // WithMembers embeds a Team along with its list of members.

--- a/pikoci/team_worker_token.go
+++ b/pikoci/team_worker_token.go
@@ -1,0 +1,51 @@
+package pikoci
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+)
+
+// GenerateTeamWorkerToken creates (or regenerates) a team-scoped worker token.
+// It generates a new UUID salt, stores it on the team, and returns a signed JWT.
+func (q *PikoCI) GenerateTeamWorkerToken(ctx context.Context, tc string) (string, error) {
+	salt := uuid.New().String()
+
+	if err := q.Teams.UpdateWorkerTokenSalt(ctx, tc, salt); err != nil {
+		return "", fmt.Errorf("failed to store worker token salt: %w", err)
+	}
+
+	tokenStr := signTeamWorkerJWT(q.JWTSecret, tc, salt)
+
+	q.audit(ctx, tc, "worker_token.regenerated", "team", tc, nil)
+
+	return tokenStr, nil
+}
+
+// GetTeamWorkerToken returns the current team worker token, or empty string
+// if no token has been generated yet.
+func (q *PikoCI) GetTeamWorkerToken(ctx context.Context, tc string) (string, error) {
+	salt, err := q.Teams.FindWorkerTokenSalt(ctx, tc)
+	if err != nil {
+		return "", fmt.Errorf("failed to find worker token salt: %w", err)
+	}
+	if salt == "" {
+		return "", nil
+	}
+	return signTeamWorkerJWT(q.JWTSecret, tc, salt), nil
+}
+
+func signTeamWorkerJWT(jwtSecret []byte, tc, salt string) string {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"is_from_worker": true,
+		"team_canonical": tc,
+		"salt":           salt,
+	})
+	tokenString, err := token.SignedString(jwtSecret)
+	if err != nil {
+		panic(err)
+	}
+	return tokenString
+}

--- a/pikoci/team_worker_token_test.go
+++ b/pikoci/team_worker_token_test.go
@@ -1,0 +1,47 @@
+package pikoci_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pikoci/pikoci/pikoci"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestGenerateTeamWorkerToken(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.WithValue(context.TODO(), pikoci.ActorContextKey, "admin")
+
+	s.Teams.EXPECT().UpdateWorkerTokenSalt(gomock.Any(), "main", gomock.Any()).Return(nil)
+
+	token, err := s.P.GenerateTeamWorkerToken(ctx, "main")
+	require.NoError(t, err)
+	assert.NotEmpty(t, token)
+}
+
+func TestGetTeamWorkerToken_Exists(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Teams.EXPECT().FindWorkerTokenSalt(gomock.Any(), "main").Return("test-salt", nil)
+
+	token, err := s.P.GetTeamWorkerToken(ctx, "main")
+	require.NoError(t, err)
+	assert.NotEmpty(t, token)
+}
+
+func TestGetTeamWorkerToken_NoToken(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Teams.EXPECT().FindWorkerTokenSalt(gomock.Any(), "main").Return("", nil)
+
+	token, err := s.P.GetTeamWorkerToken(ctx, "main")
+	require.NoError(t, err)
+	assert.Empty(t, token)
+}

--- a/pikoci/team_worker_token_test.go
+++ b/pikoci/team_worker_token_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/pikoci/pikoci/pikoci"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -73,4 +74,43 @@ func TestGetTeamWorkerToken_FindSaltError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to find worker token salt")
 	assert.Empty(t, token)
+}
+
+// TestGenerateTeamWorkerToken_RoundTrip verifies the JWT produced by
+// GenerateTeamWorkerToken has the correct claims structure that
+// validateWorkerToken expects: is_from_worker, team_canonical, salt.
+func TestGenerateTeamWorkerToken_RoundTrip(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.WithValue(context.TODO(), pikoci.ActorContextKey, "admin")
+
+	var storedSalt string
+	s.Teams.EXPECT().UpdateWorkerTokenSalt(gomock.Any(), "main", gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, salt string) error {
+			storedSalt = salt
+			return nil
+		})
+
+	token, err := s.P.GenerateTeamWorkerToken(ctx, "main")
+	require.NoError(t, err)
+	require.NotEmpty(t, token)
+	require.NotEmpty(t, storedSalt)
+
+	// Parse the JWT and verify claims match what validateWorkerToken expects
+	parsed, err := jwt.Parse(token, func(t *jwt.Token) (interface{}, error) {
+		return s.P.JWTSecret, nil
+	})
+	require.NoError(t, err)
+
+	claims, ok := parsed.Claims.(jwt.MapClaims)
+	require.True(t, ok)
+
+	isWorker, _ := claims["is_from_worker"].(bool)
+	assert.True(t, isWorker, "must have is_from_worker claim")
+
+	tc, _ := claims["team_canonical"].(string)
+	assert.Equal(t, "main", tc, "must have team_canonical claim")
+
+	salt, _ := claims["salt"].(string)
+	assert.Equal(t, storedSalt, salt, "salt claim must match stored salt")
 }

--- a/pikoci/team_worker_token_test.go
+++ b/pikoci/team_worker_token_test.go
@@ -2,6 +2,7 @@ package pikoci_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/pikoci/pikoci/pikoci"
@@ -43,5 +44,33 @@ func TestGetTeamWorkerToken_NoToken(t *testing.T) {
 
 	token, err := s.P.GetTeamWorkerToken(ctx, "main")
 	require.NoError(t, err)
+	assert.Empty(t, token)
+}
+
+func TestGenerateTeamWorkerToken_UpdateSaltError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.WithValue(context.TODO(), pikoci.ActorContextKey, "admin")
+
+	s.Teams.EXPECT().UpdateWorkerTokenSalt(gomock.Any(), "main", gomock.Any()).
+		Return(fmt.Errorf("db connection lost"))
+
+	token, err := s.P.GenerateTeamWorkerToken(ctx, "main")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to store worker token salt")
+	assert.Empty(t, token)
+}
+
+func TestGetTeamWorkerToken_FindSaltError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Teams.EXPECT().FindWorkerTokenSalt(gomock.Any(), "main").
+		Return("", fmt.Errorf("team not found"))
+
+	token, err := s.P.GetTeamWorkerToken(ctx, "main")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to find worker token salt")
 	assert.Empty(t, token)
 }

--- a/pikoci/transport/http/assets/js/app/api.js
+++ b/pikoci/transport/http/assets/js/app/api.js
@@ -183,6 +183,12 @@ export const fetchWorkers = () => api('/workers').then(r => r.data);
 export const fetchWorkersHealth = () => api('/workers/health');
 export const deleteWorker = (name) => api('/workers/' + name, { method: 'DELETE' });
 
+// --- Team Worker Tokens ---
+export const generateTeamWorkerToken = (tc) =>
+  api('/teams/' + tc + '/worker-token', { method: 'POST' }).then(r => r.token);
+export const getTeamWorkerToken = (tc) =>
+  api('/teams/' + tc + '/worker-token').then(r => r.token);
+
 // --- Webhooks ---
 export const regenerateWebhookToken = (tc, pn, rCan) =>
   api('/teams/' + tc + '/pipelines/' + pn + '/resources/' + rCan + '/webhook_token', { method: 'POST' });

--- a/pikoci/transport/http/assets/js/app/components/Teams.js
+++ b/pikoci/transport/http/assets/js/app/components/Teams.js
@@ -187,7 +187,7 @@ export function TeamShow({ tc, tab }) {
     </ul>
     ${activeTab === 'settings' && html`<${SettingsTab} tc=${tc} team=${team} />`}
     ${activeTab === 'members' && html`<${MembersTab} tc=${tc} members=${members} setMembers=${setMembers} loadTeam=${loadTeam} />`}
-    ${activeTab === 'workers' && html`<${WorkersTab} tc=${tc} />`}
+    ${activeTab === 'workers' && hasTeamRole(tc, 'admin') && html`<${WorkersTab} tc=${tc} />`}
     ${activeTab === 'audit' && html`<${AuditLogTab} tc=${tc} />`}
   `;
 }

--- a/pikoci/transport/http/assets/js/app/components/Teams.js
+++ b/pikoci/transport/http/assets/js/app/components/Teams.js
@@ -4,7 +4,7 @@ import { html } from 'htm/preact';
 import { useState, useEffect } from 'preact/hooks';
 import { route } from 'preact-router';
 import { isAdmin, hasTeamRole } from '../state.js';
-import { fetchTeams, createTeam, fetchTeam, updateTeam, deleteTeam, fetchUsers, addTeamMember, updateTeamMember, removeTeamMember, fetchAuditLog, fetchPipelines } from '../api.js';
+import { fetchTeams, createTeam, fetchTeam, updateTeam, deleteTeam, fetchUsers, addTeamMember, updateTeamMember, removeTeamMember, fetchAuditLog, fetchPipelines, generateTeamWorkerToken, getTeamWorkerToken } from '../api.js';
 import { useRequireAuth, useLoading } from '../hooks.js';
 import { showToast } from '../toast.js';
 import { Breadcrumb } from './Layout.js';
@@ -119,10 +119,10 @@ export function TeamNew() {
 }
 
 // ---------------------------------------------------------------------------
-// TeamShow – team detail with tabs: Settings | Members | Audit Log
+// TeamShow – team detail with tabs: Settings | Members | Workers | Audit Log
 // ---------------------------------------------------------------------------
 
-const VALID_TABS = ['settings', 'members', 'audit'];
+const VALID_TABS = ['settings', 'members', 'workers', 'audit'];
 
 export function TeamShow({ tc, tab }) {
   useRequireAuth();
@@ -170,6 +170,14 @@ export function TeamShow({ tc, tab }) {
           <i class="bi bi-people"></i> Members
         </a>
       </li>
+      ${hasTeamRole(tc, 'admin') && html`
+        <li class="nav-item">
+          <a class="nav-link${activeTab === 'workers' ? ' active' : ''}" href=${'/teams/' + tc + '/workers'} data-native id="tab-workers"
+            onClick=${(e) => { e.preventDefault(); switchTab('workers'); }}>
+            <i class="bi bi-cpu"></i> Workers
+          </a>
+        </li>
+      `}
       <li class="nav-item">
         <a class="nav-link${activeTab === 'audit' ? ' active' : ''}" href=${'/teams/' + tc + '/audit'} data-native id="tab-audit"
           onClick=${(e) => { e.preventDefault(); switchTab('audit'); }}>
@@ -179,6 +187,7 @@ export function TeamShow({ tc, tab }) {
     </ul>
     ${activeTab === 'settings' && html`<${SettingsTab} tc=${tc} team=${team} />`}
     ${activeTab === 'members' && html`<${MembersTab} tc=${tc} members=${members} setMembers=${setMembers} loadTeam=${loadTeam} />`}
+    ${activeTab === 'workers' && html`<${WorkersTab} tc=${tc} />`}
     ${activeTab === 'audit' && html`<${AuditLogTab} tc=${tc} />`}
   `;
 }
@@ -216,6 +225,77 @@ function SettingsTab({ tc, team }) {
         </button>
       `}
     </form>
+  `;
+}
+
+// ---------------------------------------------------------------------------
+// WorkersTab – team-scoped worker token management (Admin only)
+// ---------------------------------------------------------------------------
+
+function WorkersTab({ tc }) {
+  const [token, setToken] = useState(null);
+  const [loading, withLoading] = useLoading();
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    getTeamWorkerToken(tc).then(t => setToken(t || '')).catch(() => setToken(''));
+  }, [tc]);
+
+  const onGenerate = () => {
+    withLoading(async () => {
+      const t = await generateTeamWorkerToken(tc);
+      setToken(t);
+      showToast('Worker token generated', 'success');
+    });
+  };
+
+  const onRegenerate = () => {
+    if (!confirm('Regenerating the token will disconnect any workers using the current token. Continue?')) return;
+    onGenerate();
+  };
+
+  const onCopy = () => {
+    navigator.clipboard.writeText(token).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  if (token === null) return null;
+
+  return html`
+    <div style="max-width:640px;">
+      <h3 class="h5 fw-bold mb-3">Team Worker Token</h3>
+      <p class="text-muted mb-3">
+        Generate a token to start workers that only process this team's builds.
+        Workers started with this token will not receive builds from other teams.
+      </p>
+      ${token
+        ? html`
+          <div class="mb-3">
+            <div class="input-group">
+              <input type="text" class="form-control font-monospace" value=${'****' + token.slice(-8)} readonly />
+              <button class="btn btn-outline-primary" type="button" onClick=${onCopy}>
+                <i class="bi ${copied ? 'bi-check' : 'bi-clipboard'}"></i> ${copied ? 'Copied' : 'Copy'}
+              </button>
+            </div>
+          </div>
+          <div class="mb-3">
+            <code class="d-block p-2 rounded" style="background:var(--bg-code,#1d2021);color:var(--text-code,#ebdbb2);font-size:0.85em;">
+              pikoci worker --worker-token ${'${TOKEN}'} --pikoci-url ${'${URL}'}
+            </code>
+          </div>
+          <button class="btn btn-warning" disabled=${loading} onClick=${onRegenerate}>
+            ${loading ? html`Regenerating... <span class="spinner-border spinner-border-sm" role="status"></span>` : html`<i class="bi bi-arrow-repeat"></i> Regenerate Token`}
+          </button>
+        `
+        : html`
+          <button id="generate-worker-token" class="btn btn-success" disabled=${loading} onClick=${onGenerate}>
+            ${loading ? html`Generating... <span class="spinner-border spinner-border-sm" role="status"></span>` : html`<i class="bi bi-plus"></i> Generate Worker Token`}
+          </button>
+        `
+      }
+    </div>
   `;
 }
 

--- a/pikoci/transport/http/assets/js/app/components/Workers.js
+++ b/pikoci/transport/http/assets/js/app/components/Workers.js
@@ -53,6 +53,7 @@ export function WorkersList() {
         <tr>
           <th>Name</th>
           <th>Status</th>
+          <th>Team</th>
           <th>Tags</th>
           <th>Platform</th>
           <th>Version</th>
@@ -104,6 +105,7 @@ function WorkerRow({ worker, serverVersion, serverCommit, onDelete }) {
           : html`<span class="piko-badge piko-badge-started">stale</span>`
         }
       </td>
+      <td>${worker.team_canonical || html`<span class="text-muted">Global</span>`}</td>
       <td>
         ${worker.tags && worker.tags.length > 0 ? html`
           ${worker.tags.map(tag => html`<span class="piko-badge piko-badge-pending">${tag}</span> `)}

--- a/pikoci/transport/http/authorization.go
+++ b/pikoci/transport/http/authorization.go
@@ -84,11 +84,13 @@ var (
 		RejectBuild:  requireRole(role.Maintain),
 
 		// Admin routes
-		CreateTeamMember: requireRole(role.Admin),
-		UpdateTeamMember: requireRole(role.Admin),
-		DeleteTeamMember: requireRole(role.Admin),
-		UpdateTeam: requireRole(role.Admin),
-		DeleteTeam: requireRole(role.Admin),
+		CreateTeamMember:        requireRole(role.Admin),
+		UpdateTeamMember:        requireRole(role.Admin),
+		DeleteTeamMember:        requireRole(role.Admin),
+		UpdateTeam:              requireRole(role.Admin),
+		DeleteTeam:              requireRole(role.Admin),
+		GenerateTeamWorkerToken: requireRole(role.Admin),
+		GetTeamWorkerToken:      requireRole(role.Admin),
 
 		// Global admin routes
 		CreateUser:     globalAdmin,

--- a/pikoci/transport/http/authorization_test.go
+++ b/pikoci/transport/http/authorization_test.go
@@ -72,6 +72,13 @@ func TestRoleAuthorizationMatrix(t *testing.T) {
 		{"admin can delete team", http.MethodDelete, "/teams/main", role.Admin, false, true},
 		{"maintainer denied delete team", http.MethodDelete, "/teams/main", role.Maintain, false, false},
 
+		// --- Team worker token routes: admin only ---
+		{"admin can generate team worker token", http.MethodPost, "/teams/main/worker-token", role.Admin, false, true},
+		{"maintain denied generate team worker token", http.MethodPost, "/teams/main/worker-token", role.Maintain, false, false},
+		{"admin can get team worker token", http.MethodGet, "/teams/main/worker-token", role.Admin, false, true},
+		{"write denied get team worker token", http.MethodGet, "/teams/main/worker-token", role.Write, false, false},
+		{"read denied get team worker token", http.MethodGet, "/teams/main/worker-token", role.Read, false, false},
+
 		// --- Global admin routes: only global admin ---
 		{"global admin can list users", http.MethodGet, "/users", role.Admin, true, true},
 		{"admin denied list users (no global admin)", http.MethodGet, "/users", role.Admin, false, false},
@@ -117,6 +124,8 @@ func TestRoleAuthorizationMatrix(t *testing.T) {
 			svc.EXPECT().ApproveBuild(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			svc.EXPECT().RejectBuild(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			svc.EXPECT().GetBuildReport(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+			svc.EXPECT().GenerateTeamWorkerToken(gomock.Any(), gomock.Any()).Return("token", nil).AnyTimes()
+			svc.EXPECT().GetTeamWorkerToken(gomock.Any(), gomock.Any()).Return("token", nil).AnyTimes()
 
 			// Sign JWT
 			token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"user": um})

--- a/pikoci/transport/http/client/client.go
+++ b/pikoci/transport/http/client/client.go
@@ -1351,3 +1351,29 @@ func (cl *Client) RejectBuild(ctx context.Context, tc, pc, jn, buildNumber, user
 	}
 	return nil
 }
+
+// GenerateTeamWorkerToken generates (or regenerates) a team-scoped worker token.
+func (cl *Client) GenerateTeamWorkerToken(ctx context.Context, tc string) (string, error) {
+	var resp thttp.GenerateTeamWorkerTokenResponse
+	err := cl.Request(ctx, http.MethodPost, fmt.Sprintf("%s/teams/%s/worker-token", cl.url, tc), nil, &resp)
+	if err != nil {
+		return "", fmt.Errorf("failed to make request: %w", err)
+	}
+	if resp.Err != "" {
+		return "", fmt.Errorf("error from request: %s", resp.Err)
+	}
+	return resp.Token, nil
+}
+
+// GetTeamWorkerToken retrieves the current team worker token.
+func (cl *Client) GetTeamWorkerToken(ctx context.Context, tc string) (string, error) {
+	var resp thttp.GetTeamWorkerTokenResponse
+	err := cl.Request(ctx, http.MethodGet, fmt.Sprintf("%s/teams/%s/worker-token", cl.url, tc), nil, &resp)
+	if err != nil {
+		return "", fmt.Errorf("failed to make request: %w", err)
+	}
+	if resp.Err != "" {
+		return "", fmt.Errorf("error from request: %s", resp.Err)
+	}
+	return resp.Token, nil
+}

--- a/pikoci/transport/http/client/client_test.go
+++ b/pikoci/transport/http/client/client_test.go
@@ -2859,3 +2859,69 @@ func TestUpdateApiTokenLastUsed_ClientStub(t *testing.T) {
 	// Should not panic — it's a no-op
 	c.UpdateApiTokenLastUsed(context.Background(), 1)
 }
+
+func TestGenerateTeamWorkerToken(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/worker-token", func(w http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "POST", req.Method)
+		jsonHandler(w, thttp.GenerateTeamWorkerTokenResponse{Token: "eyJhbG..."})
+	}).Methods("POST")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	token, err := c.GenerateTeamWorkerToken(context.Background(), "main")
+	require.NoError(t, err)
+	assert.Equal(t, "eyJhbG...", token)
+}
+
+func TestGenerateTeamWorkerToken_Error(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/worker-token", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.GenerateTeamWorkerTokenResponse{Err: "not admin"})
+	}).Methods("POST")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	_, err = c.GenerateTeamWorkerToken(context.Background(), "main")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not admin")
+}
+
+func TestGetTeamWorkerToken(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/worker-token", func(w http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "GET", req.Method)
+		jsonHandler(w, thttp.GetTeamWorkerTokenResponse{Token: "eyJhbG..."})
+	}).Methods("GET")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	token, err := c.GetTeamWorkerToken(context.Background(), "main")
+	require.NoError(t, err)
+	assert.Equal(t, "eyJhbG...", token)
+}
+
+func TestGetTeamWorkerToken_Error(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/worker-token", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.GetTeamWorkerTokenResponse{Err: "not found"})
+	}).Methods("GET")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	_, err = c.GetTeamWorkerToken(context.Background(), "main")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/pikoci/transport/http/handler.go
+++ b/pikoci/transport/http/handler.go
@@ -35,6 +35,8 @@ const (
 	IsPublicAccessKey contextKey = "is_public_access_key"
 	// ApiTokenContextKey is the context key used to store the API token auth result.
 	ApiTokenContextKey contextKey = "api_token_context_key"
+	// WorkerTeamCanonicalKey is the context key for the team canonical from a team-scoped worker JWT.
+	WorkerTeamCanonicalKey contextKey = "worker_team_canonical_key"
 )
 
 // publicFallbackRoutes lists routes that can fall back to public pipeline access
@@ -126,6 +128,8 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, 
 								if !isFromWorker {
 									l.Error("missing user claim in token")
 									authFailed = true
+								} else if wtc, ok := claims["team_canonical"].(string); ok && wtc != "" {
+									rr = rr.WithContext(context.WithValue(rr.Context(), WorkerTeamCanonicalKey, wtc))
 								}
 							} else {
 								un, ok = userClaim["username"].(string)
@@ -308,6 +312,9 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, 
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/resources/{resource_canonical}/versions/{version_id}/trigger").Name(TriggerResourceVersion.String()).Handler(triggerResourceVersion(s))
 	api.Methods(http.MethodGet).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/resources/{resource_canonical}/versions/{version_id}/path").Name(GetResourceVersionPath.String()).Handler(getResourceVersionPath(s))
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/resources/{resource_canonical}/webhook_token").Name(RegenerateWebhookToken.String()).Handler(regenerateWebhookToken(s))
+
+	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/worker-token").Name(GenerateTeamWorkerToken.String()).Handler(generateTeamWorkerToken(s))
+	api.Methods(http.MethodGet).Path("/teams/{team_canonical}/worker-token").Name(GetTeamWorkerToken.String()).Handler(getTeamWorkerToken(s))
 
 	api.Methods(http.MethodGet).Path("/teams/{team_canonical}/audit").Name(ListAuditLog.String()).Handler(listAuditLog(s))
 

--- a/pikoci/transport/http/handlers_coverage_test.go
+++ b/pikoci/transport/http/handlers_coverage_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/pikoci/pikoci/pikoci/apitoken"
 	"github.com/pikoci/pikoci/pikoci/auditlog"
 	"github.com/pikoci/pikoci/pikoci/build"
@@ -20,6 +21,7 @@ import (
 	"github.com/pikoci/pikoci/pikoci/team"
 	"github.com/pikoci/pikoci/pikoci/trigger"
 	"github.com/pikoci/pikoci/pikoci/user"
+	"github.com/pikoci/pikoci/pikoci/wkr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -2717,4 +2719,60 @@ func TestGetTeamWorkerToken_NoToken(t *testing.T) {
 	json.NewDecoder(resp.Body).Decode(&got)
 	assert.Empty(t, got.Err)
 	assert.Empty(t, got.Token)
+}
+
+// TestWorkerHeartbeat_TeamScoped verifies that a team-scoped worker JWT
+// extracts team_canonical from claims and passes it to WorkerHeartbeat.
+func TestWorkerHeartbeat_TeamScoped(t *testing.T) {
+	e := newTestEnv(t)
+
+	// Sign a team-scoped worker JWT
+	workerToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"is_from_worker": true,
+		"team_canonical": "teama",
+		"salt":           "test-salt",
+	})
+	workerJWT, err := workerToken.SignedString(e.secret)
+	require.NoError(t, err)
+
+	// Expect heartbeat to be called with TeamCanonical set
+	e.svc.EXPECT().WorkerHeartbeat(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx interface{}, w interface{}) error {
+			wk := w.(wkr.Worker)
+			assert.Equal(t, "team-worker-1", wk.Name)
+			assert.Equal(t, "teama", wk.TeamCanonical)
+			return nil
+		})
+
+	resp := doRequest(t, http.MethodPost, e.server.URL+"/workers/heartbeat",
+		workerJWT, `{"name":"team-worker-1","hostname":"h1","os":"linux","arch":"amd64"}`)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestWorkerHeartbeat_GlobalWorker verifies that a global worker JWT
+// results in empty TeamCanonical on the worker.
+func TestWorkerHeartbeat_GlobalWorker(t *testing.T) {
+	e := newTestEnv(t)
+
+	workerToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"is_from_worker": true,
+	})
+	workerJWT, err := workerToken.SignedString(e.secret)
+	require.NoError(t, err)
+
+	e.svc.EXPECT().WorkerHeartbeat(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx interface{}, w interface{}) error {
+			wk := w.(wkr.Worker)
+			assert.Equal(t, "global-worker-1", wk.Name)
+			assert.Empty(t, wk.TeamCanonical)
+			return nil
+		})
+
+	resp := doRequest(t, http.MethodPost, e.server.URL+"/workers/heartbeat",
+		workerJWT, `{"name":"global-worker-1","hostname":"h1","os":"linux","arch":"amd64"}`)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }

--- a/pikoci/transport/http/handlers_coverage_test.go
+++ b/pikoci/transport/http/handlers_coverage_test.go
@@ -2657,3 +2657,64 @@ func TestListAuditLog_WithDateAndMultiFilters(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
+
+// ===== Team Worker Token Handler Tests =====
+
+func TestGenerateTeamWorkerToken_Success(t *testing.T) {
+	e := newTestEnv(t)
+	e.expectAdminAuth()
+	e.svc.EXPECT().GenerateTeamWorkerToken(gomock.Any(), "main").Return("eyJhbG...", nil)
+
+	resp := doRequest(t, http.MethodPost, e.server.URL+"/teams/main/worker-token", e.adminJWT(t), "")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	var got GenerateTeamWorkerTokenResponse
+	json.NewDecoder(resp.Body).Decode(&got)
+	assert.Empty(t, got.Err)
+	assert.Equal(t, "eyJhbG...", got.Token)
+}
+
+func TestGenerateTeamWorkerToken_ServiceError(t *testing.T) {
+	e := newTestEnv(t)
+	e.expectAdminAuth()
+	e.svc.EXPECT().GenerateTeamWorkerToken(gomock.Any(), "main").Return("", fmt.Errorf("db error"))
+
+	resp := doRequest(t, http.MethodPost, e.server.URL+"/teams/main/worker-token", e.adminJWT(t), "")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	var got GenerateTeamWorkerTokenResponse
+	json.NewDecoder(resp.Body).Decode(&got)
+	assert.Contains(t, got.Err, "db error")
+}
+
+func TestGetTeamWorkerToken_Success(t *testing.T) {
+	e := newTestEnv(t)
+	e.expectAdminAuth()
+	e.svc.EXPECT().GetTeamWorkerToken(gomock.Any(), "main").Return("eyJhbG...", nil)
+
+	resp := doRequest(t, http.MethodGet, e.server.URL+"/teams/main/worker-token", e.adminJWT(t), "")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	var got GetTeamWorkerTokenResponse
+	json.NewDecoder(resp.Body).Decode(&got)
+	assert.Empty(t, got.Err)
+	assert.Equal(t, "eyJhbG...", got.Token)
+}
+
+func TestGetTeamWorkerToken_NoToken(t *testing.T) {
+	e := newTestEnv(t)
+	e.expectAdminAuth()
+	e.svc.EXPECT().GetTeamWorkerToken(gomock.Any(), "main").Return("", nil)
+
+	resp := doRequest(t, http.MethodGet, e.server.URL+"/teams/main/worker-token", e.adminJWT(t), "")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	var got GetTeamWorkerTokenResponse
+	json.NewDecoder(resp.Body).Decode(&got)
+	assert.Empty(t, got.Err)
+	assert.Empty(t, got.Token)
+}

--- a/pikoci/transport/http/route_names.go
+++ b/pikoci/transport/http/route_names.go
@@ -171,4 +171,9 @@ const (
 	ApproveBuild
 	// RejectBuild is the route for rejecting a build waiting for approval.
 	RejectBuild
+
+	// GenerateTeamWorkerToken is the route for generating a team worker token.
+	GenerateTeamWorkerToken
+	// GetTeamWorkerToken is the route for retrieving the current team worker token.
+	GetTeamWorkerToken
 )

--- a/pikoci/transport/http/route_names_string.go
+++ b/pikoci/transport/http/route_names_string.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _RouteNameName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_joblist_pipeline_jobsget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobslist_pipeline_resourcesget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionget_resource_version_pathwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_workercreate_api_tokenlist_api_tokensdelete_api_tokenlist_audit_logget_build_reportapprove_buildreject_build"
+const _RouteNameName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_joblist_pipeline_jobsget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobslist_pipeline_resourcesget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionget_resource_version_pathwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_workercreate_api_tokenlist_api_tokensdelete_api_tokenlist_audit_logget_build_reportapprove_buildreject_buildgenerate_team_worker_tokenget_team_worker_token"
 
-var _RouteNameIndex = [...]uint16{0, 10, 23, 34, 44, 52, 63, 74, 89, 103, 114, 124, 132, 143, 154, 172, 190, 208, 223, 238, 250, 265, 279, 297, 318, 338, 356, 372, 388, 410, 426, 442, 457, 481, 504, 517, 533, 548, 567, 592, 626, 650, 673, 694, 718, 743, 766, 788, 808, 830, 854, 879, 894, 918, 932, 951, 966, 980, 996, 1005, 1016, 1027, 1043, 1055, 1069, 1082, 1098, 1113, 1129, 1143, 1159, 1172, 1184}
+var _RouteNameIndex = [...]uint16{0, 10, 23, 34, 44, 52, 63, 74, 89, 103, 114, 124, 132, 143, 154, 172, 190, 208, 223, 238, 250, 265, 279, 297, 318, 338, 356, 372, 388, 410, 426, 442, 457, 481, 504, 517, 533, 548, 567, 592, 626, 650, 673, 694, 718, 743, 766, 788, 808, 830, 854, 879, 894, 918, 932, 951, 966, 980, 996, 1005, 1016, 1027, 1043, 1055, 1069, 1082, 1098, 1113, 1129, 1143, 1159, 1172, 1184, 1210, 1231}
 
-const _RouteNameLowerName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_joblist_pipeline_jobsget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobslist_pipeline_resourcesget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionget_resource_version_pathwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_workercreate_api_tokenlist_api_tokensdelete_api_tokenlist_audit_logget_build_reportapprove_buildreject_build"
+const _RouteNameLowerName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_joblist_pipeline_jobsget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobslist_pipeline_resourcesget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionget_resource_version_pathwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_workercreate_api_tokenlist_api_tokensdelete_api_tokenlist_audit_logget_build_reportapprove_buildreject_buildgenerate_team_worker_tokenget_team_worker_token"
 
 func (i RouteName) String() string {
 	if i < 0 || i >= RouteName(len(_RouteNameIndex)-1) {
@@ -96,9 +96,11 @@ func _RouteNameNoOp() {
 	_ = x[GetBuildReport-(69)]
 	_ = x[ApproveBuild-(70)]
 	_ = x[RejectBuild-(71)]
+	_ = x[GenerateTeamWorkerToken-(72)]
+	_ = x[GetTeamWorkerToken-(73)]
 }
 
-var _RouteNameValues = []RouteName{UserLogin, RefreshToken, CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser, ChangePassword, UpdateProfile, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, ListPipelineJobs, GetPipelineJob, CreateJobBuild, CreateRetryJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, InsertBuildGetVersion, FindBuildGetVersions, GetJobBuild, CancelJobBuild, RetryJobBuild, StartPendingBuild, FindOldestPendingBuild, NotifySerialGroupPendingBuilds, EvaluateDownstreamJobs, ListPipelineResources, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions, PinResourceVersion, UnpinResourceVersion, TriggerResourceVersion, GetResourceVersionPath, WebhookTrigger, RegenerateWebhookToken, CreateTrigger, ListTriggersAfter, ExportDatabase, PausePipeline, UnpausePipeline, PauseJob, UnpauseJob, GetVersion, WorkerHeartbeat, ListWorkers, WorkersHealth, DeleteWorker, CreateApiToken, ListApiTokens, DeleteApiToken, ListAuditLog, GetBuildReport, ApproveBuild, RejectBuild}
+var _RouteNameValues = []RouteName{UserLogin, RefreshToken, CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser, ChangePassword, UpdateProfile, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, ListPipelineJobs, GetPipelineJob, CreateJobBuild, CreateRetryJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, InsertBuildGetVersion, FindBuildGetVersions, GetJobBuild, CancelJobBuild, RetryJobBuild, StartPendingBuild, FindOldestPendingBuild, NotifySerialGroupPendingBuilds, EvaluateDownstreamJobs, ListPipelineResources, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions, PinResourceVersion, UnpinResourceVersion, TriggerResourceVersion, GetResourceVersionPath, WebhookTrigger, RegenerateWebhookToken, CreateTrigger, ListTriggersAfter, ExportDatabase, PausePipeline, UnpausePipeline, PauseJob, UnpauseJob, GetVersion, WorkerHeartbeat, ListWorkers, WorkersHealth, DeleteWorker, CreateApiToken, ListApiTokens, DeleteApiToken, ListAuditLog, GetBuildReport, ApproveBuild, RejectBuild, GenerateTeamWorkerToken, GetTeamWorkerToken}
 
 var _RouteNameNameToValueMap = map[string]RouteName{
 	_RouteNameName[0:10]:           UserLogin,
@@ -245,6 +247,10 @@ var _RouteNameNameToValueMap = map[string]RouteName{
 	_RouteNameLowerName[1159:1172]: ApproveBuild,
 	_RouteNameName[1172:1184]:      RejectBuild,
 	_RouteNameLowerName[1172:1184]: RejectBuild,
+	_RouteNameName[1184:1210]:      GenerateTeamWorkerToken,
+	_RouteNameLowerName[1184:1210]: GenerateTeamWorkerToken,
+	_RouteNameName[1210:1231]:      GetTeamWorkerToken,
+	_RouteNameLowerName[1210:1231]: GetTeamWorkerToken,
 }
 
 var _RouteNameNames = []string{
@@ -320,6 +326,8 @@ var _RouteNameNames = []string{
 	_RouteNameName[1143:1159],
 	_RouteNameName[1159:1172],
 	_RouteNameName[1172:1184],
+	_RouteNameName[1184:1210],
+	_RouteNameName[1210:1231],
 }
 
 // RouteNameString retrieves an enum value from the enum constants string name.

--- a/pikoci/transport/http/team_worker_token.go
+++ b/pikoci/transport/http/team_worker_token.go
@@ -1,0 +1,50 @@
+package http
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/pikoci/pikoci/pikoci"
+)
+
+type GenerateTeamWorkerTokenResponse struct {
+	Token string `json:"token,omitempty"`
+	Err   string `json:"error,omitempty"`
+}
+
+func (r GenerateTeamWorkerTokenResponse) Error() string { return r.Err }
+
+func generateTeamWorkerToken(s pikoci.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		tc := vars["team_canonical"]
+
+		token, err := s.GenerateTeamWorkerToken(r.Context(), tc)
+		var errs string
+		if err != nil {
+			errs = err.Error()
+		}
+		encodeResponse(GenerateTeamWorkerTokenResponse{Token: token, Err: errs}, w)
+	}
+}
+
+type GetTeamWorkerTokenResponse struct {
+	Token string `json:"token,omitempty"`
+	Err   string `json:"error,omitempty"`
+}
+
+func (r GetTeamWorkerTokenResponse) Error() string { return r.Err }
+
+func getTeamWorkerToken(s pikoci.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		tc := vars["team_canonical"]
+
+		token, err := s.GetTeamWorkerToken(r.Context(), tc)
+		var errs string
+		if err != nil {
+			errs = err.Error()
+		}
+		encodeResponse(GetTeamWorkerTokenResponse{Token: token, Err: errs}, w)
+	}
+}

--- a/pikoci/transport/http/workers.go
+++ b/pikoci/transport/http/workers.go
@@ -46,6 +46,9 @@ func workerHeartbeat(s pikoci.Service) http.HandlerFunc {
 			startedAt, _ = time.Parse(time.RFC3339, req.StartedAt)
 		}
 
+		// Extract team canonical from worker JWT context (if team-scoped)
+		teamCanonical, _ := ctx.Value(WorkerTeamCanonicalKey).(string)
+
 		wk := wkr.Worker{
 			Name:          req.Name,
 			Hostname:      req.Hostname,
@@ -57,6 +60,7 @@ func workerHeartbeat(s pikoci.Service) http.HandlerFunc {
 			Concurrency:   req.Concurrency,
 			Tags:          req.Tags,
 			ExclusiveTags: req.ExclusiveTags,
+			TeamCanonical: teamCanonical,
 			StartedAt:     startedAt,
 		}
 

--- a/pikoci/wkr/worker.go
+++ b/pikoci/wkr/worker.go
@@ -21,11 +21,12 @@ type Worker struct {
 	Version     string    `json:"version"`
 	Commit      string    `json:"commit"`
 	Concurrency int       `json:"concurrency"`
-	Tags          []string  `json:"tags"`
-	ExclusiveTags bool      `json:"exclusive_tags"`
-	StartedAt     time.Time `json:"started_at"`
-	LastPingAt    time.Time `json:"last_ping_at"`
-	Status        Status    `json:"status"`
+	Tags            []string  `json:"tags"`
+	ExclusiveTags   bool      `json:"exclusive_tags"`
+	TeamCanonical   string    `json:"team_canonical"`
+	StartedAt       time.Time `json:"started_at"`
+	LastPingAt      time.Time `json:"last_ping_at"`
+	Status          Status    `json:"status"`
 }
 
 // ComputeStatus sets the worker's Status based on how recently it pinged.

--- a/pikoci/work.go
+++ b/pikoci/work.go
@@ -23,6 +23,15 @@ func (q *PikoCI) NextWork(ctx context.Context, wc workitem.WorkerContext) (*work
 	}
 
 	for _, pwt := range pps {
+		// Team isolation: team workers only serve their team;
+		// global workers defer to teams with dedicated workers.
+		if wc.TeamCanonical != "" && pwt.Team.Canonical != wc.TeamCanonical {
+			continue
+		}
+		if wc.TeamCanonical == "" && q.TeamWorkerChecker != nil && q.TeamWorkerChecker.HasTeamWorkers(pwt.Team.Canonical) {
+			continue
+		}
+
 		for _, j := range pwt.Jobs {
 			if j.Paused {
 				continue
@@ -94,6 +103,14 @@ func (q *PikoCI) NextWork(ctx context.Context, wc workitem.WorkerContext) (*work
 	}
 
 	for _, rwp := range due {
+		// Team isolation for resource checks
+		if wc.TeamCanonical != "" && rwp.TeamCanonical != wc.TeamCanonical {
+			continue
+		}
+		if wc.TeamCanonical == "" && q.TeamWorkerChecker != nil && q.TeamWorkerChecker.HasTeamWorkers(rwp.TeamCanonical) {
+			continue
+		}
+
 		rKey := rwp.TeamCanonical + "/" + rwp.PipelineCanonical + "/" + rwp.Canonical
 		if !wkr.TagsMatch(resourceTags[rKey], wc.Tags, wc.ExclusiveTags) {
 			continue

--- a/pikoci/work_team_test.go
+++ b/pikoci/work_team_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pikoci/pikoci/pikoci/build"
 	"github.com/pikoci/pikoci/pikoci/job"
 	"github.com/pikoci/pikoci/pikoci/pipeline"
+	"github.com/pikoci/pikoci/pikoci/resource"
 	"github.com/pikoci/pikoci/pikoci/team"
 	"github.com/pikoci/pikoci/pikoci/workitem"
 	"github.com/stretchr/testify/assert"
@@ -102,4 +103,70 @@ func TestNextWork_GlobalWorkerServesTeamWithoutDedicatedWorker(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, item)
 	assert.Equal(t, "teama", item.Body.TeamCanonical)
+}
+
+func TestNextWork_ResourceCheck_TeamWorkerSkipsOtherTeam(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	// Phase 1: no pipelines with pending builds
+	s.Pipelines.EXPECT().FilterAll(ctx).Return([]*pipeline.WithTeam{
+		{
+			Pipeline: pipeline.Pipeline{
+				Canonical: "pipe-b",
+				Resources: []resource.Resource{{Canonical: "repo"}},
+			},
+			Team: team.Team{Canonical: "teamb"},
+		},
+	}, nil)
+
+	// Phase 2: due resource from teamb
+	s.Resources.EXPECT().FilterDueResources(ctx).Return([]*resource.ResourceWithPipeline{
+		{
+			Resource:          resource.Resource{Canonical: "repo", CheckInterval: "@every 1h"},
+			TeamCanonical:     "teamb",
+			PipelineCanonical: "pipe-b",
+		},
+	}, nil)
+
+	// Team A worker should NOT process team B's resource checks
+	wc := workitem.WorkerContext{TeamCanonical: "teama"}
+	item, err := s.P.NextWork(ctx, wc)
+	require.NoError(t, err)
+	assert.Nil(t, item, "team A worker should skip team B's resource check")
+}
+
+func TestNextWork_ResourceCheck_GlobalWorkerDefersToTeamWorker(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.P.TeamWorkerChecker = &fakeTeamWorkerChecker{teams: map[string]bool{"teama": true}}
+
+	// Phase 1: no pending builds
+	s.Pipelines.EXPECT().FilterAll(ctx).Return([]*pipeline.WithTeam{
+		{
+			Pipeline: pipeline.Pipeline{
+				Canonical: "pipe-a",
+				Resources: []resource.Resource{{Canonical: "repo"}},
+			},
+			Team: team.Team{Canonical: "teama"},
+		},
+	}, nil)
+
+	// Phase 2: due resource from teama
+	s.Resources.EXPECT().FilterDueResources(ctx).Return([]*resource.ResourceWithPipeline{
+		{
+			Resource:          resource.Resource{Canonical: "repo", CheckInterval: "@every 1h"},
+			TeamCanonical:     "teama",
+			PipelineCanonical: "pipe-a",
+		},
+	}, nil)
+
+	// Global worker should defer resource checks to team A's workers
+	wc := workitem.WorkerContext{TeamCanonical: ""}
+	item, err := s.P.NextWork(ctx, wc)
+	require.NoError(t, err)
+	assert.Nil(t, item, "global worker should defer resource check to team worker")
 }

--- a/pikoci/work_team_test.go
+++ b/pikoci/work_team_test.go
@@ -1,0 +1,105 @@
+package pikoci_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pikoci/pikoci/pikoci/build"
+	"github.com/pikoci/pikoci/pikoci/job"
+	"github.com/pikoci/pikoci/pikoci/pipeline"
+	"github.com/pikoci/pikoci/pikoci/team"
+	"github.com/pikoci/pikoci/pikoci/workitem"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestNextWork_TeamWorkerFiltersToOwnTeam(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Pipelines.EXPECT().FilterAll(ctx).Return([]*pipeline.WithTeam{
+		{
+			Pipeline: pipeline.Pipeline{Canonical: "pipe-a", Jobs: []job.Job{{Name: "build"}}},
+			Team:     team.Team{Canonical: "teama"},
+		},
+		{
+			Pipeline: pipeline.Pipeline{Canonical: "pipe-b", Jobs: []job.Job{{Name: "build"}}},
+			Team:     team.Team{Canonical: "teamb"},
+		},
+	}, nil)
+	// Only teama's build should be queried
+	s.Builds.EXPECT().FindOldestPending(ctx, "teama", "pipe-a", "build").
+		Return(&build.Build{ID: 1, BuildNumber: "1", Status: build.Pending}, nil)
+	s.Jobs.EXPECT().Find(ctx, "teama", "pipe-a", "build").
+		Return(&job.Job{Name: "build"}, nil)
+	s.Builds.EXPECT().StartPending(ctx, "teama", "pipe-a", "build", uint32(1)).Return(nil)
+	s.Builds.EXPECT().FindByID(ctx, uint32(1)).Return(
+		&build.Build{ID: 1, BuildNumber: "1", Status: build.Started, VersionID: 1}, nil)
+
+	wc := workitem.WorkerContext{TeamCanonical: "teama"}
+	item, err := s.P.NextWork(ctx, wc)
+	require.NoError(t, err)
+	require.NotNil(t, item)
+	assert.Equal(t, "teama", item.Body.TeamCanonical)
+}
+
+// fakeTeamWorkerChecker is a test double implementing TeamWorkerChecker.
+type fakeTeamWorkerChecker struct {
+	teams map[string]bool
+}
+
+func (f *fakeTeamWorkerChecker) HasTeamWorkers(tc string) bool {
+	return f.teams[tc]
+}
+
+func TestNextWork_GlobalWorkerSkipsTeamWithDedicatedWorker(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.P.TeamWorkerChecker = &fakeTeamWorkerChecker{teams: map[string]bool{"teama": true}}
+
+	s.Pipelines.EXPECT().FilterAll(ctx).Return([]*pipeline.WithTeam{
+		{
+			Pipeline: pipeline.Pipeline{Canonical: "pipe-a", Jobs: []job.Job{{Name: "build"}}},
+			Team:     team.Team{Canonical: "teama"},
+		},
+	}, nil)
+	s.Resources.EXPECT().FilterDueResources(ctx).Return(nil, nil)
+
+	// Global worker (empty TeamCanonical) should skip teama because it has dedicated workers
+	wc := workitem.WorkerContext{TeamCanonical: ""}
+	item, err := s.P.NextWork(ctx, wc)
+	require.NoError(t, err)
+	assert.Nil(t, item, "global worker should skip team with dedicated workers")
+}
+
+func TestNextWork_GlobalWorkerServesTeamWithoutDedicatedWorker(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.P.TeamWorkerChecker = &fakeTeamWorkerChecker{teams: map[string]bool{}}
+
+	s.Pipelines.EXPECT().FilterAll(ctx).Return([]*pipeline.WithTeam{
+		{
+			Pipeline: pipeline.Pipeline{Canonical: "pipe-a", Jobs: []job.Job{{Name: "build"}}},
+			Team:     team.Team{Canonical: "teama"},
+		},
+	}, nil)
+	s.Builds.EXPECT().FindOldestPending(ctx, "teama", "pipe-a", "build").
+		Return(&build.Build{ID: 1, BuildNumber: "1", Status: build.Pending}, nil)
+	s.Jobs.EXPECT().Find(ctx, "teama", "pipe-a", "build").
+		Return(&job.Job{Name: "build"}, nil)
+	s.Builds.EXPECT().StartPending(ctx, "teama", "pipe-a", "build", uint32(1)).Return(nil)
+	s.Builds.EXPECT().FindByID(ctx, uint32(1)).Return(
+		&build.Build{ID: 1, BuildNumber: "1", Status: build.Started, VersionID: 1}, nil)
+
+	wc := workitem.WorkerContext{TeamCanonical: ""}
+	item, err := s.P.NextWork(ctx, wc)
+	require.NoError(t, err)
+	require.NotNil(t, item)
+	assert.Equal(t, "teama", item.Body.TeamCanonical)
+}

--- a/pikoci/workitem/workitem.go
+++ b/pikoci/workitem/workitem.go
@@ -8,11 +8,12 @@ type Item struct {
 	Body Body   `json:"body"`
 }
 
-// WorkerContext carries the requesting worker's tag configuration so that
-// NextWork can filter work items by tag compatibility.
+// WorkerContext carries the requesting worker's tag and team configuration so
+// that NextWork can filter work items by tag compatibility and team isolation.
 type WorkerContext struct {
 	Tags          []string
 	ExclusiveTags bool
+	TeamCanonical string
 }
 
 // Body is the JSON-serializable payload carried inside every work item.

--- a/test/js/api.test.mjs
+++ b/test/js/api.test.mjs
@@ -139,3 +139,52 @@ test('api: successful request clears notice', async () => {
     globalThis.fetch = original;
   }
 });
+
+// --- Team Worker Token API functions ---
+
+import { generateTeamWorkerToken, getTeamWorkerToken } from '../../pikoci/transport/http/assets/js/app/api.js';
+
+test('generateTeamWorkerToken: POSTs to correct endpoint and returns token', async () => {
+  const original = globalThis.fetch;
+  let capturedUrl, capturedOpts;
+  globalThis.fetch = (url, opts) => {
+    capturedUrl = url;
+    capturedOpts = opts;
+    return Promise.resolve(mockResponse(200, { token: 'eyJhbG...' }));
+  };
+  try {
+    const token = await generateTeamWorkerToken('main');
+    assert.equal(token, 'eyJhbG...');
+    assert.equal(capturedUrl, '/teams/main/worker-token');
+    assert.equal(capturedOpts.method, 'POST');
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test('getTeamWorkerToken: GETs from correct endpoint and returns token', async () => {
+  const original = globalThis.fetch;
+  let capturedUrl;
+  globalThis.fetch = (url, opts) => {
+    capturedUrl = url;
+    return Promise.resolve(mockResponse(200, { token: 'eyJtoken...' }));
+  };
+  try {
+    const token = await getTeamWorkerToken('my-team');
+    assert.equal(token, 'eyJtoken...');
+    assert.equal(capturedUrl, '/teams/my-team/worker-token');
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test('getTeamWorkerToken: returns empty string when no token', async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = () => Promise.resolve(mockResponse(200, { token: '' }));
+  try {
+    const token = await getTeamWorkerToken('main');
+    assert.equal(token, '');
+  } finally {
+    globalThis.fetch = original;
+  }
+});


### PR DESCRIPTION
## Summary

- **Team-scoped worker tokens**: JWT with `team_canonical` + `salt` claims for revocation via `POST/GET /teams/{tc}/worker-token` (Admin only)
- **Dispatch filtering**: Team workers only process their team's builds/resource checks; global workers defer to teams with dedicated workers
- **gRPC registration**: `validateWorkerToken` verifies salt against DB, `RegisteredWorker` and `WorkerStream` carry team canonical
- **HTTP heartbeat**: Extracts `team_canonical` from worker JWT context, stored in worker DB record
- **UI**: Workers tab in Team Settings (admin-only) with generate/regenerate/copy token; Team column in global Workers list
- **CLI**: `teams worker-token --team-canonical` subcommand
- **DB migration V45**: `teams.worker_token_salt`, `workers.team_canonical`
- **Docs**: Workers.md "Team-scoped workers" section, CHANGELOG entry

Closes #98