### PR TITLE
fix: eliminate build polling fan-out and N+1 query patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Build polling fan-out CPU spike**: Jobs view now fetches all non-terminal builds in a single `?status=` request instead of one HTTP call per build every 2s. Added in-flight guard and `setTimeout`-based scheduling to `usePolling` to prevent overlapping request storms.
+- **N+1 query elimination**: Pipeline image, job list, and resource list endpoints now use batch queries (`FilterByPipeline`, `LatestVersionByResources`, batch serial-group loading) instead of per-item DB calls.
+
 ### Changed
 
 - **Role rename**: Viewer→Read, Operator→Write, Maintainer→Maintain to match GitHub's model. DB migration auto-renames stored values. CLI, UI, and docs updated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Role rename**: Viewer→Read, Operator→Write, Maintainer→Maintain to match GitHub's model. DB migration auto-renames stored values. CLI, UI, and docs updated.
+- **Modulepreload hints**: Add `<link rel="modulepreload">` for all 27 ES modules, collapsing 4 discovery rounds to 1 parallel fetch ([#575](https://github.com/PikoCI/pikoci/issues/575)).
 
 ### Added
 
@@ -19,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Audit log**: Append-only team audit trail with 16 event types, filterable UI/CLI/API, cursor-based pagination. Read+ access ([#532](https://github.com/PikoCI/pikoci/issues/532)).
 - **Secrets masking in build logs**: Secret values replaced with `***` in stdout/stderr. Real-time and stored output. Skips values < 3 chars ([#147](https://github.com/PikoCI/pikoci/issues/147)).
 - **Build report export**: JSON report for any build containing status, steps, logs, approvals, and version data. Available via API (`GET .../builds/{bn}/report`), CLI (`builds report`), and UI Export button. Read+ access ([#531](https://github.com/PikoCI/pikoci/issues/531)).
-- **Worker team isolation**: Team-scoped worker tokens (JWT with salt for revocation) restrict workers to only process their team's builds. Global workers automatically defer to teams with dedicated workers. Admin-only token management via UI (Team Settings > Workers tab), CLI (`teams worker-token`), and API. Workers dashboard shows team association ([#12](https://github.com/PikoCI/pikoci/issues/12), [#98](https://github.com/PikoCI/pikoci/issues/98)).
+- **Worker team isolation**: Team-scoped worker tokens restrict workers to their team's builds with automatic global-worker deferral ([#12](https://github.com/PikoCI/pikoci/issues/12), [#98](https://github.com/PikoCI/pikoci/issues/98)).
 
 ### Fixed
 

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -1039,7 +1039,7 @@ var buildsListCmd = &cobra.Command{
 			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
 		}
 
-		builds, _, err := c.ListJobBuilds(cmd.Context(), tc, pn, jn, nil, nil, 0)
+		builds, _, err := c.ListJobBuilds(cmd.Context(), tc, pn, jn, nil, nil, 0, nil)
 		if err != nil {
 			return fmt.Errorf("failed to list builds for job %q: %w", jn, err)
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -254,7 +254,7 @@ func runLocal(ctx context.Context, logger *slog.Logger, pipelineConfig, jobName 
 			// This can happen if context is cancelled
 			return 1, nil
 		case <-ticker.C:
-			builds, _, err := svc.ListJobBuilds(ctx, mainTeamCanonical, "local", jobName, nil, nil, 0)
+			builds, _, err := svc.ListJobBuilds(ctx, mainTeamCanonical, "local", jobName, nil, nil, 0, nil)
 			if err != nil {
 				continue
 			}

--- a/integration/backends/concurrent_builds_test.go
+++ b/integration/backends/concurrent_builds_test.go
@@ -144,7 +144,7 @@ job "job-c" {
 	for _, jn := range jobs {
 		jn := jn
 		require.Eventually(t, func() bool {
-			builds, _, err := svc.ListJobBuilds(ctx, "main", "concurrent-test", jn, nil, nil, 0)
+			builds, _, err := svc.ListJobBuilds(ctx, "main", "concurrent-test", jn, nil, nil, 0, nil)
 			if err != nil || len(builds) == 0 {
 				return false
 			}
@@ -154,7 +154,7 @@ job "job-c" {
 
 	// Verify all 3 builds succeeded
 	for _, jn := range jobs {
-		builds, _, err := svc.ListJobBuilds(ctx, "main", "concurrent-test", jn, nil, nil, 0)
+		builds, _, err := svc.ListJobBuilds(ctx, "main", "concurrent-test", jn, nil, nil, 0, nil)
 		require.NoError(t, err)
 		require.NotEmpty(t, builds, "job %q should have builds", jn)
 		assert.Equal(t, build.Succeeded, builds[0].Status, "job %q build should succeed, error: %s", jn, builds[0].Error)

--- a/integration/backends/db_test.go
+++ b/integration/backends/db_test.go
@@ -190,7 +190,7 @@ func TestDBBackends(t *testing.T) {
 				assert.Equal(t, "1", bn)
 
 				// Filter builds
-				builds, err := br.Filter(ctx, "main", "test-pipeline", "test-job", nil, nil, 0)
+				builds, err := br.Filter(ctx, "main", "test-pipeline", "test-job", nil, nil, 0, nil)
 				require.NoError(t, err)
 				assert.Len(t, builds, 1)
 				assert.Equal(t, build.Started, builds[0].Status)

--- a/integration/backends/export_test.go
+++ b/integration/backends/export_test.go
@@ -108,7 +108,7 @@ job "export-job" {
 
 	// Wait for build to complete
 	require.Eventually(t, func() bool {
-		builds, _, err := svc.ListJobBuilds(ctx, "main", "export-test", "export-job", nil, nil, 0)
+		builds, _, err := svc.ListJobBuilds(ctx, "main", "export-test", "export-job", nil, nil, 0, nil)
 		if err != nil || len(builds) == 0 {
 			return false
 		}

--- a/integration/backends/grpc_worker_test.go
+++ b/integration/backends/grpc_worker_test.go
@@ -177,7 +177,7 @@ job "grpc-test" {
 
 	// --- Wait for build to complete ---
 	require.Eventually(t, func() bool {
-		builds, _, err := svc.ListJobBuilds(ctx, "main", "grpc-test", "grpc-test", nil, nil, 0)
+		builds, _, err := svc.ListJobBuilds(ctx, "main", "grpc-test", "grpc-test", nil, nil, 0, nil)
 		if err != nil || len(builds) == 0 {
 			return false
 		}
@@ -185,7 +185,7 @@ job "grpc-test" {
 	}, 15*time.Second, 200*time.Millisecond, "build should complete")
 
 	// --- Verify build succeeded with steps ---
-	builds, _, err := svc.ListJobBuilds(ctx, "main", "grpc-test", "grpc-test", nil, nil, 0)
+	builds, _, err := svc.ListJobBuilds(ctx, "main", "grpc-test", "grpc-test", nil, nil, 0, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, builds)
 
@@ -450,7 +450,7 @@ job "drain-test" {
 
 	// Wait until the build is started
 	require.Eventually(t, func() bool {
-		builds, _, err := svc.ListJobBuilds(ctx, "main", "drain-test", "drain-test", nil, nil, 0)
+		builds, _, err := svc.ListJobBuilds(ctx, "main", "drain-test", "drain-test", nil, nil, 0, nil)
 		if err != nil || len(builds) == 0 {
 			return false
 		}
@@ -484,7 +484,7 @@ job "drain-test" {
 	}
 
 	// Verify build reached terminal status
-	builds, _, err := svc.ListJobBuilds(ctx, "main", "drain-test", "drain-test", nil, nil, 0)
+	builds, _, err := svc.ListJobBuilds(ctx, "main", "drain-test", "drain-test", nil, nil, 0, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, builds)
 	b := builds[0]

--- a/integration/backends/secrets_test.go
+++ b/integration/backends/secrets_test.go
@@ -146,7 +146,7 @@ job "deploy" {
 		// Wait for the build triggered by the resource to finish
 		var builds []*build.Build
 		require.Eventually(t, func() bool {
-			builds, _, err = svc.ListJobBuilds(ctx, "main", "secrets-e2e", "deploy", nil, nil, 0)
+			builds, _, err = svc.ListJobBuilds(ctx, "main", "secrets-e2e", "deploy", nil, nil, 0, nil)
 			if err != nil || len(builds) == 0 {
 				return false
 			}
@@ -245,7 +245,7 @@ job "deploy" {
 		// Wait for the build triggered by the resource to finish
 		var builds []*build.Build
 		require.Eventually(t, func() bool {
-			builds, _, err = svc.ListJobBuilds(ctx, "main", "secrets-file-e2e", "deploy", nil, nil, 0)
+			builds, _, err = svc.ListJobBuilds(ctx, "main", "secrets-file-e2e", "deploy", nil, nil, 0, nil)
 			if err != nil || len(builds) == 0 {
 				return false
 			}
@@ -361,7 +361,7 @@ job "deploy" {
 		// Wait for the build triggered by the resource to finish
 		var builds []*build.Build
 		require.Eventually(t, func() bool {
-			builds, _, err = svc.ListJobBuilds(ctx, "main", "secrets-env-file-e2e", "deploy", nil, nil, 0)
+			builds, _, err = svc.ListJobBuilds(ctx, "main", "secrets-env-file-e2e", "deploy", nil, nil, 0, nil)
 			if err != nil || len(builds) == 0 {
 				return false
 			}

--- a/integration/backends/services_test.go
+++ b/integration/backends/services_test.go
@@ -137,7 +137,7 @@ job "use-service" {
 
 		var builds []*build.Build
 		require.Eventually(t, func() bool {
-			builds, _, err = svc.ListJobBuilds(ctx, "main", "svc-start-stop-e2e", "use-service", nil, nil, 0)
+			builds, _, err = svc.ListJobBuilds(ctx, "main", "svc-start-stop-e2e", "use-service", nil, nil, 0, nil)
 			if err != nil || len(builds) == 0 {
 				return false
 			}
@@ -232,7 +232,7 @@ job "use-slow-service" {
 		// (stop runs via defer after failBuild, so there's a brief window)
 		var builds []*build.Build
 		require.Eventually(t, func() bool {
-			builds, _, err = svc.ListJobBuilds(ctx, "main", "svc-timeout-e2e", "use-slow-service", nil, nil, 0)
+			builds, _, err = svc.ListJobBuilds(ctx, "main", "svc-timeout-e2e", "use-slow-service", nil, nil, 0, nil)
 			if err != nil || len(builds) == 0 {
 				return false
 			}
@@ -325,7 +325,7 @@ job "use-param-service" {
 
 		var builds []*build.Build
 		require.Eventually(t, func() bool {
-			builds, _, err = svc.ListJobBuilds(ctx, "main", "svc-params-e2e", "use-param-service", nil, nil, 0)
+			builds, _, err = svc.ListJobBuilds(ctx, "main", "svc-params-e2e", "use-param-service", nil, nil, 0, nil)
 			if err != nil || len(builds) == 0 {
 				return false
 			}
@@ -405,7 +405,7 @@ job "will-fail" {
 		// Wait until the build completes AND the stop step is present
 		var builds []*build.Build
 		require.Eventually(t, func() bool {
-			builds, _, err = svc.ListJobBuilds(ctx, "main", "svc-stop-fail-e2e", "will-fail", nil, nil, 0)
+			builds, _, err = svc.ListJobBuilds(ctx, "main", "svc-stop-fail-e2e", "will-fail", nil, nil, 0, nil)
 			if err != nil || len(builds) == 0 {
 				return false
 			}

--- a/integration/backends/tags_test.go
+++ b/integration/backends/tags_test.go
@@ -109,7 +109,7 @@ job "gpu-job" {
 
 	// Wait a bit — the build should stay pending because no matching worker
 	time.Sleep(3 * time.Second)
-	builds, _, err := svc.ListJobBuilds(ctx, "main", "tags-test", "gpu-job", nil, nil, 0)
+	builds, _, err := svc.ListJobBuilds(ctx, "main", "tags-test", "gpu-job", nil, nil, 0, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, builds, "build should exist")
 	assert.Equal(t, build.Pending, builds[0].Status, "build should stay pending without a gpu worker")
@@ -120,14 +120,14 @@ job "gpu-job" {
 	go func() { defer wg.Done(); gpuWorker.Run(ctx) }()
 
 	require.Eventually(t, func() bool {
-		builds, _, err := svc.ListJobBuilds(ctx, "main", "tags-test", "gpu-job", nil, nil, 0)
+		builds, _, err := svc.ListJobBuilds(ctx, "main", "tags-test", "gpu-job", nil, nil, 0, nil)
 		if err != nil || len(builds) == 0 {
 			return false
 		}
 		return builds[0].Status == build.Succeeded || builds[0].Status == build.Failed
 	}, 20*time.Second, 200*time.Millisecond, "gpu worker should complete the build")
 
-	builds, _, _ = svc.ListJobBuilds(ctx, "main", "tags-test", "gpu-job", nil, nil, 0)
+	builds, _, _ = svc.ListJobBuilds(ctx, "main", "tags-test", "gpu-job", nil, nil, 0, nil)
 	assert.Equal(t, build.Succeeded, builds[0].Status)
 
 	cancel()
@@ -197,18 +197,18 @@ job "gpu-job" {
 
 	// Wait for the gpu-job to complete
 	require.Eventually(t, func() bool {
-		builds, _, err := svc.ListJobBuilds(ctx, "main", "excl-test", "gpu-job", nil, nil, 0)
+		builds, _, err := svc.ListJobBuilds(ctx, "main", "excl-test", "gpu-job", nil, nil, 0, nil)
 		if err != nil || len(builds) == 0 {
 			return false
 		}
 		return builds[0].Status == build.Succeeded || builds[0].Status == build.Failed
 	}, 20*time.Second, 200*time.Millisecond, "exclusive worker should complete gpu-job")
 
-	gpuBuilds, _, _ := svc.ListJobBuilds(ctx, "main", "excl-test", "gpu-job", nil, nil, 0)
+	gpuBuilds, _, _ := svc.ListJobBuilds(ctx, "main", "excl-test", "gpu-job", nil, nil, 0, nil)
 	assert.Equal(t, build.Succeeded, gpuBuilds[0].Status)
 
 	// The untagged job should still be pending — exclusive worker skips it
-	untaggedBuilds, _, err := svc.ListJobBuilds(ctx, "main", "excl-test", "untagged-job", nil, nil, 0)
+	untaggedBuilds, _, err := svc.ListJobBuilds(ctx, "main", "excl-test", "untagged-job", nil, nil, 0, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, untaggedBuilds, "untagged build should exist")
 	assert.Equal(t, build.Pending, untaggedBuilds[0].Status, "untagged job should remain pending with exclusive worker")

--- a/integration/backends/team_isolation_test.go
+++ b/integration/backends/team_isolation_test.go
@@ -422,8 +422,8 @@ job "test-job" {
 
 	// --- Wait for both builds to complete ---
 	require.Eventually(t, func() bool {
-		alphaBuilds, _, _ := svc.ListJobBuilds(ctx, "alpha", "alpha-pipe", "test-job", nil, nil, 0)
-		betaBuilds, _, _ := svc.ListJobBuilds(ctx, "beta", "beta-pipe", "test-job", nil, nil, 0)
+		alphaBuilds, _, _ := svc.ListJobBuilds(ctx, "alpha", "alpha-pipe", "test-job", nil, nil, 0, nil)
+		betaBuilds, _, _ := svc.ListJobBuilds(ctx, "beta", "beta-pipe", "test-job", nil, nil, 0, nil)
 		if len(alphaBuilds) == 0 || len(betaBuilds) == 0 {
 			return false
 		}
@@ -463,7 +463,7 @@ job "test-job" {
 	// team worker must NOT pick it up.
 	time.Sleep(2 * time.Second)
 
-	betaBuilds, _, err := svc.ListJobBuilds(ctx, "beta", "beta-pipe", "test-job", nil, nil, 0)
+	betaBuilds, _, err := svc.ListJobBuilds(ctx, "beta", "beta-pipe", "test-job", nil, nil, 0, nil)
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, len(betaBuilds), 2, "should have at least 2 beta builds")
 
@@ -479,7 +479,7 @@ job "test-job" {
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		alphaBuilds, _, _ := svc.ListJobBuilds(ctx, "alpha", "alpha-pipe", "test-job", nil, nil, 0)
+		alphaBuilds, _, _ := svc.ListJobBuilds(ctx, "alpha", "alpha-pipe", "test-job", nil, nil, 0, nil)
 		if len(alphaBuilds) < 2 {
 			return false
 		}
@@ -488,7 +488,7 @@ job "test-job" {
 		"alpha build should succeed even without global worker")
 
 	// Re-check: beta build is STILL pending
-	betaBuilds, _, err = svc.ListJobBuilds(ctx, "beta", "beta-pipe", "test-job", nil, nil, 0)
+	betaBuilds, _, err = svc.ListJobBuilds(ctx, "beta", "beta-pipe", "test-job", nil, nil, 0, nil)
 	require.NoError(t, err)
 	assert.Equal(t, build.Pending, betaBuilds[0].Status,
 		"beta build must remain pending with only alpha team worker online")
@@ -516,7 +516,7 @@ job "test-job" {
 
 	// The pending beta build should now be picked up by the new global worker
 	require.Eventually(t, func() bool {
-		betaBuilds, _, _ := svc.ListJobBuilds(ctx, "beta", "beta-pipe", "test-job", nil, nil, 0)
+		betaBuilds, _, _ := svc.ListJobBuilds(ctx, "beta", "beta-pipe", "test-job", nil, nil, 0, nil)
 		if len(betaBuilds) < 2 {
 			return false
 		}

--- a/integration/backends/vault_test.go
+++ b/integration/backends/vault_test.go
@@ -214,7 +214,7 @@ job "deploy" {
 	// Wait for the build to finish
 	var builds []*build.Build
 	require.Eventually(t, func() bool {
-		builds, _, err = svc.ListJobBuilds(ctx, "main", "vault-e2e", "deploy", nil, nil, 0)
+		builds, _, err = svc.ListJobBuilds(ctx, "main", "vault-e2e", "deploy", nil, nil, 0, nil)
 		if err != nil || len(builds) == 0 {
 			return false
 		}

--- a/pikoci/build/repository.go
+++ b/pikoci/build/repository.go
@@ -16,7 +16,8 @@ type Repository interface {
 	// Find retrieves a single build by team, pipeline, job, and build number.
 	Find(ctx context.Context, tc, pn, jn string, buildNumber string) (*Build, error)
 	// Filter returns a paginated list of builds for the given team, pipeline, and job.
-	Filter(ctx context.Context, tc, pn, jn string, before *uint32, after *uint32, limit uint32) ([]*Build, error)
+	// When statuses is non-empty, only builds matching one of the given statuses are returned.
+	Filter(ctx context.Context, tc, pn, jn string, before *uint32, after *uint32, limit uint32, statuses []Status) ([]*Build, error)
 	// Update updates an existing build identified by team, pipeline, job, and build number.
 	Update(ctx context.Context, tc, pn, jn string, buildNumber string, b Build) error
 	// Delete removes a build identified by team, pipeline, job, and build number.
@@ -46,6 +47,9 @@ type Repository interface {
 	// specified jobs, including retries of matched builds.
 	// The result maps job name to a slice of builds (main build first, retries after).
 	FindByVersionAndJobs(ctx context.Context, tc, pn string, versionID uint32, jobNames []string) (map[string][]*Build, error)
+	// FilterByPipeline returns builds across all jobs in a pipeline, optionally filtered by status.
+	// Results are grouped by job name and ordered by build ID descending within each job.
+	FilterByPipeline(ctx context.Context, tc, pn string, statuses []Status) (map[string][]*Build, error)
 	// CountStarted returns the total number of builds with status "started" across all jobs.
 	CountStarted(ctx context.Context) (int, error)
 	// FailStartedBuilds transitions all builds with status "started" to "failed" with the given reason.

--- a/pikoci/builds.go
+++ b/pikoci/builds.go
@@ -75,7 +75,7 @@ func (q *PikoCI) CreateJobBuild(ctx context.Context, tc, pc, jn string, b build.
 // pagination with before and after parameters. Results are returned in
 // newest-first order. The boolean return value indicates whether more results
 // exist beyond the requested page.
-func (q *PikoCI) ListJobBuilds(ctx context.Context, tc, pc, jn string, before *uint32, after *uint32, limit uint32) ([]*build.Build, bool, error) {
+func (q *PikoCI) ListJobBuilds(ctx context.Context, tc, pc, jn string, before *uint32, after *uint32, limit uint32, statuses []build.Status) ([]*build.Build, bool, error) {
 	if !utils.ValidateCanonical(tc) {
 		return nil, false, fmt.Errorf("invalid Team Canonical format %q", tc)
 	} else if !utils.ValidateCanonical(pc) {
@@ -89,7 +89,7 @@ func (q *PikoCI) ListJobBuilds(ctx context.Context, tc, pc, jn string, before *u
 		fetchLimit = limit + 1
 	}
 
-	builds, err := q.Builds.Filter(ctx, tc, pc, jn, before, after, fetchLimit)
+	builds, err := q.Builds.Filter(ctx, tc, pc, jn, before, after, fetchLimit, statuses)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to list Builds: %w", err)
 	}

--- a/pikoci/builds_test.go
+++ b/pikoci/builds_test.go
@@ -52,12 +52,12 @@ func TestListJobBuilds(t *testing.T) {
 	ctx := context.TODO()
 
 	// limit=0 fetches all, DB returns DESC order
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{
+	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", (*uint32)(nil), (*uint32)(nil), uint32(0), ([]build.Status)(nil)).Return([]*build.Build{
 		{ID: 2, BuildNumber: "2", Status: build.Started},
 		{ID: 1, BuildNumber: "1", Status: build.Succeeded},
 	}, nil)
 
-	builds, hasMore, err := s.S.ListJobBuilds(ctx, "main", "my-pipeline", "my-job", nil, nil, 0)
+	builds, hasMore, err := s.S.ListJobBuilds(ctx, "main", "my-pipeline", "my-job", nil, nil, 0, nil)
 	require.NoError(t, err)
 	require.Len(t, builds, 2)
 	assert.False(t, hasMore)
@@ -72,13 +72,13 @@ func TestListJobBuilds_WithLimit(t *testing.T) {
 	ctx := context.TODO()
 
 	// DB returns limit+1 items (3) when we ask for limit=2 → hasMore=true
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", (*uint32)(nil), (*uint32)(nil), uint32(3)).Return([]*build.Build{
+	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", (*uint32)(nil), (*uint32)(nil), uint32(3), ([]build.Status)(nil)).Return([]*build.Build{
 		{ID: 5, BuildNumber: "5"},
 		{ID: 4, BuildNumber: "4"},
 		{ID: 3, BuildNumber: "3"},
 	}, nil)
 
-	builds, hasMore, err := s.S.ListJobBuilds(ctx, "main", "my-pipeline", "my-job", nil, nil, 2)
+	builds, hasMore, err := s.S.ListJobBuilds(ctx, "main", "my-pipeline", "my-job", nil, nil, 2, nil)
 	require.NoError(t, err)
 	require.Len(t, builds, 2)
 	assert.True(t, hasMore)
@@ -92,12 +92,12 @@ func TestListJobBuilds_Before(t *testing.T) {
 	ctx := context.TODO()
 
 	before := uint32(4)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", &before, (*uint32)(nil), uint32(3)).Return([]*build.Build{
+	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", &before, (*uint32)(nil), uint32(3), ([]build.Status)(nil)).Return([]*build.Build{
 		{ID: 3, BuildNumber: "3"},
 		{ID: 2, BuildNumber: "2"},
 	}, nil)
 
-	builds, hasMore, err := s.S.ListJobBuilds(ctx, "main", "my-pipeline", "my-job", &before, nil, 2)
+	builds, hasMore, err := s.S.ListJobBuilds(ctx, "main", "my-pipeline", "my-job", &before, nil, 2, nil)
 	require.NoError(t, err)
 	require.Len(t, builds, 2)
 	assert.False(t, hasMore)
@@ -110,12 +110,12 @@ func TestListJobBuilds_After(t *testing.T) {
 
 	after := uint32(3)
 	// DB returns ASC order for after queries
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", (*uint32)(nil), &after, uint32(0)).Return([]*build.Build{
+	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", (*uint32)(nil), &after, uint32(0), ([]build.Status)(nil)).Return([]*build.Build{
 		{ID: 4, BuildNumber: "4"},
 		{ID: 5, BuildNumber: "5"},
 	}, nil)
 
-	builds, hasMore, err := s.S.ListJobBuilds(ctx, "main", "my-pipeline", "my-job", nil, &after, 0)
+	builds, hasMore, err := s.S.ListJobBuilds(ctx, "main", "my-pipeline", "my-job", nil, &after, 0, nil)
 	require.NoError(t, err)
 	require.Len(t, builds, 2)
 	assert.False(t, hasMore)
@@ -546,13 +546,13 @@ func TestListJobBuilds_InvalidCanonical(t *testing.T) {
 	s := newService(ctrl)
 	ctx := context.TODO()
 
-	_, _, err := s.S.ListJobBuilds(ctx, "INVALID", "my-pipeline", "my-job", nil, nil, 0)
+	_, _, err := s.S.ListJobBuilds(ctx, "INVALID", "my-pipeline", "my-job", nil, nil, 0, nil)
 	require.Error(t, err)
 
-	_, _, err = s.S.ListJobBuilds(ctx, "main", "INVALID", "my-job", nil, nil, 0)
+	_, _, err = s.S.ListJobBuilds(ctx, "main", "INVALID", "my-job", nil, nil, 0, nil)
 	require.Error(t, err)
 
-	_, _, err = s.S.ListJobBuilds(ctx, "main", "my-pipeline", "INVALID", nil, nil, 0)
+	_, _, err = s.S.ListJobBuilds(ctx, "main", "my-pipeline", "INVALID", nil, nil, 0, nil)
 	require.Error(t, err)
 }
 

--- a/pikoci/for_each_test.go
+++ b/pikoci/for_each_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/pikoci/pikoci/pikoci/build"
 	"github.com/pikoci/pikoci/pikoci/job"
 	"github.com/pikoci/pikoci/pikoci/pipeline"
 	"github.com/pikoci/pikoci/pikoci/resource"
@@ -538,11 +539,11 @@ job "deploy" {
 }
 `)
 
-	// Expect Build.Filter for each expanded job + regular jobs
-	s.Builds.EXPECT().Filter(ctx, "main", "pikoci", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(nil, nil).AnyTimes()
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "pikoci", gomock.Any(), (*uint32)(nil), (*uint32)(nil), uint32(1)).
-		Return([]*resource.Version{}, nil).AnyTimes()
+	// Expect FilterByPipeline for all jobs in a single query
+	s.Builds.EXPECT().FilterByPipeline(ctx, "main", "pikoci", ([]build.Status)(nil)).
+		Return(nil, nil)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "pikoci").
+		Return(map[string]*resource.Version{}, nil)
 
 	img, err := s.S.CreatePipelineImage(ctx, "main", hclConfig, nil, "dot")
 	require.NoError(t, err)

--- a/pikoci/jobs.go
+++ b/pikoci/jobs.go
@@ -132,34 +132,39 @@ func (q *PikoCI) ListPublicPipelineJobs(ctx context.Context, tc, pn string) ([]j
 }
 
 // enrichJobsWithStatus enriches a slice of jobs with build status information.
+// It pre-fetches active and completed builds for all jobs in two batch queries
+// instead of making per-job calls.
 func (q *PikoCI) enrichJobsWithStatus(ctx context.Context, tc, pn string, jobs []job.Job) ([]job.WithStatus, error) {
+	activeByJob, err := q.Builds.FilterByPipeline(ctx, tc, pn, []build.Status{build.Started, build.Pending})
+	if err != nil {
+		return nil, fmt.Errorf("failed to filter active builds: %w", err)
+	}
+	completedByJob, err := q.Builds.FilterByPipeline(ctx, tc, pn, []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval})
+	if err != nil {
+		return nil, fmt.Errorf("failed to filter completed builds: %w", err)
+	}
+
 	result := make([]job.WithStatus, 0, len(jobs))
 	for _, j := range jobs {
 		ws := job.WithStatus{Job: j}
 
-		builds, err := q.Builds.Filter(ctx, tc, pn, j.Name, nil, nil, 0)
-		if err != nil {
-			return nil, fmt.Errorf("failed to filter builds for job %q: %w", j.Name, err)
-		}
-
-		bs := resolveBuildStatus(builds)
-
-		if bs.completedBuild != nil {
-			ws.LatestStatus = bs.completedBuild.Status.String()
-			ws.LatestBuildNumber = bs.completedBuild.BuildNumber
-			ws.LatestBuildDuration = int64(bs.completedBuild.Duration)
-			if !bs.completedBuild.StartedAt.IsZero() {
-				t := bs.completedBuild.StartedAt
+		if completed := completedByJob[j.Name]; len(completed) > 0 {
+			cb := completed[0]
+			ws.LatestStatus = cb.Status.String()
+			ws.LatestBuildNumber = cb.BuildNumber
+			ws.LatestBuildDuration = int64(cb.Duration)
+			if !cb.StartedAt.IsZero() {
+				t := cb.StartedAt
 				ws.StartedAt = &t
 			}
 		}
 
-		if bs.runningBuild != nil {
+		if active := activeByJob[j.Name]; len(active) > 0 {
 			ws.HasRunning = true
-			if bs.completedBuild == nil {
-				ws.LatestBuildNumber = bs.runningBuild.BuildNumber
-				if !bs.runningBuild.StartedAt.IsZero() {
-					t := bs.runningBuild.StartedAt
+			if len(completedByJob[j.Name]) == 0 {
+				ws.LatestBuildNumber = active[0].BuildNumber
+				if !active[0].StartedAt.IsZero() {
+					t := active[0].StartedAt
 					ws.StartedAt = &t
 				}
 			}

--- a/pikoci/mock/build_repository.go
+++ b/pikoci/mock/build_repository.go
@@ -193,18 +193,33 @@ func (mr *BuildRepositoryMockRecorder) FailStartedBuilds(ctx, reason any) *gomoc
 }
 
 // Filter mocks base method.
-func (m *BuildRepository) Filter(ctx context.Context, tc, pn, jn string, before, after *uint32, limit uint32) ([]*build.Build, error) {
+func (m *BuildRepository) Filter(ctx context.Context, tc, pn, jn string, before, after *uint32, limit uint32, statuses []build.Status) ([]*build.Build, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Filter", ctx, tc, pn, jn, before, after, limit)
+	ret := m.ctrl.Call(m, "Filter", ctx, tc, pn, jn, before, after, limit, statuses)
 	ret0, _ := ret[0].([]*build.Build)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Filter indicates an expected call of Filter.
-func (mr *BuildRepositoryMockRecorder) Filter(ctx, tc, pn, jn, before, after, limit any) *gomock.Call {
+func (mr *BuildRepositoryMockRecorder) Filter(ctx, tc, pn, jn, before, after, limit, statuses any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Filter", reflect.TypeOf((*BuildRepository)(nil).Filter), ctx, tc, pn, jn, before, after, limit)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Filter", reflect.TypeOf((*BuildRepository)(nil).Filter), ctx, tc, pn, jn, before, after, limit, statuses)
+}
+
+// FilterByPipeline mocks base method.
+func (m *BuildRepository) FilterByPipeline(ctx context.Context, tc, pn string, statuses []build.Status) (map[string][]*build.Build, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FilterByPipeline", ctx, tc, pn, statuses)
+	ret0, _ := ret[0].(map[string][]*build.Build)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FilterByPipeline indicates an expected call of FilterByPipeline.
+func (mr *BuildRepositoryMockRecorder) FilterByPipeline(ctx, tc, pn, statuses any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilterByPipeline", reflect.TypeOf((*BuildRepository)(nil).FilterByPipeline), ctx, tc, pn, statuses)
 }
 
 // Find mocks base method.

--- a/pikoci/mock/resource_repository.go
+++ b/pikoci/mock/resource_repository.go
@@ -178,6 +178,21 @@ func (mr *ResourceRepositoryMockRecorder) FindByWebhookToken(ctx, token any) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByWebhookToken", reflect.TypeOf((*ResourceRepository)(nil).FindByWebhookToken), ctx, token)
 }
 
+// LatestVersionByResources mocks base method.
+func (m *ResourceRepository) LatestVersionByResources(ctx context.Context, tc, pn string) (map[string]*resource.Version, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LatestVersionByResources", ctx, tc, pn)
+	ret0, _ := ret[0].(map[string]*resource.Version)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LatestVersionByResources indicates an expected call of LatestVersionByResources.
+func (mr *ResourceRepositoryMockRecorder) LatestVersionByResources(ctx, tc, pn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LatestVersionByResources", reflect.TypeOf((*ResourceRepository)(nil).LatestVersionByResources), ctx, tc, pn)
+}
+
 // FindVersionByID mocks base method.
 func (m *ResourceRepository) FindVersionByID(ctx context.Context, versionID uint32) (*resource.Version, string, error) {
 	m.ctrl.T.Helper()

--- a/pikoci/mock/service.go
+++ b/pikoci/mock/service.go
@@ -687,9 +687,9 @@ func (mr *ServiceMockRecorder) ListAuditLog(ctx, tc, opts any) *gomock.Call {
 }
 
 // ListJobBuilds mocks base method.
-func (m *Service) ListJobBuilds(ctx context.Context, tc, pn, jn string, before, after *uint32, limit uint32) ([]*build.Build, bool, error) {
+func (m *Service) ListJobBuilds(ctx context.Context, tc, pn, jn string, before, after *uint32, limit uint32, statuses []build.Status) ([]*build.Build, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListJobBuilds", ctx, tc, pn, jn, before, after, limit)
+	ret := m.ctrl.Call(m, "ListJobBuilds", ctx, tc, pn, jn, before, after, limit, statuses)
 	ret0, _ := ret[0].([]*build.Build)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
@@ -697,9 +697,9 @@ func (m *Service) ListJobBuilds(ctx context.Context, tc, pn, jn string, before, 
 }
 
 // ListJobBuilds indicates an expected call of ListJobBuilds.
-func (mr *ServiceMockRecorder) ListJobBuilds(ctx, tc, pn, jn, before, after, limit any) *gomock.Call {
+func (mr *ServiceMockRecorder) ListJobBuilds(ctx, tc, pn, jn, before, after, limit, statuses any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobBuilds", reflect.TypeOf((*Service)(nil).ListJobBuilds), ctx, tc, pn, jn, before, after, limit)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListJobBuilds", reflect.TypeOf((*Service)(nil).ListJobBuilds), ctx, tc, pn, jn, before, after, limit, statuses)
 }
 
 // ListPipelineJobs mocks base method.
@@ -748,9 +748,9 @@ func (mr *ServiceMockRecorder) ListPipelines(ctx, tc any) *gomock.Call {
 }
 
 // ListPublicJobBuilds mocks base method.
-func (m *Service) ListPublicJobBuilds(ctx context.Context, tc, pn, jn string, before, after *uint32, limit uint32) ([]*build.Build, bool, error) {
+func (m *Service) ListPublicJobBuilds(ctx context.Context, tc, pn, jn string, before, after *uint32, limit uint32, statuses []build.Status) ([]*build.Build, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListPublicJobBuilds", ctx, tc, pn, jn, before, after, limit)
+	ret := m.ctrl.Call(m, "ListPublicJobBuilds", ctx, tc, pn, jn, before, after, limit, statuses)
 	ret0, _ := ret[0].([]*build.Build)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
@@ -758,9 +758,9 @@ func (m *Service) ListPublicJobBuilds(ctx context.Context, tc, pn, jn string, be
 }
 
 // ListPublicJobBuilds indicates an expected call of ListPublicJobBuilds.
-func (mr *ServiceMockRecorder) ListPublicJobBuilds(ctx, tc, pn, jn, before, after, limit any) *gomock.Call {
+func (mr *ServiceMockRecorder) ListPublicJobBuilds(ctx, tc, pn, jn, before, after, limit, statuses any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPublicJobBuilds", reflect.TypeOf((*Service)(nil).ListPublicJobBuilds), ctx, tc, pn, jn, before, after, limit)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPublicJobBuilds", reflect.TypeOf((*Service)(nil).ListPublicJobBuilds), ctx, tc, pn, jn, before, after, limit, statuses)
 }
 
 // ListPublicPipelineJobs mocks base method.

--- a/pikoci/mysql/build.go
+++ b/pikoci/mysql/build.go
@@ -244,7 +244,7 @@ func (r *BuildRepository) Find(ctx context.Context, tc, pn, jn string, buildNumb
 	return j, nil
 }
 
-func (r *BuildRepository) Filter(ctx context.Context, tc, pn, jn string, before *uint32, after *uint32, limit uint32) ([]*build.Build, error) {
+func (r *BuildRepository) Filter(ctx context.Context, tc, pn, jn string, before *uint32, after *uint32, limit uint32, statuses []build.Status) ([]*build.Build, error) {
 	query := `
 		SELECT b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical, b.retry_source_build_id
 		FROM builds AS b
@@ -256,6 +256,15 @@ func (r *BuildRepository) Filter(ctx context.Context, tc, pn, jn string, before 
 			ON p.team_id = t.id
 		WHERE t.canonical = ? AND p.canonical = ? AND j.name = ?`
 	args := []interface{}{tc, pn, jn}
+
+	if len(statuses) > 0 {
+		placeholders := make([]string, len(statuses))
+		for i, s := range statuses {
+			placeholders[i] = "?"
+			args = append(args, s.String())
+		}
+		query += ` AND b.status IN (` + strings.Join(placeholders, ", ") + `)`
+	}
 
 	if after != nil {
 		query += ` AND b.id > ?`
@@ -716,6 +725,63 @@ func (r *BuildRepository) FindByVersionAndJobs(ctx context.Context, tc, pn strin
 			}
 		}
 		result[jn] = append(main, retries...)
+	}
+
+	return result, nil
+}
+
+func (r *BuildRepository) FilterByPipeline(ctx context.Context, tc, pn string, statuses []build.Status) (map[string][]*build.Build, error) {
+	query := `
+		SELECT j.name, b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical, b.retry_source_build_id
+		FROM builds AS b
+		JOIN jobs AS j ON b.job_id = j.id
+		JOIN pipelines AS p ON j.pipeline_id = p.id
+		JOIN teams AS t ON p.team_id = t.id
+		WHERE t.canonical = ? AND p.canonical = ?`
+	args := []interface{}{tc, pn}
+
+	if len(statuses) > 0 {
+		placeholders := make([]string, len(statuses))
+		for i, s := range statuses {
+			placeholders[i] = "?"
+			args = append(args, s.String())
+		}
+		query += ` AND b.status IN (` + strings.Join(placeholders, ", ") + `)`
+	}
+
+	query += ` ORDER BY b.id DESC`
+
+	rows, err := r.querier.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to filter builds by pipeline: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[string][]*build.Build)
+	for rows.Next() {
+		var dbb dbBuild
+		var jobName string
+		err := rows.Scan(
+			&jobName,
+			&dbb.ID,
+			&dbb.BuildNumber,
+			&dbb.Steps,
+			&dbb.Job,
+			&dbb.Status,
+			&dbb.Error,
+			&dbb.StartedAt,
+			&dbb.Duration,
+			&dbb.VersionID,
+			&dbb.ResourceCanonical,
+			&dbb.RetrySourceBuildID,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan build: %w", err)
+		}
+		result[jobName] = append(result[jobName], dbb.toDomainEntity())
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate builds by pipeline: %w", err)
 	}
 
 	return result, nil

--- a/pikoci/mysql/build_test.go
+++ b/pikoci/mysql/build_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/pikoci/pikoci/pikoci/build"
 	"github.com/pikoci/pikoci/pikoci/job"
 	"github.com/pikoci/pikoci/pikoci/mysql"
 )
@@ -866,4 +867,91 @@ func TestCountRunningInSerialGroups_Empty(t *testing.T) {
 	count, err := br.CountRunningInSerialGroups(ctx, "main", "pipe", []string{}, "job")
 	require.NoError(t, err)
 	assert.Equal(t, 0, count)
+}
+
+func TestFilterByPipeline(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	res, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'fbp-pipe', 'fbp-pipe')`)
+	require.NoError(t, err)
+	ppID, _ := res.LastInsertId()
+
+	res, err = db.ExecContext(ctx, `INSERT INTO jobs (pipeline_id, name) VALUES (?, 'build')`, ppID)
+	require.NoError(t, err)
+	buildJobID, _ := res.LastInsertId()
+
+	res, err = db.ExecContext(ctx, `INSERT INTO jobs (pipeline_id, name) VALUES (?, 'test')`, ppID)
+	require.NoError(t, err)
+	testJobID, _ := res.LastInsertId()
+
+	// Insert builds for 'build' job: succeeded, pending
+	res, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, build_number) VALUES (?, 'succeeded', '1')`, buildJobID)
+	require.NoError(t, err)
+	buildSucceededID, _ := res.LastInsertId()
+
+	res, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, build_number) VALUES (?, 'pending', '2')`, buildJobID)
+	require.NoError(t, err)
+	buildPendingID, _ := res.LastInsertId()
+
+	// Insert builds for 'test' job: failed, pending
+	res, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, build_number) VALUES (?, 'failed', '1')`, testJobID)
+	require.NoError(t, err)
+	testFailedID, _ := res.LastInsertId()
+
+	res, err = db.ExecContext(ctx, `INSERT INTO builds (job_id, status, build_number) VALUES (?, 'pending', '2')`, testJobID)
+	require.NoError(t, err)
+	testPendingID, _ := res.LastInsertId()
+
+	br := mysql.NewBuildRepository(db, mysql.Mem)
+
+	t.Run("no status filter returns all builds grouped by job", func(t *testing.T) {
+		result, err := br.FilterByPipeline(ctx, "main", "fbp-pipe", nil)
+		require.NoError(t, err)
+
+		assert.Contains(t, result, "build")
+		assert.Contains(t, result, "test")
+
+		buildBuilds := result["build"]
+		assert.Len(t, buildBuilds, 2)
+		// Ordered by id DESC: pending (higher id) first
+		assert.Equal(t, uint32(buildPendingID), buildBuilds[0].ID)
+		assert.Equal(t, uint32(buildSucceededID), buildBuilds[1].ID)
+
+		testBuilds := result["test"]
+		assert.Len(t, testBuilds, 2)
+		// Ordered by id DESC: pending (higher id) first
+		assert.Equal(t, uint32(testPendingID), testBuilds[0].ID)
+		assert.Equal(t, uint32(testFailedID), testBuilds[1].ID)
+	})
+
+	t.Run("status filter returns only matching builds", func(t *testing.T) {
+		result, err := br.FilterByPipeline(ctx, "main", "fbp-pipe", []build.Status{build.Pending})
+		require.NoError(t, err)
+
+		assert.Contains(t, result, "build")
+		assert.Contains(t, result, "test")
+
+		buildBuilds := result["build"]
+		assert.Len(t, buildBuilds, 1)
+		assert.Equal(t, uint32(buildPendingID), buildBuilds[0].ID)
+		assert.Equal(t, "pending", buildBuilds[0].Status.String())
+
+		testBuilds := result["test"]
+		assert.Len(t, testBuilds, 1)
+		assert.Equal(t, uint32(testPendingID), testBuilds[0].ID)
+		assert.Equal(t, "pending", testBuilds[0].Status.String())
+	})
+
+	t.Run("status filter with no matches returns empty map", func(t *testing.T) {
+		result, err := br.FilterByPipeline(ctx, "main", "fbp-pipe", []build.Status{build.Started})
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("different pipeline not included", func(t *testing.T) {
+		result, err := br.FilterByPipeline(ctx, "main", "other-pipe", nil)
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
 }

--- a/pikoci/mysql/job.go
+++ b/pikoci/mysql/job.go
@@ -224,12 +224,16 @@ func (r *JobRepository) Filter(ctx context.Context, tc, pn string) ([]*job.Job, 
 		return nil, fmt.Errorf("failed to filter jobs: %w", err)
 	}
 
+	jobIDs := make([]uint32, len(jobs))
+	for i, j := range jobs {
+		jobIDs[i] = j.ID
+	}
+	sgMap, err := r.loadSerialGroupsBatch(ctx, jobIDs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to batch load serial groups: %w", err)
+	}
 	for _, j := range jobs {
-		sgs, err := r.loadSerialGroups(ctx, j.ID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load serial groups for job %q: %w", j.Name, err)
-		}
-		j.SerialGroups = sgs
+		j.SerialGroups = sgMap[j.ID]
 	}
 
 	return jobs, nil
@@ -409,6 +413,36 @@ func (r *JobRepository) loadSerialGroups(ctx context.Context, jobID uint32) ([]s
 		groups = append(groups, sg)
 	}
 	return groups, rows.Err()
+}
+
+func (r *JobRepository) loadSerialGroupsBatch(ctx context.Context, jobIDs []uint32) (map[uint32][]string, error) {
+	if len(jobIDs) == 0 {
+		return nil, nil
+	}
+	placeholders := make([]string, len(jobIDs))
+	args := make([]interface{}, len(jobIDs))
+	for i, id := range jobIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	rows, err := r.querier.QueryContext(ctx,
+		`SELECT job_id, serial_group FROM job_serial_groups WHERE job_id IN (`+strings.Join(placeholders, ", ")+`) ORDER BY job_id, serial_group`,
+		args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to batch query serial groups: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[uint32][]string)
+	for rows.Next() {
+		var jobID uint32
+		var sg string
+		if err := rows.Scan(&jobID, &sg); err != nil {
+			return nil, fmt.Errorf("failed to scan serial group: %w", err)
+		}
+		result[jobID] = append(result[jobID], sg)
+	}
+	return result, rows.Err()
 }
 
 func (r *JobRepository) FilterByForEachGroup(ctx context.Context, tc, pn, group string) ([]*job.Job, error) {

--- a/pikoci/mysql/resource.go
+++ b/pikoci/mysql/resource.go
@@ -405,6 +405,35 @@ func (r *ResourceRepository) FilterVersions(ctx context.Context, tc, pn, rCan st
 	return rvs, nil
 }
 
+func (r *ResourceRepository) LatestVersionByResources(ctx context.Context, tc, pn string) (map[string]*resource.Version, error) {
+	rows, err := r.querier.QueryContext(ctx, `
+		SELECT r.canonical, rv.id, rv.version
+		FROM resource_versions AS rv
+		JOIN resources AS r ON rv.resource_id = r.id
+		JOIN pipelines AS p ON r.pipeline_id = p.id
+		JOIN teams AS t ON p.team_id = t.id
+		WHERE t.canonical = ? AND p.canonical = ?
+		AND rv.id = (
+			SELECT MAX(rv2.id) FROM resource_versions rv2 WHERE rv2.resource_id = rv.resource_id
+		)
+	`, tc, pn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query latest versions: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[string]*resource.Version)
+	for rows.Next() {
+		var canonical string
+		var dbrv dbResourceVersion
+		if err := rows.Scan(&canonical, &dbrv.ID, &dbrv.Version); err != nil {
+			return nil, fmt.Errorf("failed to scan: %w", err)
+		}
+		result[canonical] = dbrv.toDomainEntity()
+	}
+	return result, rows.Err()
+}
+
 // FindVersionByID retrieves a single version by its ID, returning the version
 // and the canonical of the resource it belongs to.
 func (r *ResourceRepository) FindVersionByID(ctx context.Context, versionID uint32) (*resource.Version, string, error) {

--- a/pikoci/mysql/resource_test.go
+++ b/pikoci/mysql/resource_test.go
@@ -9,6 +9,85 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestLatestVersionByResources(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	res, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'lvbr-pipe', 'lvbr-pipe')`)
+	require.NoError(t, err)
+	ppID, _ := res.LastInsertId()
+
+	// Create two resources
+	res, err = db.ExecContext(ctx, `INSERT INTO resources (pipeline_id, name, type, canonical, tags, cache) VALUES (?, 'repo', 'git', 'git.repo', '', 0)`, ppID)
+	require.NoError(t, err)
+	repoID, _ := res.LastInsertId()
+
+	res, err = db.ExecContext(ctx, `INSERT INTO resources (pipeline_id, name, type, canonical, tags, cache) VALUES (?, 'image', 'docker', 'docker.image', '', 0)`, ppID)
+	require.NoError(t, err)
+	imageID, _ := res.LastInsertId()
+
+	// Insert multiple versions for repo resource
+	res, err = db.ExecContext(ctx, `INSERT INTO resource_versions (resource_id, version) VALUES (?, '{"ref":"abc"}')`, repoID)
+	require.NoError(t, err)
+	_, _ = res.LastInsertId()
+
+	res, err = db.ExecContext(ctx, `INSERT INTO resource_versions (resource_id, version) VALUES (?, '{"ref":"def"}')`, repoID)
+	require.NoError(t, err)
+	repoLatestID, _ := res.LastInsertId()
+
+	// Insert multiple versions for image resource
+	res, err = db.ExecContext(ctx, `INSERT INTO resource_versions (resource_id, version) VALUES (?, '{"tag":"1.0"}')`, imageID)
+	require.NoError(t, err)
+	_, _ = res.LastInsertId()
+
+	res, err = db.ExecContext(ctx, `INSERT INTO resource_versions (resource_id, version) VALUES (?, '{"tag":"2.0"}')`, imageID)
+	require.NoError(t, err)
+	_, _ = res.LastInsertId()
+
+	res, err = db.ExecContext(ctx, `INSERT INTO resource_versions (resource_id, version) VALUES (?, '{"tag":"3.0"}')`, imageID)
+	require.NoError(t, err)
+	imageLatestID, _ := res.LastInsertId()
+
+	rr := mysql.NewResourceRepository(db, mysql.Mem)
+
+	result, err := rr.LatestVersionByResources(ctx, "main", "lvbr-pipe")
+	require.NoError(t, err)
+
+	// Map should be keyed by resource canonical
+	assert.Contains(t, result, "git.repo")
+	assert.Contains(t, result, "docker.image")
+
+	// Each entry should be the latest (highest ID) version
+	repoVersion := result["git.repo"]
+	require.NotNil(t, repoVersion)
+	assert.Equal(t, uint32(repoLatestID), repoVersion.ID)
+	assert.Equal(t, "def", repoVersion.Version["ref"])
+
+	imageVersion := result["docker.image"]
+	require.NotNil(t, imageVersion)
+	assert.Equal(t, uint32(imageLatestID), imageVersion.ID)
+	assert.Equal(t, "3.0", imageVersion.Version["tag"])
+
+	t.Run("returns empty map when pipeline has no versions", func(t *testing.T) {
+		res2, err := db.ExecContext(ctx, `INSERT INTO pipelines (team_id, name, canonical) VALUES (1, 'lvbr-empty', 'lvbr-empty')`)
+		require.NoError(t, err)
+		emptyPPID, _ := res2.LastInsertId()
+		// Insert a resource but no versions
+		_, err = db.ExecContext(ctx, `INSERT INTO resources (pipeline_id, name, type, canonical, tags, cache) VALUES (?, 'empty-res', 'git', 'git.empty', '', 0)`, emptyPPID)
+		require.NoError(t, err)
+
+		result, err := rr.LatestVersionByResources(ctx, "main", "lvbr-empty")
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("does not return versions from a different pipeline", func(t *testing.T) {
+		result, err := rr.LatestVersionByResources(ctx, "main", "nonexistent-pipe")
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+}
+
 func TestFindByWebhookToken(t *testing.T) {
 	db := setupTestDB(t)
 	ctx := context.Background()

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -648,50 +648,6 @@ type jobNodeVisuals struct {
 	clusterBorderColor string
 }
 
-// resolveJobVisuals fetches builds for a job and computes its fill color,
-// border color, and cluster (running indicator) style.
-func (q *PikoCI) resolveJobVisuals(ctx context.Context, tc string, pp *pipeline.Pipeline, j job.Job) (jobNodeVisuals, error) {
-	builds, err := q.Builds.Filter(ctx, tc, pp.Canonical, j.Name, nil, nil, 0)
-	if err != nil {
-		return jobNodeVisuals{}, fmt.Errorf("failed to filter builds from Job %q: %w", j.Name, err)
-	}
-
-	color := colorDefault
-	borderColor := colorDefaultBorder
-
-	bs := resolveBuildStatus(builds)
-
-	if bs.completedBuild != nil {
-		if c, ok := jobColors[bs.completedBuild.Status]; ok {
-			color = c
-		}
-		if c, ok := jobBorderColors[bs.completedBuild.Status]; ok {
-			borderColor = c
-		}
-	}
-
-	if j.Paused {
-		color = colorPaused
-		borderColor = colorPausedBorder
-	}
-
-	clusterStyle := "invis"
-	clusterBorderColor := jobBorderColors[build.Started]
-	if bs.runningBuild != nil {
-		clusterStyle = `"dashed,bold"`
-		if bs.runningBuild.Status == build.Pending {
-			clusterBorderColor = colorDefaultBorder
-		}
-	}
-
-	return jobNodeVisuals{
-		color:              color,
-		borderColor:        borderColor,
-		clusterStyle:       clusterStyle,
-		clusterBorderColor: clusterBorderColor,
-	}, nil
-}
-
 // resolveJobVisualsFromBuilds computes job node visuals from a provided set of
 // builds rather than fetching from the database. Used when rendering a
 // version-scoped graph where only specific builds are relevant.
@@ -782,13 +738,14 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 	}
 	var resVersions []resVersion
 	var versionIDs []uint32
-	for _, r := range pp.Resources {
-		vers, err := q.Resources.FilterVersions(ctx, tc, pp.Canonical, r.Canonical, nil, nil, 1)
-		if err != nil || len(vers) == 0 {
-			continue
+	latestVersions, err := q.Resources.LatestVersionByResources(ctx, tc, pp.Canonical)
+	if err == nil {
+		for _, r := range pp.Resources {
+			if v, ok := latestVersions[r.Canonical]; ok {
+				resVersions = append(resVersions, resVersion{canonical: r.Canonical, version: v})
+				versionIDs = append(versionIDs, v.ID)
+			}
 		}
-		resVersions = append(resVersions, resVersion{canonical: r.Canonical, version: vers[0]})
-		versionIDs = append(versionIDs, vers[0].ID)
 	}
 	if len(versionIDs) > 0 {
 		statuses, err := q.Builds.AggregateStatusByVersionIDs(ctx, versionIDs)
@@ -941,6 +898,18 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 		return fmt.Sprintf(`"%s"`, jobName)
 	}
 
+	// Pre-fetch all builds for all pipeline jobs in a single query when not
+	// using a version-scoped filter. This replaces per-job Filter calls in
+	// the non-parallel and parallel-group rendering below.
+	var pipelineBuilds map[string][]*build.Build
+	if versionFilter == nil {
+		var bErr error
+		pipelineBuilds, bErr = q.Builds.FilterByPipeline(ctx, tc, pp.Canonical, nil)
+		if bErr != nil {
+			return nil, fmt.Errorf("failed to pre-fetch pipeline builds: %w", bErr)
+		}
+	}
+
 	// Print all the Jobs and the connection to resources
 	for i, j := range pp.Jobs {
 		if _, grouped := jobToGroupNode[j.Name]; grouped {
@@ -952,11 +921,7 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 			// Use only the version-specific builds for coloring
 			vis = resolveJobVisualsFromBuilds(versionFilter.buildsByJob[j.Name], j)
 		} else {
-			var verr error
-			vis, verr = q.resolveJobVisuals(ctx, tc, pp, j)
-			if verr != nil {
-				return nil, verr
-			}
+			vis = resolveJobVisualsFromBuilds(pipelineBuilds[j.Name], j)
 		}
 
 		jg := fmt.Sprintf("cluster_%d", i)
@@ -1058,12 +1023,8 @@ func (q *PikoCI) generateImage(ctx context.Context, tc string, pp *pipeline.Pipe
 				vis = resolveJobVisualsFromBuilds(versionFilter.buildsByJob[j.Name], j)
 				jobBuilds = versionFilter.buildsByJob[j.Name]
 			} else {
-				var verr error
-				vis, verr = q.resolveJobVisuals(ctx, tc, pp, j)
-				if verr != nil {
-					return nil, verr
-				}
-				jobBuilds, _ = q.Builds.Filter(ctx, tc, pp.Canonical, j.Name, nil, nil, 0)
+				jobBuilds = pipelineBuilds[j.Name]
+				vis = resolveJobVisualsFromBuilds(jobBuilds, j)
 			}
 			dotColor := strings.Trim(vis.color, `"`)
 			if len(jobBuilds) > 0 {
@@ -1674,13 +1635,13 @@ func (q *PikoCI) GetPublicPipelineJob(ctx context.Context, tc, pCan, jn string) 
 
 // ListPublicJobBuilds returns paginated builds for a job on a public pipeline,
 // with secret step logs redacted for safety.
-func (q *PikoCI) ListPublicJobBuilds(ctx context.Context, tc, pCan, jn string, before *uint32, after *uint32, limit uint32) ([]*build.Build, bool, error) {
+func (q *PikoCI) ListPublicJobBuilds(ctx context.Context, tc, pCan, jn string, before *uint32, after *uint32, limit uint32, statuses []build.Status) ([]*build.Build, bool, error) {
 	_, err := q.Pipelines.FindPublic(ctx, tc, pCan)
 	if err != nil {
 		return nil, false, fmt.Errorf("pipeline not found or not public: %w", err)
 	}
 
-	builds, hasMore, err := q.ListJobBuilds(ctx, tc, pCan, jn, before, after, limit)
+	builds, hasMore, err := q.ListJobBuilds(ctx, tc, pCan, jn, before, after, limit, statuses)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -1411,9 +1411,8 @@ func TestGetPipelineImage_HidesUnlinkedResources(t *testing.T) {
 	}
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "build", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "github-check.ci", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, "main", "my-pipeline", ([]build.Status)(nil)).Return(map[string][]*build.Build{}, nil)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "my-pipeline").Return(map[string]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false, nil)
 	require.NoError(t, err)
@@ -1462,8 +1461,8 @@ func TestGetPipelineImage_QuotesHyphenatedName(t *testing.T) {
 	}
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "hello-world").Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "hello-world", "hello", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "hello-world", "cron.tick", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, "main", "hello-world", ([]build.Status)(nil)).Return(map[string][]*build.Build{}, nil)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "hello-world").Return(map[string]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "hello-world", "dot", false, false, nil)
 	require.NoError(t, err)
@@ -1506,9 +1505,8 @@ func TestGetPipelineImage_ShowsLinkedResources(t *testing.T) {
 	}
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "test", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "git.repo", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, "main", "my-pipeline", ([]build.Status)(nil)).Return(map[string][]*build.Build{}, nil)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "my-pipeline").Return(map[string]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false, nil)
 	require.NoError(t, err)
@@ -1559,10 +1557,8 @@ func TestGetPipelineImage_PassedReusesPutOutputNode(t *testing.T) {
 	}
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "artifact-pipeline").Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "artifact-pipeline", "build", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "artifact-pipeline", "deploy", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "artifact-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "artifact-pipeline", "artifact.output", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, "main", "artifact-pipeline", ([]build.Status)(nil)).Return(map[string][]*build.Build{}, nil)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "artifact-pipeline").Return(map[string]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "artifact-pipeline", "dot", false, false, nil)
 	require.NoError(t, err)
@@ -1762,8 +1758,8 @@ func TestGetPipelineImage_JobStatusColors(t *testing.T) {
 
 			pp := makePipeline()
 			s.Pipelines.EXPECT().Find(ctx, "main", "p").Return(pp, nil)
-			s.Builds.EXPECT().Filter(ctx, "main", "p", "j", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return(tt.builds, nil)
-			s.Resources.EXPECT().FilterVersions(ctx, "main", "p", "cron.tick", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+			s.Builds.EXPECT().FilterByPipeline(ctx, "main", "p", ([]build.Status)(nil)).Return(map[string][]*build.Build{"j": tt.builds}, nil)
+			s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "p").Return(map[string]*resource.Version{}, nil)
 
 			img, err := s.S.GetPipelineImage(ctx, "main", "p", "dot", false, false, nil)
 			require.NoError(t, err)
@@ -2778,7 +2774,7 @@ func TestListPublicJobBuilds(t *testing.T) {
 	s.Pipelines.EXPECT().FindPublic(ctx, "main", "my-pipeline").Return(&pipeline.Pipeline{
 		ID: 1, Canonical: "my-pipeline",
 	}, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{
+	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", (*uint32)(nil), (*uint32)(nil), uint32(0), ([]build.Status)(nil)).Return([]*build.Build{
 		{
 			ID: 1, BuildNumber: "1", Status: build.Succeeded,
 			Steps: []build.Step{
@@ -2788,7 +2784,7 @@ func TestListPublicJobBuilds(t *testing.T) {
 		},
 	}, nil)
 
-	builds, hasMore, err := s.S.ListPublicJobBuilds(ctx, "main", "my-pipeline", "my-job", nil, nil, 0)
+	builds, hasMore, err := s.S.ListPublicJobBuilds(ctx, "main", "my-pipeline", "my-job", nil, nil, 0, nil)
 	require.NoError(t, err)
 	assert.False(t, hasMore)
 	require.Len(t, builds, 1)
@@ -3548,7 +3544,7 @@ func TestListPublicJobBuilds_NotFound(t *testing.T) {
 
 	s.Pipelines.EXPECT().FindPublic(ctx, "main", "my-pipeline").Return(nil, assert.AnError)
 
-	_, _, err := s.S.ListPublicJobBuilds(ctx, "main", "my-pipeline", "my-job", nil, nil, 0)
+	_, _, err := s.S.ListPublicJobBuilds(ctx, "main", "my-pipeline", "my-job", nil, nil, 0, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pipeline not found or not public")
 }
@@ -3636,8 +3632,8 @@ job "test" {
 `)
 
 	// No builds for the job
-	s.Builds.EXPECT().Filter(ctx, "main", "pikoci", "test", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "pikoci", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, "main", "pikoci", ([]build.Status)(nil)).Return(map[string][]*build.Build{}, nil)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "pikoci").Return(map[string]*resource.Version{}, nil)
 
 	img, err := s.S.CreatePipelineImage(ctx, "main", hclConfig, nil, "dot")
 	require.NoError(t, err)
@@ -3712,8 +3708,8 @@ job "test" {
 `)
 
 	// No builds for the job
-	s.Builds.EXPECT().Filter(ctx, "main", "pikoci", "test", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "pikoci", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, "main", "pikoci", ([]build.Status)(nil)).Return(map[string][]*build.Build{}, nil)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "pikoci").Return(map[string]*resource.Version{}, nil)
 
 	img, err := s.S.CreatePipelineImage(ctx, "main", hclConfig, nil, "image.dot")
 	require.NoError(t, err)
@@ -3743,8 +3739,8 @@ func TestGetPublicPipelineImage_DOT(t *testing.T) {
 	}
 
 	s.Pipelines.EXPECT().FindPublic(ctx, "main", "my-pipeline").Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, "main", "my-pipeline", ([]build.Status)(nil)).Return(map[string][]*build.Build{}, nil)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "my-pipeline").Return(map[string]*resource.Version{}, nil)
 
 	img, err := s.S.GetPublicPipelineImage(ctx, "main", "my-pipeline", "dot", false, false, nil)
 	require.NoError(t, err)
@@ -3834,8 +3830,8 @@ func TestGetPipelineImage_DOT(t *testing.T) {
 	}
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, "main", "my-pipeline", ([]build.Status)(nil)).Return(map[string][]*build.Build{}, nil)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "my-pipeline").Return(map[string]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false, nil)
 	require.NoError(t, err)
@@ -3856,6 +3852,8 @@ func TestGetPipelineImage_FormatFromExtension(t *testing.T) {
 	}
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, "main", "my-pipeline", ([]build.Status)(nil)).Return(map[string][]*build.Build{}, nil)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "my-pipeline").Return(map[string]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "image.dot", false, false, nil)
 	require.NoError(t, err)
@@ -3876,6 +3874,8 @@ func TestGetPipelineImage_EmptyFormat(t *testing.T) {
 	}
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, "main", "my-pipeline", ([]build.Status)(nil)).Return(map[string][]*build.Build{}, nil)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "my-pipeline").Return(map[string]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "", false, false, nil)
 	require.NoError(t, err)
@@ -3926,22 +3926,12 @@ func TestGetPipelineImage_WithBuildStatuses(t *testing.T) {
 	}
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
-	// succeeded-job has a terminal build
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "succeeded-job", gomock.Any(), gomock.Any(), gomock.Any()).Return([]*build.Build{
-		{ID: 1, BuildNumber: "1", Status: build.Succeeded},
+	s.Builds.EXPECT().FilterByPipeline(ctx, "main", "my-pipeline", ([]build.Status)(nil)).Return(map[string][]*build.Build{
+		"succeeded-job": {{ID: 1, BuildNumber: "1", Status: build.Succeeded}},
+		"failed-job":    {{ID: 2, BuildNumber: "1", Status: build.Failed}},
+		"running-job":   {{ID: 3, BuildNumber: "1", Status: build.Started}},
 	}, nil)
-	// failed-job has a failed build
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "failed-job", gomock.Any(), gomock.Any(), gomock.Any()).Return([]*build.Build{
-		{ID: 2, BuildNumber: "1", Status: build.Failed},
-	}, nil)
-	// paused-job has no builds
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "paused-job", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	// running-job has a running build and a pending build
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "running-job", gomock.Any(), gomock.Any(), gomock.Any()).Return([]*build.Build{
-		{ID: 3, BuildNumber: "1", Status: build.Started},
-	}, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "git.repo", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "my-pipeline").Return(map[string]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false, nil)
 	require.NoError(t, err)
@@ -3982,9 +3972,8 @@ func TestGetPipelineImage_WithPassedConstraints(t *testing.T) {
 	}
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "upstream", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "downstream", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, "main", "my-pipeline", ([]build.Status)(nil)).Return(map[string][]*build.Build{}, nil)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "my-pipeline").Return(map[string]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false, nil)
 	require.NoError(t, err)
@@ -4016,8 +4005,8 @@ func TestGetPipelineImage_ResourceWithError(t *testing.T) {
 	}
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, "main", "my-pipeline", ([]build.Status)(nil)).Return(map[string][]*build.Build{}, nil)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "my-pipeline").Return(map[string]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false, nil)
 	require.NoError(t, err)
@@ -4048,8 +4037,8 @@ func TestGetPipelineImage_PinnedResource(t *testing.T) {
 	}
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, "main", "my-pipeline", ([]build.Status)(nil)).Return(map[string][]*build.Build{}, nil)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "my-pipeline").Return(map[string]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false, nil)
 	require.NoError(t, err)
@@ -4079,9 +4068,9 @@ func TestGetPipelineImage_ResourceTooltip(t *testing.T) {
 	}
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "git.repo", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{
-		{ID: 10, Version: map[string]interface{}{"ref": "abc1234", "sha": "deadbeef"}},
+	s.Builds.EXPECT().FilterByPipeline(ctx, "main", "my-pipeline", ([]build.Status)(nil)).Return(map[string][]*build.Build{}, nil)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "my-pipeline").Return(map[string]*resource.Version{
+		"git.repo": {ID: 10, Version: map[string]interface{}{"ref": "abc1234", "sha": "deadbeef"}},
 	}, nil)
 	s.Builds.EXPECT().AggregateStatusByVersionIDs(ctx, []uint32{10}).Return(map[uint32]string{10: "succeeded"}, nil)
 
@@ -4115,8 +4104,8 @@ func TestGetPipelineImage_ResourceTooltipNoVersions(t *testing.T) {
 	}
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, "main", "my-pipeline", ([]build.Status)(nil)).Return(map[string][]*build.Build{}, nil)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "my-pipeline").Return(map[string]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false, nil)
 	require.NoError(t, err)
@@ -4149,9 +4138,9 @@ func TestGetPipelineImage_ResourceTooltipNoStatus(t *testing.T) {
 	}
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "git.repo", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{
-		{ID: 5, Version: map[string]interface{}{"ref": "main"}},
+	s.Builds.EXPECT().FilterByPipeline(ctx, "main", "my-pipeline", ([]build.Status)(nil)).Return(map[string][]*build.Build{}, nil)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "my-pipeline").Return(map[string]*resource.Version{
+		"git.repo": {ID: 5, Version: map[string]interface{}{"ref": "main"}},
 	}, nil)
 	s.Builds.EXPECT().AggregateStatusByVersionIDs(ctx, []uint32{5}).Return(nil, nil)
 
@@ -4433,9 +4422,12 @@ func TestListPipelineJobs_NoBuilds(t *testing.T) {
 			{ID: 2, Name: "job-b"},
 		},
 	}
+	activeStatuses := []build.Status{build.Started, build.Pending}
+	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval}
+
 	s.Pipelines.EXPECT().Find(ctx, tc, pn).Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, tc, pn, "job-a", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
-	s.Builds.EXPECT().Filter(ctx, tc, pn, "job-b", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, activeStatuses).Return(map[string][]*build.Build{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, completedStatuses).Return(map[string][]*build.Build{}, nil)
 
 	result, err := s.S.ListPipelineJobs(ctx, tc, pn)
 	require.NoError(t, err)
@@ -4460,9 +4452,13 @@ func TestListPipelineJobs_SucceededBuild(t *testing.T) {
 		ID: 1, Name: pn, Canonical: pn,
 		Jobs: []job.Job{{ID: 1, Name: "build"}},
 	}
+	activeStatuses := []build.Status{build.Started, build.Pending}
+	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval}
+
 	s.Pipelines.EXPECT().Find(ctx, tc, pn).Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, tc, pn, "build", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{
-		{ID: 1, BuildNumber: "1", Status: build.Succeeded, Duration: time.Second, StartedAt: startedAt},
+	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, activeStatuses).Return(map[string][]*build.Build{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, completedStatuses).Return(map[string][]*build.Build{
+		"build": {{ID: 1, BuildNumber: "1", Status: build.Succeeded, Duration: time.Second, StartedAt: startedAt}},
 	}, nil)
 
 	result, err := s.S.ListPipelineJobs(ctx, tc, pn)
@@ -4487,9 +4483,13 @@ func TestListPipelineJobs_FailedBuild(t *testing.T) {
 		ID: 1, Name: pn, Canonical: pn,
 		Jobs: []job.Job{{ID: 1, Name: "test"}},
 	}
+	activeStatuses := []build.Status{build.Started, build.Pending}
+	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval}
+
 	s.Pipelines.EXPECT().Find(ctx, tc, pn).Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, tc, pn, "test", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{
-		{ID: 1, BuildNumber: "1", Status: build.Failed, Duration: 2 * time.Second, StartedAt: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)},
+	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, activeStatuses).Return(map[string][]*build.Build{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, completedStatuses).Return(map[string][]*build.Build{
+		"test": {{ID: 1, BuildNumber: "1", Status: build.Failed, Duration: 2 * time.Second, StartedAt: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)}},
 	}, nil)
 
 	result, err := s.S.ListPipelineJobs(ctx, tc, pn)
@@ -4510,10 +4510,14 @@ func TestListPipelineJobs_RunningBuild(t *testing.T) {
 		ID: 1, Name: pn, Canonical: pn,
 		Jobs: []job.Job{{ID: 1, Name: "deploy"}},
 	}
+	activeStatuses := []build.Status{build.Started, build.Pending}
+	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval}
+
 	s.Pipelines.EXPECT().Find(ctx, tc, pn).Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, tc, pn, "deploy", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{
-		{ID: 1, BuildNumber: "1", Status: build.Started},
+	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, activeStatuses).Return(map[string][]*build.Build{
+		"deploy": {{ID: 1, BuildNumber: "1", Status: build.Started}},
 	}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, completedStatuses).Return(map[string][]*build.Build{}, nil)
 
 	result, err := s.S.ListPipelineJobs(ctx, tc, pn)
 	require.NoError(t, err)
@@ -4534,10 +4538,14 @@ func TestListPipelineJobs_PendingBuild(t *testing.T) {
 		ID: 1, Name: pn, Canonical: pn,
 		Jobs: []job.Job{{ID: 1, Name: "gen"}},
 	}
+	activeStatuses := []build.Status{build.Started, build.Pending}
+	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval}
+
 	s.Pipelines.EXPECT().Find(ctx, tc, pn).Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, tc, pn, "gen", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{
-		{ID: 1, BuildNumber: "1", Status: build.Pending},
+	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, activeStatuses).Return(map[string][]*build.Build{
+		"gen": {{ID: 1, BuildNumber: "1", Status: build.Pending}},
 	}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, completedStatuses).Return(map[string][]*build.Build{}, nil)
 
 	result, err := s.S.ListPipelineJobs(ctx, tc, pn)
 	require.NoError(t, err)
@@ -4560,12 +4568,14 @@ func TestListPipelineJobs_MixedStatuses(t *testing.T) {
 			{ID: 2, Name: "job-fail"},
 		},
 	}
+	activeStatuses := []build.Status{build.Started, build.Pending}
+	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval}
+
 	s.Pipelines.EXPECT().Find(ctx, tc, pn).Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, tc, pn, "job-ok", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{
-		{ID: 1, BuildNumber: "1", Status: build.Succeeded, StartedAt: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)},
-	}, nil)
-	s.Builds.EXPECT().Filter(ctx, tc, pn, "job-fail", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{
-		{ID: 2, BuildNumber: "1", Status: build.Failed, StartedAt: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)},
+	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, activeStatuses).Return(map[string][]*build.Build{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, completedStatuses).Return(map[string][]*build.Build{
+		"job-ok":   {{ID: 1, BuildNumber: "1", Status: build.Succeeded, StartedAt: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)}},
+		"job-fail": {{ID: 2, BuildNumber: "1", Status: build.Failed, StartedAt: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)}},
 	}, nil)
 
 	result, err := s.S.ListPipelineJobs(ctx, tc, pn)
@@ -4587,10 +4597,13 @@ func TestListPipelineJobs_RetryBuild(t *testing.T) {
 		ID: 1, Name: pn, Canonical: pn,
 		Jobs: []job.Job{{ID: 1, Name: "build"}},
 	}
+	activeStatuses := []build.Status{build.Started, build.Pending}
+	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval}
+
 	s.Pipelines.EXPECT().Find(ctx, tc, pn).Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, tc, pn, "build", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{
-		{ID: 2, BuildNumber: "1.1", Status: build.Succeeded, Duration: 5 * time.Second, StartedAt: startedAt},
-		{ID: 1, BuildNumber: "1", Status: build.Failed, Duration: 3 * time.Second, StartedAt: startedAt},
+	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, activeStatuses).Return(map[string][]*build.Build{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, completedStatuses).Return(map[string][]*build.Build{
+		"build": {{ID: 2, BuildNumber: "1.1", Status: build.Succeeded, Duration: 5 * time.Second, StartedAt: startedAt}},
 	}, nil)
 
 	result, err := s.S.ListPipelineJobs(ctx, tc, pn)
@@ -4615,10 +4628,12 @@ func TestListPipelineJobs_JobOrder(t *testing.T) {
 			{ID: 3, Name: "third"},
 		},
 	}
+	activeStatuses := []build.Status{build.Started, build.Pending}
+	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval}
+
 	s.Pipelines.EXPECT().Find(ctx, tc, pn).Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, tc, pn, "first", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
-	s.Builds.EXPECT().Filter(ctx, tc, pn, "second", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
-	s.Builds.EXPECT().Filter(ctx, tc, pn, "third", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, activeStatuses).Return(map[string][]*build.Build{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, completedStatuses).Return(map[string][]*build.Build{}, nil)
 
 	result, err := s.S.ListPipelineJobs(ctx, tc, pn)
 	require.NoError(t, err)
@@ -4640,9 +4655,13 @@ func TestListPublicPipelineJobs_Success(t *testing.T) {
 		ID: 1, Name: pn, Canonical: pn,
 		Jobs: []job.Job{{ID: 1, Name: "build"}},
 	}
+	activeStatuses := []build.Status{build.Started, build.Pending}
+	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval}
+
 	s.Pipelines.EXPECT().FindPublic(ctx, tc, pn).Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, tc, pn, "build", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{
-		{ID: 1, BuildNumber: "1", Status: build.Succeeded, Duration: time.Second, StartedAt: startedAt},
+	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, activeStatuses).Return(map[string][]*build.Build{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, completedStatuses).Return(map[string][]*build.Build{
+		"build": {{ID: 1, BuildNumber: "1", Status: build.Succeeded, Duration: time.Second, StartedAt: startedAt}},
 	}, nil)
 
 	result, err := s.S.ListPublicPipelineJobs(ctx, tc, pn)
@@ -4695,10 +4714,8 @@ func TestGetPipelineImage_HideIntermediates(t *testing.T) {
 	}
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "build", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "deploy", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "artifact.output", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, "main", "my-pipeline", ([]build.Status)(nil)).Return(map[string][]*build.Build{}, nil)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "my-pipeline").Return(map[string]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", true, false, nil)
 	require.NoError(t, err)
@@ -4757,10 +4774,8 @@ func TestGetPipelineImage_GroupParallel(t *testing.T) {
 	}
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "build", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "lint", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "vet", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, "main", "my-pipeline", ([]build.Status)(nil)).Return(map[string][]*build.Build{}, nil)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "my-pipeline").Return(map[string]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, true, nil)
 	require.NoError(t, err)
@@ -4807,9 +4822,8 @@ func TestGetPipelineImage_GroupParallel_SingleJob(t *testing.T) {
 	}
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "build", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "deploy", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, "main", "my-pipeline", ([]build.Status)(nil)).Return(map[string][]*build.Build{}, nil)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "my-pipeline").Return(map[string]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, true, nil)
 	require.NoError(t, err)
@@ -4857,11 +4871,8 @@ func TestGetPipelineImage_GroupParallel_WithHideIntermediates(t *testing.T) {
 	}
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "build", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "lint", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "vet", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "artifact.output", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, "main", "my-pipeline", ([]build.Status)(nil)).Return(map[string][]*build.Build{}, nil)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "my-pipeline").Return(map[string]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", true, true, nil)
 	require.NoError(t, err)
@@ -4917,11 +4928,8 @@ func TestGetPipelineImage_GroupParallel_EdgeRemapping(t *testing.T) {
 	}
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "build", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "lint", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "vet", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "release", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, "main", "my-pipeline", ([]build.Status)(nil)).Return(map[string][]*build.Build{}, nil)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "my-pipeline").Return(map[string]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", true, true, nil)
 	require.NoError(t, err)
@@ -4997,9 +5005,8 @@ func TestGetPipelineImage_WithVersionFilter(t *testing.T) {
 	s.Builds.EXPECT().FindGetVersions(ctx, uint32(10)).Return(map[string]uint32{"repo": versionID}, nil)
 	s.Builds.EXPECT().FindGetVersions(ctx, uint32(11)).Return(map[string]uint32{"repo": versionID}, nil)
 
-	// generateImage: FilterVersions for all resources in the pipeline (used for tooltips)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "git.repo", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	// generateImage: LatestVersionByResources for all resources in the pipeline (used for tooltips)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "my-pipeline").Return(map[string]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false, &versionID)
 	require.NoError(t, err)
@@ -5064,8 +5071,7 @@ func TestGetPipelineImage_WithVersionFilter_DoesNotMutatePipeline(t *testing.T) 
 		nil,
 	)
 	s.Builds.EXPECT().FindGetVersions(ctx, uint32(10)).Return(map[string]uint32{"repo": versionID}, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "git.repo", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "cron.timer", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "my-pipeline").Return(map[string]*resource.Version{}, nil)
 
 	_, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, false, &versionID)
 	require.NoError(t, err)
@@ -5113,11 +5119,8 @@ func TestGetPipelineImage_GroupParallel_RootJobs(t *testing.T) {
 	}
 
 	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
-	// resolveJobVisuals is called twice per grouped job (once for coloring, once for the group node label)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "unit", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "lint", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "vet", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "git.repo", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{}, nil)
+	s.Builds.EXPECT().FilterByPipeline(ctx, "main", "my-pipeline", ([]build.Status)(nil)).Return(map[string][]*build.Build{}, nil)
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "my-pipeline").Return(map[string]*resource.Version{}, nil)
 
 	img, err := s.S.GetPipelineImage(ctx, "main", "my-pipeline", "dot", false, true, nil)
 	require.NoError(t, err)

--- a/pikoci/resource/repository.go
+++ b/pikoci/resource/repository.go
@@ -39,6 +39,9 @@ type Repository interface {
 	// FindVersionByID retrieves a single version by its ID, also returning
 	// the resource canonical it belongs to.
 	FindVersionByID(ctx context.Context, versionID uint32) (*Version, string, error)
+	// LatestVersionByResources returns the latest version for each resource in a pipeline.
+	// The key is resource canonical → latest version.
+	LatestVersionByResources(ctx context.Context, tc, pn string) (map[string]*Version, error)
 }
 
 // ResourceWithPipeline embeds a Resource along with its owning team and pipeline canonicals.

--- a/pikoci/resources.go
+++ b/pikoci/resources.go
@@ -101,15 +101,16 @@ func (q *PikoCI) ListPipelineResources(ctx context.Context, tc, pc string) ([]*r
 		return nil, fmt.Errorf("failed to list Pipeline Resources: %w", err)
 	}
 
-	// Fetch latest version for each resource
+	// Fetch latest version for each resource in a single batch query
 	var versionIDs []uint32
-	for _, r := range rs {
-		vers, err := q.Resources.FilterVersions(ctx, tc, pc, r.Canonical, nil, nil, 1)
-		if err != nil || len(vers) == 0 {
-			continue
+	latestVersions, err := q.Resources.LatestVersionByResources(ctx, tc, pc)
+	if err == nil {
+		for _, r := range rs {
+			if v, ok := latestVersions[r.Canonical]; ok {
+				r.LatestVersion = v
+				versionIDs = append(versionIDs, v.ID)
+			}
 		}
-		r.LatestVersion = vers[0]
-		versionIDs = append(versionIDs, vers[0].ID)
 	}
 
 	// Batch fetch aggregate build statuses for all latest versions
@@ -389,13 +390,13 @@ func (q *PikoCI) cancelMismatchedPendingBuilds(ctx context.Context, tc, pc, rCan
 			continue
 		}
 
-		// Fetch all builds for this job and cancel pending ones with wrong version.
-		builds, err := q.Builds.Filter(ctx, tc, pc, j.Name, nil, nil, 0)
+		// Fetch only pending builds for this job and cancel ones with wrong version.
+		builds, err := q.Builds.Filter(ctx, tc, pc, j.Name, nil, nil, 0, []build.Status{build.Pending})
 		if err != nil {
 			continue
 		}
 		for _, b := range builds {
-			if b.Status == build.Pending && b.ResourceCanonical == rCan && b.VersionID != pinnedVersionID {
+			if b.ResourceCanonical == rCan && b.VersionID != pinnedVersionID {
 				b.Status = build.Cancelled
 				_ = q.Builds.Update(ctx, tc, pc, j.Name, b.BuildNumber, *b)
 			}

--- a/pikoci/resources_test.go
+++ b/pikoci/resources_test.go
@@ -135,11 +135,10 @@ func TestListPipelineResources(t *testing.T) {
 		{Name: "res1", Canonical: "res1"},
 		{Name: "res2", Canonical: "res2"},
 	}, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "res1", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return([]*resource.Version{
-		{ID: 10, Version: map[string]interface{}{"ref": "abc"}},
+	s.Resources.EXPECT().LatestVersionByResources(ctx, "main", "my-pipeline").Return(map[string]*resource.Version{
+		"res1": {ID: 10, Version: map[string]interface{}{"ref": "abc"}},
 	}, nil)
 	s.Builds.EXPECT().AggregateStatusByVersionIDs(ctx, []uint32{10}).Return(map[uint32]string{10: "succeeded"}, nil)
-	s.Resources.EXPECT().FilterVersions(ctx, "main", "my-pipeline", "res2", (*uint32)(nil), (*uint32)(nil), uint32(1)).Return(nil, nil)
 
 	rs, err := s.S.ListPipelineResources(ctx, "main", "my-pipeline")
 	require.NoError(t, err)
@@ -224,7 +223,7 @@ func TestPinResourceVersion(t *testing.T) {
 			},
 		},
 	}, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{
+	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", (*uint32)(nil), (*uint32)(nil), uint32(0), []build.Status{build.Pending}).Return([]*build.Build{
 		{ID: 1, BuildNumber: "1", Status: build.Pending, ResourceCanonical: "git.repo", VersionID: 20},
 	}, nil)
 	// The mismatched pending build (version 20 != pinned 10) should be cancelled
@@ -596,7 +595,7 @@ func TestCancelMismatchedPendingBuilds_NoMismatch(t *testing.T) {
 			},
 		},
 	}, nil)
-	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", (*uint32)(nil), (*uint32)(nil), uint32(0)).Return([]*build.Build{
+	s.Builds.EXPECT().Filter(ctx, "main", "my-pipeline", "my-job", (*uint32)(nil), (*uint32)(nil), uint32(0), []build.Status{build.Pending}).Return([]*build.Build{
 		{ID: 1, BuildNumber: "1", Status: build.Pending, ResourceCanonical: "git.repo", VersionID: 10},
 	}, nil)
 	// No Update call — build matches pinned version

--- a/pikoci/service.go
+++ b/pikoci/service.go
@@ -114,7 +114,7 @@ type Service interface {
 	GetPublicPipelineJob(ctx context.Context, tc, pn, jn string) (*job.Job, error)
 	// ListPublicJobBuilds returns paginated builds for a job on a public pipeline,
 	// with secret step logs redacted.
-	ListPublicJobBuilds(ctx context.Context, tc, pn, jn string, before *uint32, after *uint32, limit uint32) ([]*build.Build, bool, error)
+	ListPublicJobBuilds(ctx context.Context, tc, pn, jn string, before *uint32, after *uint32, limit uint32, statuses []build.Status) ([]*build.Build, bool, error)
 	// ListPublicPipelineResources returns all resources for a public pipeline with
 	// sensitive fields sanitized.
 	ListPublicPipelineResources(ctx context.Context, tc, pn string) ([]*resource.Resource, error)
@@ -162,8 +162,9 @@ type Service interface {
 	DeleteJobBuild(ctx context.Context, tc, pn, jn string, buildNumber string) error
 	// ListJobBuilds returns paginated builds for a job, supporting cursor-based
 	// pagination with before and after parameters. The boolean return value
-	// indicates whether more results exist.
-	ListJobBuilds(ctx context.Context, tc, pn, jn string, before *uint32, after *uint32, limit uint32) ([]*build.Build, bool, error)
+	// indicates whether more results exist. When statuses is non-empty, only
+	// builds matching one of the given statuses are returned.
+	ListJobBuilds(ctx context.Context, tc, pn, jn string, before *uint32, after *uint32, limit uint32, statuses []build.Status) ([]*build.Build, bool, error)
 	// GetJobBuild retrieves a single build by its build number.
 	GetJobBuild(ctx context.Context, tc, pn, jn string, buildNumber string) (*build.Build, error)
 	// CancelJobBuild cancels a running or pending build and notifies the next

--- a/pikoci/transport/http/assets/js/app/api.js
+++ b/pikoci/transport/http/assets/js/app/api.js
@@ -127,7 +127,15 @@ export const unpauseJob = (tc, pn, jn) => api('/teams/' + tc + '/pipelines/' + p
 // --- Builds ---
 // Returns { data, meta: { has_more, newest_id, oldest_id } }
 export const fetchBuilds = (tc, pn, jn, params) => {
-  const qs = params ? '?' + new URLSearchParams(params) : '';
+  let qs = '';
+  if (params) {
+    const sp = new URLSearchParams();
+    for (const [k, v] of Object.entries(params)) {
+      if (Array.isArray(v)) { v.forEach(item => sp.append(k, item)); }
+      else { sp.append(k, v); }
+    }
+    qs = '?' + sp;
+  }
   return api('/teams/' + tc + '/pipelines/' + pn + '/jobs/' + jn + '/builds' + qs);
 };
 export const cancelBuild = (tc, pn, jn, bid) =>

--- a/pikoci/transport/http/assets/js/app/components/Jobs.js
+++ b/pikoci/transport/http/assets/js/app/components/Jobs.js
@@ -6,7 +6,7 @@ import { route } from 'preact-router';
 import { isLoggedIn, hasTeamRole, session } from '../state.js';
 import { fetchBuilds, fetchBuild, cancelBuild, retryBuild, approveBuild, rejectBuild, fetchBuildReport, triggerJob, pauseJob, unpauseJob, fetchJob, fetchResources, fetchResourceVersions, fetchVersionPath, fetchTeam, fetchPipeline } from '../api.js';
 import { useLoading, usePolling } from '../hooks.js';
-import { sortBuilds, selectActiveBuild, durationToString, processLogs, pikoTimeAgo, fetchInterval } from '../utils.js';
+import { sortBuilds, selectActiveBuild, durationToString, processLogs, pikoTimeAgo, fetchInterval, buildListCap } from '../utils.js';
 import { showToast } from '../toast.js';
 import { Breadcrumb } from './Layout.js';
 
@@ -314,7 +314,9 @@ function BuildContent({ build: rawBuild, tc, pn, jn, job: jobData, onRetry }) {
       }
     };
     update();
-    const id = setInterval(update, 1000);
+    const id = setInterval(() => {
+      if (!document.hidden) update();
+    }, 1000);
     return () => clearInterval(id);
   }, [rawBuild.status, rawBuild.started_at, rawBuild.duration]);
 
@@ -566,33 +568,35 @@ export function JobBuilds({ tc, pn, jn, bid, embedded, trackedVersionID: tracked
     try {
       const resources = await fetchResources(tc, pn);
       if (!resources) return;
-      for (const res of resources) {
-        try {
-          const pathResp = await fetchVersionPath(tc, pn, res.canonical, trackedVersionID, { silent: true });
-          if (pathResp.data && pathResp.data.path && pathResp.data.path.length > 0) {
-            const ids = {};
-            for (const entry of pathResp.data.path) {
-              if (entry.job_name === jn && entry.build) {
-                ids[entry.build.id] = true;
-                if (entry.retries) {
-                  for (const r of entry.retries) {
-                    ids[r.id] = true;
-                  }
+      const results = await Promise.allSettled(
+        resources.map(res => fetchVersionPath(tc, pn, res.canonical, trackedVersionID, { silent: true }))
+      );
+      for (let i = 0; i < results.length; i++) {
+        if (results[i].status !== 'fulfilled') continue;
+        const pathResp = results[i].value;
+        if (pathResp.data && pathResp.data.path && pathResp.data.path.length > 0) {
+          const ids = {};
+          for (const entry of pathResp.data.path) {
+            if (entry.job_name === jn && entry.build) {
+              ids[entry.build.id] = true;
+              if (entry.retries) {
+                for (const r of entry.retries) {
+                  ids[r.id] = true;
                 }
               }
             }
-            trackedBuildIDsRef.current = ids;
-
-            // Set banner info
-            const v = pathResp.data.resource.version || {};
-            const ref = v.ref || v.digest || v.tag || (() => {
-              for (const k in v) { if (v.hasOwnProperty(k)) return k + ': ' + v[k]; }
-              return '';
-            })();
-            setVersionBanner({ resource: pathResp.data.resource.canonical, ref });
-            return;
           }
-        } catch { /* try next resource */ }
+          trackedBuildIDsRef.current = ids;
+
+          // Set banner info
+          const v = pathResp.data.resource.version || {};
+          const ref = v.ref || v.digest || v.tag || (() => {
+            for (const k in v) { if (v.hasOwnProperty(k)) return k + ': ' + v[k]; }
+            return '';
+          })();
+          setVersionBanner({ resource: pathResp.data.resource.canonical, ref });
+          return;
+        }
       }
     } catch { /* ignore */ }
   }, [tc, pn, jn, trackedVersionID]);
@@ -642,7 +646,14 @@ export function JobBuilds({ tc, pn, jn, bid, embedded, trackedVersionID: tracked
         setBuilds(prev => {
           const existing = new Set(prev.map(b => b.id));
           const newOnes = resp.data.filter(b => !existing.has(b.id));
-          return sortBuilds([...prev, ...newOnes]);
+          const merged = sortBuilds([...prev, ...newOnes]);
+          if (merged.length <= buildListCap) return merged;
+          // Trim oldest terminal builds first to stay under cap
+          const terminal = new Set(['succeeded', 'failed', 'cancelled']);
+          const active = merged.filter(b => !terminal.has(b.status));
+          const done = merged.filter(b => terminal.has(b.status));
+          const keep = [...active, ...done].slice(0, buildListCap);
+          return sortBuilds(keep);
         });
       }
     } catch { /* ignore */ }
@@ -662,29 +673,18 @@ export function JobBuilds({ tc, pn, jn, bid, embedded, trackedVersionID: tracked
     return active;
   }, [tc, pn, jn, embedded, trackedVersionID]);
 
-  // Fetch the active build to get fresh data (for running builds)
-  const refreshActiveBuild = useCallback(async (buildList) => {
-    const active = buildList.find(b => b.id === (activeBuildID || (selectActiveBuild(buildList)?.id)));
-    if (active) {
-      const status = active.status;
-      if (status !== 'succeeded' && status !== 'failed' && status !== 'cancelled') {
-        try {
-          const fresh = await fetchBuild(tc, pn, jn, active.build_number);
-          setBuilds(prev => sortBuilds(prev.map(b => b.id === fresh.id ? fresh : b)));
-        } catch { /* ignore */ }
+  // Fetch all non-terminal builds in a single batch request
+  const refreshActiveBuild = useCallback(async () => {
+    try {
+      const resp = await fetchBuilds(tc, pn, jn, {
+        status: ['pending', 'started', 'waiting_for_approval'],
+      });
+      if (resp.data && resp.data.length > 0) {
+        const freshMap = new Map(resp.data.map(b => [b.id, b]));
+        setBuilds(prev => sortBuilds(prev.map(b => freshMap.get(b.id) || b)));
       }
-    }
-    // Also refresh other non-terminal builds
-    for (const b of buildList) {
-      if (b.id === active?.id) continue;
-      if (b.status === 'started' || b.status === 'pending' || b.status === 'waiting_for_approval') {
-        try {
-          const fresh = await fetchBuild(tc, pn, jn, b.build_number);
-          setBuilds(prev => sortBuilds(prev.map(x => x.id === fresh.id ? fresh : x)));
-        } catch { /* ignore */ }
-      }
-    }
-  }, [tc, pn, jn, activeBuildID]);
+    } catch { /* ignore */ }
+  }, [tc, pn, jn]);
 
   // Initial load
   useEffect(() => {
@@ -757,12 +757,8 @@ export function JobBuilds({ tc, pn, jn, bid, embedded, trackedVersionID: tracked
       });
     }
 
-    // Refresh active build
-    setBuilds(prev => {
-      // Trigger a refresh for non-terminal builds asynchronously
-      refreshActiveBuild(prev);
-      return prev;
-    });
+    // Refresh non-terminal builds in a single batch request
+    await refreshActiveBuild();
   }, [trackedVersionID, fetchNewBuilds, fetchTrackedBuilds, filterByTracked, refreshActiveBuild]);
   usePolling(pollBuilds, fetchInterval);
 

--- a/pikoci/transport/http/assets/js/app/components/PipelineShow.js
+++ b/pikoci/transport/http/assets/js/app/components/PipelineShow.js
@@ -81,7 +81,7 @@ function PipelineResourcesPanel({ tc, pn, resources, isMember, onClose, onTrackV
   // Poll expanded version lists periodically
   const hasExpanded = Object.keys(expandedResources).length > 0;
   const refreshExpanded = useCallback(() => {
-    Object.keys(expandedResources).forEach(canonical => fetchPanelVersions(canonical));
+    return Promise.all(Object.keys(expandedResources).map(canonical => fetchPanelVersions(canonical)));
   }, [expandedResources]);
   usePolling(refreshExpanded, fetchInterval, hasExpanded);
 

--- a/pikoci/transport/http/assets/js/app/hooks.js
+++ b/pikoci/transport/http/assets/js/app/hooks.js
@@ -47,20 +47,30 @@ export function usePolling(fn, interval, enabled = true) {
   useEffect(() => {
     if (!enabled) return;
 
-    let id = null;
+    let timeoutId = null;
+    let stopped = false;
+
+    const schedule = () => {
+      if (stopped) return;
+      timeoutId = setTimeout(tick, interval);
+    };
+
+    const tick = async () => {
+      if (stopped) return;
+      try { await fnRef.current(); } catch {}
+      schedule();
+    };
 
     const start = () => {
-      if (id !== null) return;
-      try { fnRef.current(); } catch {}
-      id = setInterval(() => {
-        try { fnRef.current(); } catch {}
-      }, interval);
+      if (timeoutId !== null) return;
+      // Fire immediately, then schedule next after completion
+      tick();
     };
 
     const stop = () => {
-      if (id !== null) {
-        clearInterval(id);
-        id = null;
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
       }
     };
 
@@ -78,6 +88,7 @@ export function usePolling(fn, interval, enabled = true) {
     }
 
     return () => {
+      stopped = true;
       stop();
       document.removeEventListener('visibilitychange', onVisibility);
     };

--- a/pikoci/transport/http/assets/js/app/utils.js
+++ b/pikoci/transport/http/assets/js/app/utils.js
@@ -1,6 +1,7 @@
 'use strict';
 
 export const fetchInterval = 2000;
+export const buildListCap = 500;
 
 export const durationToString = (duration) => {
   if (duration === 0) {

--- a/pikoci/transport/http/builds.go
+++ b/pikoci/transport/http/builds.go
@@ -528,13 +528,21 @@ func listJobBuilds(s pikoci.Service) http.HandlerFunc {
 
 		before, after, limit := parsePaginationParams(r)
 
+		var statuses []build.Status
+		for _, sv := range r.URL.Query()["status"] {
+			st, sErr := build.StatusString(sv)
+			if sErr == nil {
+				statuses = append(statuses, st)
+			}
+		}
+
 		var builds []*build.Build
 		var hasMore bool
 		var err error
 		if isPublic, _ := ctx.Value(IsPublicAccessKey).(bool); isPublic {
-			builds, hasMore, err = s.ListPublicJobBuilds(ctx, req.TeamCanonical, req.PipelineCanonical, req.JobName, before, after, limit)
+			builds, hasMore, err = s.ListPublicJobBuilds(ctx, req.TeamCanonical, req.PipelineCanonical, req.JobName, before, after, limit, statuses)
 		} else {
-			builds, hasMore, err = s.ListJobBuilds(ctx, req.TeamCanonical, req.PipelineCanonical, req.JobName, before, after, limit)
+			builds, hasMore, err = s.ListJobBuilds(ctx, req.TeamCanonical, req.PipelineCanonical, req.JobName, before, after, limit, statuses)
 		}
 		var errs string
 		if err != nil {

--- a/pikoci/transport/http/client/client.go
+++ b/pikoci/transport/http/client/client.go
@@ -422,8 +422,8 @@ func (cl *Client) GetPublicPipelineJob(ctx context.Context, tc, pn, jn string) (
 }
 
 // ListPublicJobBuilds lists builds for a job on a public pipeline. It delegates to ListJobBuilds.
-func (cl *Client) ListPublicJobBuilds(ctx context.Context, tc, pn, jn string, before *uint32, after *uint32, limit uint32) ([]*build.Build, bool, error) {
-	return cl.ListJobBuilds(ctx, tc, pn, jn, before, after, limit)
+func (cl *Client) ListPublicJobBuilds(ctx context.Context, tc, pn, jn string, before *uint32, after *uint32, limit uint32, statuses []build.Status) ([]*build.Build, bool, error) {
+	return cl.ListJobBuilds(ctx, tc, pn, jn, before, after, limit, statuses)
 }
 
 // ListPublicPipelineResources lists resources for a public pipeline. It delegates to ListPipelineResources.
@@ -918,10 +918,15 @@ func (cl *Client) EvaluateDownstreamJobs(ctx context.Context, tc, pn, completedJ
 
 // ListJobBuilds always fetches all builds (limit=0) for CLI backward compat.
 // The before/after/limit params satisfy the Service interface but are not sent.
-func (cl *Client) ListJobBuilds(ctx context.Context, tc, pn, jn string, before *uint32, after *uint32, limit uint32) ([]*build.Build, bool, error) {
+func (cl *Client) ListJobBuilds(ctx context.Context, tc, pn, jn string, before *uint32, after *uint32, limit uint32, statuses []build.Status) ([]*build.Build, bool, error) {
 	var resp thttp.ListJobBuildsResponse
 
-	err := cl.Request(ctx, http.MethodGet, fmt.Sprintf("%s/teams/%s/pipelines/%s/jobs/%s/builds?limit=0", cl.url, tc, pn, jn), nil, &resp)
+	u := fmt.Sprintf("%s/teams/%s/pipelines/%s/jobs/%s/builds?limit=0", cl.url, tc, pn, jn)
+	for _, s := range statuses {
+		u += "&status=" + s.String()
+	}
+
+	err := cl.Request(ctx, http.MethodGet, u, nil, &resp)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to make request: %w", err)
 	}

--- a/pikoci/transport/http/client/client_test.go
+++ b/pikoci/transport/http/client/client_test.go
@@ -599,7 +599,7 @@ func TestListJobBuilds(t *testing.T) {
 	c, err := client.New(ts.URL, "jwt")
 	require.NoError(t, err)
 
-	builds, _, err := c.ListJobBuilds(context.Background(), "team", "pipe", "job1", nil, nil, 0)
+	builds, _, err := c.ListJobBuilds(context.Background(), "team", "pipe", "job1", nil, nil, 0, nil)
 	require.NoError(t, err)
 	assert.Len(t, builds, 2)
 }
@@ -945,7 +945,7 @@ func TestListPublicJobBuilds(t *testing.T) {
 	c, err := client.New(ts.URL, "jwt")
 	require.NoError(t, err)
 
-	builds, hasMore, err := c.ListPublicJobBuilds(context.Background(), "team", "pipe", "job1", nil, nil, 0)
+	builds, hasMore, err := c.ListPublicJobBuilds(context.Background(), "team", "pipe", "job1", nil, nil, 0, nil)
 	require.NoError(t, err)
 	assert.Len(t, builds, 2)
 	assert.False(t, hasMore)
@@ -2015,7 +2015,7 @@ func TestListJobBuilds_Error(t *testing.T) {
 	c, err := client.New(ts.URL, "jwt")
 	require.NoError(t, err)
 
-	_, _, err = c.ListJobBuilds(context.Background(), "team1", "pipe", "job1", nil, nil, 0)
+	_, _, err = c.ListJobBuilds(context.Background(), "team1", "pipe", "job1", nil, nil, 0, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "forbidden")
 }
@@ -2034,7 +2034,7 @@ func TestListJobBuilds_HasMore(t *testing.T) {
 	c, err := client.New(ts.URL, "jwt")
 	require.NoError(t, err)
 
-	builds, hasMore, err := c.ListJobBuilds(context.Background(), "team1", "pipe", "job1", nil, nil, 10)
+	builds, hasMore, err := c.ListJobBuilds(context.Background(), "team1", "pipe", "job1", nil, nil, 10, nil)
 	require.NoError(t, err)
 	assert.Len(t, builds, 1)
 	assert.True(t, hasMore)
@@ -2403,7 +2403,7 @@ func TestListPublicJobBuilds_DelegatesToListJobBuilds(t *testing.T) {
 	c, err := client.New(ts.URL, "jwt")
 	require.NoError(t, err)
 
-	builds, _, err := c.ListPublicJobBuilds(context.Background(), "team1", "pipe", "job1", nil, nil, 0)
+	builds, _, err := c.ListPublicJobBuilds(context.Background(), "team1", "pipe", "job1", nil, nil, 0, nil)
 	require.NoError(t, err)
 	assert.Len(t, builds, 1)
 }

--- a/pikoci/transport/http/handlers_coverage_test.go
+++ b/pikoci/transport/http/handlers_coverage_test.go
@@ -1034,7 +1034,7 @@ func TestListJobBuilds_Success(t *testing.T) {
 		{ID: 2, BuildNumber: "2", Status: build.Succeeded},
 		{ID: 1, BuildNumber: "1", Status: build.Failed},
 	}
-	e.svc.EXPECT().ListJobBuilds(gomock.Any(), "main", "my-pipe", "build", gomock.Any(), gomock.Any(), uint32(50)).Return(builds, false, nil)
+	e.svc.EXPECT().ListJobBuilds(gomock.Any(), "main", "my-pipe", "build", gomock.Any(), gomock.Any(), uint32(50), gomock.Any()).Return(builds, false, nil)
 
 	resp := doRequest(t, http.MethodGet, e.server.URL+"/teams/main/pipelines/my-pipe/jobs/build/builds", e.memberJWT(t), "")
 	defer resp.Body.Close()
@@ -1053,7 +1053,7 @@ func TestListJobBuilds_Success(t *testing.T) {
 func TestListJobBuilds_Empty(t *testing.T) {
 	e := newTestEnv(t)
 	e.expectMemberAuth()
-	e.svc.EXPECT().ListJobBuilds(gomock.Any(), "main", "my-pipe", "build", gomock.Any(), gomock.Any(), uint32(50)).Return(nil, false, nil)
+	e.svc.EXPECT().ListJobBuilds(gomock.Any(), "main", "my-pipe", "build", gomock.Any(), gomock.Any(), uint32(50), gomock.Any()).Return(nil, false, nil)
 
 	resp := doRequest(t, http.MethodGet, e.server.URL+"/teams/main/pipelines/my-pipe/jobs/build/builds", e.memberJWT(t), "")
 	defer resp.Body.Close()
@@ -1068,7 +1068,7 @@ func TestListJobBuilds_Empty(t *testing.T) {
 func TestListJobBuilds_Error(t *testing.T) {
 	e := newTestEnv(t)
 	e.expectMemberAuth()
-	e.svc.EXPECT().ListJobBuilds(gomock.Any(), "main", "my-pipe", "build", gomock.Any(), gomock.Any(), uint32(50)).Return(nil, false, fmt.Errorf("db error"))
+	e.svc.EXPECT().ListJobBuilds(gomock.Any(), "main", "my-pipe", "build", gomock.Any(), gomock.Any(), uint32(50), gomock.Any()).Return(nil, false, fmt.Errorf("db error"))
 
 	resp := doRequest(t, http.MethodGet, e.server.URL+"/teams/main/pipelines/my-pipe/jobs/build/builds", e.memberJWT(t), "")
 	defer resp.Body.Close()
@@ -1083,7 +1083,7 @@ func TestListJobBuilds_WithPagination(t *testing.T) {
 	e := newTestEnv(t)
 	e.expectMemberAuth()
 	builds := []*build.Build{{ID: 5, BuildNumber: "5"}}
-	e.svc.EXPECT().ListJobBuilds(gomock.Any(), "main", "my-pipe", "build", gomock.Any(), gomock.Any(), uint32(10)).Return(builds, true, nil)
+	e.svc.EXPECT().ListJobBuilds(gomock.Any(), "main", "my-pipe", "build", gomock.Any(), gomock.Any(), uint32(10), gomock.Any()).Return(builds, true, nil)
 
 	resp := doRequest(t, http.MethodGet, e.server.URL+"/teams/main/pipelines/my-pipe/jobs/build/builds?limit=10&before=6", e.memberJWT(t), "")
 	defer resp.Body.Close()
@@ -2251,7 +2251,7 @@ func TestListJobBuilds_PublicFallback(t *testing.T) {
 	pp := &pipeline.Pipeline{Name: "public-pipe", Canonical: "public-pipe", Public: true}
 	builds := []*build.Build{{ID: 1, BuildNumber: "1"}}
 	e.svc.EXPECT().GetPublicPipeline(gomock.Any(), "main", "public-pipe").Return(pp, nil)
-	e.svc.EXPECT().ListPublicJobBuilds(gomock.Any(), "main", "public-pipe", "build", gomock.Any(), gomock.Any(), uint32(50)).Return(builds, false, nil)
+	e.svc.EXPECT().ListPublicJobBuilds(gomock.Any(), "main", "public-pipe", "build", gomock.Any(), gomock.Any(), uint32(50), gomock.Any()).Return(builds, false, nil)
 
 	resp := doRequest(t, http.MethodGet, e.server.URL+"/teams/main/pipelines/public-pipe/jobs/build/builds", "", "")
 	defer resp.Body.Close()

--- a/pikoci/transport/http/handlers_coverage_test.go
+++ b/pikoci/transport/http/handlers_coverage_test.go
@@ -1095,6 +1095,29 @@ func TestListJobBuilds_WithPagination(t *testing.T) {
 	assert.True(t, got.Meta.HasMore)
 }
 
+func TestListJobBuilds_WithStatusFilter(t *testing.T) {
+	e := newTestEnv(t)
+	e.expectMemberAuth()
+	builds := []*build.Build{
+		{ID: 3, BuildNumber: "3", Status: build.Pending},
+		{ID: 2, BuildNumber: "2", Status: build.Started},
+	}
+	e.svc.EXPECT().ListJobBuilds(gomock.Any(), "main", "my-pipe", "build", gomock.Any(), gomock.Any(), uint32(50), []build.Status{build.Pending, build.Started}).Return(builds, false, nil)
+
+	resp := doRequest(t, http.MethodGet, e.server.URL+"/teams/main/pipelines/my-pipe/jobs/build/builds?status=pending&status=started", e.memberJWT(t), "")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	var got ListJobBuildsResponse
+	json.NewDecoder(resp.Body).Decode(&got)
+	assert.Empty(t, got.Err)
+	assert.Len(t, got.Builds, 2)
+	assert.NotNil(t, got.Meta)
+	assert.False(t, got.Meta.HasMore)
+	assert.Equal(t, uint32(3), got.Meta.NewestID)
+	assert.Equal(t, uint32(2), got.Meta.OldestID)
+}
+
 func TestGetJobBuild_Success(t *testing.T) {
 	e := newTestEnv(t)
 	e.expectMemberAuth()

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -10,15 +10,6 @@
     <link href="/css/pikoci.css" rel="stylesheet" />
     <link href="/css/bootstrap-icons.min.css" rel="stylesheet" />
     <link href="/images/favicon.svg" rel="icon" type="image/svg+xml"/>
-  </head>
-  <body>
-    <script>
-      if (localStorage.getItem('piko-theme') === 'dark') {
-        document.documentElement.setAttribute('data-theme', 'dark');
-      }
-    </script>
-
-    <div id="app"></div>
 
     <script type="importmap">
     {
@@ -35,6 +26,46 @@
       }
     }
     </script>
+
+    <!-- Modulepreload hints: collapse 4 discovery rounds into 1 parallel fetch -->
+    <!-- Vendor modules -->
+    <link rel="modulepreload" href="/js/vendor/preact.module.js" />
+    <link rel="modulepreload" href="/js/vendor/preact/hooks.module.js" />
+    <link rel="modulepreload" href="/js/vendor/htm.module.js" />
+    <link rel="modulepreload" href="/js/vendor/htm-preact.module.js" />
+    <link rel="modulepreload" href="/js/vendor/preact-router.module.js" />
+    <link rel="modulepreload" href="/js/vendor/preact-router-match.module.js" />
+    <link rel="modulepreload" href="/js/vendor/signals.module.js" />
+    <link rel="modulepreload" href="/js/vendor/signals-core.module.js" />
+    <!-- Core app modules -->
+    <link rel="modulepreload" href="/js/app/state.js" />
+    <link rel="modulepreload" href="/js/app/api.js" />
+    <link rel="modulepreload" href="/js/app/hooks.js" />
+    <link rel="modulepreload" href="/js/app/toast.js" />
+    <link rel="modulepreload" href="/js/app/utils.js" />
+    <link rel="modulepreload" href="/js/app/graph-zoom.js" />
+    <!-- Component modules -->
+    <link rel="modulepreload" href="/js/app/components/Layout.js" />
+    <link rel="modulepreload" href="/js/app/components/Login.js" />
+    <link rel="modulepreload" href="/js/app/components/Teams.js" />
+    <link rel="modulepreload" href="/js/app/components/PipelineList.js" />
+    <link rel="modulepreload" href="/js/app/components/PipelineShow.js" />
+    <link rel="modulepreload" href="/js/app/components/PipelineGraph.js" />
+    <link rel="modulepreload" href="/js/app/components/PipelineListView.js" />
+    <link rel="modulepreload" href="/js/app/components/Editor.js" />
+    <link rel="modulepreload" href="/js/app/components/Jobs.js" />
+    <link rel="modulepreload" href="/js/app/components/Resources.js" />
+    <link rel="modulepreload" href="/js/app/components/Workers.js" />
+    <link rel="modulepreload" href="/js/app/components/Users.js" />
+  </head>
+  <body>
+    <script>
+      if (localStorage.getItem('piko-theme') === 'dark') {
+        document.documentElement.setAttribute('data-theme', 'dark');
+      }
+    </script>
+
+    <div id="app"></div>
 
     <script type="text/javascript" src="/js/bootstrap.bundle.min.js"></script>
     <script type="text/javascript" src="/js/viz-global.js"></script>

--- a/worker/service.go
+++ b/worker/service.go
@@ -590,7 +590,7 @@ func (w *Worker) checkPassedConstraints(ctx context.Context, m workitem.Body, b 
 		var intersection map[uint32]bool
 		var hasSucceeded bool
 		for _, p := range expandedPassed {
-			builds, _, err := w.pikoci.ListJobBuilds(ctx, m.TeamCanonical, m.PipelineCanonical, p, nil, nil, 0)
+			builds, _, err := w.pikoci.ListJobBuilds(ctx, m.TeamCanonical, m.PipelineCanonical, p, nil, nil, 0, nil)
 			if err != nil {
 				w.failBuild(ctx, m, *b, fmt.Errorf("failed to list builds for passed job %q: %w", p, err))
 				return false, nil

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -385,7 +385,7 @@ func TestProcessJob_FailedPassedConstraint_NoBuilds(t *testing.T) {
 		Return(&pp.Jobs[0], nil)
 
 	// Passed check: upstream-job has no builds
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "upstream-job", (*uint32)(nil), (*uint32)(nil), uint32(0)).
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "upstream-job", (*uint32)(nil), (*uint32)(nil), uint32(0), ([]build.Status)(nil)).
 		Return([]*build.Build{}, false, nil)
 
 	// Build should be deleted (not failed)
@@ -436,7 +436,7 @@ func TestProcessJob_FailedPassedConstraint_NotSucceeded(t *testing.T) {
 		Return(&pp.Jobs[0], nil)
 
 	// Passed check: upstream-job has a failed build
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "upstream-job", (*uint32)(nil), (*uint32)(nil), uint32(0)).
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "upstream-job", (*uint32)(nil), (*uint32)(nil), uint32(0), ([]build.Status)(nil)).
 		Return([]*build.Build{{ID: 5, Status: build.Failed}}, false, nil)
 
 	// Build should be deleted
@@ -998,11 +998,11 @@ func TestCheckPassedConstraints_AllPassed(t *testing.T) {
 		},
 	}
 
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "job-a", (*uint32)(nil), (*uint32)(nil), uint32(0)).
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "job-a", (*uint32)(nil), (*uint32)(nil), uint32(0), ([]build.Status)(nil)).
 		Return([]*build.Build{{ID: 1, Status: build.Succeeded, Steps: []build.Step{
 			{Type: "get", Name: "my-cron", VersionID: 5},
 		}}}, false, nil)
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "job-b", (*uint32)(nil), (*uint32)(nil), uint32(0)).
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "job-b", (*uint32)(nil), (*uint32)(nil), uint32(0), ([]build.Status)(nil)).
 		Return([]*build.Build{{ID: 2, Status: build.Succeeded, Steps: []build.Step{
 			{Type: "get", Name: "my-cron", VersionID: 5},
 		}}}, false, nil)
@@ -1039,11 +1039,11 @@ func TestCheckPassedConstraints_NoCommonVersion(t *testing.T) {
 	}
 
 	// lint succeeded with version 5, test succeeded with version 6
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "lint", (*uint32)(nil), (*uint32)(nil), uint32(0)).
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "lint", (*uint32)(nil), (*uint32)(nil), uint32(0), ([]build.Status)(nil)).
 		Return([]*build.Build{{ID: 10, Status: build.Succeeded, Steps: []build.Step{
 			{Type: "get", Name: "my-repo", VersionID: 5},
 		}}}, false, nil)
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "test", (*uint32)(nil), (*uint32)(nil), uint32(0)).
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "test", (*uint32)(nil), (*uint32)(nil), uint32(0), ([]build.Status)(nil)).
 		Return([]*build.Build{{ID: 11, Status: build.Succeeded, Steps: []build.Step{
 			{Type: "get", Name: "my-repo", VersionID: 6},
 		}}}, false, nil)
@@ -1084,7 +1084,7 @@ func TestCheckPassedConstraints_PicksNewestCommon(t *testing.T) {
 	}
 
 	// lint has builds with versions {3, 5}
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "lint", (*uint32)(nil), (*uint32)(nil), uint32(0)).
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "lint", (*uint32)(nil), (*uint32)(nil), uint32(0), ([]build.Status)(nil)).
 		Return([]*build.Build{
 			{ID: 10, Status: build.Succeeded, Steps: []build.Step{
 				{Type: "get", Name: "my-repo", VersionID: 5},
@@ -1094,7 +1094,7 @@ func TestCheckPassedConstraints_PicksNewestCommon(t *testing.T) {
 			}},
 		}, false, nil)
 	// test has builds with versions {5, 7}
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "test", (*uint32)(nil), (*uint32)(nil), uint32(0)).
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "test", (*uint32)(nil), (*uint32)(nil), uint32(0), ([]build.Status)(nil)).
 		Return([]*build.Build{
 			{ID: 12, Status: build.Succeeded, Steps: []build.Step{
 				{Type: "get", Name: "my-repo", VersionID: 7},
@@ -1166,7 +1166,7 @@ func TestCheckPassedConstraints_PutStepSatisfiesPassed(t *testing.T) {
 	}
 
 	// The upstream job has a put step (not a get step) with the version
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "upstream-job", (*uint32)(nil), (*uint32)(nil), uint32(0)).
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "upstream-job", (*uint32)(nil), (*uint32)(nil), uint32(0), ([]build.Status)(nil)).
 		Return([]*build.Build{{ID: 1, Status: build.Succeeded, Steps: []build.Step{
 			{Type: "put", Name: "my-artifact", VersionID: 7},
 		}}}, false, nil)


### PR DESCRIPTION
## Summary

- **Build polling fan-out fix**: Jobs view polled each non-terminal build individually (N HTTP requests every 2s). Now uses a single `?status=pending&status=started&status=waiting_for_approval` batch request.
- **usePolling hardening**: Added in-flight guard and switched from `setInterval` to `setTimeout`-based scheduling for consistent spacing between polls.
- **N+1 query elimination**: Pipeline image, job list, and resource list endpoints now use batch queries instead of per-item DB calls.
  - `FilterByPipeline`: single query for all builds across all jobs in a pipeline
  - `LatestVersionByResources`: single query for latest version per resource
  - Batch serial-group loading in `Job.Filter`
  - `cancelMismatchedPendingBuilds` fetches only pending builds via status filter
  - `enrichJobsWithStatus` uses 2 batch queries instead of 2N per-job queries
- **Frontend**: parallelized version-path/resource fetches with `Promise.all`, capped build list at 500, paused elapsed timer when tab hidden.