### PR TITLE
feat: enforce minimum 8-character password length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Password strength validation**: Enforce minimum 8-character passwords with inline frontend hints ([#597](https://github.com/PikoCI/pikoci/issues/597)).
+
 ### Fixed
 
 - **Build status not updating in UI**: Active build view now detects when a build transitions to a terminal state (succeeded/failed/cancelled) and re-fetches it, instead of requiring a manual page reload.

--- a/integration/http/api_tokens_test.go
+++ b/integration/http/api_tokens_test.go
@@ -181,7 +181,7 @@ func TestApiTokens_MembershipCleanup(t *testing.T) {
 
 	// Create a user
 	resp := doJSONRequest(t, http.MethodPost, pikoURL+"/users", adminJWT,
-		`{"username":"token-test-user","password":"pass123","full_name":"Token Test"}`)
+		`{"username":"token-test-user","password":"pass1234","full_name":"Token Test"}`)
 	resp.Body.Close()
 
 	// Add user to main team as operator
@@ -190,7 +190,7 @@ func TestApiTokens_MembershipCleanup(t *testing.T) {
 	resp.Body.Close()
 
 	// Login as the new user and create a team-scoped token
-	userJWT := loginAndGetJWT(t, pikoURL, "token-test-user", "pass123")
+	userJWT := loginAndGetJWT(t, pikoURL, "token-test-user", "pass1234")
 
 	var userToken apitoken.WithPlaintext
 	resp = doJSONRequest(t, http.MethodPost, pikoURL+"/api-tokens", userJWT,
@@ -227,7 +227,7 @@ func TestApiTokens_MembershipCleanup(t *testing.T) {
 		`{"role":"read","user":{"username":"token-test-user"}}`)
 	resp.Body.Close()
 
-	userJWT = loginAndGetJWT(t, pikoURL, "token-test-user", "pass123")
+	userJWT = loginAndGetJWT(t, pikoURL, "token-test-user", "pass1234")
 
 	var personalToken apitoken.WithPlaintext
 	resp = doJSONRequest(t, http.MethodPost, pikoURL+"/api-tokens", userJWT,
@@ -256,7 +256,7 @@ func TestApiTokens_RoleDowngrade(t *testing.T) {
 
 	// Create a user with maintainer role
 	resp := doJSONRequest(t, http.MethodPost, pikoURL+"/users", adminJWT,
-		`{"username":"downgrade-user","password":"pass123","full_name":"Downgrade User"}`)
+		`{"username":"downgrade-user","password":"pass1234","full_name":"Downgrade User"}`)
 	resp.Body.Close()
 
 	resp = doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/members", adminJWT,
@@ -264,7 +264,7 @@ func TestApiTokens_RoleDowngrade(t *testing.T) {
 	resp.Body.Close()
 
 	// Login and create a maintainer-scoped token
-	userJWT := loginAndGetJWT(t, pikoURL, "downgrade-user", "pass123")
+	userJWT := loginAndGetJWT(t, pikoURL, "downgrade-user", "pass1234")
 
 	var token apitoken.WithPlaintext
 	resp = doJSONRequest(t, http.MethodPost, pikoURL+"/api-tokens", userJWT,

--- a/integration/http/http_test.go
+++ b/integration/http/http_test.go
@@ -140,7 +140,7 @@ func TestHTTPEndpoints(t *testing.T) {
 			// Create a temp user, then delete
 			body, _ := json.Marshal(thttp.CreateUserRequest{
 				Username: "temp-user",
-				Password: "temp123",
+				Password: "temp1234",
 				FullName: "Temp User",
 			})
 			resp := doJSONRequest(t, http.MethodPost, pikoURL+"/users", adminJWT, string(body))

--- a/integration/http/rbac_test.go
+++ b/integration/http/rbac_test.go
@@ -24,10 +24,10 @@ func TestRBAC_PerRoleAccess(t *testing.T) {
 		password string
 		role     string
 	}{
-		{"rbac-viewer", "pass123", "read"},
-		{"rbac-operator", "pass123", "write"},
-		{"rbac-maintainer", "pass123", "maintain"},
-		{"rbac-admin", "pass123", "admin"},
+		{"rbac-viewer", "pass1234", "read"},
+		{"rbac-operator", "pass1234", "write"},
+		{"rbac-maintainer", "pass1234", "maintain"},
+		{"rbac-admin", "pass1234", "admin"},
 	}
 
 	for _, r := range roles {
@@ -175,7 +175,7 @@ func TestRBAC_PerRoleAccess(t *testing.T) {
 			requireOK(t, resp)
 
 			// Refresh JWT to get updated memberships
-			freshJWT := loginAndGetJWT(t, pikoURL, "rbac-admin", "pass123")
+			freshJWT := loginAndGetJWT(t, pikoURL, "rbac-admin", "pass1234")
 
 			resp = doJSONRequest(t, http.MethodDelete, pikoURL+"/teams/disposable", freshJWT, "")
 			defer resp.Body.Close()
@@ -194,7 +194,7 @@ func TestRBAC_PerRoleAccess(t *testing.T) {
 		require.Empty(t, ur.Err)
 
 		// Get fresh JWT for the upgraded user
-		upgradedJWT := loginAndGetJWT(t, pikoURL, "rbac-viewer", "pass123")
+		upgradedJWT := loginAndGetJWT(t, pikoURL, "rbac-viewer", "pass1234")
 
 		// Now viewer-turned-operator can pause
 		resp2 := doJSONRequest(t, http.MethodPost, pikoURL+"/teams/main/pipelines/rbac-pipe/pause", upgradedJWT, "")

--- a/pikoci/oauth_test.go
+++ b/pikoci/oauth_test.go
@@ -845,7 +845,7 @@ func TestUpdateOAuthProvider_CanDisableWhenUsersHavePassword(t *testing.T) {
 	s, opr := newServiceWithOAuth(ctrl)
 	ctx := context.TODO()
 
-	hash := testHashPassword("pass")
+	hash := testHashPassword("password")
 	opr.EXPECT().FindProviderByCanonical(ctx, "github").Return(&oauthprovider.Provider{
 		ID: 1, Canonical: "github", Name: "GitHub", Type: "oauth2",
 		AuthURL: "http://x", TokenURL: "http://x", Enabled: true,

--- a/pikoci/transport/http/assets/js/app/components/Users.js
+++ b/pikoci/transport/http/assets/js/app/components/Users.js
@@ -100,13 +100,16 @@ export function UserNew() {
         <label for="password" class="form-label">Password</label>
         <input type="password" class="form-control" id="password" placeholder="Enter password"
           value=${password} onInput=${(e) => setPassword(e.target.value)} />
+        ${password.length > 0 && password.length < 8 ? html`
+          <div class="form-text text-danger">Password must be at least 8 characters</div>
+        ` : null}
       </div>
       <div class="mb-3 form-check">
         <input type="checkbox" class="form-check-input" id="admin"
           checked=${admin} onChange=${(e) => setAdmin(e.target.checked)} />
         <label class="form-check-label" for="admin">Global Admin</label>
       </div>
-      <button type="submit" class="btn btn-primary" disabled=${loading}>
+      <button type="submit" class="btn btn-primary" disabled=${loading || (password.length > 0 && password.length < 8)}>
         ${loading ? 'Creating...' : 'Create User'}
       </button>
     </form>
@@ -225,8 +228,11 @@ export function UserShow({ username: usernameParam }) {
         <label for="new_password" class="form-label">New Password</label>
         <input type="password" class="form-control" id="new_password" placeholder="Enter new password"
           value=${newPassword} onInput=${(e) => setNewPassword(e.target.value)} />
+        ${newPassword.length > 0 && newPassword.length < 8 ? html`
+          <div class="form-text text-danger">Password must be at least 8 characters</div>
+        ` : null}
       </div>
-      <button type="submit" class="btn btn-warning" disabled=${resetLoading}>
+      <button type="submit" class="btn btn-warning" disabled=${resetLoading || (newPassword.length > 0 && newPassword.length < 8)}>
         ${resetLoading ? 'Resetting...' : 'Reset Password'}
       </button>
     </form>
@@ -411,13 +417,16 @@ function PasswordTab({ mustChange }) {
         <label for="new_password" class="form-label">New Password</label>
         <input type="password" class="form-control" id="new_password" placeholder="Enter new password"
           value=${newPassword} onInput=${(e) => setNewPassword(e.target.value)} />
+        ${newPassword.length > 0 && newPassword.length < 8 ? html`
+          <div class="form-text text-danger">Password must be at least 8 characters</div>
+        ` : null}
       </div>
       <div class="mb-3">
         <label for="confirm_password" class="form-label">Confirm New Password</label>
         <input type="password" class="form-control" id="confirm_password" placeholder="Confirm new password"
           value=${confirmPassword} onInput=${(e) => setConfirmPassword(e.target.value)} />
       </div>
-      <button type="submit" class="btn btn-warning" disabled=${pwLoading}>
+      <button type="submit" class="btn btn-warning" disabled=${pwLoading || (newPassword.length > 0 && newPassword.length < 8)}>
         ${pwLoading ? 'Changing...' : 'Change Password'}
       </button>
     </form>

--- a/pikoci/transport/http/client/client_test.go
+++ b/pikoci/transport/http/client/client_test.go
@@ -91,7 +91,7 @@ func TestCreateUser(t *testing.T) {
 	c, err := client.New(ts.URL, "jwt")
 	require.NoError(t, err)
 
-	u, err := c.CreateUser(context.Background(), user.User{Username: "newuser", Password: "pass"}, false)
+	u, err := c.CreateUser(context.Background(), user.User{Username: "newuser", Password: "password"}, false)
 	require.NoError(t, err)
 	assert.Equal(t, "newuser", u.Username)
 }

--- a/pikoci/users.go
+++ b/pikoci/users.go
@@ -106,11 +106,12 @@ func (q *PikoCI) GetUser(ctx context.Context, un string) (*user.WithMemberships,
 func (q *PikoCI) CreateUser(ctx context.Context, u user.User, isHash bool) (*user.User, error) {
 	if !utils.ValidateCanonical(u.Username) {
 		return nil, fmt.Errorf("invalid Username format %q", u.Username)
-	} else if u.Password == "" {
-		return nil, fmt.Errorf("invalid empty Password")
 	}
 
 	if !isHash {
+		if err := utils.ValidatePassword(u.Password); err != nil {
+			return nil, err
+		}
 		hash, err := utils.HashPassword(u.Password)
 		if err != nil {
 			return nil, fmt.Errorf("failed to hash Passowrd: %w", err)
@@ -203,6 +204,9 @@ func (q *PikoCI) UpdateUser(ctx context.Context, un string, u user.User, isHash 
 	}
 	if u.Password != "" {
 		if !isHash {
+			if err := utils.ValidatePassword(u.Password); err != nil {
+				return nil, err
+			}
 			hash, err := utils.HashPassword(u.Password)
 			if err != nil {
 				return nil, fmt.Errorf("failed to hash Password: %w", err)
@@ -303,8 +307,8 @@ func (q *PikoCI) ChangePassword(ctx context.Context, un, oldPassword, newPasswor
 		return fmt.Errorf("current password is incorrect")
 	}
 
-	if newPassword == "" {
-		return fmt.Errorf("new password cannot be empty")
+	if err := utils.ValidatePassword(newPassword); err != nil {
+		return err
 	}
 
 	hash, err := utils.HashPassword(newPassword)

--- a/pikoci/users_test.go
+++ b/pikoci/users_test.go
@@ -19,14 +19,14 @@ func TestCreateUser(t *testing.T) {
 
 	s.Users.EXPECT().Create(ctx, gomock.Any()).Return(uint32(1), nil)
 
-	u, err := s.S.CreateUser(ctx, user.User{Username: "admin", Password: "secret"}, false)
+	u, err := s.S.CreateUser(ctx, user.User{Username: "admin", Password: "secretpw"}, false)
 	require.NoError(t, err)
 	require.NotNil(t, u)
 	assert.Equal(t, uint32(1), u.ID)
 	assert.Equal(t, "admin", u.Username)
 	// Password should be hashed
-	assert.NotEqual(t, "secret", u.Password)
-	assert.True(t, utils.CheckPasswordHash("secret", u.Password))
+	assert.NotEqual(t, "secretpw", u.Password)
+	assert.True(t, utils.CheckPasswordHash("secretpw", u.Password))
 }
 
 func TestCreateUser_Hashed(t *testing.T) {
@@ -34,7 +34,7 @@ func TestCreateUser_Hashed(t *testing.T) {
 	s := newService(ctrl)
 	ctx := context.TODO()
 
-	hash := testHashPassword("secret")
+	hash := testHashPassword("secretpw")
 
 	s.Users.EXPECT().Create(ctx, gomock.Any()).Return(uint32(2), nil)
 
@@ -51,12 +51,12 @@ func TestCreateOrUpdateUser_CreatesNew(t *testing.T) {
 	s.Users.EXPECT().Find(ctx, "newuser").Return(nil, fmt.Errorf("not found"))
 	s.Users.EXPECT().Create(ctx, gomock.Any()).Return(uint32(1), nil)
 
-	u, err := s.P.CreateOrUpdateUser(ctx, user.User{Username: "newuser", Password: "secret"}, false)
+	u, err := s.P.CreateOrUpdateUser(ctx, user.User{Username: "newuser", Password: "secretpw"}, false)
 	require.NoError(t, err)
 	require.NotNil(t, u)
 	assert.Equal(t, uint32(1), u.ID)
 	assert.Equal(t, "newuser", u.Username)
-	assert.True(t, utils.CheckPasswordHash("secret", u.Password))
+	assert.True(t, utils.CheckPasswordHash("secretpw", u.Password))
 }
 
 func TestCreateOrUpdateUser_UpdatesExistingWithDefaultPassword(t *testing.T) {
@@ -100,7 +100,7 @@ func TestCreateUser_InvalidUsername(t *testing.T) {
 	s := newService(ctrl)
 	ctx := context.TODO()
 
-	_, err := s.S.CreateUser(ctx, user.User{Username: "INVALID USER", Password: "secret"}, false)
+	_, err := s.S.CreateUser(ctx, user.User{Username: "INVALID USER", Password: "secretpw"}, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid Username format")
 }
@@ -112,7 +112,17 @@ func TestCreateUser_EmptyPassword(t *testing.T) {
 
 	_, err := s.S.CreateUser(ctx, user.User{Username: "admin", Password: ""}, false)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid empty Password")
+	assert.Contains(t, err.Error(), "password must be at least 8 characters")
+}
+
+func TestCreateUser_ShortPassword(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	_, err := s.S.CreateUser(ctx, user.User{Username: "admin", Password: "short"}, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "password must be at least 8 characters")
 }
 
 func TestGetUser(t *testing.T) {
@@ -157,13 +167,13 @@ func TestUserLogin(t *testing.T) {
 	s := newService(ctrl)
 	ctx := context.TODO()
 
-	hash := testHashPassword("secret")
+	hash := testHashPassword("secretpw")
 	um := &user.WithMemberships{
 		User: user.User{ID: 1, Username: "admin", Password: hash},
 	}
 	s.Users.EXPECT().FindWithMemberships(ctx, "admin").Return(um, nil)
 
-	u, jwt, err := s.S.UserLogin(ctx, "admin", "secret")
+	u, jwt, err := s.S.UserLogin(ctx, "admin", "secretpw")
 	require.NoError(t, err)
 	require.NotNil(t, u)
 	assert.NotEmpty(t, jwt)
@@ -175,13 +185,13 @@ func TestUserLogin_WrongPassword(t *testing.T) {
 	s := newService(ctrl)
 	ctx := context.TODO()
 
-	hash := testHashPassword("secret")
+	hash := testHashPassword("secretpw")
 	um := &user.WithMemberships{
 		User: user.User{ID: 1, Username: "admin", Password: hash},
 	}
 	s.Users.EXPECT().FindWithMemberships(ctx, "admin").Return(um, nil)
 
-	_, _, err := s.S.UserLogin(ctx, "admin", "wrong")
+	_, _, err := s.S.UserLogin(ctx, "admin", "wrongpwd")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "wrong")
 }
@@ -240,6 +250,22 @@ func TestUpdateUser(t *testing.T) {
 	assert.True(t, u.Admin)
 }
 
+func TestUpdateUser_ShortPassword(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	existing := &user.User{ID: 1, Username: "admin", FullName: "Admin", Admin: true, Password: "old-hash"}
+	s.Users.EXPECT().Find(ctx, "admin").Return(existing, nil)
+
+	_, err := s.S.UpdateUser(ctx, "admin", user.User{
+		Password: "short",
+		Admin:    true,
+	}, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "password must be at least 8 characters")
+}
+
 func TestUpdateUser_LastAdmin(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := newService(ctrl)
@@ -290,12 +316,12 @@ func TestChangePassword(t *testing.T) {
 	s := newService(ctrl)
 	ctx := context.TODO()
 
-	hash := testHashPassword("oldpass")
+	hash := testHashPassword("oldpasswd")
 	existing := &user.User{ID: 1, Username: "admin", Password: hash}
 	s.Users.EXPECT().Find(ctx, "admin").Return(existing, nil)
 	s.Users.EXPECT().Update(ctx, "admin", gomock.Any()).Return(nil)
 
-	err := s.S.ChangePassword(ctx, "admin", "oldpass", "newpass")
+	err := s.S.ChangePassword(ctx, "admin", "oldpasswd", "newpasswd")
 	require.NoError(t, err)
 }
 
@@ -304,13 +330,27 @@ func TestChangePassword_WrongOld(t *testing.T) {
 	s := newService(ctrl)
 	ctx := context.TODO()
 
-	hash := testHashPassword("oldpass")
+	hash := testHashPassword("oldpasswd")
 	existing := &user.User{ID: 1, Username: "admin", Password: hash}
 	s.Users.EXPECT().Find(ctx, "admin").Return(existing, nil)
 
-	err := s.S.ChangePassword(ctx, "admin", "wrongpass", "newpass")
+	err := s.S.ChangePassword(ctx, "admin", "wrongpass1", "newpasswd")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "current password is incorrect")
+}
+
+func TestChangePassword_ShortNewPassword(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hash := testHashPassword("oldpasswd")
+	existing := &user.User{ID: 1, Username: "admin", Password: hash}
+	s.Users.EXPECT().Find(ctx, "admin").Return(existing, nil)
+
+	err := s.S.ChangePassword(ctx, "admin", "oldpasswd", "short")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "password must be at least 8 characters")
 }
 
 func TestRefreshToken(t *testing.T) {

--- a/pikoci/utils/validate_password.go
+++ b/pikoci/utils/validate_password.go
@@ -1,0 +1,14 @@
+package utils
+
+import "fmt"
+
+// MinPasswordLength is the minimum number of characters required for a password.
+const MinPasswordLength = 8
+
+// ValidatePassword checks that a password meets minimum strength requirements.
+func ValidatePassword(pass string) error {
+	if len(pass) < MinPasswordLength {
+		return fmt.Errorf("password must be at least %d characters", MinPasswordLength)
+	}
+	return nil
+}

--- a/pikoci/utils/validate_password_test.go
+++ b/pikoci/utils/validate_password_test.go
@@ -1,0 +1,32 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/pikoci/pikoci/pikoci/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidatePassword(t *testing.T) {
+	tests := []struct {
+		name    string
+		pass    string
+		wantErr bool
+	}{
+		{"empty", "", true},
+		{"7 chars", "1234567", true},
+		{"8 chars", "12345678", false},
+		{"long password", "this-is-a-very-long-password-that-should-be-fine", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := utils.ValidatePassword(tt.pass)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "password must be at least 8 characters")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `ValidatePassword` utility enforcing minimum 8-character passwords (NIST SP 800-63B)
- Backend: validate in `CreateUser`, `UpdateUser` (non-hashed), and `ChangePassword`
- Frontend: inline red hint + disabled submit when password is 1-7 chars
- No changes to `CreateOrUpdateUser` (startup seeding) or `OAuthCompleteProfile` (no password)

Closes #597