### PR TITLE
feat: add parameterized manual triggers (#467)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Parameterized manual triggers**: Jobs can declare `input` blocks to collect parameters on manual trigger, injected as `$input_<name>` env vars. Supports typed fields, defaults, dropdowns, and multi-select ([#467](https://github.com/PikoCI/pikoci/issues/467)).
 - **`interruptible` on jobs**: When `true`, creating a new build for the job automatically cancels all older running, pending, and waiting-for-approval builds, so only the latest build runs ([#612](https://github.com/PikoCI/pikoci/issues/612)).
 - **`allow_failure` on jobs**: When `true`, a failed build is marked as `warning` (salmon) instead of `failed`, unblocking downstream jobs. Any failed build can also be manually marked as warning via a UI button (requires Maintain role) ([#610](https://github.com/PikoCI/pikoci/issues/610)).
 - **`disable_retry` on jobs**: Prevents build retries via API and hides the retry button in the UI ([#617](https://github.com/PikoCI/pikoci/issues/617)).

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/adrg/xdg"
 	"github.com/spf13/cobra"
@@ -471,13 +472,26 @@ var jobsTriggerCmd = &cobra.Command{
 		pn, _ := cmd.Flags().GetString("pipeline-name")
 		pn = utils.Canonicalize(pn)
 		jn, _ := cmd.Flags().GetString("job-name")
+		inputFlags, _ := cmd.Flags().GetStringSlice("input")
 
 		c, err := newClientWithConfig(url, jwt)
 		if err != nil {
 			return fmt.Errorf("failed to initialize client with url %q: %w", url, err)
 		}
 
-		err = c.TriggerPipelineJob(cmd.Context(), tc, pn, jn)
+		var inputValues map[string]string
+		if len(inputFlags) > 0 {
+			inputValues = make(map[string]string, len(inputFlags))
+			for _, f := range inputFlags {
+				parts := strings.SplitN(f, "=", 2)
+				if len(parts) != 2 {
+					return fmt.Errorf("invalid --input format %q, expected key=value", f)
+				}
+				inputValues[parts[0]] = parts[1]
+			}
+		}
+
+		err = c.TriggerPipelineJob(cmd.Context(), tc, pn, jn, inputValues, len(inputValues) > 0)
 		if err != nil {
 			return fmt.Errorf("failed to trigger Job %q from Pipeline %q: %w", jn, pn, err)
 		}
@@ -489,6 +503,7 @@ var jobsTriggerCmd = &cobra.Command{
 func init() {
 	jobsTriggerCmd.Flags().StringP("job-name", "n", "", "Name of the Job")
 	jobsTriggerCmd.MarkFlagRequired("job-name")
+	jobsTriggerCmd.Flags().StringSlice("input", nil, "Input values in key=value format (repeatable)")
 }
 
 func newClientWithConfig(url, jwt string) (*client.Client, error) {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -230,7 +230,7 @@ func runLocal(ctx context.Context, logger *slog.Logger, pipelineConfig, jobName 
 	}()
 
 	// Trigger the job
-	if err := svc.TriggerPipelineJob(ctx, mainTeamCanonical, "local", jobName); err != nil {
+	if err := svc.TriggerPipelineJob(ctx, mainTeamCanonical, "local", jobName, nil, false); err != nil {
 		return 0, fmt.Errorf("failed to trigger job %q: %w", jobName, err)
 	}
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -149,15 +149,17 @@ pikoci client -u localhost:8080 jobs get -tc main -pn my-pipeline -n my-job
 
 #### jobs trigger
 
-Manually trigger a job.
+Manually trigger a job. For jobs with `input` blocks, use `--input` to provide parameter values.
 
 ```bash
 pikoci client -u localhost:8080 jobs trigger -tc main -pn my-pipeline -n my-job
+pikoci client -u localhost:8080 jobs trigger -tc main -pn my-pipeline -n deploy --input version=v1.2.3 --input environment=staging
 ```
 
 | Flag | Alias | Required | Description |
 |------|-------|----------|-------------|
 | `--job-name` | `-n`, `-jn` | **yes** | Job name |
+| `--input` | | no | Input values in `key=value` format (repeatable) |
 
 ### users
 

--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -282,10 +282,60 @@ The optional `timeout` attribute limits the total wall-clock time for a build's 
 | `notify` | no | Step block: sends a fire-and-forget notification |
 | `service` | no | Step block: references a service type for the job |
 | `in_parallel` | no | Step block: runs multiple steps concurrently |
+| `input` | no | Parameterized input block (see below) |
 | `on_success` | no | Hook: runs after all steps succeed |
 | `on_failure` | no | Hook: runs after a step fails |
 | `on_cancel` | no | Hook: runs when the build is cancelled |
 | `ensure` | no | Hook: always runs regardless of outcome |
+
+#### input
+
+Jobs can declare `input` blocks to accept parameters when manually triggered. Each input becomes an environment variable `$input_<name>` available to all steps.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | yes | Label on the block |
+| `type` | yes | `string`, `number`, or `bool` |
+| `description` | no | Helper text shown below the field in the UI |
+| `default` | no | Pre-filled value. If omitted, the field is required on manual trigger |
+| `options` | no | List of allowed values (only with `type = string`). Renders as dropdown |
+| `multiple` | no | Allow selecting multiple options (only with `options`). Values are comma-separated |
+
+**Trigger behavior:**
+- **Manual trigger (UI/CLI):** A form is shown with one field per input. Required fields (no default) must be filled.
+- **Automatic trigger:** Defaults are used. If no default exists, zero values are used (`""`, `"0"`, `"false"`). Auto-triggers are never blocked by missing inputs.
+- **Local execution (`pikoci run`):** Pass input values via `--var input_<name>=value`.
+- **Retry:** Input values from the original build are automatically copied to the retry.
+
+```hcl
+job "deploy" {
+  input "version" {
+    type        = "string"
+    description = "Version to deploy"
+    default     = "latest"
+  }
+
+  input "environment" {
+    type    = "string"
+    options = ["staging", "production"]
+    default = "staging"
+  }
+
+  input "dry_run" {
+    type    = "bool"
+    default = "false"
+  }
+
+  task "deploy" {
+    run "exec" {
+      path = "./deploy.sh"
+      args = ["$input_version", "$input_environment"]
+    }
+  }
+}
+```
+
+A maximum of 20 inputs per job is allowed.
 
 #### approve
 

--- a/integration/backends/grpc_worker_test.go
+++ b/integration/backends/grpc_worker_test.go
@@ -172,7 +172,7 @@ job "grpc-test" {
 	require.NoError(t, err)
 
 	// Trigger the job (creates a pending build + notifies workers)
-	err = svc.TriggerPipelineJob(ctx, "main", "grpc-test", "grpc-test")
+	err = svc.TriggerPipelineJob(ctx, "main", "grpc-test", "grpc-test", nil, false)
 	require.NoError(t, err)
 
 	// --- Wait for build to complete ---
@@ -445,7 +445,7 @@ job "drain-test" {
 		Version: map[string]interface{}{"date": "v2"},
 	})
 	require.NoError(t, err)
-	err = svc.TriggerPipelineJob(ctx, "main", "drain-test", "drain-test")
+	err = svc.TriggerPipelineJob(ctx, "main", "drain-test", "drain-test", nil, false)
 	require.NoError(t, err)
 
 	// Wait until the build is started

--- a/integration/backends/tags_test.go
+++ b/integration/backends/tags_test.go
@@ -104,7 +104,7 @@ job "gpu-job" {
 	go func() { defer wg.Done(); untaggedWorker.Run(ctx) }()
 
 	// Directly trigger the job to create a pending build
-	err = svc.TriggerPipelineJob(ctx, "main", "tags-test", "gpu-job")
+	err = svc.TriggerPipelineJob(ctx, "main", "tags-test", "gpu-job", nil, false)
 	require.NoError(t, err)
 
 	// Wait a bit — the build should stay pending because no matching worker
@@ -190,9 +190,9 @@ job "gpu-job" {
 	go func() { defer wg.Done(); exclWorker.Run(ctx) }()
 
 	// Directly trigger both jobs to create pending builds
-	err = svc.TriggerPipelineJob(ctx, "main", "excl-test", "gpu-job")
+	err = svc.TriggerPipelineJob(ctx, "main", "excl-test", "gpu-job", nil, false)
 	require.NoError(t, err)
-	err = svc.TriggerPipelineJob(ctx, "main", "excl-test", "untagged-job")
+	err = svc.TriggerPipelineJob(ctx, "main", "excl-test", "untagged-job", nil, false)
 	require.NoError(t, err)
 
 	// Wait for the gpu-job to complete

--- a/integration/backends/team_isolation_test.go
+++ b/integration/backends/team_isolation_test.go
@@ -415,9 +415,9 @@ job "test-job" {
 	require.False(t, streamMgr.HasTeamWorkers("beta"), "beta should not have team workers")
 
 	// --- Trigger builds on both teams ---
-	err = svc.TriggerPipelineJob(ctx, "alpha", "alpha-pipe", "test-job")
+	err = svc.TriggerPipelineJob(ctx, "alpha", "alpha-pipe", "test-job", nil, false)
 	require.NoError(t, err)
-	err = svc.TriggerPipelineJob(ctx, "beta", "beta-pipe", "test-job")
+	err = svc.TriggerPipelineJob(ctx, "beta", "beta-pipe", "test-job", nil, false)
 	require.NoError(t, err)
 
 	// --- Wait for both builds to complete ---
@@ -456,7 +456,7 @@ job "test-job" {
 	}, 5*time.Second, 50*time.Millisecond, "global worker should disconnect")
 
 	// Trigger a new build on beta
-	err = svc.TriggerPipelineJob(ctx, "beta", "beta-pipe", "test-job")
+	err = svc.TriggerPipelineJob(ctx, "beta", "beta-pipe", "test-job", nil, false)
 	require.NoError(t, err)
 
 	// Wait a bit and verify the beta build stays pending — the alpha
@@ -475,7 +475,7 @@ job "test-job" {
 	// Phase 3: Trigger an alpha build → team worker should still pick it up
 	// ===================================================================
 
-	err = svc.TriggerPipelineJob(ctx, "alpha", "alpha-pipe", "test-job")
+	err = svc.TriggerPipelineJob(ctx, "alpha", "alpha-pipe", "test-job", nil, false)
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {

--- a/pikoci/build/build.go
+++ b/pikoci/build/build.go
@@ -67,7 +67,8 @@ type Build struct {
 	// the exact versions are tracked and displayed.
 	PinnedVersions map[string]map[string]interface{} `json:"pinned_versions,omitempty"`
 
-	RetrySourceBuildID uint32 `json:"retry_source_build_id,omitempty"`
+	InputValues        map[string]string `json:"input_values,omitempty"`
+	RetrySourceBuildID uint32            `json:"retry_source_build_id,omitempty"`
 
 	// Approvals contains the approval/rejection votes for this build.
 	// Only populated for builds with WaitingForApproval status.
@@ -107,6 +108,7 @@ type BuildReportData struct {
 	ResourceCanonical string                            `json:"resource_canonical"`
 	VersionMetadata   map[string]interface{}            `json:"version_metadata"`
 	PinnedVersions    map[string]map[string]interface{} `json:"pinned_versions"`
+	InputValues       map[string]string                 `json:"input_values,omitempty"`
 	RetryOf           string                            `json:"retry_of"`
 }
 

--- a/pikoci/builds.go
+++ b/pikoci/builds.go
@@ -192,6 +192,7 @@ func (q *PikoCI) GetBuildReport(ctx context.Context, tc, pc, jn, buildNumber str
 			ResourceCanonical: b.ResourceCanonical,
 			VersionMetadata:   b.VersionMetadata,
 			PinnedVersions:    b.PinnedVersions,
+			InputValues:       b.InputValues,
 			RetryOf:           retryOf,
 		},
 		Approvals: b.Approvals,
@@ -353,8 +354,8 @@ func (q *PikoCI) RetryJobBuild(ctx context.Context, tc, pc, jn, buildNumber stri
 		return fmt.Errorf("failed to Find parent Build %q: %w", parentBN, err)
 	}
 
-	// Create a pending retry build first
-	_, err = q.CreateRetryJobBuild(ctx, tc, pc, jn, parentBN, build.Build{Status: build.Pending, RetrySourceBuildID: parentBuild.ID})
+	// Create a pending retry build first, copying input values from the original
+	_, err = q.CreateRetryJobBuild(ctx, tc, pc, jn, parentBN, build.Build{Status: build.Pending, RetrySourceBuildID: parentBuild.ID, InputValues: b.InputValues})
 	if err != nil {
 		return fmt.Errorf("failed to create pending retry build: %w", err)
 	}
@@ -731,9 +732,12 @@ func (q *PikoCI) evaluateJobDownstream(ctx context.Context, tc, pn, completedJob
 		if j.ApproveLabel != "" {
 			status = build.WaitingForApproval
 		}
+		// Resolve input defaults for auto-triggered builds.
+		inputVals, _ := resolveInputValues(j.Inputs, nil, false)
 		id, buildNumber, err := uow.Builds().Create(ctx, tc, pn, j.Name, build.Build{
-			Status:    status,
-			VersionID: versionID,
+			Status:      status,
+			VersionID:   versionID,
+			InputValues: inputVals,
 		})
 		if err != nil {
 			return fmt.Errorf("create pending build: %w", err)

--- a/pikoci/builds_test.go
+++ b/pikoci/builds_test.go
@@ -191,6 +191,28 @@ func TestRetryJobBuild_RetryOfRetry(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestRetryJobBuild_CopiesInputValues(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	inputVals := map[string]string{"version": "v1.0", "env": "staging"}
+
+	s.Jobs.EXPECT().Find(ctx, "main", "pp", "jn").Return(&job.Job{Name: "jn"}, nil).Times(2)
+	s.Builds.EXPECT().Find(ctx, "main", "pp", "jn", "1").
+		Return(&build.Build{ID: 5, BuildNumber: "1", Status: build.Failed, InputValues: inputVals}, nil).Times(2)
+	s.Builds.EXPECT().CreateRetry(ctx, "main", "pp", "jn", "1", gomock.Any()).
+		DoAndReturn(func(ctx context.Context, tc, pc, jn, pbn string, b build.Build) (uint32, string, error) {
+			require.NotNil(t, b.InputValues)
+			assert.Equal(t, "v1.0", b.InputValues["version"])
+			assert.Equal(t, "staging", b.InputValues["env"])
+			return uint32(10), "1.1", nil
+		})
+
+	err := s.S.RetryJobBuild(ctx, "main", "pp", "jn", "1")
+	require.NoError(t, err)
+}
+
 func TestRetryJobBuild_RunningBuildFails(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := newService(ctrl)
@@ -832,6 +854,58 @@ func TestEvaluateDownstreamJobs_TriggersWhenReady(t *testing.T) {
 	s.Builds.EXPECT().Create(ctx, "main", "my-pipeline", "deploy", gomock.Any()).
 		Return(uint32(10), "1", nil)
 	// Versions are pinned at creation time for all builds
+	s.Builds.EXPECT().InsertGetVersion(ctx, "main", "my-pipeline", "deploy", uint32(10), "repo", uint32(42)).Return(nil)
+
+	err := s.S.EvaluateDownstreamJobs(ctx, "main", "my-pipeline", "lint")
+	require.NoError(t, err)
+}
+
+func TestEvaluateDownstreamJobs_FillsInputDefaults(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	defVal := "staging"
+	pp := &pipeline.Pipeline{
+		Name: "my-pipeline",
+		Jobs: []job.Job{
+			{Name: "lint"},
+			{
+				Name: "deploy",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeGet,
+						Get: &job.GetStep{
+							Type: "git", Name: "repo",
+							Passed: []string{"lint"}, Trigger: true,
+						},
+					},
+				},
+				Inputs: []job.Input{
+					{Name: "env", Type: "string", Default: &defVal},
+					{Name: "count", Type: "number"}, // no default → zero value "0"
+				},
+			},
+		},
+	}
+	s.Pipelines.EXPECT().Find(ctx, "main", "my-pipeline").Return(pp, nil)
+
+	s.Builds.EXPECT().FindReadyDownstreamVersion(
+		ctx, "main", "my-pipeline",
+		[]string{"lint"}, "deploy", "repo", 1, (*uint32)(nil),
+	).Return(uint32(42), true, nil)
+	s.Resources.EXPECT().Find(ctx, "main", "my-pipeline", "git.repo").
+		Return(&resource.Resource{Type: "git", Name: "repo"}, nil)
+	s.Builds.EXPECT().FindOldestPending(ctx, "main", "my-pipeline", "deploy").
+		Return(nil, nil)
+
+	s.Builds.EXPECT().Create(ctx, "main", "my-pipeline", "deploy", gomock.Any()).
+		DoAndReturn(func(ctx context.Context, tc, pn, jn string, b build.Build) (uint32, string, error) {
+			require.NotNil(t, b.InputValues)
+			assert.Equal(t, "staging", b.InputValues["env"])
+			assert.Equal(t, "0", b.InputValues["count"])
+			return uint32(10), "1", nil
+		})
 	s.Builds.EXPECT().InsertGetVersion(ctx, "main", "my-pipeline", "deploy", uint32(10), "repo", uint32(42)).Return(nil)
 
 	err := s.S.EvaluateDownstreamJobs(ctx, "main", "my-pipeline", "lint")

--- a/pikoci/helper.go
+++ b/pikoci/helper.go
@@ -73,6 +73,16 @@ type hclPutStep struct {
 	Remain hcl.Body `hcl:",remain"`
 }
 
+// hclInput is the intermediate HCL-decoded input block inside a job.
+type hclInput struct {
+	Name        string   `hcl:"name,label"`
+	Type        string   `hcl:"type"`
+	Description string   `hcl:"description,optional"`
+	Default     *string  `hcl:"default,optional"`
+	Options     []string `hcl:"options,optional"`
+	Multiple    bool     `hcl:"multiple,optional"`
+}
+
 // hclApproveBlock is the intermediate HCL-decoded approve block inside a job.
 type hclApproveBlock struct {
 	Label     string          `hcl:"label,label"`
@@ -97,6 +107,7 @@ type hclJob struct {
 	Service      []hclServiceRef      `hcl:"service,block"`
 	InParallel   []hclInParallelBlock `hcl:"in_parallel,block"`
 	Approve      []hclApproveBlock    `hcl:"approve,block"`
+	Input        []hclInput           `hcl:"input,block"`
 
 	Remain hcl.Body `hcl:",remain"` // absorbs hook blocks; parsed by parseHooks from AST
 }
@@ -645,7 +656,7 @@ var (
 	}
 	jobBlocks = map[string]bool{
 		"get": true, "task": true, "put": true, "notify": true, "service": true,
-		"in_parallel": true, "approve": true,
+		"in_parallel": true, "approve": true, "input": true,
 		"on_success": true, "on_failure": true, "on_cancel": true, "ensure": true,
 		"matrix": true,
 	}
@@ -1480,6 +1491,53 @@ func ReadPipeline(ctx context.Context, rpp []byte, vars map[string]interface{}) 
 		if meta, ok := forEachMetas[hj.Name]; ok {
 			j.ForEachGroup = meta.baseName
 			j.ForEachKey = meta.key
+		}
+		if len(hj.Input) > 0 {
+			if len(hj.Input) > 20 {
+				return nil, fmt.Errorf("job %q: too many inputs (max 20, got %d)", hj.Name, len(hj.Input))
+			}
+			envNames := make(map[string]bool)
+			inputNames := make(map[string]bool)
+			for _, inp := range hj.Input {
+				if inputNames[inp.Name] {
+					return nil, fmt.Errorf("job %q: duplicate input name %q", hj.Name, inp.Name)
+				}
+				inputNames[inp.Name] = true
+				envName := strings.ToLower(inp.Name)
+				if envNames[envName] {
+					return nil, fmt.Errorf("job %q: input %q produces duplicate env var name input_%s", hj.Name, inp.Name, envName)
+				}
+				envNames[envName] = true
+				if inp.Type != "string" && inp.Type != "number" && inp.Type != "bool" {
+					return nil, fmt.Errorf("job %q: input %q has invalid type %q (must be string, number, or bool)", hj.Name, inp.Name, inp.Type)
+				}
+				if len(inp.Options) > 0 && inp.Type != "string" {
+					return nil, fmt.Errorf("job %q: input %q: options can only be used with type string", hj.Name, inp.Name)
+				}
+				if inp.Multiple && len(inp.Options) == 0 {
+					return nil, fmt.Errorf("job %q: input %q: multiple can only be used with options", hj.Name, inp.Name)
+				}
+				if inp.Default != nil && len(inp.Options) > 0 && !inp.Multiple {
+					found := false
+					for _, o := range inp.Options {
+						if o == *inp.Default {
+							found = true
+							break
+						}
+					}
+					if !found {
+						return nil, fmt.Errorf("job %q: input %q: default value %q is not in options list", hj.Name, inp.Name, *inp.Default)
+					}
+				}
+				j.Inputs = append(j.Inputs, job.Input{
+					Name:        inp.Name,
+					Type:        inp.Type,
+					Description: inp.Description,
+					Default:     inp.Default,
+					Options:     inp.Options,
+					Multiple:    inp.Multiple,
+				})
+			}
 		}
 		pp.Jobs = append(pp.Jobs, j)
 	}

--- a/pikoci/helper_inputs_test.go
+++ b/pikoci/helper_inputs_test.go
@@ -1,0 +1,155 @@
+package pikoci
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadPipeline_InputBlocks(t *testing.T) {
+	hcl := []byte(`
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+
+job "deploy" {
+  input "version" {
+    type        = "string"
+    description = "Version to deploy"
+    default     = "latest"
+  }
+
+  input "environment" {
+    type    = "string"
+    options = ["staging", "production"]
+    default = "staging"
+  }
+
+  input "dry_run" {
+    type    = "bool"
+    default = "false"
+  }
+
+  input "regions" {
+    type     = "string"
+    options  = ["eu-west-1", "us-east-1"]
+    multiple = true
+  }
+
+  get "cron" "timer" { trigger = true }
+  task "deploy" {
+    run "exec" { path = "echo" }
+  }
+}
+`)
+	pp, err := ReadPipeline(context.Background(), hcl, nil)
+	require.NoError(t, err)
+	require.Len(t, pp.Jobs, 1)
+
+	j := pp.Jobs[0]
+	require.Len(t, j.Inputs, 4)
+
+	assert.Equal(t, "version", j.Inputs[0].Name)
+	assert.Equal(t, "string", j.Inputs[0].Type)
+	assert.Equal(t, "Version to deploy", j.Inputs[0].Description)
+	require.NotNil(t, j.Inputs[0].Default)
+	assert.Equal(t, "latest", *j.Inputs[0].Default)
+
+	assert.Equal(t, "environment", j.Inputs[1].Name)
+	assert.Equal(t, []string{"staging", "production"}, j.Inputs[1].Options)
+
+	assert.Equal(t, "dry_run", j.Inputs[2].Name)
+	assert.Equal(t, "bool", j.Inputs[2].Type)
+
+	assert.Equal(t, "regions", j.Inputs[3].Name)
+	assert.True(t, j.Inputs[3].Multiple)
+}
+
+func TestReadPipeline_InputValidation(t *testing.T) {
+	base := func(inputBlock string) []byte {
+		return []byte(`
+resource "cron" "timer" {
+  check_interval = "@every 1h"
+}
+job "test" {
+` + inputBlock + `
+  get "cron" "timer" {
+    trigger = true
+  }
+  task "t" {
+    run "exec" {
+      path = "echo"
+    }
+  }
+}
+`)
+	}
+
+	t.Run("invalid type", func(t *testing.T) {
+		_, err := ReadPipeline(context.Background(), base(`
+  input "x" {
+    type = "invalid"
+  }`), nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid type")
+	})
+
+	t.Run("options with non-string type", func(t *testing.T) {
+		_, err := ReadPipeline(context.Background(), base(`
+  input "x" {
+    type    = "number"
+    options = ["1", "2"]
+  }`), nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "options can only be used with type string")
+	})
+
+	t.Run("multiple without options", func(t *testing.T) {
+		_, err := ReadPipeline(context.Background(), base(`
+  input "x" {
+    type     = "string"
+    multiple = true
+  }`), nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "multiple can only be used with options")
+	})
+
+	t.Run("default not in options", func(t *testing.T) {
+		_, err := ReadPipeline(context.Background(), base(`
+  input "x" {
+    type    = "string"
+    options = ["a", "b"]
+    default = "c"
+  }`), nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "default value")
+	})
+
+	t.Run("duplicate input names", func(t *testing.T) {
+		_, err := ReadPipeline(context.Background(), base(`
+  input "x" {
+    type = "string"
+  }
+  input "x" {
+    type = "string"
+  }`), nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate input name")
+	})
+
+	t.Run("too many inputs", func(t *testing.T) {
+		var inputs string
+		for i := 0; i < 21; i++ {
+			inputs += fmt.Sprintf(`  input "x%d" {
+    type = "string"
+  }
+`, i)
+		}
+		_, err := ReadPipeline(context.Background(), base(inputs), nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "too many inputs")
+	})
+}

--- a/pikoci/inputs_test.go
+++ b/pikoci/inputs_test.go
@@ -1,0 +1,128 @@
+package pikoci
+
+import (
+	"testing"
+
+	"github.com/pikoci/pikoci/pikoci/job"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveInputValues(t *testing.T) {
+	str := func(s string) *string { return &s }
+
+	t.Run("no inputs returns nil", func(t *testing.T) {
+		result, err := resolveInputValues(nil, nil, true)
+		require.NoError(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("all provided", func(t *testing.T) {
+		inputs := []job.Input{
+			{Name: "version", Type: "string"},
+			{Name: "count", Type: "number"},
+			{Name: "dry_run", Type: "bool"},
+		}
+		provided := map[string]string{
+			"version": "v1.0",
+			"count":   "5",
+			"dry_run": "true",
+		}
+		result, err := resolveInputValues(inputs, provided, true)
+		require.NoError(t, err)
+		assert.Equal(t, "v1.0", result["version"])
+		assert.Equal(t, "5", result["count"])
+		assert.Equal(t, "true", result["dry_run"])
+	})
+
+	t.Run("defaults used when not provided", func(t *testing.T) {
+		inputs := []job.Input{
+			{Name: "env", Type: "string", Default: str("staging")},
+			{Name: "count", Type: "number", Default: str("1")},
+		}
+		result, err := resolveInputValues(inputs, nil, true)
+		require.NoError(t, err)
+		assert.Equal(t, "staging", result["env"])
+		assert.Equal(t, "1", result["count"])
+	})
+
+	t.Run("required missing on manual trigger", func(t *testing.T) {
+		inputs := []job.Input{
+			{Name: "version", Type: "string"},
+		}
+		_, err := resolveInputValues(inputs, nil, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "required input")
+	})
+
+	t.Run("auto trigger uses zero values", func(t *testing.T) {
+		inputs := []job.Input{
+			{Name: "version", Type: "string"},
+			{Name: "count", Type: "number"},
+			{Name: "dry_run", Type: "bool"},
+		}
+		result, err := resolveInputValues(inputs, nil, false)
+		require.NoError(t, err)
+		assert.Equal(t, "", result["version"])
+		assert.Equal(t, "0", result["count"])
+		assert.Equal(t, "false", result["dry_run"])
+	})
+
+	t.Run("unknown key rejected", func(t *testing.T) {
+		inputs := []job.Input{
+			{Name: "version", Type: "string"},
+		}
+		_, err := resolveInputValues(inputs, map[string]string{"unknown": "val"}, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown input")
+	})
+
+	t.Run("invalid number rejected", func(t *testing.T) {
+		inputs := []job.Input{
+			{Name: "count", Type: "number"},
+		}
+		_, err := resolveInputValues(inputs, map[string]string{"count": "abc"}, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a valid number")
+	})
+
+	t.Run("invalid bool rejected", func(t *testing.T) {
+		inputs := []job.Input{
+			{Name: "flag", Type: "bool"},
+		}
+		_, err := resolveInputValues(inputs, map[string]string{"flag": "yes"}, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be")
+	})
+
+	t.Run("options validated", func(t *testing.T) {
+		inputs := []job.Input{
+			{Name: "env", Type: "string", Options: []string{"staging", "production"}},
+		}
+		_, err := resolveInputValues(inputs, map[string]string{"env": "dev"}, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not in options")
+	})
+
+	t.Run("options valid selection", func(t *testing.T) {
+		inputs := []job.Input{
+			{Name: "env", Type: "string", Options: []string{"staging", "production"}, Default: str("staging")},
+		}
+		result, err := resolveInputValues(inputs, map[string]string{"env": "production"}, true)
+		require.NoError(t, err)
+		assert.Equal(t, "production", result["env"])
+	})
+
+	t.Run("multiple options validated", func(t *testing.T) {
+		inputs := []job.Input{
+			{Name: "regions", Type: "string", Options: []string{"us-east-1", "eu-west-1"}, Multiple: true},
+		}
+		result, err := resolveInputValues(inputs, map[string]string{"regions": "us-east-1,eu-west-1"}, true)
+		require.NoError(t, err)
+		assert.Equal(t, "us-east-1,eu-west-1", result["regions"])
+
+		_, err = resolveInputValues(inputs, map[string]string{"regions": "us-east-1,invalid"}, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not in options")
+	})
+}

--- a/pikoci/job/job.go
+++ b/pikoci/job/job.go
@@ -38,6 +38,17 @@ type HookStep struct {
 	Notify *NotifyStep          `json:"notify,omitempty"`
 }
 
+// Input defines a parameter that can be provided when manually triggering a job.
+// Values are injected as $input_<name> environment variables into all steps.
+type Input struct {
+	Name        string   `json:"name"`
+	Type        string   `json:"type"`              // "string", "number", "bool"
+	Description string   `json:"description,omitempty"`
+	Default     *string  `json:"default,omitempty"`  // nil = required
+	Options     []string `json:"options,omitempty"`
+	Multiple    bool     `json:"multiple,omitempty"`
+}
+
 // Job represents a named unit of work in a pipeline. It contains a plan of
 // ordered steps and optional lifecycle hooks that run on success, failure,
 // cancellation, or unconditionally (ensure).
@@ -66,6 +77,8 @@ type Job struct {
 	ApproveCount int `json:"approve_count,omitempty"`
 	// ApproveNotify contains notification steps to fire when a build enters WaitingForApproval.
 	ApproveNotify []NotifyStep `json:"approve_notify,omitempty"`
+
+	Inputs []Input `json:"inputs,omitempty"`
 
 	OnSuccess []HookStep `json:"on_success,omitempty"`
 	OnFailure []HookStep `json:"on_failure,omitempty"`

--- a/pikoci/jobs.go
+++ b/pikoci/jobs.go
@@ -3,6 +3,8 @@ package pikoci
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/pikoci/pikoci/pikoci/auditlog"
 	"github.com/pikoci/pikoci/pikoci/build"
@@ -13,7 +15,7 @@ import (
 // TriggerPipelineJob creates a pending build for the specified job, pins the
 // latest version of its first get-step resource, and enqueues the build for
 // execution via the job topic.
-func (q *PikoCI) TriggerPipelineJob(ctx context.Context, tc, pc, jn string) error {
+func (q *PikoCI) TriggerPipelineJob(ctx context.Context, tc, pc, jn string, inputValues map[string]string, manual bool) error {
 	if !utils.ValidateCanonical(tc) {
 		return fmt.Errorf("invalid Team Canonical format %q", tc)
 	} else if !utils.ValidateCanonical(pc) {
@@ -31,7 +33,12 @@ func (q *PikoCI) TriggerPipelineJob(ctx context.Context, tc, pc, jn string) erro
 		return fmt.Errorf("job %q is paused", jn)
 	}
 
-	bb := build.Build{Status: build.Pending}
+	resolved, err := resolveInputValues(j.Inputs, inputValues, manual)
+	if err != nil {
+		return fmt.Errorf("invalid input values for job %q: %w", jn, err)
+	}
+
+	bb := build.Build{Status: build.Pending, InputValues: resolved}
 
 	// Use the pinned version if the resource is pinned, otherwise use the
 	// latest version of the first get-step resource.
@@ -191,4 +198,94 @@ func (q *PikoCI) GetPipelineJob(ctx context.Context, tc, pc, jn string) (*job.Jo
 	}
 
 	return j, nil
+}
+
+// resolveInputValues validates and resolves input values against the declared
+// inputs. For manual triggers, required inputs (no default) must be provided.
+// For automatic triggers, missing values use defaults or zero values.
+func resolveInputValues(inputs []job.Input, provided map[string]string, manual bool) (map[string]string, error) {
+	if len(inputs) == 0 {
+		return nil, nil
+	}
+
+	declared := make(map[string]job.Input, len(inputs))
+	for _, inp := range inputs {
+		declared[inp.Name] = inp
+	}
+
+	// Reject unknown keys
+	for k := range provided {
+		if _, ok := declared[k]; !ok {
+			return nil, fmt.Errorf("unknown input %q", k)
+		}
+	}
+
+	resolved := make(map[string]string, len(inputs))
+	for _, inp := range inputs {
+		val, ok := provided[inp.Name]
+		if !ok || val == "" {
+			if inp.Default != nil {
+				val = *inp.Default
+			} else if manual {
+				return nil, fmt.Errorf("required input %q not provided", inp.Name)
+			} else {
+				// Auto-trigger zero values
+				switch inp.Type {
+				case "number":
+					val = "0"
+				case "bool":
+					val = "false"
+				default:
+					val = ""
+				}
+			}
+		}
+
+		// Type validation
+		switch inp.Type {
+		case "number":
+			if _, err := strconv.ParseFloat(val, 64); err != nil {
+				return nil, fmt.Errorf("input %q: value %q is not a valid number", inp.Name, val)
+			}
+		case "bool":
+			if val != "true" && val != "false" {
+				return nil, fmt.Errorf("input %q: value %q must be \"true\" or \"false\"", inp.Name, val)
+			}
+		}
+
+		// Options validation
+		if len(inp.Options) > 0 && val != "" {
+			if inp.Multiple {
+				parts := strings.Split(val, ",")
+				for _, p := range parts {
+					p = strings.TrimSpace(p)
+					found := false
+					for _, o := range inp.Options {
+						if o == p {
+							found = true
+							break
+						}
+					}
+					if !found {
+						return nil, fmt.Errorf("input %q: value %q is not in options %v", inp.Name, p, inp.Options)
+					}
+				}
+			} else {
+				found := false
+				for _, o := range inp.Options {
+					if o == val {
+						found = true
+						break
+					}
+				}
+				if !found {
+					return nil, fmt.Errorf("input %q: value %q is not in options %v", inp.Name, val, inp.Options)
+				}
+			}
+		}
+
+		resolved[inp.Name] = val
+	}
+
+	return resolved, nil
 }

--- a/pikoci/jobs_test.go
+++ b/pikoci/jobs_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/pikoci/pikoci/pikoci/build"
 	"github.com/pikoci/pikoci/pikoci/job"
 	"github.com/pikoci/pikoci/pikoci/resource"
 	"go.uber.org/mock/gomock"
@@ -31,13 +32,13 @@ func TestTriggerPipelineJob_InvalidCanonical(t *testing.T) {
 	s := newService(ctrl)
 	ctx := context.TODO()
 
-	err := s.S.TriggerPipelineJob(ctx, "INVALID", "pp", "jn")
+	err := s.S.TriggerPipelineJob(ctx, "INVALID", "pp", "jn", nil, false)
 	require.Error(t, err)
 
-	err = s.S.TriggerPipelineJob(ctx, "main", "INVALID", "jn")
+	err = s.S.TriggerPipelineJob(ctx, "main", "INVALID", "jn", nil, false)
 	require.Error(t, err)
 
-	err = s.S.TriggerPipelineJob(ctx, "main", "pp", "INVALID")
+	err = s.S.TriggerPipelineJob(ctx, "main", "pp", "INVALID", nil, false)
 	require.Error(t, err)
 }
 
@@ -59,7 +60,7 @@ func TestTriggerPipelineJob_NotFound(t *testing.T) {
 
 	s.Jobs.EXPECT().Find(ctx, "main", "pp", "jn").Return(nil, assert.AnError)
 
-	err := s.S.TriggerPipelineJob(ctx, "main", "pp", "jn")
+	err := s.S.TriggerPipelineJob(ctx, "main", "pp", "jn", nil, false)
 	require.Error(t, err)
 }
 
@@ -71,7 +72,7 @@ func TestTriggerPipelineJob_Success(t *testing.T) {
 	s.Jobs.EXPECT().Find(ctx, "main", "pp", "jn").Return(&job.Job{ID: 1}, nil).Times(2)
 	s.Builds.EXPECT().Create(ctx, "main", "pp", "jn", gomock.Any()).Return(uint32(1), "1", nil)
 
-	err := s.S.TriggerPipelineJob(ctx, "main", "pp", "jn")
+	err := s.S.TriggerPipelineJob(ctx, "main", "pp", "jn", nil, false)
 	require.NoError(t, err)
 }
 
@@ -109,7 +110,7 @@ func TestTriggerPipelineJob_PinsLatestVersion(t *testing.T) {
 	// TriggerPipelineJob creates a pending build and calls Notify()
 	s.Builds.EXPECT().Create(ctx, tc, ppc, jn, gomock.Any()).Return(uint32(5), "1", nil)
 
-	err := s.S.TriggerPipelineJob(ctx, tc, ppc, jn)
+	err := s.S.TriggerPipelineJob(ctx, tc, ppc, jn, nil, false)
 	require.NoError(t, err)
 }
 
@@ -141,7 +142,7 @@ func TestTriggerPipelineJob_UsesPinnedVersion(t *testing.T) {
 	// FilterVersions should NOT be called — pinned version is used directly
 	s.Builds.EXPECT().Create(ctx, tc, ppc, jn, gomock.Any()).Return(uint32(5), "1", nil)
 
-	err := s.S.TriggerPipelineJob(ctx, tc, ppc, jn)
+	err := s.S.TriggerPipelineJob(ctx, tc, ppc, jn, nil, false)
 	require.NoError(t, err)
 }
 
@@ -152,9 +153,83 @@ func TestTriggerPipelineJob_JobPaused(t *testing.T) {
 
 	s.Jobs.EXPECT().Find(ctx, "main", "pp", "jn").Return(&job.Job{ID: 1, Paused: true}, nil)
 
-	err := s.S.TriggerPipelineJob(ctx, "main", "pp", "jn")
+	err := s.S.TriggerPipelineJob(ctx, "main", "pp", "jn", nil, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "is paused")
+}
+
+func TestTriggerPipelineJob_InputsDefaults(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	defVal := "latest"
+	j := &job.Job{
+		ID:   1,
+		Name: "jn",
+		Inputs: []job.Input{
+			{Name: "version", Type: "string", Default: &defVal},
+			{Name: "count", Type: "number", Default: func() *string { s := "3"; return &s }()},
+		},
+	}
+
+	s.Jobs.EXPECT().Find(ctx, "main", "pp", "jn").Return(j, nil).Times(2)
+	s.Builds.EXPECT().Create(ctx, "main", "pp", "jn", gomock.Any()).DoAndReturn(
+		func(ctx context.Context, tc, pn, jn string, b build.Build) (uint32, string, error) {
+			require.NotNil(t, b.InputValues)
+			assert.Equal(t, "latest", b.InputValues["version"])
+			assert.Equal(t, "3", b.InputValues["count"])
+			return uint32(1), "1", nil
+		})
+
+	err := s.S.TriggerPipelineJob(ctx, "main", "pp", "jn", nil, false)
+	require.NoError(t, err)
+}
+
+func TestTriggerPipelineJob_InputsProvided(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	defVal := "latest"
+	j := &job.Job{
+		ID:   1,
+		Name: "jn",
+		Inputs: []job.Input{
+			{Name: "version", Type: "string", Default: &defVal},
+		},
+	}
+
+	s.Jobs.EXPECT().Find(ctx, "main", "pp", "jn").Return(j, nil).Times(2)
+	s.Builds.EXPECT().Create(ctx, "main", "pp", "jn", gomock.Any()).DoAndReturn(
+		func(ctx context.Context, tc, pn, jn string, b build.Build) (uint32, string, error) {
+			require.NotNil(t, b.InputValues)
+			assert.Equal(t, "v2.0", b.InputValues["version"])
+			return uint32(1), "1", nil
+		})
+
+	err := s.S.TriggerPipelineJob(ctx, "main", "pp", "jn", map[string]string{"version": "v2.0"}, true)
+	require.NoError(t, err)
+}
+
+func TestTriggerPipelineJob_InputsRequiredMissing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	j := &job.Job{
+		ID:   1,
+		Name: "jn",
+		Inputs: []job.Input{
+			{Name: "version", Type: "string"}, // no default = required
+		},
+	}
+
+	s.Jobs.EXPECT().Find(ctx, "main", "pp", "jn").Return(j, nil)
+
+	err := s.S.TriggerPipelineJob(ctx, "main", "pp", "jn", nil, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required input")
 }
 
 func TestPauseJob(t *testing.T) {

--- a/pikoci/mock/service.go
+++ b/pikoci/mock/service.go
@@ -1208,17 +1208,17 @@ func (mr *ServiceMockRecorder) StartPendingBuild(ctx, tc, pn, jn, buildID any) *
 }
 
 // TriggerPipelineJob mocks base method.
-func (m *Service) TriggerPipelineJob(ctx context.Context, tc, pn, jn string) error {
+func (m *Service) TriggerPipelineJob(ctx context.Context, tc, pn, jn string, inputValues map[string]string, manual bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TriggerPipelineJob", ctx, tc, pn, jn)
+	ret := m.ctrl.Call(m, "TriggerPipelineJob", ctx, tc, pn, jn, inputValues, manual)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // TriggerPipelineJob indicates an expected call of TriggerPipelineJob.
-func (mr *ServiceMockRecorder) TriggerPipelineJob(ctx, tc, pn, jn any) *gomock.Call {
+func (mr *ServiceMockRecorder) TriggerPipelineJob(ctx, tc, pn, jn, inputValues, manual any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TriggerPipelineJob", reflect.TypeOf((*Service)(nil).TriggerPipelineJob), ctx, tc, pn, jn)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TriggerPipelineJob", reflect.TypeOf((*Service)(nil).TriggerPipelineJob), ctx, tc, pn, jn, inputValues, manual)
 }
 
 // TriggerPipelineResource mocks base method.

--- a/pikoci/mysql/build.go
+++ b/pikoci/mysql/build.go
@@ -44,13 +44,14 @@ type dbBuild struct {
 	Duration          sql.NullInt64
 	VersionID            sql.NullInt64
 	ResourceCanonical    sql.NullString
+	InputValues          sql.NullString
 	RetrySourceBuildID   int64
 }
 
 func newDBBuild(b build.Build) dbBuild {
 	s, _ := json.Marshal(b.Steps)
 	j, _ := json.Marshal(b.Job)
-	return dbBuild{
+	dbb := dbBuild{
 		Steps:             toNullString(string(s)),
 		Job:               toNullString(string(j)),
 		Status:            toNullString(b.Status.String()),
@@ -61,6 +62,11 @@ func newDBBuild(b build.Build) dbBuild {
 		ResourceCanonical:  toNullString(b.ResourceCanonical),
 		RetrySourceBuildID: int64(b.RetrySourceBuildID),
 	}
+	if len(b.InputValues) > 0 {
+		iv, _ := json.Marshal(b.InputValues)
+		dbb.InputValues = toNullString(string(iv))
+	}
+	return dbb
 }
 
 func (dbb *dbBuild) toDomainEntity() *build.Build {
@@ -79,6 +85,9 @@ func (dbb *dbBuild) toDomainEntity() *build.Build {
 
 	_ = json.Unmarshal([]byte(dbb.Steps.String), &b.Steps)
 	_ = json.Unmarshal([]byte(dbb.Job.String), &b.Job)
+	if dbb.InputValues.Valid && dbb.InputValues.String != "" {
+		_ = json.Unmarshal([]byte(dbb.InputValues.String), &b.InputValues)
+	}
 
 	return b
 }
@@ -111,8 +120,8 @@ func (r *BuildRepository) Create(ctx context.Context, tc, pn, jn string, b build
 		buildNumber := fmt.Sprintf("%d", nextNum)
 
 		res, err := r.querier.ExecContext(ctx, `
-			INSERT INTO builds(steps, job, status, error, started_at, duration, build_number, version_id, resource_canonical, retry_source_build_id, job_id)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+			INSERT INTO builds(steps, job, status, error, started_at, duration, build_number, version_id, resource_canonical, retry_source_build_id, input_values, job_id)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 				-- job_id
 				(
 					SELECT j.id
@@ -122,7 +131,7 @@ func (r *BuildRepository) Create(ctx context.Context, tc, pn, jn string, b build
 					JOIN teams AS t
 						ON p.team_id = t.id
 					WHERE t.canonical = ? AND p.canonical = ? AND j.name = ?
-				))`, dbb.Steps, dbb.Job, dbb.Status, dbb.Error, dbb.StartedAt, dbb.Duration, buildNumber, dbb.VersionID, dbb.ResourceCanonical, dbb.RetrySourceBuildID, tc, pn, jn)
+				))`, dbb.Steps, dbb.Job, dbb.Status, dbb.Error, dbb.StartedAt, dbb.Duration, buildNumber, dbb.VersionID, dbb.ResourceCanonical, dbb.RetrySourceBuildID, dbb.InputValues, tc, pn, jn)
 		if err != nil {
 			if isUniqueViolation(err) {
 				continue
@@ -170,8 +179,8 @@ func (r *BuildRepository) CreateRetry(ctx context.Context, tc, pn, jn, parentBui
 		buildNumber := fmt.Sprintf("%s.%d", parentBuildNumber, nextNum)
 
 		res, err := r.querier.ExecContext(ctx, `
-			INSERT INTO builds(steps, job, status, error, started_at, duration, build_number, version_id, resource_canonical, retry_source_build_id, job_id)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+			INSERT INTO builds(steps, job, status, error, started_at, duration, build_number, version_id, resource_canonical, retry_source_build_id, input_values, job_id)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 				(
 					SELECT j.id
 					FROM jobs AS j
@@ -180,7 +189,7 @@ func (r *BuildRepository) CreateRetry(ctx context.Context, tc, pn, jn, parentBui
 					JOIN teams AS t
 						ON p.team_id = t.id
 					WHERE t.canonical = ? AND p.canonical = ? AND j.name = ?
-				))`, dbb.Steps, dbb.Job, dbb.Status, dbb.Error, dbb.StartedAt, dbb.Duration, buildNumber, dbb.VersionID, dbb.ResourceCanonical, dbb.RetrySourceBuildID, tc, pn, jn)
+				))`, dbb.Steps, dbb.Job, dbb.Status, dbb.Error, dbb.StartedAt, dbb.Duration, buildNumber, dbb.VersionID, dbb.ResourceCanonical, dbb.RetrySourceBuildID, dbb.InputValues, tc, pn, jn)
 		if err != nil {
 			if isUniqueViolation(err) {
 				continue
@@ -225,7 +234,7 @@ func (r *BuildRepository) FindGetVersions(ctx context.Context, buildID uint32) (
 
 func (r *BuildRepository) Find(ctx context.Context, tc, pn, jn string, buildNumber string) (*build.Build, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical, b.retry_source_build_id
+		SELECT b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical, b.input_values, b.retry_source_build_id
 		FROM builds AS b
 		JOIN jobs AS j
 			ON b.job_id = j.id
@@ -246,7 +255,7 @@ func (r *BuildRepository) Find(ctx context.Context, tc, pn, jn string, buildNumb
 
 func (r *BuildRepository) Filter(ctx context.Context, tc, pn, jn string, before *uint32, after *uint32, limit uint32, statuses []build.Status) ([]*build.Build, error) {
 	query := `
-		SELECT b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical, b.retry_source_build_id
+		SELECT b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical, b.input_values, b.retry_source_build_id
 		FROM builds AS b
 		JOIN jobs AS j
 			ON b.job_id = j.id
@@ -302,7 +311,7 @@ func (r *BuildRepository) Update(ctx context.Context, tc, pn, jn string, buildNu
 	dbb := newDBBuild(b)
 	res, err := r.querier.ExecContext(ctx, `
 		UPDATE builds AS b
-		SET steps = ?, job = ?, status = ?, error = ?, started_at = ?, duration = ?, version_id = ?, resource_canonical = ?
+		SET steps = ?, job = ?, status = ?, error = ?, started_at = ?, duration = ?, version_id = ?, resource_canonical = ?, input_values = ?
 		FROM (
 			SELECT b.id
 			FROM builds AS b
@@ -315,7 +324,7 @@ func (r *BuildRepository) Update(ctx context.Context, tc, pn, jn string, buildNu
 			WHERE t.canonical = ? AND p.canonical = ? AND j.name = ? AND b.build_number = ?
 		) AS bb
 		WHERE bb.id = b.id
-	`, dbb.Steps, dbb.Job, dbb.Status, dbb.Error, dbb.StartedAt, dbb.Duration, dbb.VersionID, dbb.ResourceCanonical, tc, pn, jn, buildNumber)
+	`, dbb.Steps, dbb.Job, dbb.Status, dbb.Error, dbb.StartedAt, dbb.Duration, dbb.VersionID, dbb.ResourceCanonical, dbb.InputValues, tc, pn, jn, buildNumber)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -530,7 +539,7 @@ func (r *BuildRepository) CountRunningInSerialGroups(ctx context.Context, tc, pn
 
 func (r *BuildRepository) FindByID(ctx context.Context, buildID uint32) (*build.Build, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical, b.retry_source_build_id
+		SELECT b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical, b.input_values, b.retry_source_build_id
 		FROM builds AS b
 		WHERE b.id = ?
 	`, buildID)
@@ -544,7 +553,7 @@ func (r *BuildRepository) FindByID(ctx context.Context, buildID uint32) (*build.
 
 func (r *BuildRepository) FindOldestPending(ctx context.Context, tc, pn, jn string) (*build.Build, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical, b.retry_source_build_id
+		SELECT b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical, b.input_values, b.retry_source_build_id
 		FROM builds AS b
 		JOIN jobs AS j
 			ON b.job_id = j.id
@@ -658,7 +667,7 @@ func (r *BuildRepository) FindByVersionAndJobs(ctx context.Context, tc, pn strin
 	// Retries may not have build_get_versions entries yet (pending/started),
 	// so we also match on retry_source_build_id.
 	query := `
-		SELECT b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical, b.retry_source_build_id, j.name
+		SELECT b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical, b.input_values, b.retry_source_build_id, j.name
 		FROM builds AS b
 		JOIN jobs AS j ON b.job_id = j.id
 		JOIN pipelines AS p ON j.pipeline_id = p.id
@@ -701,6 +710,7 @@ func (r *BuildRepository) FindByVersionAndJobs(ctx context.Context, tc, pn strin
 			&dbb.Duration,
 			&dbb.VersionID,
 			&dbb.ResourceCanonical,
+			&dbb.InputValues,
 			&dbb.RetrySourceBuildID,
 			&jobName,
 		)
@@ -732,7 +742,7 @@ func (r *BuildRepository) FindByVersionAndJobs(ctx context.Context, tc, pn strin
 
 func (r *BuildRepository) FilterByPipeline(ctx context.Context, tc, pn string, statuses []build.Status) (map[string][]*build.Build, error) {
 	query := `
-		SELECT j.name, b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical, b.retry_source_build_id
+		SELECT j.name, b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical, b.input_values, b.retry_source_build_id
 		FROM builds AS b
 		JOIN jobs AS j ON b.job_id = j.id
 		JOIN pipelines AS p ON j.pipeline_id = p.id
@@ -773,6 +783,7 @@ func (r *BuildRepository) FilterByPipeline(ctx context.Context, tc, pn string, s
 			&dbb.Duration,
 			&dbb.VersionID,
 			&dbb.ResourceCanonical,
+			&dbb.InputValues,
 			&dbb.RetrySourceBuildID,
 		)
 		if err != nil {
@@ -822,6 +833,7 @@ func scanBuild(s sqlr.Scanner) (*build.Build, error) {
 		&b.Duration,
 		&b.VersionID,
 		&b.ResourceCanonical,
+		&b.InputValues,
 		&b.RetrySourceBuildID,
 	)
 
@@ -853,7 +865,7 @@ func scanBuilds(rows *sql.Rows) ([]*build.Build, error) {
 
 func (r *BuildRepository) FindActiveBuilds(ctx context.Context, tc, pn, jn string, beforeBuildID uint32) ([]*build.Build, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical, b.retry_source_build_id
+		SELECT b.id, b.build_number, b.steps, b.job, b.status, b.error, b.started_at, b.duration, b.version_id, b.resource_canonical, b.input_values, b.retry_source_build_id
 		FROM builds AS b
 		JOIN jobs AS j ON b.job_id = j.id
 		JOIN pipelines AS p ON j.pipeline_id = p.id

--- a/pikoci/mysql/job.go
+++ b/pikoci/mysql/job.go
@@ -43,6 +43,7 @@ type dbJob struct {
 	DisableRetry      sql.NullBool
 	AllowFailure      sql.NullBool
 	Interruptible     sql.NullBool
+	Inputs            sql.NullString
 }
 
 func newDBJob(p job.Job) dbJob {
@@ -51,6 +52,7 @@ func newDBJob(p job.Job) dbJob {
 	f, _ := json.Marshal(p.OnFailure)
 	c, _ := json.Marshal(p.OnCancel)
 	e, _ := json.Marshal(p.Ensure)
+	inp, _ := json.Marshal(p.Inputs)
 	dbj := dbJob{
 		Name:         toNullString(p.Name),
 		Tags:         sql.NullString{String: strings.Join(p.Tags, ","), Valid: true},
@@ -72,6 +74,9 @@ func newDBJob(p job.Job) dbJob {
 	dbj.DisableRetry = sql.NullBool{Bool: p.DisableRetry, Valid: true}
 	dbj.AllowFailure = sql.NullBool{Bool: p.AllowFailure, Valid: true}
 	dbj.Interruptible = sql.NullBool{Bool: p.Interruptible, Valid: true}
+	if len(p.Inputs) > 0 {
+		dbj.Inputs = toNullString(string(inp))
+	}
 	return dbj
 }
 
@@ -116,6 +121,9 @@ func (dbp *dbJob) toDomainEntity() *job.Job {
 	_ = json.Unmarshal([]byte(dbp.OnFailure.String), &j.OnFailure)
 	_ = json.Unmarshal([]byte(dbp.OnCancel.String), &j.OnCancel)
 	_ = json.Unmarshal([]byte(dbp.Ensure.String), &j.Ensure)
+	if dbp.Inputs.Valid && dbp.Inputs.String != "" {
+		_ = json.Unmarshal([]byte(dbp.Inputs.String), &j.Inputs)
+	}
 
 	return j
 }
@@ -123,7 +131,7 @@ func (dbp *dbJob) toDomainEntity() *job.Job {
 func (r *JobRepository) Create(ctx context.Context, tc, pn string, j job.Job) (uint32, error) {
 	dbj := newDBJob(j)
 	res, err := r.querier.ExecContext(ctx, `
-		INSERT INTO jobs(name, tags, plan, on_success, on_failure, on_cancel, ensure, concurrency, paused, timeout, for_each_group, for_each_key, pipeline_id, baseline_version_id, approve_label, approve_timeout, approve_count, disable_retry, allow_failure, interruptible)
+		INSERT INTO jobs(name, tags, plan, on_success, on_failure, on_cancel, ensure, concurrency, paused, timeout, for_each_group, for_each_key, pipeline_id, baseline_version_id, approve_label, approve_timeout, approve_count, disable_retry, allow_failure, interruptible, inputs)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 			-- pipeline_id
 			(
@@ -134,7 +142,7 @@ func (r *JobRepository) Create(ctx context.Context, tc, pn string, j job.Job) (u
 				WHERE t.canonical = ? AND p.canonical = ?
 			),
 			-- baseline_version_id
-			(SELECT MAX(id) FROM resource_versions), ?, ?, ?, ?, ?, ?)`, dbj.Name, dbj.Tags, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Paused, dbj.Timeout, dbj.ForEachGroup, dbj.ForEachKey, tc, pn, dbj.ApproveLabel, dbj.ApproveTimeout, dbj.ApproveCount, dbj.DisableRetry, dbj.AllowFailure, dbj.Interruptible)
+			(SELECT MAX(id) FROM resource_versions), ?, ?, ?, ?, ?, ?, ?)`, dbj.Name, dbj.Tags, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Paused, dbj.Timeout, dbj.ForEachGroup, dbj.ForEachKey, tc, pn, dbj.ApproveLabel, dbj.ApproveTimeout, dbj.ApproveCount, dbj.DisableRetry, dbj.AllowFailure, dbj.Interruptible, dbj.Inputs)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -155,7 +163,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 	dbj := newDBJob(j)
 	res, err := r.querier.ExecContext(ctx, `
 		UPDATE jobs AS j
-		SET name = ?, tags = ?, plan = ?, on_success = ?, on_failure = ?, on_cancel = ?, ensure = ?, concurrency = ?, timeout = ?, for_each_group = ?, for_each_key = ?, approve_label = ?, approve_timeout = ?, approve_count = ?, disable_retry = ?, allow_failure = ?, interruptible = ?
+		SET name = ?, tags = ?, plan = ?, on_success = ?, on_failure = ?, on_cancel = ?, ensure = ?, concurrency = ?, timeout = ?, for_each_group = ?, for_each_key = ?, approve_label = ?, approve_timeout = ?, approve_count = ?, disable_retry = ?, allow_failure = ?, interruptible = ?, inputs = ?
 		FROM (
 			SELECT j.id
 			FROM jobs AS j
@@ -166,7 +174,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 			WHERE t.canonical = ? AND p.canonical = ? AND j.name = ?
 		) AS jj
 		WHERE jj.id = j.id
-	`, dbj.Name, dbj.Tags, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Timeout, dbj.ForEachGroup, dbj.ForEachKey, dbj.ApproveLabel, dbj.ApproveTimeout, dbj.ApproveCount, dbj.DisableRetry, dbj.AllowFailure, dbj.Interruptible, tc, pn, jn)
+	`, dbj.Name, dbj.Tags, dbj.Plan, dbj.OnSuccess, dbj.OnFailure, dbj.OnCancel, dbj.Ensure, dbj.Concurrency, dbj.Timeout, dbj.ForEachGroup, dbj.ForEachKey, dbj.ApproveLabel, dbj.ApproveTimeout, dbj.ApproveCount, dbj.DisableRetry, dbj.AllowFailure, dbj.Interruptible, dbj.Inputs, tc, pn, jn)
 	if err != nil {
 		return fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -197,7 +205,7 @@ func (r *JobRepository) Update(ctx context.Context, tc, pn, jn string, j job.Job
 
 func (r *JobRepository) Find(ctx context.Context, tc, pn, jn string) (*job.Job, error) {
 	row := r.querier.QueryRowContext(ctx, `
-		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry, j.allow_failure, j.interruptible
+		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry, j.allow_failure, j.interruptible, j.inputs
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -222,7 +230,7 @@ func (r *JobRepository) Find(ctx context.Context, tc, pn, jn string) (*job.Job, 
 
 func (r *JobRepository) Filter(ctx context.Context, tc, pn string) ([]*job.Job, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry, j.allow_failure, j.interruptible
+		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry, j.allow_failure, j.interruptible, j.inputs
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -373,6 +381,7 @@ func scanJob(s sqlr.Scanner) (*job.Job, error) {
 		&j.DisableRetry,
 		&j.AllowFailure,
 		&j.Interruptible,
+		&j.Inputs,
 	)
 
 	if err != nil {
@@ -465,7 +474,7 @@ func (r *JobRepository) loadSerialGroupsBatch(ctx context.Context, jobIDs []uint
 
 func (r *JobRepository) FilterByForEachGroup(ctx context.Context, tc, pn, group string) ([]*job.Job, error) {
 	rows, err := r.querier.QueryContext(ctx, `
-		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry, j.allow_failure, j.interruptible
+		SELECT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry, j.allow_failure, j.interruptible, j.inputs
 		FROM jobs AS j
 		JOIN pipelines AS p
 			ON j.pipeline_id = p.id
@@ -505,7 +514,7 @@ func (r *JobRepository) FindJobsBySerialGroups(ctx context.Context, tc, pn strin
 		args = append(args, sg)
 	}
 	query := fmt.Sprintf(`
-		SELECT DISTINCT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry, j.allow_failure, j.interruptible
+		SELECT DISTINCT j.id, j.name, j.tags, j.plan, j.on_success, j.on_failure, j.on_cancel, j.ensure, j.concurrency, j.paused, j.timeout, j.for_each_group, j.for_each_key, j.baseline_version_id, j.approve_label, j.approve_timeout, j.approve_count, j.disable_retry, j.allow_failure, j.interruptible, j.inputs
 		FROM jobs AS j
 		JOIN pipelines AS p ON j.pipeline_id = p.id
 		JOIN teams AS t ON p.team_id = t.id

--- a/pikoci/mysql/migrate/migrations/V51JobInputs.go
+++ b/pikoci/mysql/migrate/migrations/V51JobInputs.go
@@ -1,0 +1,7 @@
+package migrations
+
+var V51JobInputs = Migration{
+	Name: "JobInputs",
+	SQL: `ALTER TABLE jobs ADD COLUMN inputs TEXT NULL;
+ALTER TABLE builds ADD COLUMN input_values TEXT NULL;`,
+}

--- a/pikoci/mysql/migrate/migrations/migrations.go
+++ b/pikoci/mysql/migrate/migrations/migrations.go
@@ -16,7 +16,7 @@ type Migration struct {
 // Migrations is the ordered list of all schema migrations. It is defined as
 // a fixed-size array so that the compiler catches ordering conflicts when
 // multiple developers add migrations concurrently.
-var Migrations = [51]Migration{
+var Migrations = [52]Migration{
 	V0Initial,
 	V1ResourceCheckInterval,
 	V2JobsAndBuilds,
@@ -68,4 +68,5 @@ var Migrations = [51]Migration{
 	V48DisableRetry,
 	V49AllowFailure,
 	V50Interruptible,
+	V51JobInputs,
 }

--- a/pikoci/resources.go
+++ b/pikoci/resources.go
@@ -251,10 +251,12 @@ func (q *PikoCI) TriggerResourceVersion(ctx context.Context, tc, pc, rCan string
 				continue
 			}
 
+			inputVals, _ := resolveInputValues(j.Inputs, nil, false)
 			bb := build.Build{
 				Status:            build.Pending,
 				VersionID:         versionID,
 				ResourceCanonical: rCan,
+				InputValues:       inputVals,
 			}
 
 			_, err := q.CreateJobBuild(ctx, tc, pc, j.Name, bb)

--- a/pikoci/service.go
+++ b/pikoci/service.go
@@ -142,8 +142,9 @@ type Service interface {
 	CreatePipelineImage(ctx context.Context, tc string, pp []byte, vars map[string]interface{}, format string) ([]byte, error)
 
 	// TriggerPipelineJob creates a pending build for the specified job and enqueues
-	// it for execution.
-	TriggerPipelineJob(ctx context.Context, tc, pn, jn string) error
+	// it for execution. inputValues provides parameter values for jobs with input
+	// blocks; manual indicates whether this is a manual trigger (requiring required inputs).
+	TriggerPipelineJob(ctx context.Context, tc, pn, jn string, inputValues map[string]string, manual bool) error
 	// ListPipelineJobs returns all jobs for the given pipeline enriched with
 	// their latest build status.
 	ListPipelineJobs(ctx context.Context, tc, pn string) ([]job.WithStatus, error)

--- a/pikoci/service_test.go
+++ b/pikoci/service_test.go
@@ -57,7 +57,7 @@ func TestTriggerPipelineJob(t *testing.T) {
 	// TriggerPipelineJob creates a pending build and calls Notify()
 	s.Builds.EXPECT().Create(ctx, tc, ppc, jn, gomock.Any()).Return(uint32(1), "1", nil)
 
-	err := s.S.TriggerPipelineJob(ctx, tc, ppc, jn)
+	err := s.S.TriggerPipelineJob(ctx, tc, ppc, jn, nil, false)
 	require.NoError(t, err)
 }
 

--- a/pikoci/testdata/cron.hcl
+++ b/pikoci/testdata/cron.hcl
@@ -47,6 +47,24 @@ job "slow-build" {
 
 job "deploy-staging" {
   disable_retry = true
+
+  input "version" {
+    type        = "string"
+    description = "Version to deploy"
+    default     = "latest"
+  }
+
+  input "environment" {
+    type    = "string"
+    options = ["staging", "production"]
+    default = "staging"
+  }
+
+  input "dry_run" {
+    type    = "bool"
+    default = "false"
+  }
+
   get "artifact" "cron_output" {
     trigger = true
     passed  = ["gen"]
@@ -55,7 +73,7 @@ job "deploy-staging" {
   task "deploy" {
     run "exec" {
       path = "/bin/sh"
-      args = ["-ec", "echo '--- deploy-staging ---' && cat cron-output/timestamp.txt && echo 'deploying to staging...' && sleep 5 && echo 'done'"]
+      args = ["-ec", "echo '--- deploy-staging ---' && echo version=$input_version env=$input_environment dry_run=$input_dry_run && cat cron-output/timestamp.txt && echo 'deploying to staging...' && sleep 5 && echo 'done'"]
     }
   }
 }
@@ -177,6 +195,17 @@ job "nightly-report" {
 }
 
 job "monitor" {
+  input "target" {
+    type        = "string"
+    description = "Service to monitor"
+    default     = "all"
+  }
+
+  input "verbose" {
+    type    = "bool"
+    default = "false"
+  }
+
   get "cron" "my_cron" {
     trigger = true
     passed  = ["gen"]
@@ -184,7 +213,7 @@ job "monitor" {
   task "check" {
     run "exec" {
       path = "/bin/sh"
-      args = ["-ec", "echo '--- monitor ---' && echo 'cron version: $GET_MY_CRON_DATE' && echo 'done'"]
+      args = ["-ec", "echo '--- monitor ---' && echo target=$input_target verbose=$input_verbose && echo 'cron version: $GET_MY_CRON_DATE' && echo 'done'"]
     }
     on_success "exec" {
       path = "/bin/sh"

--- a/pikoci/transport/http/assets/js/app/api.js
+++ b/pikoci/transport/http/assets/js/app/api.js
@@ -128,7 +128,13 @@ export const previewPipelineImage = (tc, data) =>
 // --- Jobs ---
 export const fetchJobs = (tc, pn) => api('/teams/' + tc + '/pipelines/' + pn + '/jobs').then(r => r.data);
 export const fetchJob = (tc, pn, jn) => api('/teams/' + tc + '/pipelines/' + pn + '/jobs/' + jn).then(r => r.data);
-export const triggerJob = (tc, pn, jn) => api('/teams/' + tc + '/pipelines/' + pn + '/jobs/' + jn + '/trigger', { method: 'POST' });
+export const triggerJob = (tc, pn, jn, inputValues) => {
+  const opts = { method: 'POST' };
+  if (inputValues && Object.keys(inputValues).length > 0) {
+    opts.body = JSON.stringify({ input_values: inputValues });
+  }
+  return api('/teams/' + tc + '/pipelines/' + pn + '/jobs/' + jn + '/trigger', opts);
+};
 export const pauseJob = (tc, pn, jn) => api('/teams/' + tc + '/pipelines/' + pn + '/jobs/' + jn + '/pause', { method: 'POST' });
 export const unpauseJob = (tc, pn, jn) => api('/teams/' + tc + '/pipelines/' + pn + '/jobs/' + jn + '/unpause', { method: 'POST' });
 

--- a/pikoci/transport/http/assets/js/app/components/Jobs.js
+++ b/pikoci/transport/http/assets/js/app/components/Jobs.js
@@ -18,6 +18,7 @@ const stepIcon = {
   service: 'bi-hdd-stack',
   runner: 'bi-gear',
   job: 'bi-braces',
+  input: 'bi-sliders2',
 };
 
 function getStepIcon(type) {
@@ -139,6 +140,29 @@ function StepRow({ step, expanded, onToggle, autoFollow, setAutoFollow, isAutoSc
           </button>
           <pre ref=${preRef} onScroll=${onScroll}>${logs}</pre>
         </div>
+      </div>
+    </div>
+  `;
+}
+
+// ---------- InputStep ----------
+
+function InputStep({ inputValues, expanded, onToggle }) {
+  const entries = Object.entries(inputValues);
+  return html`
+    <div class="piko-step-row" data-status="succeeded">
+      <div class="piko-step-row-header" onClick=${onToggle}>
+        <span>
+          <span class="piko-step-label"><i class="bi bi-sliders2"></i> input</span>
+          ${' '}parameters${' '}
+          <span style="color:var(--text-muted);">(${entries.length} ${entries.length === 1 ? 'value' : 'values'})</span>
+        </span>
+        <span style="display:flex;align-items:center;gap:6px;">
+          ${statusBadge('succeeded', true)}
+        </span>
+      </div>
+      <div class="piko-step-row-body" style="display:${expanded ? 'block' : 'none'};">
+        <pre>${entries.map(([k, v]) => k + '=' + (v || '""') + '\n')}</pre>
       </div>
     </div>
   `;
@@ -512,6 +536,13 @@ function BuildContent({ build: rawBuild, tc, pn, jn, job: jobData, onRetry }) {
           </span>
         `}
       </div>
+      ${jobData && jobData.inputs && jobData.inputs.length > 0 ? html`
+        <${InputStep}
+          inputValues=${build.input_values || Object.fromEntries(jobData.inputs.map(inp => [inp.name, inp.default !== undefined && inp.default !== null ? inp.default : (inp.type === 'bool' ? 'false' : inp.type === 'number' ? '0' : '')]))}
+          expanded=${!!expandedSteps['inputs']}
+          onToggle=${() => toggleStep('inputs')}
+        />
+      ` : null}
       ${steps.map((s, i) => {
         if (s.type === 'in_parallel') {
           return html`
@@ -815,13 +846,39 @@ export function JobBuilds({ tc, pn, jn, bid, embedded, trackedVersionID: tracked
     }
   }, [tc, pn, jn, embedded, trackedVersionID]);
 
-  // Trigger/pause/unpause handlers
-  const onTrigger = useCallback(async () => {
+  // Input modal state
+  const [showInputModal, setShowInputModal] = useState(false);
+  const [inputFormValues, setInputFormValues] = useState({});
+
+  const doTriggerWithInputs = useCallback(async (values) => {
     await withTriggerLoading(async () => {
-      await triggerJob(tc, pn, jn);
+      await triggerJob(tc, pn, jn, values);
       showToast('Job triggered', 'success');
     });
   }, [tc, pn, jn, withTriggerLoading]);
+
+  // Trigger/pause/unpause handlers
+  const onTrigger = useCallback(async () => {
+    if (job && job.inputs && job.inputs.length > 0) {
+      // Pre-fill defaults
+      const defaults = {};
+      for (const inp of job.inputs) {
+        if (inp.default !== undefined && inp.default !== null) {
+          defaults[inp.name] = inp.default;
+        } else if (inp.type === 'bool') {
+          defaults[inp.name] = 'false';
+        } else if (inp.type === 'number') {
+          defaults[inp.name] = '0';
+        } else {
+          defaults[inp.name] = '';
+        }
+      }
+      setInputFormValues(defaults);
+      setShowInputModal(true);
+      return;
+    }
+    await doTriggerWithInputs(null);
+  }, [job, doTriggerWithInputs]);
 
   const onPause = useCallback(async () => {
     await withPauseLoading(async () => {
@@ -870,6 +927,36 @@ export function JobBuilds({ tc, pn, jn, bid, embedded, trackedVersionID: tracked
   }, [tc, pn, trackedVersionID]);
 
   const isMember = hasTeamRole(tc, 'write');
+
+  const onInputSubmit = useCallback(async (e) => {
+    e.preventDefault();
+    setShowInputModal(false);
+    await doTriggerWithInputs(inputFormValues);
+  }, [inputFormValues, doTriggerWithInputs]);
+
+  const onInputChange = useCallback((name, value) => {
+    setInputFormValues(prev => ({ ...prev, [name]: value }));
+  }, []);
+
+  const onMultiSelectChange = useCallback((name, option, checked) => {
+    setInputFormValues(prev => {
+      const current = prev[name] ? prev[name].split(',').filter(Boolean) : [];
+      let next;
+      if (checked) {
+        next = [...current, option];
+      } else {
+        next = current.filter(v => v !== option);
+      }
+      return { ...prev, [name]: next.join(',') };
+    });
+  }, []);
+
+  // Check if all required fields are filled
+  const inputsValid = !job || !job.inputs || job.inputs.every(inp => {
+    if (inp.default !== undefined && inp.default !== null) return true;
+    const val = inputFormValues[inp.name];
+    return val !== undefined && val !== '';
+  });
 
   return html`
     <div>
@@ -932,6 +1019,66 @@ export function JobBuilds({ tc, pn, jn, bid, embedded, trackedVersionID: tracked
           </div>
         `)}
       </div>
+      ${showInputModal && job && job.inputs ? html`
+        <div class="modal d-block" tabindex="-1" style="background:rgba(0,0,0,0.5)">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <form onSubmit=${onInputSubmit}>
+                <div class="modal-header">
+                  <h5 class="modal-title">Trigger Job: ${job.name}</h5>
+                  <button type="button" class="btn-close" onClick=${() => setShowInputModal(false)}></button>
+                </div>
+                <div class="modal-body">
+                  ${job.inputs.map(inp => html`
+                    <div class="mb-3" key=${inp.name}>
+                      <label class="form-label fw-semibold">
+                        ${inp.name}${inp.default === undefined || inp.default === null ? html` <span class="text-danger">*</span>` : ''}
+                      </label>
+                      ${inp.description ? html`<div class="form-text mt-0 mb-1">${inp.description}</div>` : null}
+                      ${inp.type === 'bool' ? html`
+                        <div class="form-check form-switch">
+                          <input class="form-check-input" type="checkbox"
+                            checked=${inputFormValues[inp.name] === 'true'}
+                            onChange=${(e) => onInputChange(inp.name, e.target.checked ? 'true' : 'false')} />
+                        </div>
+                      ` : inp.options && inp.options.length > 0 && inp.multiple ? html`
+                        <div>
+                          ${inp.options.map(opt => html`
+                            <div class="form-check" key=${opt}>
+                              <input class="form-check-input" type="checkbox"
+                                checked=${(inputFormValues[inp.name] || '').split(',').includes(opt)}
+                                onChange=${(e) => onMultiSelectChange(inp.name, opt, e.target.checked)} />
+                              <label class="form-check-label">${opt}</label>
+                            </div>
+                          `)}
+                        </div>
+                      ` : inp.options && inp.options.length > 0 ? html`
+                        <select class="form-select" value=${inputFormValues[inp.name] || ''}
+                          onChange=${(e) => onInputChange(inp.name, e.target.value)}>
+                          <option value="">-- select --</option>
+                          ${inp.options.map(opt => html`<option key=${opt} value=${opt}>${opt}</option>`)}
+                        </select>
+                      ` : inp.type === 'number' ? html`
+                        <input type="number" class="form-control" value=${inputFormValues[inp.name] || ''}
+                          onInput=${(e) => onInputChange(inp.name, e.target.value)} />
+                      ` : html`
+                        <input type="text" class="form-control" value=${inputFormValues[inp.name] || ''}
+                          onInput=${(e) => onInputChange(inp.name, e.target.value)} />
+                      `}
+                    </div>
+                  `)}
+                </div>
+                <div class="modal-footer">
+                  <button type="button" class="btn btn-secondary" onClick=${() => setShowInputModal(false)}>Cancel</button>
+                  <button type="submit" class="btn btn-warning" disabled=${!inputsValid || triggerLoading}>
+                    ${triggerLoading ? 'Triggering...' : 'Trigger'}
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      ` : null}
     </div>
   `;
 }

--- a/pikoci/transport/http/authorization_test.go
+++ b/pikoci/transport/http/authorization_test.go
@@ -124,7 +124,7 @@ func TestRoleAuthorizationMatrix(t *testing.T) {
 			// We use AnyTimes() + permissive returns so the test only checks auth.
 			svc.EXPECT().ListPipelines(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 			svc.EXPECT().GetTeam(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
-			svc.EXPECT().TriggerPipelineJob(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			svc.EXPECT().TriggerPipelineJob(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			svc.EXPECT().PausePipeline(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			svc.EXPECT().UnpausePipeline(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			svc.EXPECT().CancelJobBuild(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()

--- a/pikoci/transport/http/client/client.go
+++ b/pikoci/transport/http/client/client.go
@@ -607,11 +607,15 @@ func (cl *Client) ListPublicPipelineJobs(ctx context.Context, tc, pn string) ([]
 	return cl.ListPipelineJobs(ctx, tc, pn)
 }
 
-// TriggerPipelineJob triggers a manual run of the specified job.
-func (cl *Client) TriggerPipelineJob(ctx context.Context, tc, pn, jn string) error {
+// TriggerPipelineJob triggers a manual run of the specified job with optional input values.
+func (cl *Client) TriggerPipelineJob(ctx context.Context, tc, pn, jn string, inputValues map[string]string, manual bool) error {
 	var resp thttp.TriggerPipelineJobResponse
+	var body interface{}
+	if len(inputValues) > 0 {
+		body = thttp.TriggerPipelineJobRequest{InputValues: inputValues}
+	}
 
-	err := cl.Request(ctx, http.MethodPost, fmt.Sprintf("%s/teams/%s/pipelines/%s/jobs/%s/trigger", cl.url, tc, pn, jn), nil, &resp)
+	err := cl.Request(ctx, http.MethodPost, fmt.Sprintf("%s/teams/%s/pipelines/%s/jobs/%s/trigger", cl.url, tc, pn, jn), body, &resp)
 	if err != nil {
 		return fmt.Errorf("failed to make request: %w", err)
 	}

--- a/pikoci/transport/http/client/client_test.go
+++ b/pikoci/transport/http/client/client_test.go
@@ -503,7 +503,7 @@ func TestTriggerPipelineJob(t *testing.T) {
 	c, err := client.New(ts.URL, "jwt")
 	require.NoError(t, err)
 
-	err = c.TriggerPipelineJob(context.Background(), "team", "pipe", "job1")
+	err = c.TriggerPipelineJob(context.Background(), "team", "pipe", "job1", nil, false)
 	require.NoError(t, err)
 }
 
@@ -1683,7 +1683,7 @@ func TestTriggerPipelineJob_Error(t *testing.T) {
 	c, err := client.New(ts.URL, "jwt")
 	require.NoError(t, err)
 
-	err = c.TriggerPipelineJob(context.Background(), "team1", "pipe", "nojob")
+	err = c.TriggerPipelineJob(context.Background(), "team1", "pipe", "nojob", nil, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "job not found")
 }

--- a/pikoci/transport/http/handlers_coverage_test.go
+++ b/pikoci/transport/http/handlers_coverage_test.go
@@ -918,7 +918,7 @@ func TestUnpausePipeline_Error(t *testing.T) {
 func TestTriggerPipelineJob_Success(t *testing.T) {
 	e := newTestEnv(t)
 	e.expectMemberAuth()
-	e.svc.EXPECT().TriggerPipelineJob(gomock.Any(), "main", "my-pipe", "build").Return(nil)
+	e.svc.EXPECT().TriggerPipelineJob(gomock.Any(), "main", "my-pipe", "build", gomock.Any(), gomock.Any()).Return(nil)
 
 	resp := doRequest(t, http.MethodPost, e.server.URL+"/teams/main/pipelines/my-pipe/jobs/build/trigger", e.memberJWT(t), "")
 	defer resp.Body.Close()
@@ -932,7 +932,7 @@ func TestTriggerPipelineJob_Success(t *testing.T) {
 func TestTriggerPipelineJob_Error(t *testing.T) {
 	e := newTestEnv(t)
 	e.expectMemberAuth()
-	e.svc.EXPECT().TriggerPipelineJob(gomock.Any(), "main", "my-pipe", "build").Return(fmt.Errorf("trigger error"))
+	e.svc.EXPECT().TriggerPipelineJob(gomock.Any(), "main", "my-pipe", "build", gomock.Any(), gomock.Any()).Return(fmt.Errorf("trigger error"))
 
 	resp := doRequest(t, http.MethodPost, e.server.URL+"/teams/main/pipelines/my-pipe/jobs/build/trigger", e.memberJWT(t), "")
 	defer resp.Body.Close()

--- a/pikoci/transport/http/jobs.go
+++ b/pikoci/transport/http/jobs.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -37,9 +38,10 @@ func listPipelineJobs(s pikoci.Service) http.HandlerFunc {
 }
 
 type TriggerPipelineJobRequest struct {
-	TeamCanonical     string `json:"team_canonical"`
-	PipelineCanonical string `json:"pipeline_canonical"`
-	JobName           string `json:"job_name"`
+	TeamCanonical     string            `json:"team_canonical"`
+	PipelineCanonical string            `json:"pipeline_canonical"`
+	JobName           string            `json:"job_name"`
+	InputValues       map[string]string `json:"input_values,omitempty"`
 }
 type TriggerPipelineJobResponse struct {
 	Err string `json:"error,omitempty"`
@@ -57,7 +59,12 @@ func triggerPipelineJob(s pikoci.Service) http.HandlerFunc {
 		req.TeamCanonical = vars["team_canonical"]
 		req.PipelineCanonical = vars["pipeline_canonical"]
 		req.JobName = vars["job_name"]
-		err := s.TriggerPipelineJob(ctx, req.TeamCanonical, req.PipelineCanonical, req.JobName)
+		// Decode optional JSON body for input values
+		if r.Body != nil && r.ContentLength > 0 {
+			_ = json.NewDecoder(r.Body).Decode(&req)
+		}
+		manual := len(req.InputValues) > 0 || r.ContentLength > 0
+		err := s.TriggerPipelineJob(ctx, req.TeamCanonical, req.PipelineCanonical, req.JobName, req.InputValues, manual)
 		var errs string
 		if err != nil {
 			errs = err.Error()

--- a/worker/service.go
+++ b/worker/service.go
@@ -415,6 +415,7 @@ func (w *Worker) processJob(ctx context.Context, m workitem.Body, cwd string, pp
 		Steps:             []build.Step{},
 		VersionID:         nb.VersionID,
 		ResourceCanonical: nb.ResourceCanonical,
+		InputValues:       nb.InputValues,
 	}
 
 	// If the message doesn't carry version info, fall back to what was stored on the build
@@ -2664,12 +2665,16 @@ func (w *Worker) startServices(ctx context.Context, m workitem.Body, b *build.Bu
 
 // buildMetadataParams returns the standard build metadata environment variables.
 func buildMetadataParams(b *build.Build, m workitem.Body) map[string]string {
-	return map[string]string{
+	params := map[string]string{
 		"BUILD_NUMBER":        b.BuildNumber,
 		"BUILD_JOB_NAME":      m.JobName,
 		"BUILD_PIPELINE_NAME": m.PipelineCanonical,
 		"BUILD_TEAM_NAME":     m.TeamCanonical,
 	}
+	for k, v := range b.InputValues {
+		params["input_"+strings.ToLower(k)] = v
+	}
+	return params
 }
 
 // flattenVersionValue flattens a version metadata value into params with the

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -9846,3 +9846,160 @@ func TestAutoNotification_MessageInterpolation(t *testing.T) {
 	require.Len(t, reqs, 1, "mock server should have received the notification")
 	assert.Contains(t, reqs[0].Body, "Job my-job in test-pipeline: success", "message should have interpolated $BUILD_JOB_NAME, $BUILD_PIPELINE_NAME, and $notify_build_status")
 }
+
+func TestProcessJob_InputValues_PreservedOnUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	svc := mock.NewService(ctrl)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	inputVals := map[string]string{"version": "v1.0", "env": "staging"}
+
+	// GetJobBuild returns a build with InputValues
+	svc.EXPECT().GetJobBuild(gomock.Any(), "main", "test-pipeline", "echo-job", "10").
+		Return(&build.Build{
+			ID: 10, BuildNumber: "10", Status: build.Started,
+			StartedAt: time.Now(), InputValues: inputVals,
+		}, nil).AnyTimes()
+
+	svc.EXPECT().GetPipelineJob(gomock.Any(), "main", "test-pipeline", "echo-job").
+		Return(&job.Job{
+			ID: 1, Name: "echo-job",
+			Inputs: []job.Input{
+				{Name: "version", Type: "string"},
+				{Name: "env", Type: "string"},
+			},
+			Plan: []job.PlanStep{
+				{
+					Type: job.StepTypeTask,
+					Task: &job.TaskStep{
+						Name: "echo",
+						Run:  utils.RunnerCommand{Runner: "exec", Args: []string{"hello"}, Params: map[string]string{"path": "echo"}},
+					},
+				},
+			},
+		}, nil)
+
+	svc.EXPECT().NotifySerialGroupPendingBuilds(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	svc.EXPECT().FindBuildGetVersions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	svc.EXPECT().EvaluateDownstreamJobs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	// Capture all UpdateJobBuild calls and verify InputValues is always present
+	var lastBuild build.Build
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), "main", "test-pipeline", "echo-job", "10", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, b build.Build) error {
+			lastBuild = b
+			return nil
+		}).AnyTimes()
+
+	w := &Worker{pikoci: svc, logger: logger}
+
+	pp := &pipeline.Pipeline{
+		ID: 1, Name: "test-pipeline",
+		Jobs: []job.Job{
+			{ID: 1, Name: "echo-job", Plan: []job.PlanStep{
+				{Type: job.StepTypeTask, Task: &job.TaskStep{
+					Name: "echo",
+					Run:  utils.RunnerCommand{Runner: "exec", Args: []string{"hello"}, Params: map[string]string{"path": "echo"}},
+				}},
+			}},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+
+	m := workitem.Body{
+		TeamCanonical: "main", PipelineCanonical: "test-pipeline",
+		JobName: "echo-job", BuildID: 10, BuildNumber: "10",
+	}
+
+	w.processJob(context.Background(), m, t.TempDir(), pp)
+
+	// The last update (marking succeeded) must still carry InputValues
+	require.NotNil(t, lastBuild.InputValues, "InputValues must be preserved across build updates")
+	assert.Equal(t, "v1.0", lastBuild.InputValues["version"])
+	assert.Equal(t, "staging", lastBuild.InputValues["env"])
+}
+
+func TestProcessJob_InputValues_InjectedAsEnvVars(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	svc := mock.NewService(ctrl)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	inputVals := map[string]string{"version": "v2.0", "debug": "true"}
+
+	svc.EXPECT().GetJobBuild(gomock.Any(), "main", "test-pipeline", "env-job", "20").
+		Return(&build.Build{
+			ID: 20, BuildNumber: "20", Status: build.Started,
+			StartedAt: time.Now(), InputValues: inputVals,
+		}, nil).AnyTimes()
+
+	svc.EXPECT().GetPipelineJob(gomock.Any(), "main", "test-pipeline", "env-job").
+		Return(&job.Job{
+			ID: 1, Name: "env-job",
+			Plan: []job.PlanStep{
+				{
+					Type: job.StepTypeTask,
+					Task: &job.TaskStep{
+						Name: "print-env",
+						Run: utils.RunnerCommand{
+							Runner: "exec",
+							Args:   []string{"-ec", "echo version=$input_version debug=$input_debug"},
+							Params: map[string]string{"path": "/bin/sh"},
+						},
+					},
+				},
+			},
+		}, nil)
+
+	svc.EXPECT().NotifySerialGroupPendingBuilds(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	svc.EXPECT().FindBuildGetVersions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	svc.EXPECT().EvaluateDownstreamJobs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	// Capture the final build to check logs contain expanded env vars
+	var lastBuild build.Build
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), "main", "test-pipeline", "env-job", "20", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, b build.Build) error {
+			lastBuild = b
+			return nil
+		}).AnyTimes()
+
+	w := &Worker{pikoci: svc, logger: logger}
+
+	pp := &pipeline.Pipeline{
+		ID: 1, Name: "test-pipeline",
+		Jobs: []job.Job{
+			{ID: 1, Name: "env-job", Plan: []job.PlanStep{
+				{Type: job.StepTypeTask, Task: &job.TaskStep{
+					Name: "print-env",
+					Run: utils.RunnerCommand{
+						Runner: "exec",
+						Args:   []string{"-ec", "echo version=$input_version debug=$input_debug"},
+						Params: map[string]string{"path": "/bin/sh"},
+					},
+				}},
+			}},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+
+	m := workitem.Body{
+		TeamCanonical: "main", PipelineCanonical: "test-pipeline",
+		JobName: "env-job", BuildID: 20, BuildNumber: "20",
+	}
+
+	w.processJob(context.Background(), m, t.TempDir(), pp)
+
+	// Verify the task step logs contain the expanded input env vars
+	require.True(t, len(lastBuild.Steps) > 0, "build should have steps")
+	taskLogs := ""
+	for _, s := range lastBuild.Steps {
+		if s.Name == "print-env" {
+			taskLogs = s.Logs
+		}
+	}
+	assert.Contains(t, taskLogs, "version=v2.0", "input_version env var should be expanded in task logs")
+	assert.Contains(t, taskLogs, "debug=true", "input_debug env var should be expanded in task logs")
+}


### PR DESCRIPTION
## Summary

- Add `input` block to jobs for parameterized manual triggers
- Input values injected as `$input_<name>` env vars to all steps
- UI modal form with text, number, checkbox, dropdown, and multi-select fields
- CLI `--input key=value` flag on `jobs trigger`
- Input values displayed as a collapsible step on every build
- Auto-triggered builds use defaults/zero values

Closes #467