### PR TITLE
feat: add allow_failure on jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`allow_failure` on jobs**: When `true`, a failed build is marked as `warning` (salmon) instead of `failed`, unblocking downstream jobs. Any failed build can also be manually marked as warning via a UI button (requires Maintain role) ([#610](https://github.com/PikoCI/pikoci/issues/610)).
 - **`disable_retry` on jobs**: Prevents build retries via API and hides the retry button in the UI ([#617](https://github.com/PikoCI/pikoci/issues/617)).
+
+### Fixed
+
+- **Build list tabs show stale status**: Build tabs no longer stay stuck on "running" after a build completes — they now refresh automatically when a non-terminal build transitions to a terminal state.
 
 ## [0.7.0] - 2026-07-08
 

--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -267,6 +267,7 @@ The optional `timeout` attribute limits the total wall-clock time for a build's 
 | `tags` | no | Route to workers with matching tags |
 | `serial_groups` | no | Cross-job mutual exclusion groups |
 | `disable_retry` | no | When `true`, prevents build retries (default `false`) |
+| `allow_failure` | no | When `true`, a failed build is marked as `warning` instead of `failed`, unblocking downstream jobs (default `false`) |
 | `for_each` | no | Generate job instances from a set or map |
 | `matrix` | no | Generate job instances from cartesian product (mutually exclusive with `for_each`) |
 | `get` | no | Step block — fetches a resource version |

--- a/pikoci/auditlog/auditlog.go
+++ b/pikoci/auditlog/auditlog.go
@@ -24,8 +24,9 @@ const (
 	ResourceUnpinned Action = "resource.unpinned"
 	ResourceChecked  Action = "resource.check_triggered"
 
-	BuildApproved Action = "build.approved"
-	BuildRejected Action = "build.rejected"
+	BuildApproved      Action = "build.approved"
+	BuildRejected      Action = "build.rejected"
+	BuildMarkedWarning Action = "build.marked_warning"
 
 	MemberAdded       Action = "member.added"
 	MemberRemoved     Action = "member.removed"

--- a/pikoci/build/build.go
+++ b/pikoci/build/build.go
@@ -30,6 +30,9 @@ const (
 	Pending
 	// WaitingForApproval indicates the build is waiting for human approval before starting.
 	WaitingForApproval
+	// Warning indicates the build failed but the job has allow_failure enabled,
+	// so downstream jobs are not blocked.
+	Warning
 )
 
 // Approval represents a single approve/reject vote on a build.

--- a/pikoci/build/status_string.go
+++ b/pikoci/build/status_string.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 )
 
-const _StatusName = "succeededfailedstartedcancelledpendingwaiting_for_approval"
+const _StatusName = "succeededfailedstartedcancelledpendingwaiting_for_approvalwarning"
 
-var _StatusIndex = [...]uint8{0, 9, 15, 22, 31, 38, 58}
+var _StatusIndex = [...]uint8{0, 9, 15, 22, 31, 38, 58, 65}
 
-const _StatusLowerName = "succeededfailedstartedcancelledpendingwaiting_for_approval"
+const _StatusLowerName = "succeededfailedstartedcancelledpendingwaiting_for_approvalwarning"
 
 func (i Status) String() string {
 	if i < 0 || i >= Status(len(_StatusIndex)-1) {
@@ -31,9 +31,10 @@ func _StatusNoOp() {
 	_ = x[Cancelled-(3)]
 	_ = x[Pending-(4)]
 	_ = x[WaitingForApproval-(5)]
+	_ = x[Warning-(6)]
 }
 
-var _StatusValues = []Status{Succeeded, Failed, Started, Cancelled, Pending, WaitingForApproval}
+var _StatusValues = []Status{Succeeded, Failed, Started, Cancelled, Pending, WaitingForApproval, Warning}
 
 var _StatusNameToValueMap = map[string]Status{
 	_StatusName[0:9]:        Succeeded,
@@ -48,6 +49,8 @@ var _StatusNameToValueMap = map[string]Status{
 	_StatusLowerName[31:38]: Pending,
 	_StatusName[38:58]:      WaitingForApproval,
 	_StatusLowerName[38:58]: WaitingForApproval,
+	_StatusName[58:65]:      Warning,
+	_StatusLowerName[58:65]: Warning,
 }
 
 var _StatusNames = []string{
@@ -57,6 +60,7 @@ var _StatusNames = []string{
 	_StatusName[22:31],
 	_StatusName[31:38],
 	_StatusName[38:58],
+	_StatusName[58:65],
 }
 
 // StatusString retrieves an enum value from the enum constants string name.

--- a/pikoci/builds.go
+++ b/pikoci/builds.go
@@ -725,3 +725,38 @@ func (q *PikoCI) evaluateJobDownstream(ctx context.Context, tc, pn, completedJob
 	}
 	return nil
 }
+
+// MarkBuildAsWarning changes a failed build's status to warning and triggers
+// downstream job evaluation to unblock downstream jobs.
+func (q *PikoCI) MarkBuildAsWarning(ctx context.Context, tc, pc, jn, buildNumber string) error {
+	if !utils.ValidateCanonical(tc) {
+		return fmt.Errorf("invalid Team Canonical format %q", tc)
+	} else if !utils.ValidateCanonical(pc) {
+		return fmt.Errorf("invalid Pipeline Canonical format %q", pc)
+	} else if !utils.ValidateCanonical(jn) {
+		return fmt.Errorf("invalid Job Name format %q", jn)
+	}
+
+	b, err := q.Builds.Find(ctx, tc, pc, jn, buildNumber)
+	if err != nil {
+		return fmt.Errorf("failed to Find Build: %w", err)
+	}
+	if b.Status != build.Failed {
+		return fmt.Errorf("build %s is not failed (status: %s)", buildNumber, b.Status)
+	}
+
+	b.Status = build.Warning
+	if err := q.Builds.Update(ctx, tc, pc, jn, buildNumber, *b); err != nil {
+		return fmt.Errorf("failed to Update Build: %w", err)
+	}
+
+	// Unblock downstream jobs
+	if err := q.EvaluateDownstreamJobs(ctx, tc, pc, jn); err != nil {
+		q.logger.Error("failed to evaluate downstream jobs after marking warning",
+			"pipeline", pc, "job", jn, "error", err)
+	}
+
+	q.audit(ctx, tc, auditlog.BuildMarkedWarning, "job", pc+"/"+jn,
+		map[string]interface{}{"pipeline": pc, "build_number": buildNumber})
+	return nil
+}

--- a/pikoci/builds_test.go
+++ b/pikoci/builds_test.go
@@ -1216,3 +1216,48 @@ func TestCreateRetryJobBuild_DisableRetry(t *testing.T) {
 	_, err := s.S.CreateRetryJobBuild(ctx, "main", "my-pipeline", "my-job", "3", build.Build{})
 	require.ErrorIs(t, err, pikoci.ErrRetryDisabled)
 }
+
+func TestMarkBuildAsWarning_HappyPath(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Builds.EXPECT().Find(ctx, "main", "my-pipeline", "my-job", "1").
+		Return(&build.Build{ID: 1, BuildNumber: "1", Status: build.Failed}, nil)
+	s.Builds.EXPECT().Update(ctx, "main", "my-pipeline", "my-job", "1", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, b build.Build) error {
+			assert.Equal(t, build.Warning, b.Status)
+			return nil
+		})
+
+	// EvaluateDownstreamJobs needs pipeline
+	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(&pipeline.Pipeline{
+		Name: "my-pipeline",
+		Jobs: []job.Job{{Name: "my-job"}},
+	}, nil)
+
+	err := s.S.MarkBuildAsWarning(ctx, "main", "my-pipeline", "my-job", "1")
+	require.NoError(t, err)
+}
+
+func TestMarkBuildAsWarning_NotFailed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Builds.EXPECT().Find(ctx, "main", "my-pipeline", "my-job", "1").
+		Return(&build.Build{ID: 1, BuildNumber: "1", Status: build.Succeeded}, nil)
+
+	err := s.S.MarkBuildAsWarning(ctx, "main", "my-pipeline", "my-job", "1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not failed")
+}
+
+func TestMarkBuildAsWarning_InvalidCanonical(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	err := s.S.MarkBuildAsWarning(ctx, "INVALID", "my-pipeline", "my-job", "1")
+	require.Error(t, err)
+}

--- a/pikoci/helper.go
+++ b/pikoci/helper.go
@@ -88,6 +88,7 @@ type hclJob struct {
 	SerialGroups []string         `hcl:"serial_groups,optional"`
 	Timeout      string           `hcl:"timeout,optional"`
 	DisableRetry bool             `hcl:"disable_retry,optional"`
+	AllowFailure bool             `hcl:"allow_failure,optional"`
 	Get          []hclGetStep     `hcl:"get,block"`
 	Task         []hclTaskStep    `hcl:"task,block"`
 	Put          []hclPutStep     `hcl:"put,block"`
@@ -663,7 +664,7 @@ var (
 	taskStepKnownAttrs = []string{"timeout", "attempts", "inputs", "outputs"}
 	putStepKnownAttrs  = []string{"timeout", "attempts"}
 	notifyStepKnownAttrs = []string{"message"}
-	jobKnownAttrs          = []string{"concurrency", "serial_groups", "timeout", "disable_retry"}
+	jobKnownAttrs          = []string{"concurrency", "serial_groups", "timeout", "disable_retry", "allow_failure"}
 	inParallelKnownAttrs   = []string{"limit", "fail_fast"}
 	inParallelBlocks       = map[string]bool{
 		"get": true, "task": true, "put": true, "notify": true,
@@ -1452,6 +1453,7 @@ func ReadPipeline(ctx context.Context, rpp []byte, vars map[string]interface{}) 
 			SerialGroups: hj.SerialGroups,
 			Timeout:      jobTimeout,
 			DisableRetry: hj.DisableRetry,
+			AllowFailure: hj.AllowFailure,
 			Plan:         jobPlans[hj.Name],
 			OnSuccess:    jh.OnSuccess,
 			OnFailure:    jh.OnFailure,

--- a/pikoci/job/job.go
+++ b/pikoci/job/job.go
@@ -49,6 +49,7 @@ type Job struct {
 	Tags         []string      `json:"tags,omitempty"`
 	Paused       bool          `json:"paused"`
 	DisableRetry bool          `json:"disable_retry,omitempty"`
+	AllowFailure bool          `json:"allow_failure,omitempty"`
 	Timeout      time.Duration `json:"timeout,omitempty"`
 	Plan         []PlanStep    `json:"plan"`
 

--- a/pikoci/jobs.go
+++ b/pikoci/jobs.go
@@ -139,7 +139,7 @@ func (q *PikoCI) enrichJobsWithStatus(ctx context.Context, tc, pn string, jobs [
 	if err != nil {
 		return nil, fmt.Errorf("failed to filter active builds: %w", err)
 	}
-	completedByJob, err := q.Builds.FilterByPipeline(ctx, tc, pn, []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval})
+	completedByJob, err := q.Builds.FilterByPipeline(ctx, tc, pn, []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval, build.Warning})
 	if err != nil {
 		return nil, fmt.Errorf("failed to filter completed builds: %w", err)
 	}

--- a/pikoci/mock/service.go
+++ b/pikoci/mock/service.go
@@ -1035,6 +1035,20 @@ func (mr *ServiceMockRecorder) ListWorkers(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkers", reflect.TypeOf((*Service)(nil).ListWorkers), ctx)
 }
 
+// MarkBuildAsWarning mocks base method.
+func (m *Service) MarkBuildAsWarning(ctx context.Context, tc, pc, jn, buildNumber string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MarkBuildAsWarning", ctx, tc, pc, jn, buildNumber)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MarkBuildAsWarning indicates an expected call of MarkBuildAsWarning.
+func (mr *ServiceMockRecorder) MarkBuildAsWarning(ctx, tc, pc, jn, buildNumber any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkBuildAsWarning", reflect.TypeOf((*Service)(nil).MarkBuildAsWarning), ctx, tc, pc, jn, buildNumber)
+}
+
 // NotifySerialGroupPendingBuilds mocks base method.
 func (m *Service) NotifySerialGroupPendingBuilds(ctx context.Context, tc, pn, jn string) {
 	m.ctrl.T.Helper()

--- a/pikoci/mysql/build.go
+++ b/pikoci/mysql/build.go
@@ -398,7 +398,7 @@ func (r *BuildRepository) FindReadyDownstreamVersion(ctx context.Context, tc, pn
 		JOIN jobs j ON b.job_id = j.id
 		JOIN pipelines p ON j.pipeline_id = p.id
 		JOIN teams t ON p.team_id = t.id
-		WHERE t.canonical = ? AND p.canonical = ? AND b.status = 'succeeded'
+		WHERE t.canonical = ? AND p.canonical = ? AND b.status IN ('succeeded', 'warning')
 		  AND j.name IN (` + strings.Join(placeholders, ", ") + `)
 		  AND bgv.step_name = ?
 		  ` + baselineClause + `

--- a/pikoci/mysql/job.go
+++ b/pikoci/mysql/job.go
@@ -41,6 +41,7 @@ type dbJob struct {
 	ApproveTimeout    sql.NullString
 	ApproveCount      sql.NullInt64
 	DisableRetry      sql.NullBool
+	AllowFailure      sql.NullBool
 }
 
 func newDBJob(p job.Job) dbJob {
@@ -68,6 +69,7 @@ func newDBJob(p job.Job) dbJob {
 	dbj.ApproveLabel = toNullString(p.ApproveLabel)
 	dbj.ApproveCount = sql.NullInt64{Int64: int64(p.ApproveCount), Valid: true}
 	dbj.DisableRetry = sql.NullBool{Bool: p.DisableRetry, Valid: true}
+	dbj.AllowFailure = sql.NullBool{Bool: p.AllowFailure, Valid: true}
 	return dbj
 }
 
@@ -100,6 +102,9 @@ func (dbp *dbJob) toDomainEntity() *job.Job {
 	if dbp.DisableRetry.Valid {
 		j.DisableRetry = dbp.DisableRetry.Bool
 	}
+	if dbp.AllowFailure.Valid {
+		j.AllowFailure = dbp.AllowFailure.Bool
+	}
 
 	_ = json.Unmarshal([]byte(dbp.Plan.String), &j.Plan)
 	_ = json.Unmarshal([]byte(dbp.OnSuccess.String), &j.OnSuccess)
@@ -113,7 +118,7 @@ func (dbp *dbJob) toDomainEntity() *job.Job {
 func (r *JobRepository) Create(ctx context.Context, tc, pn string, j job.Job) (uint32, error) {
 	dbj := newDBJob(j)
 	res, err := r.querier.ExecContext(ctx, `
-		INSERT INTO jobs(name, tags, plan, on_success, on_failure, on_cancel, ensure, concurrency, paused, timeout, for_each_group, for_each_key, pipeline_id, baseline_version_id, approve_label, approve_timeout, approve_count, disable_retry)
+		INSERT INTO jobs(name, tags, plan, on_success, on_failure, on_cancel, ensure, concurrency, paused, timeout, for_each_group, for_each_key, pipeline_id, baseline_version_id, approve_label, approve_timeout, approve_count, disable_retry, allow_failure)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 			-- pipeline_id
 			(
@@ -124,7 +129,7 @@ func (r *JobRepository) Create(ctx context.Context, tc, pn string, j job.Job) (u
 				WHERE t.canonical = ? AND p.canonical = ?
 			),
 			-- baseline_version_id
-			(SELECT MAX(id) FROM resource_versions), ?, ?, ?, ?)`, dbj.Name, dbj.Tags, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Paused, dbj.Timeout, dbj.ForEachGroup, dbj.ForEachKey, tc, pn, dbj.ApproveLabel, dbj.ApproveTimeout, dbj.ApproveCount, dbj.DisableRetry)
+			(SELECT MAX(id) FROM resource_versions), ?, ?, ?, ?, ?)`, dbj.Name, dbj.Tags, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Paused, dbj.Timeout, dbj.ForEachGroup, dbj.ForEachKey, tc, pn, dbj.ApproveLabel, dbj.ApproveTimeout, dbj.ApproveCount, dbj.DisableRetry, dbj.AllowFailure)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -145,7 +150,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 	dbj := newDBJob(j)
 	res, err := r.querier.ExecContext(ctx, `
 		UPDATE jobs AS j
-		SET name = ?, tags = ?, plan = ?, on_success = ?, on_failure = ?, on_cancel = ?, ensure = ?, concurrency = ?, timeout = ?, for_each_group = ?, for_each_key = ?, approve_label = ?, approve_timeout = ?, approve_count = ?, disable_retry = ?
+		SET name = ?, tags = ?, plan = ?, on_success = ?, on_failure = ?, on_cancel = ?, ensure = ?, concurrency = ?, timeout = ?, for_each_group = ?, for_each_key = ?, approve_label = ?, approve_timeout = ?, approve_count = ?, disable_retry = ?, allow_failure = ?
 		FROM (
 			SELECT j.id
 			FROM jobs AS j
@@ -156,7 +161,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 			WHERE t.canonical = ? AND p.canonical = ? AND j.name = ?
 		) AS jj
 		WHERE jj.id = j.id
-	`, dbj.Name, dbj.Tags, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Timeout, dbj.ForEachGroup, dbj.ForEachKey, dbj.ApproveLabel, dbj.ApproveTimeout, dbj.ApproveCount, dbj.DisableRetry, tc, pn, jn)
+	`, dbj.Name, dbj.Tags, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Timeout, dbj.ForEachGroup, dbj.ForEachKey, dbj.ApproveLabel, dbj.ApproveTimeout, dbj.ApproveCount, dbj.DisableRetry, dbj.AllowFailure, tc, pn, jn)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -187,7 +192,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 
 func (r *JobRepository) Find(ctx context.Context, tc, pn, jn string) (*job.Job, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry
+		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry, j.allow_failure
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -212,7 +217,7 @@ func (r *JobRepository) Find(ctx context.Context, tc, pn, jn string) (*job.Job, 
 
 func (r *JobRepository) Filter(ctx context.Context, tc, pn string) ([]*job.Job, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry
+		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry, j.allow_failure
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -361,6 +366,7 @@ func scanJob(s sqlr.Scanner) (*job.Job, error) {
 		&j.ApproveTimeout,
 		&j.ApproveCount,
 		&j.DisableRetry,
+		&j.AllowFailure,
 	)
 
 	if err != nil {
@@ -453,7 +459,7 @@ func (r *JobRepository) loadSerialGroupsBatch(ctx context.Context, jobIDs []uint
 
 func (r *JobRepository) FilterByForEachGroup(ctx context.Context, tc, pn, group string) ([]*job.Job, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry
+		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry, j.allow_failure
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -493,7 +499,7 @@ func (r *JobRepository) FindJobsBySerialGroups(ctx context.Context, tc, pn strin
 		args = append(args, sg)
 	}
 	query := fmt.Sprintf(`
-		SELECT DISTINCT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry
+		SELECT DISTINCT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry, j.allow_failure
 		FROM jobs AS j
 		JOIN pipelines AS p ON j.pipeline_id = p.id
 		JOIN teams AS t ON p.team_id = t.id

--- a/pikoci/mysql/migrate/migrations/V49AllowFailure.go
+++ b/pikoci/mysql/migrate/migrations/V49AllowFailure.go
@@ -1,0 +1,6 @@
+package migrations
+
+var V49AllowFailure = Migration{
+	Name: "AllowFailure",
+	SQL:  `ALTER TABLE jobs ADD COLUMN allow_failure BOOLEAN NOT NULL DEFAULT FALSE;`,
+}

--- a/pikoci/mysql/migrate/migrations/migrations.go
+++ b/pikoci/mysql/migrate/migrations/migrations.go
@@ -16,7 +16,7 @@ type Migration struct {
 // Migrations is the ordered list of all schema migrations. It is defined as
 // a fixed-size array so that the compiler catches ordering conflicts when
 // multiple developers add migrations concurrently.
-var Migrations = [49]Migration{
+var Migrations = [50]Migration{
 	V0Initial,
 	V1ResourceCheckInterval,
 	V2JobsAndBuilds,
@@ -66,4 +66,5 @@ var Migrations = [49]Migration{
 	V46OAuthProviders,
 	V47TokenGen,
 	V48DisableRetry,
+	V49AllowFailure,
 }

--- a/pikoci/pipelines.go
+++ b/pikoci/pipelines.go
@@ -499,6 +499,7 @@ var (
 		build.Succeeded:       `"#00A83A"`,
 		build.Cancelled:       `"#AB5236"`,
 		build.WaitingForApproval: `"#8e44ad"`,
+		build.Warning:            `"#FA8072"`,
 	}
 	jobBorderColors = map[build.Status]string{
 		build.Started:         `"#CC8200"`,
@@ -506,6 +507,7 @@ var (
 		build.Succeeded:       `"#008030"`,
 		build.Cancelled:       `"#8A3F2B"`,
 		build.WaitingForApproval: `"#6c3483"`,
+		build.Warning:            `"#C8645A"`,
 	}
 	colorResource       = `"#83769C"`
 	colorResourceBorder = `"#5F574F"`

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -4423,7 +4423,7 @@ func TestListPipelineJobs_NoBuilds(t *testing.T) {
 		},
 	}
 	activeStatuses := []build.Status{build.Started, build.Pending}
-	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval}
+	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval, build.Warning}
 
 	s.Pipelines.EXPECT().Find(ctx, tc, pn).Return(pp, nil)
 	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, activeStatuses).Return(map[string][]*build.Build{}, nil)
@@ -4453,7 +4453,7 @@ func TestListPipelineJobs_SucceededBuild(t *testing.T) {
 		Jobs: []job.Job{{ID: 1, Name: "build"}},
 	}
 	activeStatuses := []build.Status{build.Started, build.Pending}
-	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval}
+	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval, build.Warning}
 
 	s.Pipelines.EXPECT().Find(ctx, tc, pn).Return(pp, nil)
 	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, activeStatuses).Return(map[string][]*build.Build{}, nil)
@@ -4484,7 +4484,7 @@ func TestListPipelineJobs_FailedBuild(t *testing.T) {
 		Jobs: []job.Job{{ID: 1, Name: "test"}},
 	}
 	activeStatuses := []build.Status{build.Started, build.Pending}
-	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval}
+	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval, build.Warning}
 
 	s.Pipelines.EXPECT().Find(ctx, tc, pn).Return(pp, nil)
 	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, activeStatuses).Return(map[string][]*build.Build{}, nil)
@@ -4511,7 +4511,7 @@ func TestListPipelineJobs_RunningBuild(t *testing.T) {
 		Jobs: []job.Job{{ID: 1, Name: "deploy"}},
 	}
 	activeStatuses := []build.Status{build.Started, build.Pending}
-	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval}
+	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval, build.Warning}
 
 	s.Pipelines.EXPECT().Find(ctx, tc, pn).Return(pp, nil)
 	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, activeStatuses).Return(map[string][]*build.Build{
@@ -4539,7 +4539,7 @@ func TestListPipelineJobs_PendingBuild(t *testing.T) {
 		Jobs: []job.Job{{ID: 1, Name: "gen"}},
 	}
 	activeStatuses := []build.Status{build.Started, build.Pending}
-	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval}
+	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval, build.Warning}
 
 	s.Pipelines.EXPECT().Find(ctx, tc, pn).Return(pp, nil)
 	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, activeStatuses).Return(map[string][]*build.Build{
@@ -4569,7 +4569,7 @@ func TestListPipelineJobs_MixedStatuses(t *testing.T) {
 		},
 	}
 	activeStatuses := []build.Status{build.Started, build.Pending}
-	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval}
+	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval, build.Warning}
 
 	s.Pipelines.EXPECT().Find(ctx, tc, pn).Return(pp, nil)
 	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, activeStatuses).Return(map[string][]*build.Build{}, nil)
@@ -4598,7 +4598,7 @@ func TestListPipelineJobs_RetryBuild(t *testing.T) {
 		Jobs: []job.Job{{ID: 1, Name: "build"}},
 	}
 	activeStatuses := []build.Status{build.Started, build.Pending}
-	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval}
+	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval, build.Warning}
 
 	s.Pipelines.EXPECT().Find(ctx, tc, pn).Return(pp, nil)
 	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, activeStatuses).Return(map[string][]*build.Build{}, nil)
@@ -4629,7 +4629,7 @@ func TestListPipelineJobs_JobOrder(t *testing.T) {
 		},
 	}
 	activeStatuses := []build.Status{build.Started, build.Pending}
-	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval}
+	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval, build.Warning}
 
 	s.Pipelines.EXPECT().Find(ctx, tc, pn).Return(pp, nil)
 	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, activeStatuses).Return(map[string][]*build.Build{}, nil)
@@ -4656,7 +4656,7 @@ func TestListPublicPipelineJobs_Success(t *testing.T) {
 		Jobs: []job.Job{{ID: 1, Name: "build"}},
 	}
 	activeStatuses := []build.Status{build.Started, build.Pending}
-	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval}
+	completedStatuses := []build.Status{build.Succeeded, build.Failed, build.Cancelled, build.WaitingForApproval, build.Warning}
 
 	s.Pipelines.EXPECT().FindPublic(ctx, tc, pn).Return(pp, nil)
 	s.Builds.EXPECT().FilterByPipeline(ctx, tc, pn, activeStatuses).Return(map[string][]*build.Build{}, nil)

--- a/pikoci/service.go
+++ b/pikoci/service.go
@@ -259,6 +259,9 @@ type Service interface {
 	ApproveBuild(ctx context.Context, tc, pc, jn, buildNumber, username, message string) error
 	// RejectBuild records a rejection vote and immediately fails the build.
 	RejectBuild(ctx context.Context, tc, pc, jn, buildNumber, username, message string) error
+	// MarkBuildAsWarning changes a failed build to warning status and triggers
+	// downstream job evaluation.
+	MarkBuildAsWarning(ctx context.Context, tc, pc, jn, buildNumber string) error
 
 	// ListAuditLog returns audit log entries for the given team matching the
 	// filter options. The boolean return value indicates whether more results exist.

--- a/pikoci/testdata/cron.hcl
+++ b/pikoci/testdata/cron.hcl
@@ -107,6 +107,7 @@ job "validate-report" {
 }
 
 job "failing" {
+  allow_failure = true
   get "cron" "my_cron" {
     trigger = true
     passed  = ["gen"]
@@ -115,6 +116,19 @@ job "failing" {
     run "exec" {
       path = "/bin/sh"
       args = ["-ec", "echo 'about to fail' && sleep 10 && exit 1"]
+    }
+  }
+}
+
+job "after-failing" {
+  get "cron" "my_cron" {
+    trigger = true
+    passed  = ["failing"]
+  }
+  task "run" {
+    run "exec" {
+      path = "/bin/sh"
+      args = ["-ec", "echo 'runs after failing (which has allow_failure=true)'"]
     }
   }
 }

--- a/pikoci/transport/http/assets/css/pikoci.css
+++ b/pikoci/transport/http/assets/css/pikoci.css
@@ -34,6 +34,7 @@
   --status-cancelled: #AB5236;
   --status-pending:   #83769C;
   --status-waiting_for_approval: #8e44ad;
+  --status-warning: #FA8072;
 
   --font-body:     'Plus Jakarta Sans', system-ui, sans-serif;
   --font-mono:     'JetBrains Mono', monospace;
@@ -560,6 +561,7 @@ textarea.form-control {
 .piko-tab-status.status-cancelled { background: var(--status-cancelled); }
 .piko-tab-status.status-pending { background: var(--status-pending); }
 .piko-tab-status.status-waiting_for_approval { background: var(--status-waiting_for_approval); }
+.piko-tab-status.status-warning { background: var(--status-warning); }
 
 /* ============================================================
    BUILD META & STEP LABELS
@@ -987,6 +989,7 @@ textarea.form-control {
 .piko-status-dot-started { background: var(--status-started); }
 .piko-status-dot-pending { background: var(--status-pending); }
 .piko-status-dot-waiting_for_approval { background: var(--status-waiting_for_approval); }
+.piko-status-dot-warning { background: var(--status-warning); }
 .piko-status-dot-cancelled { background: var(--status-cancelled); }
 .piko-status-dot-paused { background: #29ADFF; }
 .piko-status-dot- { background: var(--status-pending); }
@@ -1296,6 +1299,7 @@ textarea.form-control {
 .piko-badge-cancelled { background: #f5e6df; color: #8A3F2B; }
 .piko-badge-pending { background: #e8e0f0; color: #5F574F; }
 .piko-badge-waiting_for_approval { background: rgba(142,68,173,0.15); color: #8e44ad; }
+.piko-badge-warning { background: #fde8e5; color: #b5453a; }
 .piko-badge-primary { background: rgba(41,173,255,0.15); color: #29ADFF; }
 [data-theme="dark"] .piko-badge-succeeded { background: rgba(0,168,58,0.15); color: #00E436; }
 [data-theme="dark"] .piko-badge-failed { background: rgba(255,0,77,0.15); color: #FF77A8; }
@@ -1303,6 +1307,7 @@ textarea.form-control {
 [data-theme="dark"] .piko-badge-cancelled { background: rgba(171,82,54,0.15); color: #D4845E; }
 [data-theme="dark"] .piko-badge-pending { background: rgba(131,118,156,0.15); color: #83769C; }
 [data-theme="dark"] .piko-badge-waiting_for_approval { background: rgba(142,68,173,0.15); color: #b370cf; }
+[data-theme="dark"] .piko-badge-warning { background: rgba(250,128,114,0.15); color: #FA8072; }
 
 /* In-parallel step group */
 .piko-parallel-group > .piko-step-row-body {

--- a/pikoci/transport/http/assets/js/app/api.js
+++ b/pikoci/transport/http/assets/js/app/api.js
@@ -156,6 +156,8 @@ export const approveBuild = (tc, pn, jn, bid, message) =>
   api('/teams/' + tc + '/pipelines/' + pn + '/jobs/' + jn + '/builds/' + bid + '/approve', { method: 'POST', body: JSON.stringify({ message }) });
 export const rejectBuild = (tc, pn, jn, bid, message) =>
   api('/teams/' + tc + '/pipelines/' + pn + '/jobs/' + jn + '/builds/' + bid + '/reject', { method: 'POST', body: JSON.stringify({ message }) });
+export const markBuildAsWarning = (tc, pn, jn, bid) =>
+  api('/teams/' + tc + '/pipelines/' + pn + '/jobs/' + jn + '/builds/' + bid + '/warning', { method: 'PUT' });
 export const fetchBuildReport = (tc, pn, jn, bid) =>
   api('/teams/' + tc + '/pipelines/' + pn + '/jobs/' + jn + '/builds/' + bid + '/report');
 

--- a/pikoci/transport/http/assets/js/app/components/Jobs.js
+++ b/pikoci/transport/http/assets/js/app/components/Jobs.js
@@ -4,7 +4,7 @@ import { html } from 'htm/preact';
 import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
 import { route } from 'preact-router';
 import { isLoggedIn, hasTeamRole, session } from '../state.js';
-import { fetchBuilds, fetchBuild, cancelBuild, retryBuild, approveBuild, rejectBuild, fetchBuildReport, triggerJob, pauseJob, unpauseJob, fetchJob, fetchResources, fetchResourceVersions, fetchVersionPath, fetchTeam, fetchPipeline } from '../api.js';
+import { fetchBuilds, fetchBuild, cancelBuild, retryBuild, approveBuild, rejectBuild, markBuildAsWarning, fetchBuildReport, triggerJob, pauseJob, unpauseJob, fetchJob, fetchResources, fetchResourceVersions, fetchVersionPath, fetchTeam, fetchPipeline } from '../api.js';
 import { useLoading, usePolling } from '../hooks.js';
 import { sortBuilds, selectActiveBuild, durationToString, processLogs, pikoTimeAgo, fetchInterval, buildListCap } from '../utils.js';
 import { showToast } from '../toast.js';
@@ -29,6 +29,7 @@ function statusBadge(status, hasLogs) {
   if (status === 'started') return html`<span class="piko-badge piko-badge-started">running</span>`;
   if (status === 'pending') return html`<span class="piko-badge piko-badge-pending">pending</span>`;
   if (status === 'cancelled') return html`<span class="piko-badge piko-badge-cancelled">cancel</span>`;
+  if (status === 'warning') return html`<span class="piko-badge piko-badge-warning">warn</span>`;
   if (status === 'succeeded' || hasLogs) return html`<span class="piko-badge piko-badge-succeeded">ok</span>`;
   return null;
 }
@@ -40,6 +41,7 @@ function buildStatusBadge(status) {
   if (status === 'cancelled') return html`<span class="piko-badge piko-badge-cancelled">Cancelled</span>`;
   if (status === 'pending') return html`<span class="piko-badge piko-badge-pending">Pending</span>`;
   if (status === 'waiting_for_approval') return html`<span class="piko-badge piko-badge-waiting_for_approval">Waiting for Approval</span>`;
+  if (status === 'warning') return html`<span class="piko-badge piko-badge-warning">Warning</span>`;
   return null;
 }
 
@@ -253,6 +255,7 @@ function BuildContent({ build: rawBuild, tc, pn, jn, job: jobData, onRetry }) {
   const [exportLoading, withExportLoading] = useLoading();
   const [approveLoading, withApproveLoading] = useLoading();
   const [rejectLoading, withRejectLoading] = useLoading();
+  const [warningLoading, withWarningLoading] = useLoading();
   const initializedRef = useRef(false);
 
   // Fetch full build detail to get approvals (not in list endpoint).
@@ -489,6 +492,18 @@ function BuildContent({ build: rawBuild, tc, pn, jn, job: jobData, onRetry }) {
                 <i class="bi bi-arrow-clockwise"></i> ${retryLoading ? 'Retrying...' : 'Retry'}
               </button>
             ` : null}
+            ${isMaintainer && build.status === 'failed' ? html`
+              <button type="button" class="btn btn-sm btn-outline-secondary" title="Mark as warning" onClick=${() => {
+                withWarningLoading(async () => {
+                  await markBuildAsWarning(tc, pn, jn, build.build_number);
+                  showToast('Build marked as warning', 'success');
+                  refreshFullBuild();
+                  if (onRetry) onRetry();
+                });
+              }} disabled=${warningLoading}>
+                <i class="bi bi-exclamation-triangle"></i> ${warningLoading ? 'Marking...' : 'Mark Warning'}
+              </button>
+            ` : null}
             ${isReader ? html`
               <button type="button" class="btn btn-sm btn-outline-secondary" title="Export build report" onClick=${onExport} disabled=${exportLoading}>
                 <i class="bi bi-download"></i> ${exportLoading ? 'Exporting...' : 'Export'}
@@ -676,21 +691,19 @@ export function JobBuilds({ tc, pn, jn, bid, embedded, trackedVersionID: tracked
   // Fetch all non-terminal builds in a single batch request
   const refreshActiveBuild = useCallback(async () => {
     try {
+      const nonTerminal = ['pending', 'started', 'waiting_for_approval'];
       const resp = await fetchBuilds(tc, pn, jn, {
-        status: ['pending', 'started', 'waiting_for_approval'],
+        status: nonTerminal,
       });
       const freshMap = new Map((resp.data || []).map(b => [b.id, b]));
 
-      // If the active build was non-terminal but is missing from the refresh,
-      // it transitioned to a terminal state — re-fetch it individually.
+      // Builds that were non-terminal in prev but are missing from freshMap
+      // have transitioned to a terminal state — re-fetch them individually
+      // so their tabs update immediately.
       setBuilds(prev => {
-        const activeB = prev.find(b => b.id === activeBuildID);
-        const needsRefetch = activeB
-          && ['pending', 'started', 'waiting_for_approval'].includes(activeB.status)
-          && !freshMap.has(activeB.id);
-
-        if (needsRefetch) {
-          fetchBuild(tc, pn, jn, activeB.build_number)
+        const stale = prev.filter(b => nonTerminal.includes(b.status) && !freshMap.has(b.id));
+        for (const s of stale) {
+          fetchBuild(tc, pn, jn, s.build_number)
             .then(b => { if (b) setBuilds(p => sortBuilds(p.map(x => x.id === b.id ? b : x))); })
             .catch(() => {});
         }
@@ -701,7 +714,7 @@ export function JobBuilds({ tc, pn, jn, bid, embedded, trackedVersionID: tracked
         return prev;
       });
     } catch { /* ignore */ }
-  }, [tc, pn, jn, activeBuildID]);
+  }, [tc, pn, jn]);
 
   // Initial load
   useEffect(() => {
@@ -838,7 +851,15 @@ export function JobBuilds({ tc, pn, jn, bid, embedded, trackedVersionID: tracked
         return sortBuilds([...fresh, ...prev]);
       });
     }
-  }, [fetchNewBuilds]);
+
+    // Re-fetch the active build so the tab reflects status changes (e.g. mark as warning)
+    const activeB = builds.find(b => b.id === activeBuildID);
+    if (activeB) {
+      fetchBuild(tc, pn, jn, activeB.build_number)
+        .then(b => { if (b) setBuilds(p => sortBuilds(p.map(x => x.id === b.id ? b : x))); })
+        .catch(() => {});
+    }
+  }, [fetchNewBuilds, builds, activeBuildID, tc, pn, jn]);
 
   // Back to pipeline (version tracking)
   const onBackToPipeline = useCallback((e) => {

--- a/pikoci/transport/http/assets/js/app/components/PipelineList.js
+++ b/pikoci/transport/http/assets/js/app/components/PipelineList.js
@@ -134,18 +134,21 @@ function PipelineCard({ pipeline, tc, liveEnabled }) {
 
 function updateStatusFromSVG(svg, lastBuildAt, setStatusHtml) {
   if (!svg) return;
-  let hasFailed = false, hasRunning = false, hasSucceeded = false;
+  let hasFailed = false, hasRunning = false, hasSucceeded = false, hasWarning = false;
   svg.querySelectorAll('polygon, rect, ellipse, path').forEach(el => {
     const fill = (el.getAttribute('fill') || '').toLowerCase();
     if (fill === '#ff004d') hasFailed = true;
     if (fill === '#ffa300') hasRunning = true;
     if (fill === '#00a83a') hasSucceeded = true;
+    if (fill === '#fa8072') hasWarning = true;
   });
   const timeAgo = lastBuildAt ? ' \u00b7 ' + pikoTimeAgo(lastBuildAt) : '';
   if (hasFailed) {
     setStatusHtml(html`<span class="piko-card-status-dot" style="background:var(--status-failed);"></span> Last build failed${timeAgo}`);
   } else if (hasRunning) {
     setStatusHtml(html`<span class="piko-card-status-dot" style="background:var(--status-started);"></span> Running${timeAgo}`);
+  } else if (hasWarning) {
+    setStatusHtml(html`<span class="piko-card-status-dot" style="background:var(--status-warning);"></span> Last build warning${timeAgo}`);
   } else if (hasSucceeded) {
     setStatusHtml(html`<span class="piko-card-status-dot" style="background:var(--status-succeeded);"></span> Last build passed${timeAgo}`);
   } else {

--- a/pikoci/transport/http/assets/js/app/components/PipelineShow.js
+++ b/pikoci/transport/http/assets/js/app/components/PipelineShow.js
@@ -653,6 +653,10 @@ export function PipelineShow({ tc, pn }) {
             Waiting for approval
           </span>
           <span class="piko-graph-legend-item">
+            <span class="piko-graph-legend-swatch" style="background:var(--status-warning);"></span>
+            Warning
+          </span>
+          <span class="piko-graph-legend-item">
             <span class="piko-graph-legend-swatch" style="background:var(--primary);"></span>
             Paused
           </span>

--- a/pikoci/transport/http/authorization.go
+++ b/pikoci/transport/http/authorization.go
@@ -86,8 +86,9 @@ var (
 		FindBuildGetVersions:           requireRole(role.Maintain),
 
 		// Approval routes (Maintain+)
-		ApproveBuild: requireRole(role.Maintain),
-		RejectBuild:  requireRole(role.Maintain),
+		ApproveBuild:       requireRole(role.Maintain),
+		RejectBuild:        requireRole(role.Maintain),
+		MarkBuildAsWarning: requireRole(role.Maintain),
 
 		// Admin routes
 		CreateTeamMember:        requireRole(role.Admin),

--- a/pikoci/transport/http/builds.go
+++ b/pikoci/transport/http/builds.go
@@ -515,6 +515,30 @@ func rejectBuild(s pikoci.Service) http.HandlerFunc {
 	}
 }
 
+// MarkBuildAsWarningResponse is the response body for the mark-as-warning endpoint.
+type MarkBuildAsWarningResponse struct {
+	Err string `json:"error,omitempty"`
+}
+
+func (r MarkBuildAsWarningResponse) Error() string { return r.Err }
+
+func markBuildAsWarning(s pikoci.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		vars := mux.Vars(r)
+		tc := vars["team_canonical"]
+		pc := vars["pipeline_canonical"]
+		jn := vars["job_name"]
+		bn := vars["build_number"]
+		err := s.MarkBuildAsWarning(ctx, tc, pc, jn, bn)
+		var errs string
+		if err != nil {
+			errs = err.Error()
+		}
+		encodeResponse(MarkBuildAsWarningResponse{Err: errs}, w)
+	}
+}
+
 func listJobBuilds(s pikoci.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var (

--- a/pikoci/transport/http/client/client.go
+++ b/pikoci/transport/http/client/client.go
@@ -1358,6 +1358,19 @@ func (cl *Client) RejectBuild(ctx context.Context, tc, pc, jn, buildNumber, user
 	return nil
 }
 
+func (cl *Client) MarkBuildAsWarning(ctx context.Context, tc, pc, jn, buildNumber string) error {
+	u := fmt.Sprintf("%s/teams/%s/pipelines/%s/jobs/%s/builds/%s/warning", cl.url, tc, pc, jn, buildNumber)
+	var resp thttp.ErrorResponse
+	err := cl.Request(ctx, http.MethodPut, u, nil, &resp)
+	if err != nil {
+		return fmt.Errorf("failed to make request: %w", err)
+	}
+	if resp.Err != "" {
+		return fmt.Errorf("error from request: %s", resp.Err)
+	}
+	return nil
+}
+
 // GenerateTeamWorkerToken generates (or regenerates) a team-scoped worker token.
 func (cl *Client) GenerateTeamWorkerToken(ctx context.Context, tc string) (string, error) {
 	var resp thttp.GenerateTeamWorkerTokenResponse

--- a/pikoci/transport/http/client/client_test.go
+++ b/pikoci/transport/http/client/client_test.go
@@ -2925,3 +2925,34 @@ func TestGetTeamWorkerToken_Error(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
+
+func TestMarkBuildAsWarning(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/{pc}/jobs/{jn}/builds/{bn}/warning", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.MarkBuildAsWarningResponse{})
+	}).Methods("PUT")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	err = c.MarkBuildAsWarning(context.Background(), "main", "my-pipe", "build", "1")
+	require.NoError(t, err)
+}
+
+func TestMarkBuildAsWarning_Error(t *testing.T) {
+	r := mux.NewRouter()
+	r.HandleFunc("/teams/{tc}/pipelines/{pc}/jobs/{jn}/builds/{bn}/warning", func(w http.ResponseWriter, req *http.Request) {
+		jsonHandler(w, thttp.MarkBuildAsWarningResponse{Err: "not failed"})
+	}).Methods("PUT")
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	c, err := client.New(ts.URL, "jwt")
+	require.NoError(t, err)
+
+	err = c.MarkBuildAsWarning(context.Background(), "main", "my-pipe", "build", "1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not failed")
+}

--- a/pikoci/transport/http/handler.go
+++ b/pikoci/transport/http/handler.go
@@ -320,6 +320,7 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, 
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/builds/{build_number}/retry").Name(RetryJobBuild.String()).Handler(retryJobBuild(s))
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/builds/{build_number}/approve").Name(ApproveBuild.String()).Handler(approveBuild(s))
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/builds/{build_number}/reject").Name(RejectBuild.String()).Handler(rejectBuild(s))
+	api.Methods(http.MethodPut).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/builds/{build_number}/warning").Name(MarkBuildAsWarning.String()).Handler(markBuildAsWarning(s))
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/builds/start-pending").Name(StartPendingBuild.String()).Handler(startPendingBuild(s))
 	api.Methods(http.MethodGet).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/builds/oldest-pending").Name(FindOldestPendingBuild.String()).Handler(findOldestPendingBuild(s))
 	api.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/jobs/{job_name}/notify-serial-groups").Name(NotifySerialGroupPendingBuilds.String()).Handler(notifySerialGroupPendingBuilds(s))

--- a/pikoci/transport/http/handlers_coverage_test.go
+++ b/pikoci/transport/http/handlers_coverage_test.go
@@ -2929,3 +2929,41 @@ func TestOAuthCompleteProfileHandler(t *testing.T) {
 	assert.Empty(t, got.Err)
 	assert.Equal(t, "jwt-token-456", got.Data.JWT)
 }
+
+func TestMarkBuildAsWarning_Handler_Success(t *testing.T) {
+	e := newTestEnv(t)
+	e.expectAdminAuth()
+	e.svc.EXPECT().MarkBuildAsWarning(gomock.Any(), "main", "my-pipe", "build", "1").Return(nil)
+
+	resp := doRequest(t, http.MethodPut, e.server.URL+"/teams/main/pipelines/my-pipe/jobs/build/builds/1/warning", e.adminJWT(t), "")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	var got MarkBuildAsWarningResponse
+	json.NewDecoder(resp.Body).Decode(&got)
+	assert.Empty(t, got.Err)
+}
+
+func TestMarkBuildAsWarning_Handler_Error(t *testing.T) {
+	e := newTestEnv(t)
+	e.expectAdminAuth()
+	e.svc.EXPECT().MarkBuildAsWarning(gomock.Any(), "main", "my-pipe", "build", "1").Return(fmt.Errorf("not failed"))
+
+	resp := doRequest(t, http.MethodPut, e.server.URL+"/teams/main/pipelines/my-pipe/jobs/build/builds/1/warning", e.adminJWT(t), "")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	var got MarkBuildAsWarningResponse
+	json.NewDecoder(resp.Body).Decode(&got)
+	assert.Equal(t, "not failed", got.Err)
+}
+
+func TestMarkBuildAsWarning_Handler_Unauthorized(t *testing.T) {
+	e := newTestEnv(t)
+	e.expectMemberAuth()
+
+	resp := doRequest(t, http.MethodPut, e.server.URL+"/teams/main/pipelines/my-pipe/jobs/build/builds/1/warning", e.memberJWT(t), "")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}

--- a/pikoci/transport/http/route_names.go
+++ b/pikoci/transport/http/route_names.go
@@ -172,6 +172,9 @@ const (
 	// RejectBuild is the route for rejecting a build waiting for approval.
 	RejectBuild
 
+	// MarkBuildAsWarning is the route for marking a failed build as warning.
+	MarkBuildAsWarning
+
 	// GenerateTeamWorkerToken is the route for generating a team worker token.
 	GenerateTeamWorkerToken
 	// GetTeamWorkerToken is the route for retrieving the current team worker token.

--- a/pikoci/transport/http/route_names_string.go
+++ b/pikoci/transport/http/route_names_string.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _RouteNameName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_joblist_pipeline_jobsget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobslist_pipeline_resourcesget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionget_resource_version_pathwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_workercreate_api_tokenlist_api_tokensdelete_api_tokenlist_audit_logget_build_reportapprove_buildreject_buildgenerate_team_worker_tokenget_team_worker_tokenget_auth_methodso_auth_starto_auth_callbacko_auth_complete_profilelist_o_auth_providerscreate_o_auth_providerupdate_o_auth_providerdelete_o_auth_providerget_admin_auth_settingsupdate_admin_auth_settingslist_linked_accountsunlink_account"
+const _RouteNameName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_joblist_pipeline_jobsget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobslist_pipeline_resourcesget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionget_resource_version_pathwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_workercreate_api_tokenlist_api_tokensdelete_api_tokenlist_audit_logget_build_reportapprove_buildreject_buildmark_build_as_warninggenerate_team_worker_tokenget_team_worker_tokenget_auth_methodso_auth_starto_auth_callbacko_auth_complete_profilelist_o_auth_providerscreate_o_auth_providerupdate_o_auth_providerdelete_o_auth_providerget_admin_auth_settingsupdate_admin_auth_settingslist_linked_accountsunlink_account"
 
-var _RouteNameIndex = [...]uint16{0, 10, 23, 34, 44, 52, 63, 74, 89, 103, 114, 124, 132, 143, 154, 172, 190, 208, 223, 238, 250, 265, 279, 297, 318, 338, 356, 372, 388, 410, 426, 442, 457, 481, 504, 517, 533, 548, 567, 592, 626, 650, 673, 694, 718, 743, 766, 788, 808, 830, 854, 879, 894, 918, 932, 951, 966, 980, 996, 1005, 1016, 1027, 1043, 1055, 1069, 1082, 1098, 1113, 1129, 1143, 1159, 1172, 1184, 1210, 1231, 1247, 1259, 1274, 1297, 1318, 1340, 1362, 1384, 1407, 1433, 1453, 1467}
+var _RouteNameIndex = [...]uint16{0, 10, 23, 34, 44, 52, 63, 74, 89, 103, 114, 124, 132, 143, 154, 172, 190, 208, 223, 238, 250, 265, 279, 297, 318, 338, 356, 372, 388, 410, 426, 442, 457, 481, 504, 517, 533, 548, 567, 592, 626, 650, 673, 694, 718, 743, 766, 788, 808, 830, 854, 879, 894, 918, 932, 951, 966, 980, 996, 1005, 1016, 1027, 1043, 1055, 1069, 1082, 1098, 1113, 1129, 1143, 1159, 1172, 1184, 1205, 1231, 1252, 1268, 1280, 1295, 1318, 1339, 1361, 1383, 1405, 1428, 1454, 1474, 1488}
 
-const _RouteNameLowerName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_joblist_pipeline_jobsget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobslist_pipeline_resourcesget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionget_resource_version_pathwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_workercreate_api_tokenlist_api_tokensdelete_api_tokenlist_audit_logget_build_reportapprove_buildreject_buildgenerate_team_worker_tokenget_team_worker_tokenget_auth_methodso_auth_starto_auth_callbacko_auth_complete_profilelist_o_auth_providerscreate_o_auth_providerupdate_o_auth_providerdelete_o_auth_providerget_admin_auth_settingsupdate_admin_auth_settingslist_linked_accountsunlink_account"
+const _RouteNameLowerName = "user_loginrefresh_tokencreate_userlist_usersget_userupdate_userdelete_userchange_passwordupdate_profilecreate_teamlist_teamsget_teamupdate_teamdelete_teamcreate_team_memberupdate_team_memberdelete_team_membercreate_pipelineupdate_pipelineget_pipelinedelete_pipelinelist_pipelinesget_pipeline_imagecreate_pipeline_imagetrigger_pipeline_joblist_pipeline_jobsget_pipeline_jobcreate_job_buildcreate_retry_job_buildupdate_job_builddelete_job_buildlist_job_buildsinsert_build_get_versionfind_build_get_versionsget_job_buildcancel_job_buildretry_job_buildstart_pending_buildfind_oldest_pending_buildnotify_serial_group_pending_buildsevaluate_downstream_jobslist_pipeline_resourcesget_pipeline_resourceupdate_pipeline_resourcetrigger_pipeline_resourcecreate_resource_versionlist_resource_versionspin_resource_versionunpin_resource_versiontrigger_resource_versionget_resource_version_pathwebhook_triggerregenerate_webhook_tokencreate_triggerlist_triggers_afterexport_databasepause_pipelineunpause_pipelinepause_jobunpause_jobget_versionworker_heartbeatlist_workersworkers_healthdelete_workercreate_api_tokenlist_api_tokensdelete_api_tokenlist_audit_logget_build_reportapprove_buildreject_buildmark_build_as_warninggenerate_team_worker_tokenget_team_worker_tokenget_auth_methodso_auth_starto_auth_callbacko_auth_complete_profilelist_o_auth_providerscreate_o_auth_providerupdate_o_auth_providerdelete_o_auth_providerget_admin_auth_settingsupdate_admin_auth_settingslist_linked_accountsunlink_account"
 
 func (i RouteName) String() string {
 	if i < 0 || i >= RouteName(len(_RouteNameIndex)-1) {
@@ -96,23 +96,24 @@ func _RouteNameNoOp() {
 	_ = x[GetBuildReport-(69)]
 	_ = x[ApproveBuild-(70)]
 	_ = x[RejectBuild-(71)]
-	_ = x[GenerateTeamWorkerToken-(72)]
-	_ = x[GetTeamWorkerToken-(73)]
-	_ = x[GetAuthMethods-(74)]
-	_ = x[OAuthStart-(75)]
-	_ = x[OAuthCallback-(76)]
-	_ = x[OAuthCompleteProfile-(77)]
-	_ = x[ListOAuthProviders-(78)]
-	_ = x[CreateOAuthProvider-(79)]
-	_ = x[UpdateOAuthProvider-(80)]
-	_ = x[DeleteOAuthProvider-(81)]
-	_ = x[GetAdminAuthSettings-(82)]
-	_ = x[UpdateAdminAuthSettings-(83)]
-	_ = x[ListLinkedAccounts-(84)]
-	_ = x[UnlinkAccount-(85)]
+	_ = x[MarkBuildAsWarning-(72)]
+	_ = x[GenerateTeamWorkerToken-(73)]
+	_ = x[GetTeamWorkerToken-(74)]
+	_ = x[GetAuthMethods-(75)]
+	_ = x[OAuthStart-(76)]
+	_ = x[OAuthCallback-(77)]
+	_ = x[OAuthCompleteProfile-(78)]
+	_ = x[ListOAuthProviders-(79)]
+	_ = x[CreateOAuthProvider-(80)]
+	_ = x[UpdateOAuthProvider-(81)]
+	_ = x[DeleteOAuthProvider-(82)]
+	_ = x[GetAdminAuthSettings-(83)]
+	_ = x[UpdateAdminAuthSettings-(84)]
+	_ = x[ListLinkedAccounts-(85)]
+	_ = x[UnlinkAccount-(86)]
 }
 
-var _RouteNameValues = []RouteName{UserLogin, RefreshToken, CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser, ChangePassword, UpdateProfile, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, ListPipelineJobs, GetPipelineJob, CreateJobBuild, CreateRetryJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, InsertBuildGetVersion, FindBuildGetVersions, GetJobBuild, CancelJobBuild, RetryJobBuild, StartPendingBuild, FindOldestPendingBuild, NotifySerialGroupPendingBuilds, EvaluateDownstreamJobs, ListPipelineResources, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions, PinResourceVersion, UnpinResourceVersion, TriggerResourceVersion, GetResourceVersionPath, WebhookTrigger, RegenerateWebhookToken, CreateTrigger, ListTriggersAfter, ExportDatabase, PausePipeline, UnpausePipeline, PauseJob, UnpauseJob, GetVersion, WorkerHeartbeat, ListWorkers, WorkersHealth, DeleteWorker, CreateApiToken, ListApiTokens, DeleteApiToken, ListAuditLog, GetBuildReport, ApproveBuild, RejectBuild, GenerateTeamWorkerToken, GetTeamWorkerToken, GetAuthMethods, OAuthStart, OAuthCallback, OAuthCompleteProfile, ListOAuthProviders, CreateOAuthProvider, UpdateOAuthProvider, DeleteOAuthProvider, GetAdminAuthSettings, UpdateAdminAuthSettings, ListLinkedAccounts, UnlinkAccount}
+var _RouteNameValues = []RouteName{UserLogin, RefreshToken, CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser, ChangePassword, UpdateProfile, CreateTeam, ListTeams, GetTeam, UpdateTeam, DeleteTeam, CreateTeamMember, UpdateTeamMember, DeleteTeamMember, CreatePipeline, UpdatePipeline, GetPipeline, DeletePipeline, ListPipelines, GetPipelineImage, CreatePipelineImage, TriggerPipelineJob, ListPipelineJobs, GetPipelineJob, CreateJobBuild, CreateRetryJobBuild, UpdateJobBuild, DeleteJobBuild, ListJobBuilds, InsertBuildGetVersion, FindBuildGetVersions, GetJobBuild, CancelJobBuild, RetryJobBuild, StartPendingBuild, FindOldestPendingBuild, NotifySerialGroupPendingBuilds, EvaluateDownstreamJobs, ListPipelineResources, GetPipelineResource, UpdatePipelineResource, TriggerPipelineResource, CreateResourceVersion, ListResourceVersions, PinResourceVersion, UnpinResourceVersion, TriggerResourceVersion, GetResourceVersionPath, WebhookTrigger, RegenerateWebhookToken, CreateTrigger, ListTriggersAfter, ExportDatabase, PausePipeline, UnpausePipeline, PauseJob, UnpauseJob, GetVersion, WorkerHeartbeat, ListWorkers, WorkersHealth, DeleteWorker, CreateApiToken, ListApiTokens, DeleteApiToken, ListAuditLog, GetBuildReport, ApproveBuild, RejectBuild, MarkBuildAsWarning, GenerateTeamWorkerToken, GetTeamWorkerToken, GetAuthMethods, OAuthStart, OAuthCallback, OAuthCompleteProfile, ListOAuthProviders, CreateOAuthProvider, UpdateOAuthProvider, DeleteOAuthProvider, GetAdminAuthSettings, UpdateAdminAuthSettings, ListLinkedAccounts, UnlinkAccount}
 
 var _RouteNameNameToValueMap = map[string]RouteName{
 	_RouteNameName[0:10]:           UserLogin,
@@ -259,34 +260,36 @@ var _RouteNameNameToValueMap = map[string]RouteName{
 	_RouteNameLowerName[1159:1172]: ApproveBuild,
 	_RouteNameName[1172:1184]:      RejectBuild,
 	_RouteNameLowerName[1172:1184]: RejectBuild,
-	_RouteNameName[1184:1210]:      GenerateTeamWorkerToken,
-	_RouteNameLowerName[1184:1210]: GenerateTeamWorkerToken,
-	_RouteNameName[1210:1231]:      GetTeamWorkerToken,
-	_RouteNameLowerName[1210:1231]: GetTeamWorkerToken,
-	_RouteNameName[1231:1247]:      GetAuthMethods,
-	_RouteNameLowerName[1231:1247]: GetAuthMethods,
-	_RouteNameName[1247:1259]:      OAuthStart,
-	_RouteNameLowerName[1247:1259]: OAuthStart,
-	_RouteNameName[1259:1274]:      OAuthCallback,
-	_RouteNameLowerName[1259:1274]: OAuthCallback,
-	_RouteNameName[1274:1297]:      OAuthCompleteProfile,
-	_RouteNameLowerName[1274:1297]: OAuthCompleteProfile,
-	_RouteNameName[1297:1318]:      ListOAuthProviders,
-	_RouteNameLowerName[1297:1318]: ListOAuthProviders,
-	_RouteNameName[1318:1340]:      CreateOAuthProvider,
-	_RouteNameLowerName[1318:1340]: CreateOAuthProvider,
-	_RouteNameName[1340:1362]:      UpdateOAuthProvider,
-	_RouteNameLowerName[1340:1362]: UpdateOAuthProvider,
-	_RouteNameName[1362:1384]:      DeleteOAuthProvider,
-	_RouteNameLowerName[1362:1384]: DeleteOAuthProvider,
-	_RouteNameName[1384:1407]:      GetAdminAuthSettings,
-	_RouteNameLowerName[1384:1407]: GetAdminAuthSettings,
-	_RouteNameName[1407:1433]:      UpdateAdminAuthSettings,
-	_RouteNameLowerName[1407:1433]: UpdateAdminAuthSettings,
-	_RouteNameName[1433:1453]:      ListLinkedAccounts,
-	_RouteNameLowerName[1433:1453]: ListLinkedAccounts,
-	_RouteNameName[1453:1467]:      UnlinkAccount,
-	_RouteNameLowerName[1453:1467]: UnlinkAccount,
+	_RouteNameName[1184:1205]:      MarkBuildAsWarning,
+	_RouteNameLowerName[1184:1205]: MarkBuildAsWarning,
+	_RouteNameName[1205:1231]:      GenerateTeamWorkerToken,
+	_RouteNameLowerName[1205:1231]: GenerateTeamWorkerToken,
+	_RouteNameName[1231:1252]:      GetTeamWorkerToken,
+	_RouteNameLowerName[1231:1252]: GetTeamWorkerToken,
+	_RouteNameName[1252:1268]:      GetAuthMethods,
+	_RouteNameLowerName[1252:1268]: GetAuthMethods,
+	_RouteNameName[1268:1280]:      OAuthStart,
+	_RouteNameLowerName[1268:1280]: OAuthStart,
+	_RouteNameName[1280:1295]:      OAuthCallback,
+	_RouteNameLowerName[1280:1295]: OAuthCallback,
+	_RouteNameName[1295:1318]:      OAuthCompleteProfile,
+	_RouteNameLowerName[1295:1318]: OAuthCompleteProfile,
+	_RouteNameName[1318:1339]:      ListOAuthProviders,
+	_RouteNameLowerName[1318:1339]: ListOAuthProviders,
+	_RouteNameName[1339:1361]:      CreateOAuthProvider,
+	_RouteNameLowerName[1339:1361]: CreateOAuthProvider,
+	_RouteNameName[1361:1383]:      UpdateOAuthProvider,
+	_RouteNameLowerName[1361:1383]: UpdateOAuthProvider,
+	_RouteNameName[1383:1405]:      DeleteOAuthProvider,
+	_RouteNameLowerName[1383:1405]: DeleteOAuthProvider,
+	_RouteNameName[1405:1428]:      GetAdminAuthSettings,
+	_RouteNameLowerName[1405:1428]: GetAdminAuthSettings,
+	_RouteNameName[1428:1454]:      UpdateAdminAuthSettings,
+	_RouteNameLowerName[1428:1454]: UpdateAdminAuthSettings,
+	_RouteNameName[1454:1474]:      ListLinkedAccounts,
+	_RouteNameLowerName[1454:1474]: ListLinkedAccounts,
+	_RouteNameName[1474:1488]:      UnlinkAccount,
+	_RouteNameLowerName[1474:1488]: UnlinkAccount,
 }
 
 var _RouteNameNames = []string{
@@ -362,20 +365,21 @@ var _RouteNameNames = []string{
 	_RouteNameName[1143:1159],
 	_RouteNameName[1159:1172],
 	_RouteNameName[1172:1184],
-	_RouteNameName[1184:1210],
-	_RouteNameName[1210:1231],
-	_RouteNameName[1231:1247],
-	_RouteNameName[1247:1259],
-	_RouteNameName[1259:1274],
-	_RouteNameName[1274:1297],
-	_RouteNameName[1297:1318],
-	_RouteNameName[1318:1340],
-	_RouteNameName[1340:1362],
-	_RouteNameName[1362:1384],
-	_RouteNameName[1384:1407],
-	_RouteNameName[1407:1433],
-	_RouteNameName[1433:1453],
-	_RouteNameName[1453:1467],
+	_RouteNameName[1184:1205],
+	_RouteNameName[1205:1231],
+	_RouteNameName[1231:1252],
+	_RouteNameName[1252:1268],
+	_RouteNameName[1268:1280],
+	_RouteNameName[1280:1295],
+	_RouteNameName[1295:1318],
+	_RouteNameName[1318:1339],
+	_RouteNameName[1339:1361],
+	_RouteNameName[1361:1383],
+	_RouteNameName[1383:1405],
+	_RouteNameName[1405:1428],
+	_RouteNameName[1428:1454],
+	_RouteNameName[1454:1474],
+	_RouteNameName[1474:1488],
 }
 
 // RouteNameString retrieves an enum value from the enum constants string name.

--- a/worker/service.go
+++ b/worker/service.go
@@ -541,17 +541,29 @@ func (w *Worker) processJob(ctx context.Context, m workitem.Body, cwd string, pp
 		}
 		w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.OnSuccess, "on_success", resolved, exportedVars, "succeeded")
 	} else {
-		// Ensure local b reflects the Failed status set by failBuild (which
-		// operates on a copy) so that any subsequent updateBuild calls from
-		// hooks don't overwrite the DB status back to Started.
-		if b.Status != build.Failed {
+		// Ensure local b reflects the Failed/Warning status set by failBuild
+		// (which operates on a copy) so that any subsequent updateBuild calls
+		// from hooks don't overwrite the DB status back to Started.
+		if j.AllowFailure {
+			b.Status = build.Warning
+			if err := w.updateBuild(ctx, m, b); err != nil {
+				return
+			}
+			// Warning builds unblock downstream just like success
+			if err := w.pikoci.EvaluateDownstreamJobs(ctx, m.TeamCanonical, m.PipelineCanonical, j.Name); err != nil {
+				w.logger.Error("failed to evaluate downstream jobs",
+					"pipeline", m.PipelineCanonical, "job", j.Name, "error", err)
+			}
+		} else if b.Status != build.Failed {
 			b.Status = build.Failed
 		}
-		w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.OnFailure, "on_failure", resolved, exportedVars, "failed")
+		w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.OnFailure, "on_failure", resolved, exportedVars, b.Status.String())
 	}
 	status := "succeeded"
 	if b.Status == build.Failed {
 		status = "failed"
+	} else if b.Status == build.Warning {
+		status = "warning"
 	}
 	w.runHooks(ctx, m, &b, &b.Job, cwd, pp, "", j.Ensure, "ensure", resolved, exportedVars, status)
 
@@ -599,7 +611,7 @@ func (w *Worker) checkPassedConstraints(ctx context.Context, m workitem.Body, b 
 			// Collect version IDs from successful builds where a get step matches this resource
 			versionSet := make(map[uint32]bool)
 			for _, bu := range builds {
-				if bu.Status != build.Succeeded {
+				if bu.Status != build.Succeeded && bu.Status != build.Warning {
 					continue
 				}
 				hasSucceeded = true

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -446,6 +446,102 @@ func TestProcessJob_FailedPassedConstraint_NotSucceeded(t *testing.T) {
 	w.processJob(ctx, m, cwd, pp)
 }
 
+func TestProcessJob_PassedConstraint_AcceptsWarningBuilds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := workitem.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "downstream-job",
+		BuildID:           10,
+		BuildNumber:       "22",
+		VersionID:         1,
+	}
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   2,
+				Name: "downstream-job",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeGet,
+						Get: &job.GetStep{
+							Type:    "cron",
+							Name:    "my-cron",
+							Passed:  []string{"upstream-job"},
+							Trigger: true,
+						},
+					},
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "echo",
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Args:   []string{"downstream ran"},
+								Params: map[string]string{"path": "echo"},
+							},
+						},
+					},
+				},
+			},
+		},
+		Resources: []resource.Resource{
+			{ID: 1, Name: "my-cron", Type: "cron", Canonical: "cron.my-cron", Params: &resource.Params{}},
+		},
+		ResourceTypes: []restype.ResourceType{
+			{
+				ID: 1, Name: "cron", Params: []string{},
+				Check: &utils.RunnerCommand{Runner: "exec", Args: []string{"-ec", `echo "[{\"date\":\"now\"}]"`}, Params: map[string]string{"path": "/bin/sh"}},
+				Pull:  &utils.RunnerCommand{Runner: "exec", Params: map[string]string{}},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+
+	cwd := t.TempDir()
+
+	svc.EXPECT().GetPipelineJob(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName).
+		Return(&pp.Jobs[0], nil)
+
+	// Upstream job has a WARNING build (from allow_failure) — should be treated as success
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "upstream-job", (*uint32)(nil), (*uint32)(nil), uint32(0), ([]build.Status)(nil)).
+		Return([]*build.Build{{
+			ID:     5,
+			Status: build.Warning,
+			Steps: []build.Step{
+				{Type: "get", Name: "my-cron", VersionID: 42},
+			},
+		}}, false, nil)
+
+	// checkVersionAvailability needs resource versions
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "cron.my-cron", (*uint32)(nil), (*uint32)(nil), uint32(0)).
+		Return([]*resource.Version{
+			{ID: 42, Version: map[string]interface{}{"date": "now"}},
+		}, false, nil).AnyTimes()
+
+	// Build should proceed (not be deleted)
+	var capturedStatuses []build.Status
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "22", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, b build.Build) error {
+			capturedStatuses = append(capturedStatuses, b.Status)
+			return nil
+		}).AnyTimes()
+
+	w.processJob(ctx, m, cwd, pp)
+
+	// The build should NOT have been deleted — it should run
+	require.NotEmpty(t, capturedStatuses, "build should have been updated (not deleted), meaning passed constraints accepted warning builds")
+	assert.Equal(t, build.Succeeded, capturedStatuses[len(capturedStatuses)-1], "downstream build should succeed")
+}
+
 func TestProcessJob_TaskFailure_RunsHooks(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	w, svc := newTestWorker(ctrl)
@@ -9115,6 +9211,144 @@ func TestFailBuildWithRetry(t *testing.T) {
 	)
 
 	w.failBuild(ctx, m, b, fmt.Errorf("step failed"))
+}
+
+func TestProcessJob_AllowFailure_SetsWarningAndTriggersDownstream(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := workitem.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "allow-fail-job",
+		BuildID:           10,
+		BuildNumber:       "500",
+		VersionID:         1,
+	}
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:           1,
+				Name:         "allow-fail-job",
+				AllowFailure: true,
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "will-fail",
+							Run:  utils.RunnerCommand{Runner: "exec", Params: map[string]string{"path": "false"}},
+						},
+					},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().GetPipelineJob(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName).
+		Return(&pp.Jobs[0], nil)
+
+	var capturedStatuses []build.Status
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "500", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, b build.Build) error {
+			capturedStatuses = append(capturedStatuses, b.Status)
+			return nil
+		}).AnyTimes()
+
+	w.processJob(ctx, m, cwd, pp)
+
+	// The last update should be Warning
+	require.NotEmpty(t, capturedStatuses)
+	assert.Equal(t, build.Warning, capturedStatuses[len(capturedStatuses)-1], "final build status should be warning")
+}
+
+func TestProcessJob_AllowFailure_OnFailureHookStillRuns(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := workitem.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "allow-fail-hooks-job",
+		BuildID:           10,
+		BuildNumber:       "501",
+		VersionID:         1,
+	}
+
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:           1,
+				Name:         "allow-fail-hooks-job",
+				AllowFailure: true,
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "will-fail",
+							Run:  utils.RunnerCommand{Runner: "exec", Params: map[string]string{"path": "false"}},
+						},
+					},
+				},
+				OnFailure: []job.HookStep{
+					runnerHook(utils.RunnerCommand{
+						Runner: "exec",
+						Args:   []string{"on_failure ran"},
+						Params: map[string]string{"path": "echo"},
+					}),
+				},
+				Ensure: []job.HookStep{
+					runnerHook(utils.RunnerCommand{
+						Runner: "exec",
+						Args:   []string{"ensure ran"},
+						Params: map[string]string{"path": "echo"},
+					}),
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().GetPipelineJob(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName).
+		Return(&pp.Jobs[0], nil)
+
+	var capturedBuild build.Build
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "501", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, b build.Build) error {
+			capturedBuild = b
+			return nil
+		}).AnyTimes()
+
+	w.processJob(ctx, m, cwd, pp)
+
+	assert.Equal(t, build.Warning, capturedBuild.Status, "build should be warning")
+
+	// on_failure hooks should have run
+	foundOnFailure := false
+	foundEnsure := false
+	for _, step := range capturedBuild.Job {
+		if step.Type == "hook" && step.Name == "on_failure" {
+			foundOnFailure = true
+		}
+		if step.Type == "hook" && step.Name == "ensure" {
+			foundEnsure = true
+		}
+	}
+	assert.True(t, foundOnFailure, "on_failure hook should run for allow_failure builds")
+	assert.True(t, foundEnsure, "ensure hook should run for allow_failure builds")
 }
 
 func TestUpdateBuild_SuppressUpdates(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `allow_failure = true` on jobs: failed builds get `warning` status (salmon color) instead of `failed`, unblocking downstream jobs
- New `Warning` build status with salmon UI color (`#FA8072`), distinct from failed (red) and running (orange)
- "Mark Warning" button on failed builds (Maintain role) to manually convert failed → warning and trigger downstream
- `PUT /teams/{tc}/pipelines/{pc}/jobs/{jn}/builds/{bn}/warning` API endpoint + client method
- DB migration V49 adds `allow_failure` column to jobs table
- Fix: build list tabs no longer stay stuck on "running" after builds complete

Closes #610