### PR TITLE
feat: add disable_rerun flag on jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`disable_retry` flag on jobs**: HCL boolean flag that prevents build retries for specific jobs. When `true`, the retry button is hidden in the UI and the retry API returns an error. Designed for production deploy jobs that should not be accidentally rerun ([#617](https://github.com/PikoCI/pikoci/issues/617)).
+
 ## [0.7.0] - 2026-07-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`disable_retry` flag on jobs**: HCL boolean flag that prevents build retries for specific jobs. When `true`, the retry button is hidden in the UI and the retry API returns an error. Designed for production deploy jobs that should not be accidentally rerun ([#617](https://github.com/PikoCI/pikoci/issues/617)).
+- **`disable_retry` on jobs**: Prevents build retries via API and hides the retry button in the UI ([#617](https://github.com/PikoCI/pikoci/issues/617)).
 
 ## [0.7.0] - 2026-07-08
 

--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -266,6 +266,7 @@ The optional `timeout` attribute limits the total wall-clock time for a build's 
 | `timeout` | no | Max wall-clock time for the build (Go duration string) |
 | `tags` | no | Route to workers with matching tags |
 | `serial_groups` | no | Cross-job mutual exclusion groups |
+| `disable_rerun` | no | When `true`, prevents build reruns (default `false`) |
 | `for_each` | no | Generate job instances from a set or map |
 | `matrix` | no | Generate job instances from cartesian product (mutually exclusive with `for_each`) |
 | `get` | no | Step block — fetches a resource version |

--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -266,7 +266,7 @@ The optional `timeout` attribute limits the total wall-clock time for a build's 
 | `timeout` | no | Max wall-clock time for the build (Go duration string) |
 | `tags` | no | Route to workers with matching tags |
 | `serial_groups` | no | Cross-job mutual exclusion groups |
-| `disable_rerun` | no | When `true`, prevents build reruns (default `false`) |
+| `disable_retry` | no | When `true`, prevents build retries (default `false`) |
 | `for_each` | no | Generate job instances from a set or map |
 | `matrix` | no | Generate job instances from cartesian product (mutually exclusive with `for_each`) |
 | `get` | no | Step block — fetches a resource version |

--- a/pikoci/approvals_test.go
+++ b/pikoci/approvals_test.go
@@ -203,6 +203,9 @@ func TestRetryJobBuild_SkipsApprovalGate(t *testing.T) {
 	s := newService(ctrl)
 	ctx := context.TODO()
 
+	// Called twice: once in RetryJobBuild, once in CreateRetryJobBuild
+	s.Jobs.EXPECT().Find(ctx, "main", "pp", "jn").Return(&job.Job{Name: "jn"}, nil).Times(2)
+
 	// Original build was rejected (failed)
 	s.Builds.EXPECT().Find(ctx, "main", "pp", "jn", "1").Return(&build.Build{
 		ID: 1, BuildNumber: "1", Status: build.Failed,

--- a/pikoci/builds.go
+++ b/pikoci/builds.go
@@ -27,9 +27,9 @@ var (
 	// ErrSerialGroupLimit is returned when a build cannot be started because
 	// another job in the same serial group already has a running build.
 	ErrSerialGroupLimit = errors.New("serial group limit reached")
-	// ErrRerunDisabled is returned when attempting to retry a build for a job
-	// that has disable_rerun = true.
-	ErrRerunDisabled = errors.New("reruns are disabled for this job")
+	// ErrRetryDisabled is returned when attempting to retry a build for a job
+	// that has disable_retry = true.
+	ErrRetryDisabled = errors.New("retries are disabled for this job")
 )
 
 // CreateJobBuild creates a new pending build for the specified job within a unit
@@ -325,8 +325,8 @@ func (q *PikoCI) RetryJobBuild(ctx context.Context, tc, pc, jn, buildNumber stri
 	if err != nil {
 		return fmt.Errorf("failed to Find Job: %w", err)
 	}
-	if j.DisableRerun {
-		return ErrRerunDisabled
+	if j.DisableRetry {
+		return ErrRetryDisabled
 	}
 
 	b, err := q.Builds.Find(ctx, tc, pc, jn, buildNumber)
@@ -378,8 +378,8 @@ func (q *PikoCI) CreateRetryJobBuild(ctx context.Context, tc, pc, jn, parentBuil
 	if jErr != nil {
 		return nil, fmt.Errorf("failed to Find Job: %w", jErr)
 	}
-	if j.DisableRerun {
-		return nil, ErrRerunDisabled
+	if j.DisableRetry {
+		return nil, ErrRetryDisabled
 	}
 
 	b.Status = build.Pending

--- a/pikoci/builds.go
+++ b/pikoci/builds.go
@@ -27,6 +27,9 @@ var (
 	// ErrSerialGroupLimit is returned when a build cannot be started because
 	// another job in the same serial group already has a running build.
 	ErrSerialGroupLimit = errors.New("serial group limit reached")
+	// ErrRerunDisabled is returned when attempting to retry a build for a job
+	// that has disable_rerun = true.
+	ErrRerunDisabled = errors.New("reruns are disabled for this job")
 )
 
 // CreateJobBuild creates a new pending build for the specified job within a unit
@@ -318,6 +321,14 @@ func (q *PikoCI) RetryJobBuild(ctx context.Context, tc, pc, jn, buildNumber stri
 		return fmt.Errorf("invalid Job Name format %q", jn)
 	}
 
+	j, err := q.Jobs.Find(ctx, tc, pc, jn)
+	if err != nil {
+		return fmt.Errorf("failed to Find Job: %w", err)
+	}
+	if j.DisableRerun {
+		return ErrRerunDisabled
+	}
+
 	b, err := q.Builds.Find(ctx, tc, pc, jn, buildNumber)
 	if err != nil {
 		return fmt.Errorf("failed to Find Build: %w", err)
@@ -361,6 +372,14 @@ func (q *PikoCI) CreateRetryJobBuild(ctx context.Context, tc, pc, jn, parentBuil
 		return nil, fmt.Errorf("invalid Pipeline Canonical format %q", pc)
 	} else if !utils.ValidateCanonical(jn) {
 		return nil, fmt.Errorf("invalid Job Name format %q", jn)
+	}
+
+	j, jErr := q.Jobs.Find(ctx, tc, pc, jn)
+	if jErr != nil {
+		return nil, fmt.Errorf("failed to Find Job: %w", jErr)
+	}
+	if j.DisableRerun {
+		return nil, ErrRerunDisabled
 	}
 
 	b.Status = build.Pending

--- a/pikoci/builds_test.go
+++ b/pikoci/builds_test.go
@@ -152,6 +152,8 @@ func TestRetryJobBuild_BaseBuild(t *testing.T) {
 	s := newService(ctrl)
 	ctx := context.TODO()
 
+	// Called twice: once in RetryJobBuild, once in CreateRetryJobBuild
+	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "my-job").Return(&job.Job{Name: "my-job"}, nil).Times(2)
 	s.Builds.EXPECT().Find(ctx, "main", "my-pipeline", "my-job", "3").
 		Return(&build.Build{ID: 5, BuildNumber: "3", Status: build.Succeeded}, nil).Times(2)
 	// RetryJobBuild now creates a pending build with RetrySourceBuildID set
@@ -170,6 +172,8 @@ func TestRetryJobBuild_RetryOfRetry(t *testing.T) {
 	s := newService(ctrl)
 	ctx := context.TODO()
 
+	// Called twice: once in RetryJobBuild, once in CreateRetryJobBuild
+	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "my-job").Return(&job.Job{Name: "my-job"}, nil).Times(2)
 	// Retrying "3.1" should extract parent "3"
 	s.Builds.EXPECT().Find(ctx, "main", "my-pipeline", "my-job", "3.1").
 		Return(&build.Build{ID: 7, BuildNumber: "3.1", Status: build.Failed}, nil)
@@ -192,6 +196,7 @@ func TestRetryJobBuild_RunningBuildFails(t *testing.T) {
 	s := newService(ctrl)
 	ctx := context.TODO()
 
+	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "my-job").Return(&job.Job{Name: "my-job"}, nil)
 	s.Builds.EXPECT().Find(ctx, "main", "my-pipeline", "my-job", "1").
 		Return(&build.Build{ID: 1, BuildNumber: "1", Status: build.Started}, nil)
 
@@ -205,6 +210,7 @@ func TestCreateRetryJobBuild(t *testing.T) {
 	s := newService(ctrl)
 	ctx := context.TODO()
 
+	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "my-job").Return(&job.Job{Name: "my-job"}, nil)
 	s.Builds.EXPECT().CreateRetry(ctx, "main", "my-pipeline", "my-job", "3", gomock.Any()).
 		Return(uint32(8), "3.1", nil)
 
@@ -1185,4 +1191,28 @@ func TestNextWork_NonRetryBuildNoRetryFields(t *testing.T) {
 	assert.Equal(t, "job", item.Type)
 	assert.Equal(t, uint32(0), item.Body.RetryBuildID)
 	assert.Equal(t, "", item.Body.RetryBuildNumber)
+}
+
+func TestRetryJobBuild_DisableRerun(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "my-job").
+		Return(&job.Job{Name: "my-job", DisableRerun: true}, nil)
+
+	err := s.S.RetryJobBuild(ctx, "main", "my-pipeline", "my-job", "1")
+	require.ErrorIs(t, err, pikoci.ErrRerunDisabled)
+}
+
+func TestCreateRetryJobBuild_DisableRerun(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "my-job").
+		Return(&job.Job{Name: "my-job", DisableRerun: true}, nil)
+
+	_, err := s.S.CreateRetryJobBuild(ctx, "main", "my-pipeline", "my-job", "3", build.Build{})
+	require.ErrorIs(t, err, pikoci.ErrRerunDisabled)
 }

--- a/pikoci/builds_test.go
+++ b/pikoci/builds_test.go
@@ -1193,26 +1193,26 @@ func TestNextWork_NonRetryBuildNoRetryFields(t *testing.T) {
 	assert.Equal(t, "", item.Body.RetryBuildNumber)
 }
 
-func TestRetryJobBuild_DisableRerun(t *testing.T) {
+func TestRetryJobBuild_DisableRetry(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := newService(ctrl)
 	ctx := context.TODO()
 
 	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "my-job").
-		Return(&job.Job{Name: "my-job", DisableRerun: true}, nil)
+		Return(&job.Job{Name: "my-job", DisableRetry: true}, nil)
 
 	err := s.S.RetryJobBuild(ctx, "main", "my-pipeline", "my-job", "1")
-	require.ErrorIs(t, err, pikoci.ErrRerunDisabled)
+	require.ErrorIs(t, err, pikoci.ErrRetryDisabled)
 }
 
-func TestCreateRetryJobBuild_DisableRerun(t *testing.T) {
+func TestCreateRetryJobBuild_DisableRetry(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := newService(ctrl)
 	ctx := context.TODO()
 
 	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "my-job").
-		Return(&job.Job{Name: "my-job", DisableRerun: true}, nil)
+		Return(&job.Job{Name: "my-job", DisableRetry: true}, nil)
 
 	_, err := s.S.CreateRetryJobBuild(ctx, "main", "my-pipeline", "my-job", "3", build.Build{})
-	require.ErrorIs(t, err, pikoci.ErrRerunDisabled)
+	require.ErrorIs(t, err, pikoci.ErrRetryDisabled)
 }

--- a/pikoci/helper.go
+++ b/pikoci/helper.go
@@ -87,7 +87,7 @@ type hclJob struct {
 	Concurrency  int              `hcl:"concurrency,optional"`
 	SerialGroups []string         `hcl:"serial_groups,optional"`
 	Timeout      string           `hcl:"timeout,optional"`
-	DisableRerun bool             `hcl:"disable_rerun,optional"`
+	DisableRetry bool             `hcl:"disable_retry,optional"`
 	Get          []hclGetStep     `hcl:"get,block"`
 	Task         []hclTaskStep    `hcl:"task,block"`
 	Put          []hclPutStep     `hcl:"put,block"`
@@ -663,7 +663,7 @@ var (
 	taskStepKnownAttrs = []string{"timeout", "attempts", "inputs", "outputs"}
 	putStepKnownAttrs  = []string{"timeout", "attempts"}
 	notifyStepKnownAttrs = []string{"message"}
-	jobKnownAttrs          = []string{"concurrency", "serial_groups", "timeout", "disable_rerun"}
+	jobKnownAttrs          = []string{"concurrency", "serial_groups", "timeout", "disable_retry"}
 	inParallelKnownAttrs   = []string{"limit", "fail_fast"}
 	inParallelBlocks       = map[string]bool{
 		"get": true, "task": true, "put": true, "notify": true,
@@ -1451,7 +1451,7 @@ func ReadPipeline(ctx context.Context, rpp []byte, vars map[string]interface{}) 
 			Concurrency:  hj.Concurrency,
 			SerialGroups: hj.SerialGroups,
 			Timeout:      jobTimeout,
-			DisableRerun: hj.DisableRerun,
+			DisableRetry: hj.DisableRetry,
 			Plan:         jobPlans[hj.Name],
 			OnSuccess:    jh.OnSuccess,
 			OnFailure:    jh.OnFailure,

--- a/pikoci/helper.go
+++ b/pikoci/helper.go
@@ -87,6 +87,7 @@ type hclJob struct {
 	Concurrency  int              `hcl:"concurrency,optional"`
 	SerialGroups []string         `hcl:"serial_groups,optional"`
 	Timeout      string           `hcl:"timeout,optional"`
+	DisableRerun bool             `hcl:"disable_rerun,optional"`
 	Get          []hclGetStep     `hcl:"get,block"`
 	Task         []hclTaskStep    `hcl:"task,block"`
 	Put          []hclPutStep     `hcl:"put,block"`
@@ -662,7 +663,7 @@ var (
 	taskStepKnownAttrs = []string{"timeout", "attempts", "inputs", "outputs"}
 	putStepKnownAttrs  = []string{"timeout", "attempts"}
 	notifyStepKnownAttrs = []string{"message"}
-	jobKnownAttrs          = []string{"concurrency", "serial_groups", "timeout"}
+	jobKnownAttrs          = []string{"concurrency", "serial_groups", "timeout", "disable_rerun"}
 	inParallelKnownAttrs   = []string{"limit", "fail_fast"}
 	inParallelBlocks       = map[string]bool{
 		"get": true, "task": true, "put": true, "notify": true,
@@ -1450,6 +1451,7 @@ func ReadPipeline(ctx context.Context, rpp []byte, vars map[string]interface{}) 
 			Concurrency:  hj.Concurrency,
 			SerialGroups: hj.SerialGroups,
 			Timeout:      jobTimeout,
+			DisableRerun: hj.DisableRerun,
 			Plan:         jobPlans[hj.Name],
 			OnSuccess:    jh.OnSuccess,
 			OnFailure:    jh.OnFailure,

--- a/pikoci/job/job.go
+++ b/pikoci/job/job.go
@@ -48,7 +48,7 @@ type Job struct {
 	SerialGroups []string      `json:"serial_groups,omitempty"`
 	Tags         []string      `json:"tags,omitempty"`
 	Paused       bool          `json:"paused"`
-	DisableRerun bool          `json:"disable_rerun,omitempty"`
+	DisableRetry bool          `json:"disable_retry,omitempty"`
 	Timeout      time.Duration `json:"timeout,omitempty"`
 	Plan         []PlanStep    `json:"plan"`
 

--- a/pikoci/job/job.go
+++ b/pikoci/job/job.go
@@ -48,6 +48,7 @@ type Job struct {
 	SerialGroups []string      `json:"serial_groups,omitempty"`
 	Tags         []string      `json:"tags,omitempty"`
 	Paused       bool          `json:"paused"`
+	DisableRerun bool          `json:"disable_rerun,omitempty"`
 	Timeout      time.Duration `json:"timeout,omitempty"`
 	Plan         []PlanStep    `json:"plan"`
 

--- a/pikoci/mysql/job.go
+++ b/pikoci/mysql/job.go
@@ -40,6 +40,7 @@ type dbJob struct {
 	ApproveLabel      sql.NullString
 	ApproveTimeout    sql.NullString
 	ApproveCount      sql.NullInt64
+	DisableRerun      sql.NullBool
 }
 
 func newDBJob(p job.Job) dbJob {
@@ -66,6 +67,7 @@ func newDBJob(p job.Job) dbJob {
 	}
 	dbj.ApproveLabel = toNullString(p.ApproveLabel)
 	dbj.ApproveCount = sql.NullInt64{Int64: int64(p.ApproveCount), Valid: true}
+	dbj.DisableRerun = sql.NullBool{Bool: p.DisableRerun, Valid: true}
 	return dbj
 }
 
@@ -95,6 +97,9 @@ func (dbp *dbJob) toDomainEntity() *job.Job {
 		j.ApproveLabel = dbp.ApproveLabel.String
 		j.ApproveCount = int(dbp.ApproveCount.Int64)
 	}
+	if dbp.DisableRerun.Valid {
+		j.DisableRerun = dbp.DisableRerun.Bool
+	}
 
 	_ = json.Unmarshal([]byte(dbp.Plan.String), &j.Plan)
 	_ = json.Unmarshal([]byte(dbp.OnSuccess.String), &j.OnSuccess)
@@ -108,7 +113,7 @@ func (dbp *dbJob) toDomainEntity() *job.Job {
 func (r *JobRepository) Create(ctx context.Context, tc, pn string, j job.Job) (uint32, error) {
 	dbj := newDBJob(j)
 	res, err := r.querier.ExecContext(ctx, `
-		INSERT INTO jobs(name, tags, plan, on_success, on_failure, on_cancel, ensure, concurrency, paused, timeout, for_each_group, for_each_key, pipeline_id, baseline_version_id, approve_label, approve_timeout, approve_count)
+		INSERT INTO jobs(name, tags, plan, on_success, on_failure, on_cancel, ensure, concurrency, paused, timeout, for_each_group, for_each_key, pipeline_id, baseline_version_id, approve_label, approve_timeout, approve_count, disable_rerun)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 			-- pipeline_id
 			(
@@ -119,7 +124,7 @@ func (r *JobRepository) Create(ctx context.Context, tc, pn string, j job.Job) (u
 				WHERE t.canonical = ? AND p.canonical = ?
 			),
 			-- baseline_version_id
-			(SELECT MAX(id) FROM resource_versions), ?, ?, ?)`, dbj.Name, dbj.Tags, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Paused, dbj.Timeout, dbj.ForEachGroup, dbj.ForEachKey, tc, pn, dbj.ApproveLabel, dbj.ApproveTimeout, dbj.ApproveCount)
+			(SELECT MAX(id) FROM resource_versions), ?, ?, ?, ?)`, dbj.Name, dbj.Tags, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Paused, dbj.Timeout, dbj.ForEachGroup, dbj.ForEachKey, tc, pn, dbj.ApproveLabel, dbj.ApproveTimeout, dbj.ApproveCount, dbj.DisableRerun)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -140,7 +145,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 	dbj := newDBJob(j)
 	res, err := r.querier.ExecContext(ctx, `
 		UPDATE jobs AS j
-		SET name = ?, tags = ?, plan = ?, on_success = ?, on_failure = ?, on_cancel = ?, ensure = ?, concurrency = ?, timeout = ?, for_each_group = ?, for_each_key = ?, approve_label = ?, approve_timeout = ?, approve_count = ?
+		SET name = ?, tags = ?, plan = ?, on_success = ?, on_failure = ?, on_cancel = ?, ensure = ?, concurrency = ?, timeout = ?, for_each_group = ?, for_each_key = ?, approve_label = ?, approve_timeout = ?, approve_count = ?, disable_rerun = ?
 		FROM (
 			SELECT j.id
 			FROM jobs AS j
@@ -151,7 +156,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 			WHERE t.canonical = ? AND p.canonical = ? AND j.name = ?
 		) AS jj
 		WHERE jj.id = j.id
-	`, dbj.Name, dbj.Tags, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Timeout, dbj.ForEachGroup, dbj.ForEachKey, dbj.ApproveLabel, dbj.ApproveTimeout, dbj.ApproveCount, tc, pn, jn)
+	`, dbj.Name, dbj.Tags, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Timeout, dbj.ForEachGroup, dbj.ForEachKey, dbj.ApproveLabel, dbj.ApproveTimeout, dbj.ApproveCount, dbj.DisableRerun, tc, pn, jn)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -182,7 +187,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 
 func (r *JobRepository) Find(ctx context.Context, tc, pn, jn string) (*job.Job, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count
+		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_rerun
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -207,7 +212,7 @@ func (r *JobRepository) Find(ctx context.Context, tc, pn, jn string) (*job.Job, 
 
 func (r *JobRepository) Filter(ctx context.Context, tc, pn string) ([]*job.Job, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count
+		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_rerun
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -355,6 +360,7 @@ func scanJob(s sqlr.Scanner) (*job.Job, error) {
 		&j.ApproveLabel,
 		&j.ApproveTimeout,
 		&j.ApproveCount,
+		&j.DisableRerun,
 	)
 
 	if err != nil {
@@ -447,7 +453,7 @@ func (r *JobRepository) loadSerialGroupsBatch(ctx context.Context, jobIDs []uint
 
 func (r *JobRepository) FilterByForEachGroup(ctx context.Context, tc, pn, group string) ([]*job.Job, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count
+		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_rerun
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -487,7 +493,7 @@ func (r *JobRepository) FindJobsBySerialGroups(ctx context.Context, tc, pn strin
 		args = append(args, sg)
 	}
 	query := fmt.Sprintf(`
-		SELECT DISTINCT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count
+		SELECT DISTINCT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_rerun
 		FROM jobs AS j
 		JOIN pipelines AS p ON j.pipeline_id = p.id
 		JOIN teams AS t ON p.team_id = t.id

--- a/pikoci/mysql/job.go
+++ b/pikoci/mysql/job.go
@@ -40,7 +40,7 @@ type dbJob struct {
 	ApproveLabel      sql.NullString
 	ApproveTimeout    sql.NullString
 	ApproveCount      sql.NullInt64
-	DisableRerun      sql.NullBool
+	DisableRetry      sql.NullBool
 }
 
 func newDBJob(p job.Job) dbJob {
@@ -67,7 +67,7 @@ func newDBJob(p job.Job) dbJob {
 	}
 	dbj.ApproveLabel = toNullString(p.ApproveLabel)
 	dbj.ApproveCount = sql.NullInt64{Int64: int64(p.ApproveCount), Valid: true}
-	dbj.DisableRerun = sql.NullBool{Bool: p.DisableRerun, Valid: true}
+	dbj.DisableRetry = sql.NullBool{Bool: p.DisableRetry, Valid: true}
 	return dbj
 }
 
@@ -97,8 +97,8 @@ func (dbp *dbJob) toDomainEntity() *job.Job {
 		j.ApproveLabel = dbp.ApproveLabel.String
 		j.ApproveCount = int(dbp.ApproveCount.Int64)
 	}
-	if dbp.DisableRerun.Valid {
-		j.DisableRerun = dbp.DisableRerun.Bool
+	if dbp.DisableRetry.Valid {
+		j.DisableRetry = dbp.DisableRetry.Bool
 	}
 
 	_ = json.Unmarshal([]byte(dbp.Plan.String), &j.Plan)
@@ -113,7 +113,7 @@ func (dbp *dbJob) toDomainEntity() *job.Job {
 func (r *JobRepository) Create(ctx context.Context, tc, pn string, j job.Job) (uint32, error) {
 	dbj := newDBJob(j)
 	res, err := r.querier.ExecContext(ctx, `
-		INSERT INTO jobs(name, tags, plan, on_success, on_failure, on_cancel, ensure, concurrency, paused, timeout, for_each_group, for_each_key, pipeline_id, baseline_version_id, approve_label, approve_timeout, approve_count, disable_rerun)
+		INSERT INTO jobs(name, tags, plan, on_success, on_failure, on_cancel, ensure, concurrency, paused, timeout, for_each_group, for_each_key, pipeline_id, baseline_version_id, approve_label, approve_timeout, approve_count, disable_retry)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 			-- pipeline_id
 			(
@@ -124,7 +124,7 @@ func (r *JobRepository) Create(ctx context.Context, tc, pn string, j job.Job) (u
 				WHERE t.canonical = ? AND p.canonical = ?
 			),
 			-- baseline_version_id
-			(SELECT MAX(id) FROM resource_versions), ?, ?, ?, ?)`, dbj.Name, dbj.Tags, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Paused, dbj.Timeout, dbj.ForEachGroup, dbj.ForEachKey, tc, pn, dbj.ApproveLabel, dbj.ApproveTimeout, dbj.ApproveCount, dbj.DisableRerun)
+			(SELECT MAX(id) FROM resource_versions), ?, ?, ?, ?)`, dbj.Name, dbj.Tags, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Paused, dbj.Timeout, dbj.ForEachGroup, dbj.ForEachKey, tc, pn, dbj.ApproveLabel, dbj.ApproveTimeout, dbj.ApproveCount, dbj.DisableRetry)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -145,7 +145,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 	dbj := newDBJob(j)
 	res, err := r.querier.ExecContext(ctx, `
 		UPDATE jobs AS j
-		SET name = ?, tags = ?, plan = ?, on_success = ?, on_failure = ?, on_cancel = ?, ensure = ?, concurrency = ?, timeout = ?, for_each_group = ?, for_each_key = ?, approve_label = ?, approve_timeout = ?, approve_count = ?, disable_rerun = ?
+		SET name = ?, tags = ?, plan = ?, on_success = ?, on_failure = ?, on_cancel = ?, ensure = ?, concurrency = ?, timeout = ?, for_each_group = ?, for_each_key = ?, approve_label = ?, approve_timeout = ?, approve_count = ?, disable_retry = ?
 		FROM (
 			SELECT j.id
 			FROM jobs AS j
@@ -156,7 +156,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 			WHERE t.canonical = ? AND p.canonical = ? AND j.name = ?
 		) AS jj
 		WHERE jj.id = j.id
-	`, dbj.Name, dbj.Tags, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Timeout, dbj.ForEachGroup, dbj.ForEachKey, dbj.ApproveLabel, dbj.ApproveTimeout, dbj.ApproveCount, dbj.DisableRerun, tc, pn, jn)
+	`, dbj.Name, dbj.Tags, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Timeout, dbj.ForEachGroup, dbj.ForEachKey, dbj.ApproveLabel, dbj.ApproveTimeout, dbj.ApproveCount, dbj.DisableRetry, tc, pn, jn)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -187,7 +187,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 
 func (r *JobRepository) Find(ctx context.Context, tc, pn, jn string) (*job.Job, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_rerun
+		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -212,7 +212,7 @@ func (r *JobRepository) Find(ctx context.Context, tc, pn, jn string) (*job.Job, 
 
 func (r *JobRepository) Filter(ctx context.Context, tc, pn string) ([]*job.Job, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_rerun
+		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -360,7 +360,7 @@ func scanJob(s sqlr.Scanner) (*job.Job, error) {
 		&j.ApproveLabel,
 		&j.ApproveTimeout,
 		&j.ApproveCount,
-		&j.DisableRerun,
+		&j.DisableRetry,
 	)
 
 	if err != nil {
@@ -453,7 +453,7 @@ func (r *JobRepository) loadSerialGroupsBatch(ctx context.Context, jobIDs []uint
 
 func (r *JobRepository) FilterByForEachGroup(ctx context.Context, tc, pn, group string) ([]*job.Job, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_rerun
+		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -493,7 +493,7 @@ func (r *JobRepository) FindJobsBySerialGroups(ctx context.Context, tc, pn strin
 		args = append(args, sg)
 	}
 	query := fmt.Sprintf(`
-		SELECT DISTINCT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_rerun
+		SELECT DISTINCT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry
 		FROM jobs AS j
 		JOIN pipelines AS p ON j.pipeline_id = p.id
 		JOIN teams AS t ON p.team_id = t.id

--- a/pikoci/mysql/migrate/migrations/V48DisableRerun.go
+++ b/pikoci/mysql/migrate/migrations/V48DisableRerun.go
@@ -1,6 +1,0 @@
-package migrations
-
-var V48DisableRerun = Migration{
-	Name: "DisableRerun",
-	SQL:  `ALTER TABLE jobs ADD COLUMN disable_rerun BOOLEAN NOT NULL DEFAULT FALSE;`,
-}

--- a/pikoci/mysql/migrate/migrations/V48DisableRerun.go
+++ b/pikoci/mysql/migrate/migrations/V48DisableRerun.go
@@ -1,0 +1,6 @@
+package migrations
+
+var V48DisableRerun = Migration{
+	Name: "DisableRerun",
+	SQL:  `ALTER TABLE jobs ADD COLUMN disable_rerun BOOLEAN NOT NULL DEFAULT FALSE;`,
+}

--- a/pikoci/mysql/migrate/migrations/V48DisableRetry.go
+++ b/pikoci/mysql/migrate/migrations/V48DisableRetry.go
@@ -1,0 +1,6 @@
+package migrations
+
+var V48DisableRetry = Migration{
+	Name: "DisableRetry",
+	SQL:  `ALTER TABLE jobs ADD COLUMN disable_retry BOOLEAN NOT NULL DEFAULT FALSE;`,
+}

--- a/pikoci/mysql/migrate/migrations/migrations.go
+++ b/pikoci/mysql/migrate/migrations/migrations.go
@@ -16,7 +16,7 @@ type Migration struct {
 // Migrations is the ordered list of all schema migrations. It is defined as
 // a fixed-size array so that the compiler catches ordering conflicts when
 // multiple developers add migrations concurrently.
-var Migrations = [48]Migration{
+var Migrations = [49]Migration{
 	V0Initial,
 	V1ResourceCheckInterval,
 	V2JobsAndBuilds,
@@ -65,4 +65,5 @@ var Migrations = [48]Migration{
 	V45TeamWorkerIsolation,
 	V46OAuthProviders,
 	V47TokenGen,
+	V48DisableRerun,
 }

--- a/pikoci/mysql/migrate/migrations/migrations.go
+++ b/pikoci/mysql/migrate/migrations/migrations.go
@@ -65,5 +65,5 @@ var Migrations = [49]Migration{
 	V45TeamWorkerIsolation,
 	V46OAuthProviders,
 	V47TokenGen,
-	V48DisableRerun,
+	V48DisableRetry,
 }

--- a/pikoci/testdata/cron.hcl
+++ b/pikoci/testdata/cron.hcl
@@ -32,7 +32,7 @@ job "gen" {
 }
 
 job "deploy-staging" {
-  disable_rerun = true
+  disable_retry = true
   get "artifact" "cron_output" {
     trigger = true
     passed  = ["gen"]
@@ -47,7 +47,7 @@ job "deploy-staging" {
 }
 
 job "deploy-prod" {
-  disable_rerun = true
+  disable_retry = true
   get "artifact" "cron_output" {
     trigger = true
     passed  = ["gen"]

--- a/pikoci/testdata/cron.hcl
+++ b/pikoci/testdata/cron.hcl
@@ -32,6 +32,7 @@ job "gen" {
 }
 
 job "deploy-staging" {
+  disable_rerun = true
   get "artifact" "cron_output" {
     trigger = true
     passed  = ["gen"]
@@ -46,6 +47,7 @@ job "deploy-staging" {
 }
 
 job "deploy-prod" {
+  disable_rerun = true
   get "artifact" "cron_output" {
     trigger = true
     passed  = ["gen"]

--- a/pikoci/transport/http/assets/js/app/components/Jobs.js
+++ b/pikoci/transport/http/assets/js/app/components/Jobs.js
@@ -484,7 +484,7 @@ function BuildContent({ build: rawBuild, tc, pn, jn, job: jobData, onRetry }) {
           </span>
         ` : html`
           <span style="margin-left:auto;display:flex;gap:6px;align-items:center;">
-            ${isOperator && !isWaitingApproval ? html`
+            ${isOperator && !isWaitingApproval && !(jobData && jobData.disable_rerun) ? html`
               <button type="button" class="btn btn-sm btn-outline-warning piko-retry-build" title="Retry build" onClick=${handleRetry} disabled=${retryLoading}>
                 <i class="bi bi-arrow-clockwise"></i> ${retryLoading ? 'Retrying...' : 'Retry'}
               </button>

--- a/pikoci/transport/http/assets/js/app/components/Jobs.js
+++ b/pikoci/transport/http/assets/js/app/components/Jobs.js
@@ -484,7 +484,7 @@ function BuildContent({ build: rawBuild, tc, pn, jn, job: jobData, onRetry }) {
           </span>
         ` : html`
           <span style="margin-left:auto;display:flex;gap:6px;align-items:center;">
-            ${isOperator && !isWaitingApproval && !(jobData && jobData.disable_rerun) ? html`
+            ${isOperator && !isWaitingApproval && !(jobData && jobData.disable_retry) ? html`
               <button type="button" class="btn btn-sm btn-outline-warning piko-retry-build" title="Retry build" onClick=${handleRetry} disabled=${retryLoading}>
                 <i class="bi bi-arrow-clockwise"></i> ${retryLoading ? 'Retrying...' : 'Retry'}
               </button>


### PR DESCRIPTION
## Summary

- Add `disable_rerun = true` HCL flag on jobs to prevent accidental build retries (#617)
- Both `RetryJobBuild()` and `CreateRetryJobBuild()` return `ErrRerunDisabled` when flag is set
- Retry button hidden in the UI when `disable_rerun` is true
- New DB migration (V48) adds `disable_rerun` column to `jobs` table

Closes #617