### PR TITLE
feat: add JWT session expiration and password-change invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **JWT session expiration**: Configurable `--session-lifetime` flag (e.g. `24h`, `7d`, `30d`) adds `exp` claim to session tokens. Default `0` preserves current behavior (no expiry) ([#599](https://github.com/PikoCI/pikoci/issues/599)).
+- **Password-change session invalidation**: Changing a password (self or admin reset) immediately invalidates all existing sessions for that user via a `token_gen` generation counter ([#599](https://github.com/PikoCI/pikoci/issues/599)).
 - **Password strength validation**: Enforce minimum 8-character passwords with inline frontend hints ([#597](https://github.com/PikoCI/pikoci/issues/597)).
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ dserve: ## Serves the server
 
 .PHONY: serve
 serve: ## Serves the server
-	@go run . server -p 4000 --log-level=debug --jwt-secret potato --concurrency=2 --session-lifetime=1m --users 'pepito:$$2a$$14$$rwQk8Qvc2rij7qhFO4P1W.OiSF6AkgVU1RCrLaY2wawJcpkPEKwbm,grillo:$$2a$$14$$SvWir17.jlXxiZfe0pJuDedznetc/HWKv43YPsQQNo6MJiuypS2q6' --pipeline-name=test --pipeline-config=./pikoci/testdata/cron.hcl
+	@go run . server -p 4000 --log-level=debug --jwt-secret potato --concurrency=2 --users 'pepito:$$2a$$14$$rwQk8Qvc2rij7qhFO4P1W.OiSF6AkgVU1RCrLaY2wawJcpkPEKwbm,grillo:$$2a$$14$$SvWir17.jlXxiZfe0pJuDedznetc/HWKv43YPsQQNo6MJiuypS2q6' --pipeline-name=test --pipeline-config=./pikoci/testdata/cron.hcl
 
 .PHONY: worker
 worker: ## Starts a worker

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ dserve: ## Serves the server
 
 .PHONY: serve
 serve: ## Serves the server
-	@go run . server -p 4000 --log-level=debug --jwt-secret potato --concurrency=2 --users 'pepito:$$2a$$14$$rwQk8Qvc2rij7qhFO4P1W.OiSF6AkgVU1RCrLaY2wawJcpkPEKwbm,grillo:$$2a$$14$$SvWir17.jlXxiZfe0pJuDedznetc/HWKv43YPsQQNo6MJiuypS2q6' --pipeline-name=test --pipeline-config=./pikoci/testdata/cron.hcl
+	@go run . server -p 4000 --log-level=debug --jwt-secret potato --concurrency=2 --session-lifetime=1m --users 'pepito:$$2a$$14$$rwQk8Qvc2rij7qhFO4P1W.OiSF6AkgVU1RCrLaY2wawJcpkPEKwbm,grillo:$$2a$$14$$SvWir17.jlXxiZfe0pJuDedznetc/HWKv43YPsQQNo6MJiuypS2q6' --pipeline-name=test --pipeline-config=./pikoci/testdata/cron.hcl
 
 .PHONY: worker
 worker: ## Starts a worker

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -26,6 +26,7 @@ import (
 	workerv1 "github.com/pikoci/pikoci/gen/worker/v1"
 	"github.com/pikoci/pikoci/pikoci"
 	"github.com/pikoci/pikoci/pikoci/config"
+	"github.com/xescugc/duration"
 	pikogrpc "github.com/pikoci/pikoci/pikoci/grpc"
 	"github.com/pikoci/pikoci/pikoci/notifier"
 	"github.com/pikoci/pikoci/pikoci/mysql"
@@ -132,6 +133,15 @@ var serverCmd = &cobra.Command{
 
 		logger.Info("initializing service")
 		var svc = pikoci.New(ctx, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, wr, atr, alr, opr, suow, jwtSecret, wn, logger)
+
+		if cfg.SessionLifetime != "" && cfg.SessionLifetime != "0" {
+			d, err := duration.Parse(cfg.SessionLifetime)
+			if err != nil {
+				return fmt.Errorf("invalid --session-lifetime value %q: %w", cfg.SessionLifetime, err)
+			}
+			svc.SessionLifetime = d
+			logger.Info("session lifetime configured", "duration", d)
+		}
 
 		// Recover builds orphaned by a previous crash or unclean shutdown.
 		if n, err := svc.RecoverOrphanedBuilds(ctx); err != nil {
@@ -409,6 +419,7 @@ func init() {
 	serverCmd.Flags().String("drain-timeout", "10m", "Maximum time to wait for in-flight jobs to finish during graceful shutdown (SIGQUIT)")
 	serverCmd.Flags().String("log-level", "info", "Sets the log level ('debug', 'info', 'warn', 'error')")
 	serverCmd.Flags().String("external-url", "", "External URL for OAuth callbacks (e.g. https://ci.pikoci.com)")
+	serverCmd.Flags().String("session-lifetime", "0", "Maximum session duration before re-login is required (e.g. 24h, 7d, 30d). 0 means sessions never expire")
 	serverCmd.Flags().String("team-canonical", mainTeamCanonical, "Team Canonical to scope the action")
 	serverCmd.Flags().String("pipeline-config", "", "Path to the Pipeline config file")
 	serverCmd.Flags().StringP("vars", "v", "", "Path to the Pipeline var file (JSON)")

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -271,4 +271,16 @@ Changes take effect immediately — no server restart needed.
 - **Callback URLs**: Built from the `--external-url` flag to prevent open redirect attacks.
 - **Lockout prevention**: PikoCI prevents actions that would lock users out of their accounts — disabling local auth, disabling/deleting a provider, or unlinking an account are all blocked if any user would be left with no way to log in.
 
+### Session Lifetime
+
+The `--session-lifetime` flag controls how long a user session remains valid after login. By default it is `0`, meaning sessions never expire (backward compatible).
+
+When set, a JWT `exp` claim is added to all session tokens. After the session expires, the user must re-login. The flag accepts Go duration syntax plus day/week/month/year units (e.g. `24h`, `7d`, `30d`, `1M`).
+
+Password changes immediately invalidate all existing sessions for that user. Admin password resets also invalidate the user's sessions. This is done via a generation counter (`token_gen`) embedded in the JWT — when the counter doesn't match the database, the session is rejected.
+
+```bash
+pikoci server --jwt-secret my-secret --session-lifetime 24h
+```
+
 See also: [Roles & Permissions](Roles.md) · [API Tokens](API-Tokens.md) · [Server Configuration](Server.md)

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -25,6 +25,7 @@ pikoci server [flags]
 | `--drain-timeout` | | `10m` | no | Max time to wait for in-flight jobs during graceful shutdown (`SIGQUIT`) |
 | `--log-level` | | `info` | no | Log level: `debug`, `info`, `warn`, `error` |
 | `--external-url` | | | no | Public URL for OAuth callbacks (e.g., `https://ci.example.com`). Required for OAuth/OIDC. |
+| `--session-lifetime` | | `0` | no | Maximum session duration before re-login is required. Supports Go duration syntax plus days/weeks/months (e.g. `24h`, `7d`, `30d`). `0` means sessions never expire. |
 | `--config` | `-c` | | no | Path to a config file |
 | `--team-canonical` | | `main` | no | Team to use for `--pipeline-*` flags |
 | `--pipeline-config` | | | no | Load a pipeline config file at startup |

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/xescugc/duration v1.1.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 // indirect

--- a/go.sum
+++ b/go.sum
@@ -204,6 +204,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/tebeka/selenium v0.9.9 h1:cNziB+etNgyH/7KlNI7RMC1ua5aH1+5wUlFQyzeMh+w=
 github.com/tebeka/selenium v0.9.9/go.mod h1:5Fr8+pUvU6B1OiPfkdCKdXZyr5znvVkxuPd0NOdZCQc=
+github.com/xescugc/duration v1.1.1 h1:R6h8Yxd3oO+gDZkWjWDFAUlCcJmR4N+jRaRX4wVtLB4=
+github.com/xescugc/duration v1.1.1/go.mod h1:Ld4pJfotLd6rHnF6f8lEWlkDvLWGfej8o2A/tLu6tFo=
 github.com/xyproto/randomstring v1.2.0 h1:y7PXAEBM3XlwJjPG2JQg4voxBYZ4+hPgRdGKCfU8wik=
 github.com/xyproto/randomstring v1.2.0/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/zclconf/go-cty v1.16.3 h1:osr++gw2T61A8KVYHoQiFbFd1Lh3JOCXc/jFLJXKTxk=

--- a/pikoci/config/config.go
+++ b/pikoci/config/config.go
@@ -34,4 +34,6 @@ type Config struct {
 	PipelineDisplayName string `mapstructure:"pipeline-name"`
 	PipelineConfig      string `mapstructure:"pipeline-config"`
 	PipelineVars        string `mapstructure:"vars"`
+
+	SessionLifetime string `mapstructure:"session-lifetime"`
 }

--- a/pikoci/mysql/migrate/migrations/V47TokenGen.go
+++ b/pikoci/mysql/migrate/migrations/V47TokenGen.go
@@ -1,0 +1,6 @@
+package migrations
+
+var V47TokenGen = Migration{
+	Name: "TokenGen",
+	SQL:  `ALTER TABLE users ADD COLUMN token_gen INTEGER NOT NULL DEFAULT 0;`,
+}

--- a/pikoci/mysql/migrate/migrations/migrations.go
+++ b/pikoci/mysql/migrate/migrations/migrations.go
@@ -16,7 +16,7 @@ type Migration struct {
 // Migrations is the ordered list of all schema migrations. It is defined as
 // a fixed-size array so that the compiler catches ordering conflicts when
 // multiple developers add migrations concurrently.
-var Migrations = [47]Migration{
+var Migrations = [48]Migration{
 	V0Initial,
 	V1ResourceCheckInterval,
 	V2JobsAndBuilds,
@@ -64,4 +64,5 @@ var Migrations = [47]Migration{
 	V44JobApproveColumns,
 	V45TeamWorkerIsolation,
 	V46OAuthProviders,
+	V47TokenGen,
 }

--- a/pikoci/mysql/user.go
+++ b/pikoci/mysql/user.go
@@ -26,6 +26,7 @@ type dbUser struct {
 	Username sql.NullString
 	Password sql.NullString
 	Admin    sql.NullBool
+	TokenGen sql.NullInt64
 }
 
 func newDBUser(u user.User) dbUser {
@@ -34,6 +35,7 @@ func newDBUser(u user.User) dbUser {
 		Username: toNullString(u.Username),
 		Password: toNullString(u.Password),
 		Admin:    toNullBool(u.Admin),
+		TokenGen: sql.NullInt64{Int64: int64(u.TokenGen), Valid: true},
 	}
 }
 
@@ -44,15 +46,16 @@ func (dbu *dbUser) toDomainEntity() *user.User {
 		Username: dbu.Username.String,
 		Password: dbu.Password.String,
 		Admin:    dbu.Admin.Bool,
+		TokenGen: uint32(dbu.TokenGen.Int64),
 	}
 }
 
 func (r *UserRepository) Create(ctx context.Context, u user.User) (uint32, error) {
 	dbu := newDBUser(u)
 	res, err := r.querier.ExecContext(ctx, `
-		INSERT INTO users(full_name, username, password, admin)
-		VALUES (?, ?, ?, ?)
-	`, dbu.FullName, dbu.Username, dbu.Password, dbu.Admin)
+		INSERT INTO users(full_name, username, password, admin, token_gen)
+		VALUES (?, ?, ?, ?, ?)
+	`, dbu.FullName, dbu.Username, dbu.Password, dbu.Admin, dbu.TokenGen)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -69,9 +72,9 @@ func (r *UserRepository) Update(ctx context.Context, un string, u user.User) err
 	dbu := newDBUser(u)
 	res, err := r.querier.ExecContext(ctx, `
 		UPDATE users AS u
-		SET full_name = ?, username = ?, password = ?, admin = ?
+		SET full_name = ?, username = ?, password = ?, admin = ?, token_gen = ?
 		WHERE u.username = ?
-	`, dbu.FullName, dbu.Username, dbu.Password, dbu.Admin, un)
+	`, dbu.FullName, dbu.Username, dbu.Password, dbu.Admin, dbu.TokenGen, un)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -86,7 +89,7 @@ func (r *UserRepository) Update(ctx context.Context, un string, u user.User) err
 
 func (r *UserRepository) Find(ctx context.Context, un string) (*user.User, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT u.id, u.full_name, u.username, u.password, u.admin
+		SELECT u.id, u.full_name, u.username, u.password, u.admin, u.token_gen
 		FROM users AS u
 		WHERE u.username = ?
 	`, un)
@@ -101,7 +104,7 @@ func (r *UserRepository) Find(ctx context.Context, un string) (*user.User, error
 
 func (r *UserRepository) FindByID(ctx context.Context, id uint32) (*user.User, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT u.id, u.full_name, u.username, u.password, u.admin
+		SELECT u.id, u.full_name, u.username, u.password, u.admin, u.token_gen
 		FROM users AS u
 		WHERE u.id = ?
 	`, id)
@@ -116,7 +119,7 @@ func (r *UserRepository) FindByID(ctx context.Context, id uint32) (*user.User, e
 
 func (r *UserRepository) FindWithMemberships(ctx context.Context, un string) (*user.WithMemberships, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT u.id, u.full_name, u.username, u.password, u.admin,
+		SELECT u.id, u.full_name, u.username, u.password, u.admin, u.token_gen,
 			tu.role, t.id, t.name, t.canonical
 		FROM users AS u
 		LEFT JOIN teams_users AS tu
@@ -139,7 +142,7 @@ func (r *UserRepository) FindWithMemberships(ctx context.Context, un string) (*u
 
 func (r *UserRepository) Filter(ctx context.Context) ([]*user.User, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT u.id, u.full_name, u.username, u.password, u.admin
+		SELECT u.id, u.full_name, u.username, u.password, u.admin, u.token_gen
 		FROM users AS u
 	`)
 	if err != nil {
@@ -181,6 +184,7 @@ func scanUser(s sqlr.Scanner) (*user.User, error) {
 		&u.Username,
 		&u.Password,
 		&u.Admin,
+		&u.TokenGen,
 	)
 
 	if err != nil {
@@ -224,6 +228,7 @@ func scanUserWithMemberships(rows *sql.Rows) (*user.WithMemberships, error) {
 			&du.Username,
 			&du.Password,
 			&du.Admin,
+			&du.TokenGen,
 			&roleStr,
 			&dt.ID,
 			&dt.Name,

--- a/pikoci/oauth.go
+++ b/pikoci/oauth.go
@@ -599,9 +599,14 @@ func (q *PikoCI) OAuthCompleteProfile(ctx context.Context, tempToken, username, 
 	}
 	um.HasPassword = um.Password != ""
 
-	jwtToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"user": um,
-	})
+	oauthClaims := jwt.MapClaims{
+		"user":      um,
+		"token_gen": um.TokenGen,
+	}
+	if q.SessionLifetime > 0 {
+		oauthClaims["exp"] = time.Now().Add(q.SessionLifetime).Unix()
+	}
+	jwtToken := jwt.NewWithClaims(jwt.SigningMethodHS256, oauthClaims)
 	tokenString, err := jwtToken.SignedString(q.JWTSecret)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to sign token: %w", err)

--- a/pikoci/oauth_test.go
+++ b/pikoci/oauth_test.go
@@ -366,6 +366,16 @@ func TestOAuthCompleteProfile_Valid(t *testing.T) {
 	require.NotNil(t, um)
 	assert.Equal(t, "testuser", um.Username)
 	assert.NotEmpty(t, jwtToken)
+
+	// Verify JWT contains token_gen claim
+	parsedToken, err := jwt.Parse(jwtToken, func(token *jwt.Token) (any, error) {
+		return []byte("test-secret"), nil
+	}, jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}))
+	require.NoError(t, err)
+	claims := parsedToken.Claims.(jwt.MapClaims)
+	tg, ok := claims["token_gen"]
+	require.True(t, ok, "JWT should contain token_gen claim")
+	assert.Equal(t, float64(0), tg)
 }
 
 func TestOAuthCompleteProfile_InvalidToken(t *testing.T) {

--- a/pikoci/service.go
+++ b/pikoci/service.go
@@ -343,6 +343,9 @@ type PikoCI struct {
 
 	// JWTSecret is the signing key used for JWT token generation and validation.
 	JWTSecret []byte
+	// SessionLifetime is the maximum duration a session token is valid.
+	// Zero means sessions never expire.
+	SessionLifetime time.Duration
 
 	// GRPCServer is set by the server command to enable cancellation routing
 	// via gRPC streams. It is nil when no gRPC server is running.

--- a/pikoci/transport/http/assets/js/app/api.js
+++ b/pikoci/transport/http/assets/js/app/api.js
@@ -1,7 +1,8 @@
 'use strict';
 
-import { session, apiNotice, login } from './state.js';
+import { session, apiNotice, login, logout } from './state.js';
 import { showToast } from './toast.js';
+import { route } from 'preact-router';
 
 export class ApiError extends Error {
   constructor(response, body) {
@@ -40,6 +41,13 @@ export async function api(url, opts = {}) {
   if (!res.ok) {
     const body = await res.json().catch(() => null);
     const err = new ApiError(res, body);
+
+    // Session expired or invalidated — force re-login
+    if (err.message === 'Authentication required' && session.value.jwt) {
+      logout();
+      route('/login');
+      throw err;
+    }
 
     if (opts.isInterval && apiNotice.value.error !== '') {
       // Already showing an error — don't overwrite during polling

--- a/pikoci/transport/http/assets/js/app/components/Users.js
+++ b/pikoci/transport/http/assets/js/app/components/Users.js
@@ -369,25 +369,16 @@ function PasswordTab({ mustChange }) {
       return;
     }
     withPwLoading(async () => {
+      let resp;
       try {
-        await changePassword({ old_password: currentPassword, new_password: newPassword });
+        resp = await changePassword({ old_password: currentPassword, new_password: newPassword });
       } catch {
         return;
       }
-      // Refresh JWT to update has_password and must_change_password flags
-      try {
-        const resp = await postRefreshToken();
-        if (resp.data && resp.data.jwt) {
-          login(resp.data.jwt, resp.data.user);
-          setHasPassword(resp.data.user.has_password !== false);
-        }
-      } catch {
-        // Fallback: update locally
-        const currentUser = session.value.user;
-        if (currentUser) {
-          login(session.value.jwt, { ...currentUser, must_change_password: false, has_password: true });
-          setHasPassword(true);
-        }
+      // Use the refreshed JWT returned by changePassword to survive the token_gen bump
+      if (resp.data && resp.data.jwt) {
+        login(resp.data.jwt, resp.data.user);
+        setHasPassword(resp.data.user.has_password !== false);
       }
       setCurrentPassword('');
       setNewPassword('');

--- a/pikoci/transport/http/authorization_test.go
+++ b/pikoci/transport/http/authorization_test.go
@@ -154,7 +154,7 @@ func TestRoleAuthorizationMatrix(t *testing.T) {
 			svc.EXPECT().UnlinkAccount(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 			// Sign JWT
-			token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"user": um})
+			token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"user": um, "token_gen": um.TokenGen})
 			jwtStr, err := token.SignedString(secret)
 			require.NoError(t, err)
 

--- a/pikoci/transport/http/handler.go
+++ b/pikoci/transport/http/handler.go
@@ -86,6 +86,7 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, 
 				un           string
 				isFromWorker bool
 				userClaim    map[string]interface{}
+				jwtClaims    jwt.MapClaims
 			)
 
 			if !authFailed {
@@ -122,6 +123,7 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, 
 							l.Error("invalid token claims")
 							authFailed = true
 						} else {
+							jwtClaims = claims
 							userClaim, ok = claims["user"].(map[string]interface{})
 							if !ok {
 								isFromWorker, _ = claims["is_from_worker"].(bool)
@@ -217,8 +219,26 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, 
 				// Check if JWT claims are stale compared to DB (skip for API tokens)
 				if un != "" && userClaim != nil {
 					um, err := s.GetUser(rr.Context(), un)
-					if err == nil && membershipsDiffer(userClaim, um) {
-						rw.Header().Set("X-Refresh-Token", "true")
+					if err != nil {
+						l.Error("failed to fetch user for stale-check", "username", un, "error", err)
+					} else {
+						// Reject tokens with stale token_gen (password changed).
+						// Missing token_gen claim (pre-deployment tokens) is treated as 0.
+						if jwtClaims != nil {
+							var claimGen uint32
+							if tg, ok := jwtClaims["token_gen"]; ok {
+								if v, ok := tg.(float64); ok {
+									claimGen = uint32(v)
+								}
+							}
+							if claimGen != um.TokenGen {
+								encodeError("Authentication required", rw)
+								return
+							}
+						}
+						if membershipsDiffer(userClaim, um) {
+							rw.Header().Set("X-Refresh-Token", "true")
+						}
 					}
 				}
 			}

--- a/pikoci/transport/http/handler_test.go
+++ b/pikoci/transport/http/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
@@ -226,7 +227,8 @@ func TestMembershipsDiffer(t *testing.T) {
 func signJWT(t *testing.T, secret []byte, um *user.WithMemberships) string {
 	t.Helper()
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"user": um,
+		"user":      um,
+		"token_gen": um.TokenGen,
 	})
 	s, err := token.SignedString(secret)
 	require.NoError(t, err)
@@ -1255,4 +1257,231 @@ func TestGetResourceVersionPath_Error(t *testing.T) {
 	err = json.NewDecoder(resp.Body).Decode(&result)
 	require.NoError(t, err)
 	assert.NotEmpty(t, result.Err)
+}
+
+func TestTokenGen_StaleTokenRejected(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	handler := Handler(s, secret, logger, nil, "", "test", "abc1234", "", nil)
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// JWT has token_gen=0 but DB has token_gen=1 (password was changed)
+	um := &user.WithMemberships{
+		User:        user.User{Username: "pepito", TokenGen: 0},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Write}},
+	}
+	jwtToken := signJWT(t, secret, um)
+
+	dbUM := &user.WithMemberships{
+		User:        user.User{Username: "pepito", TokenGen: 1},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Write}},
+	}
+	// member() authz calls GetUser, then middleware stale-check calls GetUser
+	s.EXPECT().GetUser(gomock.Any(), "pepito").Return(dbUM, nil).Times(2)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams", nil)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+jwtToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var body map[string]string
+	json.NewDecoder(resp.Body).Decode(&body)
+	assert.Equal(t, "Authentication required", body["error"])
+}
+
+func TestTokenGen_MatchingTokenAccepted(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	handler := Handler(s, secret, logger, nil, "", "test", "abc1234", "", nil)
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	um := &user.WithMemberships{
+		User:        user.User{Username: "pepito", TokenGen: 3},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Write}},
+	}
+	jwtToken := signJWT(t, secret, um)
+
+	// member() authz and stale-check both call GetUser
+	s.EXPECT().GetUser(gomock.Any(), "pepito").Return(um, nil).Times(2)
+	s.EXPECT().ListTeams(gomock.Any(), "pepito").Return(nil, nil)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams", nil)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+jwtToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestExpiredJWT_Rejected(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	handler := Handler(s, secret, logger, nil, "", "test", "abc1234", "", nil)
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// Create a JWT with exp in the past
+	um := &user.WithMemberships{
+		User:        user.User{Username: "pepito"},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Write}},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"user":      um,
+		"token_gen": um.TokenGen,
+		"exp":       time.Now().Add(-10 * time.Minute).Unix(),
+	})
+	expiredToken, err := token.SignedString(secret)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams", nil)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+expiredToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var body map[string]string
+	json.NewDecoder(resp.Body).Decode(&body)
+	assert.Equal(t, "Authentication required", body["error"])
+}
+
+func TestLegacyToken_NoTokenGenClaim_AcceptedWhenDBIsZero(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	handler := Handler(s, secret, logger, nil, "", "test", "abc1234", "", nil)
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// Simulate a pre-deployment JWT without token_gen claim
+	um := &user.WithMemberships{
+		User:        user.User{Username: "pepito"},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Write}},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"user": um,
+		// no token_gen claim
+	})
+	legacyToken, err := token.SignedString(secret)
+	require.NoError(t, err)
+
+	// DB user has TokenGen=0 (never changed password) — should be accepted
+	s.EXPECT().GetUser(gomock.Any(), "pepito").Return(um, nil).Times(2)
+	s.EXPECT().ListTeams(gomock.Any(), "pepito").Return(nil, nil)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams", nil)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+legacyToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestLegacyToken_NoTokenGenClaim_RejectedWhenDBIncremented(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	handler := Handler(s, secret, logger, nil, "", "test", "abc1234", "", nil)
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// Simulate a pre-deployment JWT without token_gen claim
+	um := &user.WithMemberships{
+		User:        user.User{Username: "pepito"},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Write}},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"user": um,
+		// no token_gen claim — treated as 0
+	})
+	legacyToken, err := token.SignedString(secret)
+	require.NoError(t, err)
+
+	// DB user has TokenGen=1 (password was changed after deployment) — should be rejected
+	dbUM := &user.WithMemberships{
+		User:        user.User{Username: "pepito", TokenGen: 1},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Write}},
+	}
+	s.EXPECT().GetUser(gomock.Any(), "pepito").Return(dbUM, nil).Times(2)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams", nil)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+legacyToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var body map[string]string
+	json.NewDecoder(resp.Body).Decode(&body)
+	assert.Equal(t, "Authentication required", body["error"])
+}
+
+func TestPasswordChange_InvalidatesOldToken(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+	secret := []byte("test-secret")
+	logger := slog.Default()
+
+	handler := Handler(s, secret, logger, nil, "", "test", "abc1234", "", nil)
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// Create a JWT with token_gen=2 (the value before password change)
+	um := &user.WithMemberships{
+		User:        user.User{Username: "pepito", TokenGen: 2},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Write}},
+	}
+	jwtToken := signJWT(t, secret, um)
+
+	// After password change, DB has token_gen=3
+	dbUM := &user.WithMemberships{
+		User:        user.User{Username: "pepito", TokenGen: 3},
+		Memberships: []user.Member{{TeamCanonical: "main", Role: role.Write}},
+	}
+	// member() authz calls GetUser, then stale-check calls GetUser
+	s.EXPECT().GetUser(gomock.Any(), "pepito").Return(dbUM, nil).Times(2)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams", nil)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+jwtToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var body map[string]string
+	json.NewDecoder(resp.Body).Decode(&body)
+	assert.Equal(t, "Authentication required", body["error"])
 }

--- a/pikoci/transport/http/handlers_coverage_test.go
+++ b/pikoci/transport/http/handlers_coverage_test.go
@@ -341,6 +341,7 @@ func TestChangePassword_Success(t *testing.T) {
 	e := newTestEnv(t)
 	e.expectMemberAuth()
 	e.svc.EXPECT().ChangePassword(gomock.Any(), "member", "old", "new").Return(nil)
+	e.svc.EXPECT().RefreshToken(gomock.Any(), "member").Return(e.memberUM, signJWT(t, e.secret, e.memberUM), nil)
 
 	body := `{"old_password":"old","new_password":"new"}`
 	resp := doRequest(t, http.MethodPost, e.server.URL+"/users/change-password", e.memberJWT(t), body)
@@ -350,6 +351,8 @@ func TestChangePassword_Success(t *testing.T) {
 	var got ChangePasswordResponse
 	json.NewDecoder(resp.Body).Decode(&got)
 	assert.Empty(t, got.Err)
+	assert.NotEmpty(t, got.Data.JWT)
+	assert.Equal(t, "member", got.Data.User.Username)
 }
 
 func TestChangePassword_BadJSON(t *testing.T) {

--- a/pikoci/transport/http/users.go
+++ b/pikoci/transport/http/users.go
@@ -255,7 +255,11 @@ type ChangePasswordRequest struct {
 	NewPassword string `json:"new_password"`
 }
 type ChangePasswordResponse struct {
-	Err string `json:"error,omitempty"`
+	Err  string `json:"error,omitempty"`
+	Data struct {
+		User *user.WithMemberships `json:"user,omitempty"`
+		JWT  string                `json:"jwt,omitempty"`
+	} `json:"data,omitempty"`
 }
 
 func (r ChangePasswordResponse) Error() string {
@@ -281,11 +285,22 @@ func changePassword(s pikoci.Service) http.HandlerFunc {
 		}
 
 		err = s.ChangePassword(ctx, un, req.OldPassword, req.NewPassword)
-		var errs string
 		if err != nil {
-			errs = err.Error()
+			encodeResponse(ChangePasswordResponse{Err: err.Error()}, w)
+			return
 		}
-		encodeResponse(ChangePasswordResponse{Err: errs}, w)
+
+		// Return a refreshed JWT so the current session survives the token_gen bump.
+		u, jwt, err := s.RefreshToken(ctx, un)
+		if err != nil {
+			encodeResponse(ChangePasswordResponse{Err: err.Error()}, w)
+			return
+		}
+
+		resp := ChangePasswordResponse{}
+		resp.Data.User = u
+		resp.Data.JWT = jwt
+		encodeResponse(resp, w)
 	}
 }
 

--- a/pikoci/user/user.go
+++ b/pikoci/user/user.go
@@ -13,6 +13,7 @@ type User struct {
 	Username string `json:"username"`
 	Password string `json:"-"`
 	Admin    bool   `json:"admin"`
+	TokenGen uint32 `json:"-"`
 }
 
 // WithMemberships embeds a User along with their team memberships and a flag

--- a/pikoci/users.go
+++ b/pikoci/users.go
@@ -3,6 +3,7 @@ package pikoci
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 
@@ -53,12 +54,17 @@ func (q *PikoCI) UserLogin(ctx context.Context, un, pass string) (*user.WithMemb
 	}
 	setHasPassword(um)
 
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"user": um,
-	})
+	claims := jwt.MapClaims{
+		"user":      um,
+		"token_gen": um.TokenGen,
+	}
+	if q.SessionLifetime > 0 {
+		claims["exp"] = time.Now().Add(q.SessionLifetime).Unix()
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	tokenString, err := token.SignedString(q.JWTSecret)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to Find User: %w", err)
+		return nil, "", fmt.Errorf("failed to sign token: %w", err)
 	}
 
 	return um, tokenString, nil
@@ -76,9 +82,14 @@ func (q *PikoCI) RefreshToken(ctx context.Context, un string) (*user.WithMembers
 	}
 	setHasPassword(um)
 
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"user": um,
-	})
+	claims := jwt.MapClaims{
+		"user":      um,
+		"token_gen": um.TokenGen,
+	}
+	if q.SessionLifetime > 0 {
+		claims["exp"] = time.Now().Add(q.SessionLifetime).Unix()
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	tokenString, err := token.SignedString(q.JWTSecret)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to sign token: %w", err)
@@ -215,6 +226,7 @@ func (q *PikoCI) UpdateUser(ctx context.Context, un string, u user.User, isHash 
 		} else {
 			existing.Password = u.Password
 		}
+		existing.TokenGen++
 	}
 
 	// Prevent demoting the last admin
@@ -316,6 +328,7 @@ func (q *PikoCI) ChangePassword(ctx context.Context, un, oldPassword, newPasswor
 		return fmt.Errorf("failed to hash Password: %w", err)
 	}
 	existing.Password = hash
+	existing.TokenGen++
 
 	err = q.Users.Update(ctx, un, *existing)
 	if err != nil {

--- a/pikoci/users_test.go
+++ b/pikoci/users_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/pikoci/pikoci/pikoci/user"
@@ -403,4 +405,173 @@ func TestUpdateProfile(t *testing.T) {
 	u, err := s.S.UpdateProfile(ctx, "admin", "New Name", "admin")
 	require.NoError(t, err)
 	assert.Equal(t, "New Name", u.FullName)
+}
+
+func TestUserLogin_JWTContainsTokenGen(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hash := testHashPassword("secretpw")
+	um := &user.WithMemberships{
+		User: user.User{ID: 1, Username: "admin", Password: hash, TokenGen: 5},
+	}
+	s.Users.EXPECT().FindWithMemberships(ctx, "admin").Return(um, nil)
+
+	_, tokenString, err := s.S.UserLogin(ctx, "admin", "secretpw")
+	require.NoError(t, err)
+
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
+		return []byte("test-secret"), nil
+	}, jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}))
+	require.NoError(t, err)
+
+	claims := token.Claims.(jwt.MapClaims)
+	tg, ok := claims["token_gen"]
+	require.True(t, ok, "JWT should contain token_gen claim")
+	assert.Equal(t, float64(5), tg)
+}
+
+func TestChangePassword_IncrementsTokenGen(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hash := testHashPassword("oldpasswd")
+	existing := &user.User{ID: 1, Username: "admin", Password: hash, TokenGen: 3}
+	s.Users.EXPECT().Find(ctx, "admin").Return(existing, nil)
+	s.Users.EXPECT().Update(ctx, "admin", gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, u user.User) error {
+			assert.Equal(t, uint32(4), u.TokenGen)
+			return nil
+		},
+	)
+
+	err := s.S.ChangePassword(ctx, "admin", "oldpasswd", "newpasswd")
+	require.NoError(t, err)
+}
+
+func TestUpdateUser_PasswordChangeIncrementsTokenGen(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	existing := &user.User{ID: 1, Username: "admin", FullName: "Admin", Admin: true, Password: "old-hash", TokenGen: 2}
+	s.Users.EXPECT().Find(ctx, "admin").Return(existing, nil)
+	s.Users.EXPECT().Update(ctx, "admin", gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, u user.User) error {
+			assert.Equal(t, uint32(3), u.TokenGen)
+			return nil
+		},
+	)
+
+	_, err := s.S.UpdateUser(ctx, "admin", user.User{
+		Password: "newpassword",
+		Admin:    true,
+	}, false)
+	require.NoError(t, err)
+}
+
+func TestUserLogin_SessionLifetimeAddsExp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.P.SessionLifetime = 1 * time.Hour
+
+	hash := testHashPassword("secretpw")
+	um := &user.WithMemberships{
+		User: user.User{ID: 1, Username: "admin", Password: hash},
+	}
+	s.Users.EXPECT().FindWithMemberships(ctx, "admin").Return(um, nil)
+
+	_, tokenString, err := s.S.UserLogin(ctx, "admin", "secretpw")
+	require.NoError(t, err)
+
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
+		return []byte("test-secret"), nil
+	}, jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}))
+	require.NoError(t, err)
+
+	claims := token.Claims.(jwt.MapClaims)
+	exp, err := claims.GetExpirationTime()
+	require.NoError(t, err)
+	require.NotNil(t, exp)
+	assert.True(t, exp.After(time.Now()))
+	assert.True(t, exp.Before(time.Now().Add(2*time.Hour)))
+}
+
+func TestUserLogin_NoSessionLifetimeNoExp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hash := testHashPassword("secretpw")
+	um := &user.WithMemberships{
+		User: user.User{ID: 1, Username: "admin", Password: hash},
+	}
+	s.Users.EXPECT().FindWithMemberships(ctx, "admin").Return(um, nil)
+
+	_, tokenString, err := s.S.UserLogin(ctx, "admin", "secretpw")
+	require.NoError(t, err)
+
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
+		return []byte("test-secret"), nil
+	}, jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}))
+	require.NoError(t, err)
+
+	claims := token.Claims.(jwt.MapClaims)
+	_, ok := claims["exp"]
+	assert.False(t, ok, "JWT should not contain exp claim when SessionLifetime is 0")
+}
+
+func TestRefreshToken_JWTContainsTokenGen(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	um := &user.WithMemberships{
+		User: user.User{ID: 1, Username: "admin", TokenGen: 7},
+	}
+	s.Users.EXPECT().FindWithMemberships(ctx, "admin").Return(um, nil)
+
+	_, tokenString, err := s.S.RefreshToken(ctx, "admin")
+	require.NoError(t, err)
+
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
+		return []byte("test-secret"), nil
+	}, jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}))
+	require.NoError(t, err)
+
+	claims := token.Claims.(jwt.MapClaims)
+	tg, ok := claims["token_gen"]
+	require.True(t, ok, "JWT should contain token_gen claim")
+	assert.Equal(t, float64(7), tg)
+}
+
+func TestRefreshToken_SessionLifetimeAddsExp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.P.SessionLifetime = 2 * time.Hour
+
+	um := &user.WithMemberships{
+		User: user.User{ID: 1, Username: "admin"},
+	}
+	s.Users.EXPECT().FindWithMemberships(ctx, "admin").Return(um, nil)
+
+	_, tokenString, err := s.S.RefreshToken(ctx, "admin")
+	require.NoError(t, err)
+
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
+		return []byte("test-secret"), nil
+	}, jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}))
+	require.NoError(t, err)
+
+	claims := token.Claims.(jwt.MapClaims)
+	exp, err := claims.GetExpirationTime()
+	require.NoError(t, err)
+	require.NotNil(t, exp)
+	assert.True(t, exp.After(time.Now()))
 }


### PR DESCRIPTION
## Summary

- Add configurable `--session-lifetime` flag (e.g. `24h`, `7d`, `30d`) that adds `exp` claim to JWT session tokens. Default `0` preserves current behavior (no expiry).
- Add `token_gen` generation counter on `users` table, incremented on password change. Auth middleware rejects JWTs with stale `token_gen`, immediately invalidating all sessions after a password change.
- Frontend detects "Authentication required" on authenticated sessions and forces logout + redirect to `/login`.
- Worker tokens, API tokens, and temp OAuth tokens are not affected.

Closes #599