### PR TITLE
feat: add interruptible flag on jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`interruptible` on jobs**: When `true`, creating a new build for the job automatically cancels all older running, pending, and waiting-for-approval builds, so only the latest build runs ([#612](https://github.com/PikoCI/pikoci/issues/612)).
 - **`allow_failure` on jobs**: When `true`, a failed build is marked as `warning` (salmon) instead of `failed`, unblocking downstream jobs. Any failed build can also be manually marked as warning via a UI button (requires Maintain role) ([#610](https://github.com/PikoCI/pikoci/issues/610)).
 - **`disable_retry` on jobs**: Prevents build retries via API and hides the retry button in the UI ([#617](https://github.com/PikoCI/pikoci/issues/617)).
 - **Notification integration tests**: Worker-level tests with mock HTTP server verifying notify steps, auto-notification lifecycle filtering (`on`, `jobs`, `exclude`), and message interpolation ([#608](https://github.com/PikoCI/pikoci/issues/608)).

--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -268,6 +268,7 @@ The optional `timeout` attribute limits the total wall-clock time for a build's 
 | `serial_groups` | no | Cross-job mutual exclusion groups |
 | `disable_retry` | no | When `true`, prevents build retries (default `false`) |
 | `allow_failure` | no | When `true`, a failed build is marked as `warning` instead of `failed`, unblocking downstream jobs (default `false`) |
+| `interruptible` | no | When `true`, creating a new build automatically cancels all older running, pending, and waiting-for-approval builds (default `false`) |
 | `for_each` | no | Generate job instances from a set or map |
 | `matrix` | no | Generate job instances from cartesian product (mutually exclusive with `for_each`) |
 | `get` | no | Step block — fetches a resource version |

--- a/pikoci/build/repository.go
+++ b/pikoci/build/repository.go
@@ -56,6 +56,10 @@ type Repository interface {
 	// It returns the number of builds that were updated.
 	FailStartedBuilds(ctx context.Context, reason string) (int, error)
 
+	// FindActiveBuilds returns all builds for the given job with status started, pending, or
+	// waiting_for_approval that have an ID less than beforeBuildID.
+	FindActiveBuilds(ctx context.Context, tc, pn, jn string, beforeBuildID uint32) ([]*Build, error)
+
 	// CreateApproval records an approve or reject vote for a build.
 	CreateApproval(ctx context.Context, buildID uint32, username, action, message string) error
 	// FindApprovals returns all approval/rejection votes for a build.

--- a/pikoci/builds.go
+++ b/pikoci/builds.go
@@ -65,6 +65,10 @@ func (q *PikoCI) CreateJobBuild(ctx context.Context, tc, pc, jn string, b build.
 		return nil, err
 	}
 
+	if jErr == nil && j.Interruptible {
+		q.cancelOlderBuilds(ctx, tc, pc, jn, b.ID)
+	}
+
 	if b.Status != build.WaitingForApproval {
 		q.Notifier.Notify()
 	} else if jErr == nil {
@@ -398,6 +402,10 @@ func (q *PikoCI) CreateRetryJobBuild(ctx context.Context, tc, pc, jn, parentBuil
 		return nil, err
 	}
 
+	if j.Interruptible {
+		q.cancelOlderBuilds(ctx, tc, pc, jn, b.ID)
+	}
+
 	return &b, nil
 }
 
@@ -475,6 +483,40 @@ func (q *PikoCI) FindOldestPendingBuild(ctx context.Context, tc, pn, jn string) 
 	}
 
 	return q.Builds.FindOldestPending(ctx, tc, pn, jn)
+}
+
+// cancelOlderBuilds cancels all running, pending, and waiting-for-approval builds
+// for the given job that are older than newBuildID. This implements the interruptible
+// job behavior: only the newest build should run.
+func (q *PikoCI) cancelOlderBuilds(ctx context.Context, tc, pc, jn string, newBuildID uint32) {
+	older, err := q.Builds.FindActiveBuilds(ctx, tc, pc, jn, newBuildID)
+	if err != nil {
+		q.logger.Error("failed to find active builds for interruptible cancellation",
+			"pipeline", pc, "job", jn, "error", err)
+		return
+	}
+	for _, ob := range older {
+		wasRunning := ob.Status == build.Started
+		ob.Status = build.Cancelled
+		ob.Error = "superseded by newer build"
+		if wasRunning {
+			ob.Duration = time.Since(ob.StartedAt)
+		}
+		if err := q.Builds.Update(ctx, tc, pc, jn, ob.BuildNumber, *ob); err != nil {
+			q.logger.Error("failed to cancel older build",
+				"pipeline", pc, "job", jn, "build_number", ob.BuildNumber, "error", err)
+			continue
+		}
+		if wasRunning && q.GRPCServer != nil {
+			buildID := fmt.Sprintf("%d", ob.ID)
+			if err := q.GRPCServer.CancelBuild(buildID, "superseded by newer build"); err != nil {
+				q.logger.Debug("gRPC cancel routing failed for interruptible build",
+					"build_id", buildID, "error", err)
+			}
+		}
+		q.logger.Info("cancelled older build (interruptible)",
+			"pipeline", pc, "job", jn, "build_number", ob.BuildNumber)
+	}
 }
 
 // notifyNextPendingBuild finds the oldest pending build for the job and sends a
@@ -674,6 +716,7 @@ func (q *PikoCI) evaluateJobDownstream(ctx context.Context, tc, pn, completedJob
 	// Note: waiting_for_approval builds are allowed to pile up — each
 	// resource version gets its own approval gate.
 	var triggered bool
+	var createdBuildID uint32
 	var createdBuildNumber string
 	err := q.StartUoW(ctx, func(uow unitwork.UnitOfWork) error {
 		pending, err := uow.Builds().FindOldestPending(ctx, tc, pn, j.Name)
@@ -712,11 +755,15 @@ func (q *PikoCI) evaluateJobDownstream(ctx context.Context, tc, pn, completedJob
 			"completed_job", completedJobName)
 
 		triggered = true
+		createdBuildID = id
 		createdBuildNumber = buildNumber
 		return nil
 	})
 	if err != nil {
 		return err
+	}
+	if triggered && j.Interruptible {
+		q.cancelOlderBuilds(ctx, tc, pn, j.Name, createdBuildID)
 	}
 	if triggered && j.ApproveLabel == "" {
 		q.Notifier.Notify()

--- a/pikoci/builds_test.go
+++ b/pikoci/builds_test.go
@@ -1261,3 +1261,157 @@ func TestMarkBuildAsWarning_InvalidCanonical(t *testing.T) {
 	err := s.S.MarkBuildAsWarning(ctx, "INVALID", "my-pipeline", "my-job", "1")
 	require.Error(t, err)
 }
+
+func TestCreateJobBuild_Interruptible_CancelsOlderRunning(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "my-job").
+		Return(&job.Job{Name: "my-job", Interruptible: true}, nil)
+	s.Builds.EXPECT().Create(ctx, "main", "my-pipeline", "my-job", gomock.Any()).
+		Return(uint32(5), "5", nil)
+	// FindActiveBuilds returns an older running build
+	s.Builds.EXPECT().FindActiveBuilds(ctx, "main", "my-pipeline", "my-job", uint32(5)).
+		Return([]*build.Build{
+			{ID: 3, BuildNumber: "3", Status: build.Started},
+		}, nil)
+	// The older build should be cancelled
+	s.Builds.EXPECT().Update(ctx, "main", "my-pipeline", "my-job", "3", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, b build.Build) error {
+			assert.Equal(t, build.Cancelled, b.Status)
+			assert.Equal(t, "superseded by newer build", b.Error)
+			return nil
+		})
+
+	b, err := s.S.CreateJobBuild(ctx, "main", "my-pipeline", "my-job", build.Build{})
+	require.NoError(t, err)
+	assert.Equal(t, uint32(5), b.ID)
+}
+
+func TestCreateJobBuild_Interruptible_CancelsPending(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "my-job").
+		Return(&job.Job{Name: "my-job", Interruptible: true}, nil)
+	s.Builds.EXPECT().Create(ctx, "main", "my-pipeline", "my-job", gomock.Any()).
+		Return(uint32(5), "5", nil)
+	s.Builds.EXPECT().FindActiveBuilds(ctx, "main", "my-pipeline", "my-job", uint32(5)).
+		Return([]*build.Build{
+			{ID: 2, BuildNumber: "2", Status: build.Pending},
+		}, nil)
+	s.Builds.EXPECT().Update(ctx, "main", "my-pipeline", "my-job", "2", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, b build.Build) error {
+			assert.Equal(t, build.Cancelled, b.Status)
+			assert.Equal(t, "superseded by newer build", b.Error)
+			return nil
+		})
+
+	b, err := s.S.CreateJobBuild(ctx, "main", "my-pipeline", "my-job", build.Build{})
+	require.NoError(t, err)
+	assert.Equal(t, uint32(5), b.ID)
+}
+
+func TestCreateJobBuild_NotInterruptible_KeepsOlderBuilds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	// Job is NOT interruptible
+	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "my-job").
+		Return(&job.Job{Name: "my-job", Interruptible: false}, nil)
+	s.Builds.EXPECT().Create(ctx, "main", "my-pipeline", "my-job", gomock.Any()).
+		Return(uint32(5), "5", nil)
+	// FindActiveBuilds should NOT be called
+
+	b, err := s.S.CreateJobBuild(ctx, "main", "my-pipeline", "my-job", build.Build{})
+	require.NoError(t, err)
+	assert.Equal(t, uint32(5), b.ID)
+}
+
+func TestCreateRetryJobBuild_Interruptible_CancelsOlder(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Jobs.EXPECT().Find(ctx, "main", "my-pipeline", "my-job").
+		Return(&job.Job{Name: "my-job", Interruptible: true}, nil)
+	s.Builds.EXPECT().CreateRetry(ctx, "main", "my-pipeline", "my-job", "3", gomock.Any()).
+		Return(uint32(10), "3.1", nil)
+	// FindActiveBuilds returns an older pending build
+	s.Builds.EXPECT().FindActiveBuilds(ctx, "main", "my-pipeline", "my-job", uint32(10)).
+		Return([]*build.Build{
+			{ID: 4, BuildNumber: "4", Status: build.Pending},
+		}, nil)
+	s.Builds.EXPECT().Update(ctx, "main", "my-pipeline", "my-job", "4", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, b build.Build) error {
+			assert.Equal(t, build.Cancelled, b.Status)
+			return nil
+		})
+
+	b, err := s.S.CreateRetryJobBuild(ctx, "main", "my-pipeline", "my-job", "3", build.Build{})
+	require.NoError(t, err)
+	assert.Equal(t, uint32(10), b.ID)
+	assert.Equal(t, "3.1", b.BuildNumber)
+}
+
+func TestEvaluateDownstreamJobs_Interruptible_CancelsOlderBuilds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	pp := &pipeline.Pipeline{
+		Name: "my-pipeline",
+		Jobs: []job.Job{
+			{Name: "lint"},
+			{
+				Name:          "deploy",
+				Interruptible: true,
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeGet,
+						Get: &job.GetStep{
+							Type:    "git",
+							Name:    "repo",
+							Passed:  []string{"lint"},
+							Trigger: true,
+						},
+					},
+				},
+			},
+		},
+	}
+	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
+
+	s.Builds.EXPECT().FindReadyDownstreamVersion(
+		ctx, "main", "my-pipeline",
+		[]string{"lint"}, "deploy", "repo", 1, (*uint32)(nil),
+	).Return(uint32(42), true, nil)
+
+	s.Resources.EXPECT().Find(ctx, "main", "my-pipeline", "git.repo").
+		Return(&resource.Resource{Type: "git", Name: "repo"}, nil)
+
+	s.Builds.EXPECT().FindOldestPending(ctx, "main", "my-pipeline", "deploy").
+		Return(nil, nil)
+
+	s.Builds.EXPECT().Create(ctx, "main", "my-pipeline", "deploy", gomock.Any()).
+		Return(uint32(10), "2", nil)
+	s.Builds.EXPECT().InsertGetVersion(ctx, "main", "my-pipeline", "deploy", uint32(10), "repo", uint32(42)).Return(nil)
+
+	// Interruptible: should cancel older running build
+	s.Builds.EXPECT().FindActiveBuilds(ctx, "main", "my-pipeline", "deploy", uint32(10)).
+		Return([]*build.Build{
+			{ID: 5, BuildNumber: "1", Status: build.Started},
+		}, nil)
+	s.Builds.EXPECT().Update(ctx, "main", "my-pipeline", "deploy", "1", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, b build.Build) error {
+			assert.Equal(t, build.Cancelled, b.Status)
+			assert.Equal(t, "superseded by newer build", b.Error)
+			return nil
+		})
+
+	err := s.S.EvaluateDownstreamJobs(ctx, "main", "my-pipeline", "lint")
+	require.NoError(t, err)
+}

--- a/pikoci/helper.go
+++ b/pikoci/helper.go
@@ -88,7 +88,8 @@ type hclJob struct {
 	SerialGroups []string         `hcl:"serial_groups,optional"`
 	Timeout      string           `hcl:"timeout,optional"`
 	DisableRetry bool             `hcl:"disable_retry,optional"`
-	AllowFailure bool             `hcl:"allow_failure,optional"`
+	AllowFailure  bool             `hcl:"allow_failure,optional"`
+	Interruptible bool             `hcl:"interruptible,optional"`
 	Get          []hclGetStep     `hcl:"get,block"`
 	Task         []hclTaskStep    `hcl:"task,block"`
 	Put          []hclPutStep     `hcl:"put,block"`
@@ -664,7 +665,7 @@ var (
 	taskStepKnownAttrs = []string{"timeout", "attempts", "inputs", "outputs"}
 	putStepKnownAttrs  = []string{"timeout", "attempts"}
 	notifyStepKnownAttrs = []string{"message"}
-	jobKnownAttrs          = []string{"concurrency", "serial_groups", "timeout", "disable_retry", "allow_failure"}
+	jobKnownAttrs          = []string{"concurrency", "serial_groups", "timeout", "disable_retry", "allow_failure", "interruptible"}
 	inParallelKnownAttrs   = []string{"limit", "fail_fast"}
 	inParallelBlocks       = map[string]bool{
 		"get": true, "task": true, "put": true, "notify": true,
@@ -1453,7 +1454,8 @@ func ReadPipeline(ctx context.Context, rpp []byte, vars map[string]interface{}) 
 			SerialGroups: hj.SerialGroups,
 			Timeout:      jobTimeout,
 			DisableRetry: hj.DisableRetry,
-			AllowFailure: hj.AllowFailure,
+			AllowFailure:  hj.AllowFailure,
+			Interruptible: hj.Interruptible,
 			Plan:         jobPlans[hj.Name],
 			OnSuccess:    jh.OnSuccess,
 			OnFailure:    jh.OnFailure,

--- a/pikoci/job/job.go
+++ b/pikoci/job/job.go
@@ -49,7 +49,8 @@ type Job struct {
 	Tags         []string      `json:"tags,omitempty"`
 	Paused       bool          `json:"paused"`
 	DisableRetry bool          `json:"disable_retry,omitempty"`
-	AllowFailure bool          `json:"allow_failure,omitempty"`
+	AllowFailure    bool          `json:"allow_failure,omitempty"`
+	Interruptible   bool          `json:"interruptible,omitempty"`
 	Timeout      time.Duration `json:"timeout,omitempty"`
 	Plan         []PlanStep    `json:"plan"`
 

--- a/pikoci/mock/build_repository.go
+++ b/pikoci/mock/build_repository.go
@@ -237,6 +237,21 @@ func (mr *BuildRepositoryMockRecorder) Find(ctx, tc, pn, jn, buildNumber any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Find", reflect.TypeOf((*BuildRepository)(nil).Find), ctx, tc, pn, jn, buildNumber)
 }
 
+// FindActiveBuilds mocks base method.
+func (m *BuildRepository) FindActiveBuilds(ctx context.Context, tc, pn, jn string, beforeBuildID uint32) ([]*build.Build, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindActiveBuilds", ctx, tc, pn, jn, beforeBuildID)
+	ret0, _ := ret[0].([]*build.Build)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindActiveBuilds indicates an expected call of FindActiveBuilds.
+func (mr *BuildRepositoryMockRecorder) FindActiveBuilds(ctx, tc, pn, jn, beforeBuildID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindActiveBuilds", reflect.TypeOf((*BuildRepository)(nil).FindActiveBuilds), ctx, tc, pn, jn, beforeBuildID)
+}
+
 // FindApprovals mocks base method.
 func (m *BuildRepository) FindApprovals(ctx context.Context, buildID uint32) ([]build.Approval, error) {
 	m.ctrl.T.Helper()

--- a/pikoci/mysql/build.go
+++ b/pikoci/mysql/build.go
@@ -851,6 +851,30 @@ func scanBuilds(rows *sql.Rows) ([]*build.Build, error) {
 	return bs, nil
 }
 
+func (r *BuildRepository) FindActiveBuilds(ctx context.Context, tc, pn, jn string, beforeBuildID uint32) ([]*build.Build, error) {
+	rows, err := r.querier.QueryContext(ctx, `
+		SELECT b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical, b.retry_source_build_id
+		FROM builds AS b
+		JOIN jobs AS j ON b.job_id = j.id
+		JOIN pipelines AS p ON j.pipeline_id = p.id
+		JOIN teams AS t ON p.team_id = t.id
+		WHERE t.canonical = ? AND p.canonical = ? AND j.name = ?
+		  AND b.id < ?
+		  AND b.status IN ('started', 'pending', 'waiting_for_approval')
+		ORDER BY b.id ASC
+	`, tc, pn, jn, beforeBuildID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find active builds: %w", err)
+	}
+	defer rows.Close()
+
+	builds, err := scanBuilds(rows)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan active builds: %w", err)
+	}
+	return builds, nil
+}
+
 func (r *BuildRepository) CreateApproval(ctx context.Context, buildID uint32, username, action, message string) error {
 	_, err := r.querier.ExecContext(ctx, `
 		INSERT INTO build_approvals (build_id, username, action, message)

--- a/pikoci/mysql/job.go
+++ b/pikoci/mysql/job.go
@@ -42,6 +42,7 @@ type dbJob struct {
 	ApproveCount      sql.NullInt64
 	DisableRetry      sql.NullBool
 	AllowFailure      sql.NullBool
+	Interruptible     sql.NullBool
 }
 
 func newDBJob(p job.Job) dbJob {
@@ -70,6 +71,7 @@ func newDBJob(p job.Job) dbJob {
 	dbj.ApproveCount = sql.NullInt64{Int64: int64(p.ApproveCount), Valid: true}
 	dbj.DisableRetry = sql.NullBool{Bool: p.DisableRetry, Valid: true}
 	dbj.AllowFailure = sql.NullBool{Bool: p.AllowFailure, Valid: true}
+	dbj.Interruptible = sql.NullBool{Bool: p.Interruptible, Valid: true}
 	return dbj
 }
 
@@ -105,6 +107,9 @@ func (dbp *dbJob) toDomainEntity() *job.Job {
 	if dbp.AllowFailure.Valid {
 		j.AllowFailure = dbp.AllowFailure.Bool
 	}
+	if dbp.Interruptible.Valid {
+		j.Interruptible = dbp.Interruptible.Bool
+	}
 
 	_ = json.Unmarshal([]byte(dbp.Plan.String), &j.Plan)
 	_ = json.Unmarshal([]byte(dbp.OnSuccess.String), &j.OnSuccess)
@@ -118,7 +123,7 @@ func (dbp *dbJob) toDomainEntity() *job.Job {
 func (r *JobRepository) Create(ctx context.Context, tc, pn string, j job.Job) (uint32, error) {
 	dbj := newDBJob(j)
 	res, err := r.querier.ExecContext(ctx, `
-		INSERT INTO jobs(name, tags, plan, on_success, on_failure, on_cancel, ensure, concurrency, paused, timeout, for_each_group, for_each_key, pipeline_id, baseline_version_id, approve_label, approve_timeout, approve_count, disable_retry, allow_failure)
+		INSERT INTO jobs(name, tags, plan, on_success, on_failure, on_cancel, ensure, concurrency, paused, timeout, for_each_group, for_each_key, pipeline_id, baseline_version_id, approve_label, approve_timeout, approve_count, disable_retry, allow_failure, interruptible)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 			-- pipeline_id
 			(
@@ -129,7 +134,7 @@ func (r *JobRepository) Create(ctx context.Context, tc, pn string, j job.Job) (u
 				WHERE t.canonical = ? AND p.canonical = ?
 			),
 			-- baseline_version_id
-			(SELECT MAX(id) FROM resource_versions), ?, ?, ?, ?, ?)`, dbj.Name, dbj.Tags, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Paused, dbj.Timeout, dbj.ForEachGroup, dbj.ForEachKey, tc, pn, dbj.ApproveLabel, dbj.ApproveTimeout, dbj.ApproveCount, dbj.DisableRetry, dbj.AllowFailure)
+			(SELECT MAX(id) FROM resource_versions), ?, ?, ?, ?, ?, ?)`, dbj.Name, dbj.Tags, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Paused, dbj.Timeout, dbj.ForEachGroup, dbj.ForEachKey, tc, pn, dbj.ApproveLabel, dbj.ApproveTimeout, dbj.ApproveCount, dbj.DisableRetry, dbj.AllowFailure, dbj.Interruptible)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -150,7 +155,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 	dbj := newDBJob(j)
 	res, err := r.querier.ExecContext(ctx, `
 		UPDATE jobs AS j
-		SET name = ?, tags = ?, plan = ?, on_success = ?, on_failure = ?, on_cancel = ?, ensure = ?, concurrency = ?, timeout = ?, for_each_group = ?, for_each_key = ?, approve_label = ?, approve_timeout = ?, approve_count = ?, disable_retry = ?, allow_failure = ?
+		SET name = ?, tags = ?, plan = ?, on_success = ?, on_failure = ?, on_cancel = ?, ensure = ?, concurrency = ?, timeout = ?, for_each_group = ?, for_each_key = ?, approve_label = ?, approve_timeout = ?, approve_count = ?, disable_retry = ?, allow_failure = ?, interruptible = ?
 		FROM (
 			SELECT j.id
 			FROM jobs AS j
@@ -161,7 +166,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 			WHERE t.canonical = ? AND p.canonical = ? AND j.name = ?
 		) AS jj
 		WHERE jj.id = j.id
-	`, dbj.Name, dbj.Tags, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Timeout, dbj.ForEachGroup, dbj.ForEachKey, dbj.ApproveLabel, dbj.ApproveTimeout, dbj.ApproveCount, dbj.DisableRetry, dbj.AllowFailure, tc, pn, jn)
+	`, dbj.Name, dbj.Tags, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Timeout, dbj.ForEachGroup, dbj.ForEachKey, dbj.ApproveLabel, dbj.ApproveTimeout, dbj.ApproveCount, dbj.DisableRetry, dbj.AllowFailure, dbj.Interruptible, tc, pn, jn)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -192,7 +197,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 
 func (r *JobRepository) Find(ctx context.Context, tc, pn, jn string) (*job.Job, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry, j.allow_failure
+		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry, j.allow_failure, j.interruptible
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -217,7 +222,7 @@ func (r *JobRepository) Find(ctx context.Context, tc, pn, jn string) (*job.Job, 
 
 func (r *JobRepository) Filter(ctx context.Context, tc, pn string) ([]*job.Job, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry, j.allow_failure
+		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry, j.allow_failure, j.interruptible
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -367,6 +372,7 @@ func scanJob(s sqlr.Scanner) (*job.Job, error) {
 		&j.ApproveCount,
 		&j.DisableRetry,
 		&j.AllowFailure,
+		&j.Interruptible,
 	)
 
 	if err != nil {
@@ -459,7 +465,7 @@ func (r *JobRepository) loadSerialGroupsBatch(ctx context.Context, jobIDs []uint
 
 func (r *JobRepository) FilterByForEachGroup(ctx context.Context, tc, pn, group string) ([]*job.Job, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry, j.allow_failure
+		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry, j.allow_failure, j.interruptible
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -499,7 +505,7 @@ func (r *JobRepository) FindJobsBySerialGroups(ctx context.Context, tc, pn strin
 		args = append(args, sg)
 	}
 	query := fmt.Sprintf(`
-		SELECT DISTINCT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry, j.allow_failure
+		SELECT DISTINCT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry, j.allow_failure, j.interruptible
 		FROM jobs AS j
 		JOIN pipelines AS p ON j.pipeline_id = p.id
 		JOIN teams AS t ON p.team_id = t.id

--- a/pikoci/mysql/migrate/migrations/V50Interruptible.go
+++ b/pikoci/mysql/migrate/migrations/V50Interruptible.go
@@ -1,0 +1,6 @@
+package migrations
+
+var V50Interruptible = Migration{
+	Name: "Interruptible",
+	SQL:  `ALTER TABLE jobs ADD COLUMN interruptible BOOLEAN NOT NULL DEFAULT FALSE;`,
+}

--- a/pikoci/mysql/migrate/migrations/migrations.go
+++ b/pikoci/mysql/migrate/migrations/migrations.go
@@ -16,7 +16,7 @@ type Migration struct {
 // Migrations is the ordered list of all schema migrations. It is defined as
 // a fixed-size array so that the compiler catches ordering conflicts when
 // multiple developers add migrations concurrently.
-var Migrations = [50]Migration{
+var Migrations = [51]Migration{
 	V0Initial,
 	V1ResourceCheckInterval,
 	V2JobsAndBuilds,
@@ -67,4 +67,5 @@ var Migrations = [50]Migration{
 	V47TokenGen,
 	V48DisableRetry,
 	V49AllowFailure,
+	V50Interruptible,
 }

--- a/pikoci/mysql/pipeline.go
+++ b/pikoci/mysql/pipeline.go
@@ -181,7 +181,7 @@ func (r *PipelineRepository) FilterAll(ctx context.Context) ([]*pipeline.WithTea
 		SELECT
 			t.id, t.name, t.canonical,
 			p.id, p.name, p.canonical, p.raw, p.public,
-			j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.paused, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count,
+			j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.paused, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry, j.allow_failure, j.interruptible,
 			r.id, r.name, r.type, r.canonical, r.params, r.check_interval, r.logs, r.last_check, r.next_check, r.tags, r.pinned_version_id,
 			rt.id, rt.name, rt.`+"`check`"+`, rt.pull, rt.push, rt.params,
 			ru.id, ru.name, ru.run,
@@ -237,7 +237,7 @@ func scanPipelinesWithTeam(rows *sql.Rows) ([]*pipeline.WithTeam, error) {
 		err := rows.Scan(
 			&tt.ID, &tt.Name, &tt.Canonical,
 			&pp.ID, &pp.Name, &pp.Canonical, &pp.Raw, &pp.Public,
-			&j.ID, &j.Name, &j.Tags, &j.Plan, &j.OnSuccess, &j.OnFailure, &j.OnCancel, &j.Ensure, &j.Paused, &j.ForEachGroup, &j.ForEachKey, &j.BaselineVersionID, &j.ApproveLabel, &j.ApproveTimeout, &j.ApproveCount,
+			&j.ID, &j.Name, &j.Tags, &j.Plan, &j.OnSuccess, &j.OnFailure, &j.OnCancel, &j.Ensure, &j.Paused, &j.ForEachGroup, &j.ForEachKey, &j.BaselineVersionID, &j.ApproveLabel, &j.ApproveTimeout, &j.ApproveCount, &j.DisableRetry, &j.AllowFailure, &j.Interruptible,
 			&r.ID, &r.Name, &r.Type, &r.Canonical, &r.Params, &r.CheckInterval, &r.Logs, &r.LastCheck, &r.NextCheck, &r.Tags, &r.PinnedVersionID,
 			&rt.ID, &rt.Name, &rt.Check, &rt.Pull, &rt.Push, &rt.Params,
 			&ru.ID, &ru.Name, &ru.Run,
@@ -351,7 +351,7 @@ func (r *PipelineRepository) Delete(ctx context.Context, tc, pCan string) error 
 const pipelineQuery = `
 	SELECT
 		p.id, p.name, p.canonical, p.raw, p.public,
-		j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.paused, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count,
+		j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.paused, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry, j.allow_failure, j.interruptible,
 		r.id, r.name, r.type, r.canonical, r.params, r.check_interval, r.logs, r.last_check, r.next_check, r.webhook_token, r.tags, r.pinned_version_id,
 		rt.id, rt.name, rt.` + "`check`" + `, rt.pull, rt.push, rt.params,
 		ru.id, ru.name, ru.run,
@@ -395,7 +395,7 @@ func scanPipelines(rows *sql.Rows) ([]*pipeline.Pipeline, error) {
 
 		err := rows.Scan(
 			&pp.ID, &pp.Name, &pp.Canonical, &pp.Raw, &pp.Public,
-			&j.ID, &j.Name, &j.Tags, &j.Plan, &j.OnSuccess, &j.OnFailure, &j.OnCancel, &j.Ensure, &j.Paused, &j.ForEachGroup, &j.ForEachKey, &j.BaselineVersionID, &j.ApproveLabel, &j.ApproveTimeout, &j.ApproveCount,
+			&j.ID, &j.Name, &j.Tags, &j.Plan, &j.OnSuccess, &j.OnFailure, &j.OnCancel, &j.Ensure, &j.Paused, &j.ForEachGroup, &j.ForEachKey, &j.BaselineVersionID, &j.ApproveLabel, &j.ApproveTimeout, &j.ApproveCount, &j.DisableRetry, &j.AllowFailure, &j.Interruptible,
 			&r.ID, &r.Name, &r.Type, &r.Canonical, &r.Params, &r.CheckInterval, &r.Logs, &r.LastCheck, &r.NextCheck, &r.WebhookToken, &r.Tags, &r.PinnedVersionID,
 			&rt.ID, &rt.Name, &rt.Check, &rt.Pull, &rt.Push, &rt.Params,
 			&ru.ID, &ru.Name, &ru.Run,

--- a/pikoci/testdata/cron.hcl
+++ b/pikoci/testdata/cron.hcl
@@ -31,6 +31,20 @@ job "gen" {
   }
 }
 
+job "slow-build" {
+  interruptible = true
+  get "cron" "my_cron" {
+    trigger = true
+    passed  = ["gen"]
+  }
+  task "build" {
+    run "exec" {
+      path = "/bin/sh"
+      args = ["-ec", "echo 'building...' && sleep 30 && echo 'done'"]
+    }
+  }
+}
+
 job "deploy-staging" {
   disable_retry = true
   get "artifact" "cron_output" {


### PR DESCRIPTION
## Summary

- Add `interruptible` HCL attribute on jobs: when `true`, creating a new build automatically cancels all older running, pending, and waiting-for-approval builds so only the latest build runs ([#612](https://github.com/PikoCI/pikoci/issues/612))
- Works across manual triggers, retries, and downstream evaluation (auto-triggered builds)
- Includes DB migration V50, `FindActiveBuilds` repository method, gRPC cancel routing for in-flight builds, and unit tests

## Changes

- `pikoci/job/job.go`: Add `Interruptible` field to Job struct
- `pikoci/helper.go`: Parse `interruptible` HCL attribute
- `pikoci/builds.go`: `cancelOlderBuilds` helper called from `CreateJobBuild`, `CreateRetryJobBuild`, and `evaluateJobDownstream`
- `pikoci/build/repository.go`: `FindActiveBuilds` interface method
- `pikoci/mysql/build.go`: MySQL implementation of `FindActiveBuilds`
- `pikoci/mysql/job.go`: Persist and query `interruptible` column
- `pikoci/mysql/pipeline.go`: Include `interruptible` in pipeline scan queries
- `pikoci/mysql/migrate/migrations/V50Interruptible.go`: Add column migration
- `pikoci/mock/build_repository.go`: Mock for `FindActiveBuilds`
- `pikoci/builds_test.go`: 5 unit tests covering interruptible cancellation scenarios
- `pikoci/testdata/cron.hcl`: Test fixture with `interruptible = true` job
- `CHANGELOG.md`: Add entry under Unreleased
