### PR TITLE
feat: add conditional job execution with if/else_if/else blocks (#164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Conditional job execution (`if`/`else_if`/`else`)**: Jobs can use declarative conditional blocks to branch execution based on runtime values (`$GET_*`, `$TASK_*`, `$BUILD_*`, `$input_*`). Supports `==`, `!=`, `>`, `<`, `contains`, `!contains`, `&&`, `||` operators with parentheses. Skipped branches display with a muted badge in the UI ([#164](https://github.com/PikoCI/pikoci/issues/164)).
 - **Parameterized manual triggers**: Jobs can declare `input` blocks to collect parameters on manual trigger, injected as `$input_<name>` env vars. Supports typed fields, defaults, dropdowns, and multi-select ([#467](https://github.com/PikoCI/pikoci/issues/467)).
 - **`interruptible` on jobs**: When `true`, creating a new build for the job automatically cancels all older running, pending, and waiting-for-approval builds, so only the latest build runs ([#612](https://github.com/PikoCI/pikoci/issues/612)).
 - **`allow_failure` on jobs**: When `true`, a failed build is marked as `warning` (salmon) instead of `failed`, unblocking downstream jobs. Any failed build can also be manually marked as warning via a UI button (requires Maintain role) ([#610](https://github.com/PikoCI/pikoci/issues/610)).

--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -282,6 +282,7 @@ The optional `timeout` attribute limits the total wall-clock time for a build's 
 | `notify` | no | Step block: sends a fire-and-forget notification |
 | `service` | no | Step block: references a service type for the job |
 | `in_parallel` | no | Step block: runs multiple steps concurrently |
+| `if` / `else_if` / `else` | no | Step block: conditional execution (see below) |
 | `input` | no | Parameterized input block (see below) |
 | `on_success` | no | Hook: runs after all steps succeed |
 | `on_failure` | no | Hook: runs after a step fails |
@@ -875,6 +876,82 @@ job "build" {
 **Timeout/Attempts:** `timeout` on the block applies to wall-clock time of the entire group. `attempts` retries the entire block. Inner steps can have their own `timeout` and `attempts` independently.
 
 **Hooks:** The `in_parallel` block supports `on_success`, `on_failure`, `on_cancel`, and `ensure` hooks, which fire based on whether the group as a whole succeeded or failed.
+
+### Conditional execution (if / else_if / else)
+
+Conditional blocks let you branch job execution based on runtime values such as resource metadata, task outputs, build metadata, or input parameters.
+
+```hcl
+job "deploy" {
+  get "git" "app" { trigger = true }
+  task "test" {
+    run "exec" { path = "make" args = ["test"] }
+  }
+
+  if "check-branch" {
+    condition = "$GET_APP_BRANCH == 'main'"
+    task "deploy-prod" {
+      run "exec" { path = "./deploy.sh" args = ["prod"] }
+    }
+  }
+
+  else_if "check-staging" {
+    condition = "$GET_APP_BRANCH == 'staging'"
+    task "deploy-staging" {
+      run "exec" { path = "./deploy.sh" args = ["staging"] }
+    }
+  }
+
+  else {
+    task "skip-deploy" {
+      run "exec" { path = "echo" args = ["Branch not deployed"] }
+    }
+  }
+}
+```
+
+**Labels:** `if` and `else_if` blocks take an optional label (e.g. `if "check-branch"`). `else` blocks do not take a label.
+
+**Chaining:** `else_if` and `else` must immediately follow an `if` or `else_if` block. Only one `else` is allowed per chain.
+
+**Allowed inner step types:** `get`, `task`, `put`, `notify`, `service`, `in_parallel`.
+
+**Nesting:** Conditional blocks cannot be nested inside other conditional blocks.
+
+**Multiple chains:** A job can have multiple independent `if`/`else_if`/`else` chains.
+
+#### Condition operators
+
+Conditions are evaluated at runtime after `$VAR` expansion. Supported operators:
+
+| Operator | Meaning |
+|----------|---------|
+| `==` | string equality |
+| `!=` | not equal |
+| `>` | greater than (numeric if parseable, else string) |
+| `<` | less than (numeric if parseable, else string) |
+| `contains` | substring match |
+| `!contains` | negated substring match |
+| `&&` | logical AND |
+| `\|\|` | logical OR |
+
+Parentheses are supported for grouping: `($GET_APP_BRANCH == 'main' || $GET_APP_BRANCH == 'develop') && $TASK_TEST_EXIT_CODE == '0'`
+
+#### Available variables
+
+- `$GET_<STEP>_<KEY>` — resource version metadata from get steps
+- `$TASK_<STEP>_<KEY>` — values exported via `$PIKOCI_OUTPUT` from task steps
+- `$BUILD_NUMBER`, `$BUILD_JOB_NAME`, `$BUILD_PIPELINE_NAME`, `$BUILD_TEAM_NAME`
+- `$input_<name>` — input parameter values
+
+#### Behavior
+
+- **No match:** If no `if`/`else_if` condition is true and there is no `else`, all branches are skipped and execution continues.
+- **Empty condition:** Treated as `true` (always enters the branch).
+- **Malformed condition:** The build fails with an error message.
+- **Failure:** If a step inside the entered branch fails, the job fails. There is no fallthrough to the next branch.
+- **Exported variables:** Variables exported by steps in the selected branch are available to subsequent steps after the conditional block.
+- **Hooks:** The `if` block supports `on_success`, `on_failure`, `on_cancel`, and `ensure` hooks.
 
 ### Step hooks
 

--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -910,7 +910,7 @@ job "deploy" {
 }
 ```
 
-**Labels:** `if` and `else_if` blocks take an optional label (e.g. `if "check-branch"`). `else` blocks do not take a label.
+**Labels:** `if` and `else_if` blocks take an optional label (e.g. `if "check-branch"`). The label is used as the display name in the build UI and logs, making it easy to identify which branch was entered or skipped at a glance. `else` blocks do not take a label.
 
 **Chaining:** `else_if` and `else` must immediately follow an `if` or `else_if` block. Only one `else` is allowed per chain.
 

--- a/pikoci/build/build.go
+++ b/pikoci/build/build.go
@@ -33,6 +33,8 @@ const (
 	// Warning indicates the build failed but the job has allow_failure enabled,
 	// so downstream jobs are not blocked.
 	Warning
+	// Skipped indicates a conditional branch was not selected at runtime.
+	Skipped
 )
 
 // Approval represents a single approve/reject vote on a build.

--- a/pikoci/build/status_string.go
+++ b/pikoci/build/status_string.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 )
 
-const _StatusName = "succeededfailedstartedcancelledpendingwaiting_for_approvalwarning"
+const _StatusName = "succeededfailedstartedcancelledpendingwaiting_for_approvalwarningskipped"
 
-var _StatusIndex = [...]uint8{0, 9, 15, 22, 31, 38, 58, 65}
+var _StatusIndex = [...]uint8{0, 9, 15, 22, 31, 38, 58, 65, 72}
 
-const _StatusLowerName = "succeededfailedstartedcancelledpendingwaiting_for_approvalwarning"
+const _StatusLowerName = "succeededfailedstartedcancelledpendingwaiting_for_approvalwarningskipped"
 
 func (i Status) String() string {
 	if i < 0 || i >= Status(len(_StatusIndex)-1) {
@@ -32,9 +32,10 @@ func _StatusNoOp() {
 	_ = x[Pending-(4)]
 	_ = x[WaitingForApproval-(5)]
 	_ = x[Warning-(6)]
+	_ = x[Skipped-(7)]
 }
 
-var _StatusValues = []Status{Succeeded, Failed, Started, Cancelled, Pending, WaitingForApproval, Warning}
+var _StatusValues = []Status{Succeeded, Failed, Started, Cancelled, Pending, WaitingForApproval, Warning, Skipped}
 
 var _StatusNameToValueMap = map[string]Status{
 	_StatusName[0:9]:        Succeeded,
@@ -51,6 +52,8 @@ var _StatusNameToValueMap = map[string]Status{
 	_StatusLowerName[38:58]: WaitingForApproval,
 	_StatusName[58:65]:      Warning,
 	_StatusLowerName[58:65]: Warning,
+	_StatusName[65:72]:      Skipped,
+	_StatusLowerName[65:72]: Skipped,
 }
 
 var _StatusNames = []string{
@@ -61,6 +64,7 @@ var _StatusNames = []string{
 	_StatusName[31:38],
 	_StatusName[38:58],
 	_StatusName[58:65],
+	_StatusName[65:72],
 }
 
 // StatusString retrieves an enum value from the enum constants string name.

--- a/pikoci/helper.go
+++ b/pikoci/helper.go
@@ -659,7 +659,14 @@ var (
 		"in_parallel": true, "approve": true, "input": true,
 		"on_success": true, "on_failure": true, "on_cancel": true, "ensure": true,
 		"matrix": true,
+		"if": true, "else_if": true, "else": true,
 	}
+	ifBranchBlocks = map[string]bool{
+		"get": true, "task": true, "put": true, "notify": true, "service": true,
+		"in_parallel": true,
+		"on_success": true, "on_failure": true, "on_cancel": true, "ensure": true,
+	}
+	ifBlockKnownAttrs = []string{"condition"}
 	stepHookBlocks = map[string]bool{
 		"on_success": true, "on_failure": true, "on_cancel": true, "ensure": true,
 	}
@@ -734,12 +741,66 @@ func validateJobBlock(block *hclsyntax.Block) []string {
 
 	errs = append(errs, validateAttrTypos(block, jobCtx, jobKnownAttrs)...)
 
-	for _, inner := range block.Body.Blocks {
+	lastIfIdx := -1
+	for i, inner := range block.Body.Blocks {
 		if !jobBlocks[inner.Type] {
 			errs = append(errs, suggestBlockTypo(inner.Type, jobBlocks, jobCtx, inner.TypeRange))
 			continue
 		}
 
+		switch inner.Type {
+		case "task":
+			errs = append(errs, validateTaskBlock(inner, jobName)...)
+		case "get":
+			errs = append(errs, validateStepBlock(inner, jobName, getStepKnownAttrs)...)
+		case "put":
+			errs = append(errs, validateStepBlock(inner, jobName, putStepKnownAttrs)...)
+		case "notify":
+			errs = append(errs, validateStepBlock(inner, jobName, notifyStepKnownAttrs)...)
+		case "in_parallel":
+			errs = append(errs, validateInParallelBlock(inner, jobName)...)
+		case "if":
+			lastIfIdx = i
+			errs = append(errs, validateIfBranchBlock(inner, jobName)...)
+		case "else_if":
+			if lastIfIdx < 0 {
+				errs = append(errs, fmt.Sprintf("%s: else_if without preceding if (line %d)", jobCtx, inner.TypeRange.Start.Line))
+			}
+			errs = append(errs, validateIfBranchBlock(inner, jobName)...)
+		case "else":
+			if lastIfIdx < 0 {
+				errs = append(errs, fmt.Sprintf("%s: else without preceding if (line %d)", jobCtx, inner.TypeRange.Start.Line))
+			}
+			errs = append(errs, validateIfBranchBlock(inner, jobName)...)
+			lastIfIdx = -1 // reset: only one else per chain
+		}
+
+		// Reset chain tracking when a non-conditional block appears
+		if inner.Type != "if" && inner.Type != "else_if" && inner.Type != "else" {
+			lastIfIdx = -1
+		}
+	}
+	return errs
+}
+
+// validateIfBranchBlock checks for unknown blocks/attrs inside if/else_if/else branches.
+func validateIfBranchBlock(block *hclsyntax.Block, jobName string) []string {
+	var errs []string
+	ctx := fmt.Sprintf("%s in job %q", block.Type, jobName)
+
+	if block.Type != "else" {
+		errs = append(errs, validateAttrTypos(block, ctx, ifBlockKnownAttrs)...)
+	}
+
+	for _, inner := range block.Body.Blocks {
+		if inner.Type == "if" || inner.Type == "else_if" || inner.Type == "else" {
+			errs = append(errs, fmt.Sprintf("%s: nested conditional blocks are not allowed (line %d)", ctx, inner.TypeRange.Start.Line))
+			continue
+		}
+		if !ifBranchBlocks[inner.Type] {
+			errs = append(errs, suggestBlockTypo(inner.Type, ifBranchBlocks, ctx, inner.TypeRange))
+			continue
+		}
 		switch inner.Type {
 		case "task":
 			errs = append(errs, validateTaskBlock(inner, jobName)...)
@@ -1819,10 +1880,81 @@ func parseJobPlansFromPairs(pairs []jobBlockPair, services []service.Service) (m
 		var plan []job.PlanStep
 		getIdx, taskIdx, putIdx, notifyIdx, serviceIdx, inParallelIdx := 0, 0, 0, 0, 0, 0
 
-		for _, innerBlock := range block.Body.Blocks {
+		allBlocks := block.Body.Blocks
+		for blockI := 0; blockI < len(allBlocks); blockI++ {
+			innerBlock := allBlocks[blockI]
 			switch innerBlock.Type {
 			case "matrix":
 				// Skip matrix blocks (already processed during expansion)
+				continue
+			case "if", "else_if", "else":
+				// Parse if/else_if/else chain from AST
+				serviceByNameCopy := make(map[string]service.Service, len(serviceByName))
+				for k, v := range serviceByName {
+					serviceByNameCopy[k] = v
+				}
+
+				var branches []job.IfBranch
+				ifBlockIdx := blockI // remember the first "if" block for hooks
+				for blockI < len(allBlocks) {
+					cb := allBlocks[blockI]
+					if cb.Type != "if" && cb.Type != "else_if" && cb.Type != "else" {
+						break
+					}
+					// First block must be "if"
+					if len(branches) == 0 && cb.Type != "if" {
+						break
+					}
+
+					branch := job.IfBranch{Type: cb.Type}
+					if len(cb.Labels) > 0 {
+						branch.Label = cb.Labels[0]
+					}
+
+					// Parse condition attribute (not on else)
+					if cb.Type != "else" {
+						if attr, exists := cb.Body.Attributes["condition"]; exists {
+							val, vd := attr.Expr.Value(pairEctx)
+							if vd.HasErrors() {
+								return nil, nil, nil, fmt.Errorf("failed to evaluate condition in %s block: %s", cb.Type, vd.Error())
+							}
+							branch.Condition = val.AsString()
+						}
+					}
+
+					// Parse inner step blocks
+					{
+						innerSteps, err := parseInnerStepsFromAST(cb.Body.Blocks, pairEctx, serviceByNameCopy)
+						if err != nil {
+							label := branch.Label
+							if label == "" {
+								label = cb.Type
+							}
+							return nil, nil, nil, fmt.Errorf("failed to parse steps in %s %q: %w", cb.Type, label, err)
+						}
+						branch.Steps = innerSteps
+					}
+
+					branches = append(branches, branch)
+
+					if cb.Type == "else" {
+						blockI++
+						break
+					}
+					blockI++
+				}
+				blockI-- // outer loop will increment
+
+				plan = append(plan, job.PlanStep{
+					Type: job.StepTypeIf,
+					If: &job.IfStep{
+						Branches: branches,
+					},
+					OnSuccess: parseHooks(allBlocks[ifBlockIdx], pairEctx, "on_success"),
+					OnFailure: parseHooks(allBlocks[ifBlockIdx], pairEctx, "on_failure"),
+					OnCancel:  parseHooks(allBlocks[ifBlockIdx], pairEctx, "on_cancel"),
+					Ensure:    parseHooks(allBlocks[ifBlockIdx], pairEctx, "ensure"),
+				})
 				continue
 			case "service":
 				if serviceIdx >= len(hj.Service) {
@@ -2148,4 +2280,262 @@ func parseJobPlansFromPairs(pairs []jobBlockPair, services []service.Service) (m
 	}
 
 	return result, jhMap, services, nil
+}
+
+// parseInnerStepsFromAST parses get/task/put/notify/service/in_parallel steps
+// directly from AST blocks, without relying on hclsimple-decoded structs.
+// Used for if/else_if/else branch bodies which are not decoded by hclsimple.
+func parseInnerStepsFromAST(blocks []*hclsyntax.Block, ectx *hcl.EvalContext, services map[string]service.Service) ([]job.PlanStep, error) {
+	var steps []job.PlanStep
+	for _, b := range blocks {
+		body := b.Body
+		switch b.Type {
+		case "get":
+			if len(b.Labels) < 2 {
+				return nil, fmt.Errorf("get step requires type and name labels")
+			}
+			gs := job.GetStep{Type: b.Labels[0], Name: b.Labels[1]}
+			var timeout time.Duration
+			var attempts int
+			for name, attr := range body.Attributes {
+				val, vd := attr.Expr.Value(ectx)
+				if vd.HasErrors() {
+					continue
+				}
+				switch name {
+				case "passed":
+					if val.Type().IsListType() || val.Type().IsTupleType() {
+						for it := val.ElementIterator(); it.Next(); {
+							_, v := it.Element()
+							gs.Passed = append(gs.Passed, v.AsString())
+						}
+					}
+				case "trigger":
+					gs.Trigger = val.True()
+				case "timeout":
+					d, err := time.ParseDuration(val.AsString())
+					if err != nil {
+						return nil, fmt.Errorf("invalid timeout on get step %q: %w", gs.Name, err)
+					}
+					timeout = d
+				case "attempts":
+					var n int64
+					if err := gocty.FromCtyValue(val, &n); err != nil {
+						return nil, fmt.Errorf("invalid attempts on get step %q: %w", gs.Name, err)
+					}
+					attempts = int(n)
+				}
+			}
+			steps = append(steps, job.PlanStep{
+				Type: job.StepTypeGet, Timeout: timeout, Attempts: attempts,
+				Get:       &gs,
+				OnSuccess: parseHooks(b, ectx, "on_success"),
+				OnFailure: parseHooks(b, ectx, "on_failure"),
+				OnCancel:  parseHooks(b, ectx, "on_cancel"),
+				Ensure:    parseHooks(b, ectx, "ensure"),
+			})
+		case "task":
+			if len(b.Labels) < 1 {
+				return nil, fmt.Errorf("task step requires a name label")
+			}
+			ts := job.TaskStep{Name: b.Labels[0]}
+			var timeout time.Duration
+			var attempts int
+			for name, attr := range body.Attributes {
+				val, vd := attr.Expr.Value(ectx)
+				if vd.HasErrors() {
+					continue
+				}
+				switch name {
+				case "timeout":
+					d, err := time.ParseDuration(val.AsString())
+					if err != nil {
+						return nil, fmt.Errorf("invalid timeout on task step %q: %w", ts.Name, err)
+					}
+					timeout = d
+				case "attempts":
+					var n int64
+					if err := gocty.FromCtyValue(val, &n); err != nil {
+						return nil, fmt.Errorf("invalid attempts on task step %q: %w", ts.Name, err)
+					}
+					attempts = int(n)
+				case "inputs":
+					if val.Type().IsListType() || val.Type().IsTupleType() {
+						for it := val.ElementIterator(); it.Next(); {
+							_, v := it.Element()
+							ts.Inputs = append(ts.Inputs, v.AsString())
+						}
+					}
+				case "outputs":
+					if val.Type().IsListType() || val.Type().IsTupleType() {
+						for it := val.ElementIterator(); it.Next(); {
+							_, v := it.Element()
+							ts.Outputs = append(ts.Outputs, v.AsString())
+						}
+					}
+				}
+			}
+			// Parse run block
+			for _, inner := range body.Blocks {
+				if inner.Type == "run" && len(inner.Labels) >= 1 {
+					rc := utils.RunnerCommand{Runner: inner.Labels[0]}
+					for rname, rattr := range inner.Body.Attributes {
+						rval, rvd := rattr.Expr.Value(ectx)
+						if rvd.HasErrors() {
+							continue
+						}
+						if rname == "args" {
+							if rval.Type().IsListType() || rval.Type().IsTupleType() {
+								for it := rval.ElementIterator(); it.Next(); {
+									_, v := it.Element()
+									rc.Args = append(rc.Args, v.AsString())
+								}
+							}
+						} else {
+							if rc.Params == nil {
+								rc.Params = make(map[string]string)
+							}
+							rc.Params[rname] = rval.AsString()
+						}
+					}
+					ts.Run = rc
+				}
+			}
+			steps = append(steps, job.PlanStep{
+				Type: job.StepTypeTask, Timeout: timeout, Attempts: attempts,
+				Task:      &ts,
+				OnSuccess: parseHooks(b, ectx, "on_success"),
+				OnFailure: parseHooks(b, ectx, "on_failure"),
+				OnCancel:  parseHooks(b, ectx, "on_cancel"),
+				Ensure:    parseHooks(b, ectx, "ensure"),
+			})
+		case "put":
+			if len(b.Labels) < 2 {
+				return nil, fmt.Errorf("put step requires type and name labels")
+			}
+			ps := job.PutStep{Type: b.Labels[0], Name: b.Labels[1]}
+			var timeout time.Duration
+			var attempts int
+			params := make(map[string]string)
+			for name, attr := range body.Attributes {
+				val, vd := attr.Expr.Value(ectx)
+				if vd.HasErrors() {
+					continue
+				}
+				switch name {
+				case "timeout":
+					d, err := time.ParseDuration(val.AsString())
+					if err != nil {
+						return nil, fmt.Errorf("invalid timeout on put step %q: %w", ps.Name, err)
+					}
+					timeout = d
+				case "attempts":
+					var n int64
+					if err := gocty.FromCtyValue(val, &n); err != nil {
+						return nil, fmt.Errorf("invalid attempts on put step %q: %w", ps.Name, err)
+					}
+					attempts = int(n)
+				default:
+					params[name] = val.AsString()
+				}
+			}
+			ps.Params = params
+			steps = append(steps, job.PlanStep{
+				Type: job.StepTypePut, Timeout: timeout, Attempts: attempts,
+				Put:       &ps,
+				OnSuccess: parseHooks(b, ectx, "on_success"),
+				OnFailure: parseHooks(b, ectx, "on_failure"),
+				OnCancel:  parseHooks(b, ectx, "on_cancel"),
+				Ensure:    parseHooks(b, ectx, "ensure"),
+			})
+		case "notify":
+			if len(b.Labels) < 2 {
+				return nil, fmt.Errorf("notify step requires type and name labels")
+			}
+			ns := job.NotifyStep{Type: b.Labels[0], Name: b.Labels[1]}
+			params := make(map[string]string)
+			for name, attr := range body.Attributes {
+				val, vd := attr.Expr.Value(ectx)
+				if vd.HasErrors() {
+					continue
+				}
+				if name == "message" {
+					ns.Message = val.AsString()
+				} else {
+					params[name] = val.AsString()
+				}
+			}
+			ns.Params = params
+			steps = append(steps, job.PlanStep{
+				Type: job.StepTypeNotify,
+				Notify:    &ns,
+				OnSuccess: parseHooks(b, ectx, "on_success"),
+				OnFailure: parseHooks(b, ectx, "on_failure"),
+				OnCancel:  parseHooks(b, ectx, "on_cancel"),
+				Ensure:    parseHooks(b, ectx, "ensure"),
+			})
+		case "service":
+			if len(b.Labels) < 1 {
+				return nil, fmt.Errorf("service step requires a name label")
+			}
+			svcName := b.Labels[0]
+			if _, ok := services[svcName]; !ok {
+				return nil, fmt.Errorf("service_type %q does not exist", svcName)
+			}
+			params := make(map[string]string)
+			for name, attr := range body.Attributes {
+				val, vd := attr.Expr.Value(ectx)
+				if vd.HasErrors() {
+					continue
+				}
+				params[name] = val.AsString()
+			}
+			var paramMap map[string]string
+			if len(params) > 0 {
+				paramMap = params
+			}
+			steps = append(steps, job.PlanStep{
+				Type: job.StepTypeService,
+				Service: &job.ServiceStep{
+					Name:   svcName,
+					Params: paramMap,
+				},
+			})
+		case "in_parallel":
+			subSteps, err := parseInnerStepsFromAST(body.Blocks, ectx, services)
+			if err != nil {
+				return nil, fmt.Errorf("in_parallel: %w", err)
+			}
+			var limit int
+			var failFast bool
+			for name, attr := range body.Attributes {
+				val, vd := attr.Expr.Value(ectx)
+				if vd.HasErrors() {
+					continue
+				}
+				switch name {
+				case "limit":
+					var n int64
+					if err := gocty.FromCtyValue(val, &n); err == nil {
+						limit = int(n)
+					}
+				case "fail_fast":
+					failFast = val.True()
+				}
+			}
+			steps = append(steps, job.PlanStep{
+				Type: job.StepTypeInParallel,
+				InParallel: &job.InParallelStep{
+					Steps:    subSteps,
+					Limit:    limit,
+					FailFast: failFast,
+				},
+				OnSuccess: parseHooks(b, ectx, "on_success"),
+				OnFailure: parseHooks(b, ectx, "on_failure"),
+				OnCancel:  parseHooks(b, ectx, "on_cancel"),
+				Ensure:    parseHooks(b, ectx, "ensure"),
+			})
+		}
+	}
+	return steps, nil
 }

--- a/pikoci/job/job.go
+++ b/pikoci/job/job.go
@@ -27,6 +27,8 @@ const (
 	StepTypeNotify StepType = "notify"
 	// StepTypeInParallel represents a step that runs multiple sub-steps concurrently.
 	StepTypeInParallel StepType = "in_parallel"
+	// StepTypeIf represents a conditional step with if/else_if/else branches.
+	StepTypeIf StepType = "if"
 )
 
 // HookStep represents a single step inside a hook (on_success, on_failure, on_cancel, ensure).
@@ -142,6 +144,10 @@ func (j *Job) FlatPlanSteps() []PlanStep {
 	for _, p := range j.Plan {
 		if p.Type == StepTypeInParallel && p.InParallel != nil {
 			steps = append(steps, p.InParallel.Steps...)
+		} else if p.Type == StepTypeIf && p.If != nil {
+			for _, branch := range p.If.Branches {
+				steps = append(steps, branch.Steps...)
+			}
 		} else {
 			steps = append(steps, p)
 		}
@@ -173,6 +179,7 @@ type PlanStep struct {
 	Notify     *NotifyStep     `json:"notify,omitempty"`
 	Service    *ServiceStep   `json:"service,omitempty"`
 	InParallel *InParallelStep `json:"in_parallel,omitempty"`
+	If         *IfStep         `json:"if,omitempty"`
 	OnSuccess []HookStep    `json:"on_success,omitempty"`
 	OnFailure []HookStep    `json:"on_failure,omitempty"`
 	OnCancel  []HookStep    `json:"on_cancel,omitempty"`
@@ -248,6 +255,20 @@ type InParallelStep struct {
 	Steps    []PlanStep `json:"steps"`
 	Limit    int        `json:"limit,omitempty"`
 	FailFast bool       `json:"fail_fast,omitempty"`
+}
+
+// IfStep defines a conditional step with one or more branches.
+// Exactly one branch is selected at runtime based on condition evaluation.
+type IfStep struct {
+	Branches []IfBranch `json:"branches"`
+}
+
+// IfBranch represents a single branch in a conditional step.
+type IfBranch struct {
+	Type      string     `json:"type"`               // "if", "else_if", "else"
+	Label     string     `json:"label,omitempty"`
+	Condition string     `json:"condition,omitempty"` // empty for "else"
+	Steps     []PlanStep `json:"steps"`
 }
 
 // WithStatus enriches a Job with its latest build status information,

--- a/pikoci/job/job_test.go
+++ b/pikoci/job/job_test.go
@@ -311,6 +311,173 @@ func TestPlanGetSteps_IncludesInParallelSteps(t *testing.T) {
 	assert.Equal(t, job.StepTypeGet, steps[0].Type)
 }
 
+func TestFlatPlanSteps_IfBranches(t *testing.T) {
+	j := job.Job{
+		Name: "test",
+		Plan: []job.PlanStep{
+			{Type: job.StepTypeGet, Get: &job.GetStep{Type: "git", Name: "app"}},
+			{
+				Type: job.StepTypeIf,
+				If: &job.IfStep{
+					Branches: []job.IfBranch{
+						{
+							Type:      "if",
+							Label:     "check-prod",
+							Condition: "$BRANCH == 'main'",
+							Steps: []job.PlanStep{
+								{Type: job.StepTypeTask, Task: &job.TaskStep{Name: "deploy-prod"}},
+								{Type: job.StepTypePut, Put: &job.PutStep{Type: "git", Name: "release"}},
+							},
+						},
+						{
+							Type: "else",
+							Steps: []job.PlanStep{
+								{Type: job.StepTypeTask, Task: &job.TaskStep{Name: "skip"}},
+							},
+						},
+					},
+				},
+			},
+			{Type: job.StepTypeTask, Task: &job.TaskStep{Name: "notify"}},
+		},
+	}
+
+	flat := j.FlatPlanSteps()
+	require.Len(t, flat, 5)
+	assert.Equal(t, job.StepTypeGet, flat[0].Type)
+	assert.Equal(t, "deploy-prod", flat[1].Task.Name)
+	assert.Equal(t, "release", flat[2].Put.Name)
+	assert.Equal(t, "skip", flat[3].Task.Name)
+	assert.Equal(t, "notify", flat[4].Task.Name)
+}
+
+func TestFlatPlanSteps_IfOnly(t *testing.T) {
+	j := job.Job{
+		Name: "test",
+		Plan: []job.PlanStep{
+			{
+				Type: job.StepTypeIf,
+				If: &job.IfStep{
+					Branches: []job.IfBranch{
+						{
+							Type:      "if",
+							Condition: "$BRANCH == 'main'",
+							Steps: []job.PlanStep{
+								{Type: job.StepTypeTask, Task: &job.TaskStep{Name: "only-task"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	flat := j.FlatPlanSteps()
+	require.Len(t, flat, 1)
+	assert.Equal(t, "only-task", flat[0].Task.Name)
+}
+
+func TestGetSteps_InsideIfBranches(t *testing.T) {
+	j := job.Job{
+		Name: "test",
+		Plan: []job.PlanStep{
+			{
+				Type: job.StepTypeIf,
+				If: &job.IfStep{
+					Branches: []job.IfBranch{
+						{
+							Type: "if",
+							Steps: []job.PlanStep{
+								{Type: job.StepTypeGet, Get: &job.GetStep{Type: "git", Name: "app", Trigger: true}},
+							},
+						},
+						{
+							Type: "else",
+							Steps: []job.PlanStep{
+								{Type: job.StepTypeGet, Get: &job.GetStep{Type: "git", Name: "backup"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	gets := j.GetSteps()
+	require.Len(t, gets, 2)
+	assert.Equal(t, "app", gets[0].Name)
+	assert.Equal(t, "backup", gets[1].Name)
+}
+
+func TestAllPutSteps_InsideIfBranches(t *testing.T) {
+	j := job.Job{
+		Name: "test",
+		Plan: []job.PlanStep{
+			{
+				Type: job.StepTypeIf,
+				If: &job.IfStep{
+					Branches: []job.IfBranch{
+						{
+							Type: "if",
+							Steps: []job.PlanStep{
+								{Type: job.StepTypePut, Put: &job.PutStep{Type: "git", Name: "release"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	puts := j.AllPutSteps()
+	require.Len(t, puts, 1)
+	assert.Equal(t, "release", puts[0].Name)
+}
+
+func TestIfStep_JSONRoundTrip(t *testing.T) {
+	original := job.PlanStep{
+		Type: job.StepTypeIf,
+		If: &job.IfStep{
+			Branches: []job.IfBranch{
+				{
+					Type:      "if",
+					Label:     "check-branch",
+					Condition: "$GET_APP_BRANCH == 'main'",
+					Steps: []job.PlanStep{
+						{Type: job.StepTypeTask, Task: &job.TaskStep{Name: "deploy"}},
+					},
+				},
+				{
+					Type:      "else_if",
+					Label:     "check-staging",
+					Condition: "$GET_APP_BRANCH == 'staging'",
+					Steps:     []job.PlanStep{},
+				},
+				{
+					Type:  "else",
+					Steps: []job.PlanStep{},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded job.PlanStep
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	require.NotNil(t, decoded.If)
+	require.Len(t, decoded.If.Branches, 3)
+	assert.Equal(t, "if", decoded.If.Branches[0].Type)
+	assert.Equal(t, "check-branch", decoded.If.Branches[0].Label)
+	assert.Equal(t, "$GET_APP_BRANCH == 'main'", decoded.If.Branches[0].Condition)
+	assert.Equal(t, "else_if", decoded.If.Branches[1].Type)
+	assert.Equal(t, "else", decoded.If.Branches[2].Type)
+	assert.Empty(t, decoded.If.Branches[2].Condition)
+}
+
 func TestNotifyStep_NotificationCanonical(t *testing.T) {
 	n := &job.NotifyStep{Type: "slack", Name: "deploy-alerts"}
 	assert.Equal(t, "slack.deploy-alerts", n.NotificationCanonical())

--- a/pikoci/pipelines_test.go
+++ b/pikoci/pipelines_test.go
@@ -5135,3 +5135,111 @@ func TestGetPipelineImage_GroupParallel_RootJobs(t *testing.T) {
 	assert.NotContains(t, dot, `"lint" [`)
 	assert.NotContains(t, dot, `"vet" [`)
 }
+
+func TestCreatePipeline_ConditionalValidation_OrphanElseIf(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclData := []byte(`
+resource "cron" "tick" { check_interval = "@every 30s" }
+job "bad" {
+  get "cron" "tick" {}
+  else_if "orphan" {
+    condition = "$FOO == 'bar'"
+    task "x" {
+      run "exec" { args = ["true"] }
+    }
+  }
+}
+`)
+	_, err := s.S.CreatePipeline(ctx, "main", "bad-pipeline", hclData, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "else_if without preceding if")
+}
+
+func TestCreatePipeline_ConditionalValidation_OrphanElse(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclData := []byte(`
+resource "cron" "tick" { check_interval = "@every 30s" }
+job "bad" {
+  get "cron" "tick" {}
+  else {
+    task "x" {
+      run "exec" { args = ["true"] }
+    }
+  }
+}
+`)
+	_, err := s.S.CreatePipeline(ctx, "main", "bad-pipeline", hclData, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "else without preceding if")
+}
+
+func TestCreatePipeline_ConditionalValidation_NestedIf(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclData := []byte(`
+resource "cron" "tick" { check_interval = "@every 30s" }
+job "bad" {
+  get "cron" "tick" {}
+  if "outer" {
+    condition = "$FOO == 'bar'"
+    if "inner" {
+      condition = "$BAZ == 'qux'"
+      task "x" {
+        run "exec" { args = ["true"] }
+      }
+    }
+  }
+}
+`)
+	_, err := s.S.CreatePipeline(ctx, "main", "bad-pipeline", hclData, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nested conditional blocks are not allowed")
+}
+
+func TestCreatePipeline_Conditional_IfOnly(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclData := []byte(`
+resource "cron" "tick" { check_interval = "@every 30s" }
+job "simple" {
+  get "cron" "tick" { trigger = true }
+  if "check" {
+    condition = "$GET_TICK_TS != ''"
+    task "deploy" {
+      run "exec" { args = ["echo", "hi"] }
+    }
+  }
+}
+`)
+
+	var capturedJob job.Job
+	s.Pipelines.EXPECT().Create(ctx, "main", gomock.Any()).Return(uint32(1), nil)
+	s.Jobs.EXPECT().Create(ctx, "main", "simple-pipeline", gomock.Any()).DoAndReturn(
+		func(_ context.Context, _, _ string, j job.Job) (uint32, error) {
+			capturedJob = j
+			return uint32(1), nil
+		}).Times(1)
+	s.Resources.EXPECT().Create(ctx, "main", "simple-pipeline", gomock.Any()).Return(uint32(1), nil).Times(1)
+	s.Pipelines.EXPECT().Find(ctx, "main", "simple-pipeline").Return(&pipeline.Pipeline{Name: "simple-pipeline"}, nil)
+
+	pp, err := s.S.CreatePipeline(ctx, "main", "simple-pipeline", hclData, nil)
+	require.NoError(t, err)
+	require.NotNil(t, pp)
+
+	require.Len(t, capturedJob.Plan, 2)
+	assert.Equal(t, job.StepTypeIf, capturedJob.Plan[1].Type)
+	require.NotNil(t, capturedJob.Plan[1].If)
+	require.Len(t, capturedJob.Plan[1].If.Branches, 1)
+	assert.Equal(t, "if", capturedJob.Plan[1].If.Branches[0].Type)
+	assert.Equal(t, "check", capturedJob.Plan[1].If.Branches[0].Label)
+}

--- a/pikoci/service_test.go
+++ b/pikoci/service_test.go
@@ -119,6 +119,72 @@ job "bad-job" {
 	assert.Contains(t, err.Error(), "invalid serial_group name")
 }
 
+func TestCreatePipeline_ConditionalSteps(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+	tc := "team-canonical"
+	ppc := "conditional-pipeline"
+
+	b, err := os.ReadFile("testdata/conditional.hcl")
+	require.NoError(t, err)
+
+	var capturedJob job.Job
+	s.Pipelines.EXPECT().Create(ctx, tc, gomock.Any()).Return(uint32(1), nil)
+	s.Jobs.EXPECT().Create(ctx, tc, ppc, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _, _ string, j job.Job) (uint32, error) {
+			capturedJob = j
+			return uint32(1), nil
+		}).Times(1)
+	s.Resources.EXPECT().Create(ctx, tc, ppc, gomock.Any()).Return(uint32(1), nil).Times(1)
+	s.Pipelines.EXPECT().Find(ctx, tc, ppc).Return(&pipeline.Pipeline{Name: ppc}, nil)
+
+	pp, err := s.S.CreatePipeline(ctx, tc, ppc, b, nil)
+	require.NoError(t, err)
+	require.NotNil(t, pp)
+
+	// Plan should have: get, task, if (with 3 branches)
+	require.Len(t, capturedJob.Plan, 3, "expected 3 top-level plan steps")
+	assert.Equal(t, job.StepTypeGet, capturedJob.Plan[0].Type)
+	assert.Equal(t, job.StepTypeTask, capturedJob.Plan[1].Type)
+	assert.Equal(t, job.StepTypeIf, capturedJob.Plan[2].Type)
+
+	ifStep := capturedJob.Plan[2].If
+	require.NotNil(t, ifStep)
+	require.Len(t, ifStep.Branches, 3)
+
+	assert.Equal(t, "if", ifStep.Branches[0].Type)
+	assert.Equal(t, "check-prod", ifStep.Branches[0].Label)
+	assert.Equal(t, "$TASK_DETECT_ENV_ENV == 'production'", ifStep.Branches[0].Condition)
+	require.Len(t, ifStep.Branches[0].Steps, 1)
+	assert.Equal(t, job.StepTypeTask, ifStep.Branches[0].Steps[0].Type)
+	assert.Equal(t, "deploy-prod", ifStep.Branches[0].Steps[0].Task.Name)
+
+	assert.Equal(t, "else_if", ifStep.Branches[1].Type)
+	assert.Equal(t, "check-staging", ifStep.Branches[1].Label)
+	assert.Equal(t, "$TASK_DETECT_ENV_ENV == 'staging'", ifStep.Branches[1].Condition)
+	require.Len(t, ifStep.Branches[1].Steps, 1)
+	assert.Equal(t, "deploy-staging", ifStep.Branches[1].Steps[0].Task.Name)
+
+	assert.Equal(t, "else", ifStep.Branches[2].Type)
+	assert.Empty(t, ifStep.Branches[2].Condition)
+	require.Len(t, ifStep.Branches[2].Steps, 1)
+	assert.Equal(t, "skip-deploy", ifStep.Branches[2].Steps[0].Task.Name)
+
+	// FlatPlanSteps should include steps from all branches
+	flat := capturedJob.FlatPlanSteps()
+	var taskNames []string
+	for _, fp := range flat {
+		if fp.Type == job.StepTypeTask && fp.Task != nil {
+			taskNames = append(taskNames, fp.Task.Name)
+		}
+	}
+	assert.Contains(t, taskNames, "detect-env")
+	assert.Contains(t, taskNames, "deploy-prod")
+	assert.Contains(t, taskNames, "deploy-staging")
+	assert.Contains(t, taskNames, "skip-deploy")
+}
+
 func TestGetPipelineJob(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := newService(ctrl)

--- a/pikoci/testdata/conditional.hcl
+++ b/pikoci/testdata/conditional.hcl
@@ -1,0 +1,45 @@
+resource "cron" "trigger" {
+  check_interval = "@every 30s"
+}
+
+job "conditional-demo" {
+  get "cron" "trigger" {
+    trigger = true
+  }
+
+  task "detect-env" {
+    run "exec" {
+      path = "/bin/sh"
+      args = ["-ec", "printf 'ENV=staging\\n' > $PIKOCI_OUTPUT"]
+    }
+  }
+
+  if "check-prod" {
+    condition = "$TASK_DETECT_ENV_ENV == 'production'"
+    task "deploy-prod" {
+      run "exec" {
+        path = "echo"
+        args = ["Deploying to production"]
+      }
+    }
+  }
+
+  else_if "check-staging" {
+    condition = "$TASK_DETECT_ENV_ENV == 'staging'"
+    task "deploy-staging" {
+      run "exec" {
+        path = "echo"
+        args = ["Deploying to staging"]
+      }
+    }
+  }
+
+  else {
+    task "skip-deploy" {
+      run "exec" {
+        path = "echo"
+        args = ["Unknown environment, skipping deploy"]
+      }
+    }
+  }
+}

--- a/pikoci/testdata/cron.hcl
+++ b/pikoci/testdata/cron.hcl
@@ -70,10 +70,33 @@ job "deploy-staging" {
     passed  = ["gen"]
   }
   approve "deploy to staging" {}
-  task "deploy" {
-    run "exec" {
-      path = "/bin/sh"
-      args = ["-ec", "echo '--- deploy-staging ---' && echo version=$input_version env=$input_environment dry_run=$input_dry_run && cat cron-output/timestamp.txt && echo 'deploying to staging...' && sleep 5 && echo 'done'"]
+
+  if "check-dry-run" {
+    condition = "$input_dry_run == 'true'"
+    task "dry-run" {
+      run "exec" {
+        path = "/bin/sh"
+        args = ["-ec", "echo '--- DRY RUN ---' && echo version=$input_version env=$input_environment && echo 'would deploy to $input_environment (skipped)' && cat cron-output/timestamp.txt"]
+      }
+    }
+  }
+
+  else_if "check-production" {
+    condition = "$input_environment == 'production'"
+    task "deploy-prod" {
+      run "exec" {
+        path = "/bin/sh"
+        args = ["-ec", "echo '--- PRODUCTION DEPLOY ---' && echo version=$input_version && cat cron-output/timestamp.txt && echo 'deploying to production...' && sleep 5 && echo 'done'"]
+      }
+    }
+  }
+
+  else {
+    task "deploy-staging" {
+      run "exec" {
+        path = "/bin/sh"
+        args = ["-ec", "echo '--- STAGING DEPLOY ---' && echo version=$input_version && cat cron-output/timestamp.txt && echo 'deploying to staging...' && sleep 5 && echo 'done'"]
+      }
     }
   }
 }

--- a/pikoci/transport/http/assets/css/pikoci.css
+++ b/pikoci/transport/http/assets/css/pikoci.css
@@ -1300,6 +1300,7 @@ textarea.form-control {
 .piko-badge-pending { background: #e8e0f0; color: #5F574F; }
 .piko-badge-waiting_for_approval { background: rgba(142,68,173,0.15); color: #8e44ad; }
 .piko-badge-warning { background: #fde8e5; color: #b5453a; }
+.piko-badge-skipped { background: #e8e0f0; color: #83769C; }
 .piko-badge-primary { background: rgba(41,173,255,0.15); color: #29ADFF; }
 [data-theme="dark"] .piko-badge-succeeded { background: rgba(0,168,58,0.15); color: #00E436; }
 [data-theme="dark"] .piko-badge-failed { background: rgba(255,0,77,0.15); color: #FF77A8; }
@@ -1308,6 +1309,7 @@ textarea.form-control {
 [data-theme="dark"] .piko-badge-pending { background: rgba(131,118,156,0.15); color: #83769C; }
 [data-theme="dark"] .piko-badge-waiting_for_approval { background: rgba(142,68,173,0.15); color: #b370cf; }
 [data-theme="dark"] .piko-badge-warning { background: rgba(250,128,114,0.15); color: #FA8072; }
+[data-theme="dark"] .piko-badge-skipped { background: rgba(131,118,156,0.15); color: #83769C; }
 
 /* In-parallel step group */
 .piko-parallel-group > .piko-step-row-body {
@@ -1315,6 +1317,17 @@ textarea.form-control {
 }
 .piko-parallel-group > .piko-step-row-body > .piko-step-row {
   margin-left: 0;
+}
+
+/* Conditional step group */
+.piko-conditional-group > .piko-step-row-body {
+  border-top: 1px solid var(--border);
+}
+.piko-conditional-group > .piko-step-row-body > .piko-step-row {
+  margin-left: 0;
+}
+.piko-step-skipped {
+  opacity: 0.6;
 }
 
 /* ============================================================

--- a/pikoci/transport/http/assets/js/app/components/Jobs.js
+++ b/pikoci/transport/http/assets/js/app/components/Jobs.js
@@ -19,6 +19,7 @@ const stepIcon = {
   runner: 'bi-gear',
   job: 'bi-braces',
   input: 'bi-sliders2',
+  if: 'bi-signpost-split',
 };
 
 function getStepIcon(type) {
@@ -31,6 +32,7 @@ function statusBadge(status, hasLogs) {
   if (status === 'pending') return html`<span class="piko-badge piko-badge-pending">pending</span>`;
   if (status === 'cancelled') return html`<span class="piko-badge piko-badge-cancelled">cancel</span>`;
   if (status === 'warning') return html`<span class="piko-badge piko-badge-warning">warn</span>`;
+  if (status === 'skipped') return html`<span class="piko-badge piko-badge-skipped">skip</span>`;
   if (status === 'succeeded' || hasLogs) return html`<span class="piko-badge piko-badge-succeeded">ok</span>`;
   return null;
 }
@@ -43,6 +45,7 @@ function buildStatusBadge(status) {
   if (status === 'pending') return html`<span class="piko-badge piko-badge-pending">Pending</span>`;
   if (status === 'waiting_for_approval') return html`<span class="piko-badge piko-badge-waiting_for_approval">Waiting for Approval</span>`;
   if (status === 'warning') return html`<span class="piko-badge piko-badge-warning">Warning</span>`;
+  if (status === 'skipped') return html`<span class="piko-badge piko-badge-skipped">Skipped</span>`;
   return null;
 }
 
@@ -197,6 +200,64 @@ function ParallelGroup({ step, expandedSteps, onToggleStep, stepIndexBase, autoF
             isAutoScrollingRef=${isAutoScrollingRef}
           />
         `)}
+      </div>
+    </div>
+  `;
+}
+
+// ---------- ConditionalGroup ----------
+
+function ConditionalGroup({ step, expandedSteps, onToggleStep, stepIndexBase, autoFollow, setAutoFollow, isAutoScrollingRef }) {
+  const [groupExpanded, setGroupExpanded] = useState(true);
+  const branches = step.sub_steps || [];
+  const entered = branches.find(b => b.status !== 'skipped');
+
+  return html`
+    <div class="piko-step-row piko-conditional-group" data-status="${step.status}">
+      <div class="piko-step-row-header" onClick=${() => setGroupExpanded(!groupExpanded)}>
+        <span>
+          <span class="piko-step-label"><i class="bi bi-signpost-split"></i> if</span>
+          ${' '}${step.name || ''}${' '}
+          <span style="color:var(--text-muted);">(${entered ? 'entered ' + (entered.name || entered.type) : 'skipped all'}, ${step.duration})</span>
+        </span>
+        <span style="display:flex;align-items:center;gap:6px;">
+          ${statusBadge(step.status, false)}
+        </span>
+      </div>
+      <div class="piko-step-row-body" style="display:${groupExpanded ? 'block' : 'none'};padding:4px 4px 4px 16px;">
+        ${branches.map((branch, bi) => {
+          const isSkipped = branch.status === 'skipped';
+          const branchKey = stepIndexBase + '_if_' + bi;
+          return html`
+            <div class="piko-step-row ${isSkipped ? 'piko-step-skipped' : ''}" data-status="${branch.status}" key=${bi}>
+              <div class="piko-step-row-header" onClick=${() => !isSkipped && onToggleStep(branchKey)}>
+                <span>
+                  <span class="piko-step-label"><i class="bi ${branch.type === 'else' ? 'bi-arrow-return-right' : 'bi-signpost-split'}"></i> ${branch.type}</span>
+                  ${' '}${branch.name || ''}${' '}
+                  ${branch.duration ? html`<span style="color:var(--text-muted);">(${branch.duration})</span>` : null}
+                </span>
+                <span style="display:flex;align-items:center;gap:6px;">
+                  ${statusBadge(branch.status, false)}
+                </span>
+              </div>
+              ${!isSkipped && (branch.sub_steps || []).length > 0 ? html`
+                <div class="piko-step-row-body" style="display:block;padding:4px 4px 4px 16px;">
+                  ${(branch.sub_steps || []).map((child, ci) => html`
+                    <${StepRow}
+                      key=${ci}
+                      step=${child}
+                      expanded=${!!expandedSteps[branchKey + '_' + ci]}
+                      onToggle=${() => onToggleStep(branchKey + '_' + ci)}
+                      autoFollow=${autoFollow}
+                      setAutoFollow=${setAutoFollow}
+                      isAutoScrollingRef=${isAutoScrollingRef}
+                    />
+                  `)}
+                </div>
+              ` : null}
+            </div>
+          `;
+        })}
       </div>
     </div>
   `;
@@ -547,6 +608,20 @@ function BuildContent({ build: rawBuild, tc, pn, jn, job: jobData, onRetry }) {
         if (s.type === 'in_parallel') {
           return html`
             <${ParallelGroup}
+              key=${i}
+              step=${s}
+              expandedSteps=${expandedSteps}
+              onToggleStep=${toggleStep}
+              stepIndexBase=${i}
+              autoFollow=${autoFollow}
+              setAutoFollow=${setAutoFollow}
+              isAutoScrollingRef=${isAutoScrollingRef}
+            />
+          `;
+        }
+        if (s.type === 'if') {
+          return html`
+            <${ConditionalGroup}
               key=${i}
               step=${s}
               expandedSteps=${expandedSteps}

--- a/worker/condition.go
+++ b/worker/condition.go
@@ -1,0 +1,241 @@
+package worker
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+// EvaluateCondition expands $VAR references using the provided vars map,
+// then evaluates the resulting expression. Supported operators:
+// ==, !=, >, <, contains, !contains, && (AND), || (OR).
+// Values can be single-quoted strings or bare words. Parentheses are supported.
+func EvaluateCondition(condition string, vars map[string]string) (bool, error) {
+	if condition == "" {
+		return true, nil
+	}
+
+	expanded := os.Expand(condition, func(key string) string {
+		return vars[key]
+	})
+
+	p := &condParser{input: expanded}
+	result, err := p.parseOr()
+	if err != nil {
+		return false, fmt.Errorf("condition %q: %w", condition, err)
+	}
+
+	p.skipSpaces()
+	if p.pos < len(p.input) {
+		return false, fmt.Errorf("condition %q: unexpected trailing text %q", condition, p.input[p.pos:])
+	}
+
+	return result, nil
+}
+
+type condParser struct {
+	input string
+	pos   int
+}
+
+func (p *condParser) skipSpaces() {
+	for p.pos < len(p.input) && unicode.IsSpace(rune(p.input[p.pos])) {
+		p.pos++
+	}
+}
+
+func (p *condParser) parseOr() (bool, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return false, err
+	}
+
+	for {
+		p.skipSpaces()
+		if p.pos+1 < len(p.input) && p.input[p.pos:p.pos+2] == "||" {
+			p.pos += 2
+			right, err := p.parseAnd()
+			if err != nil {
+				return false, err
+			}
+			left = left || right
+		} else {
+			break
+		}
+	}
+	return left, nil
+}
+
+
+func (p *condParser) parseAnd() (bool, error) {
+	left, err := p.parseCompare()
+	if err != nil {
+		return false, err
+	}
+
+	for {
+		p.skipSpaces()
+		if p.pos+1 < len(p.input) && p.input[p.pos:p.pos+2] == "&&" {
+			p.pos += 2
+			right, err := p.parseCompare()
+			if err != nil {
+				return false, err
+			}
+			left = left && right
+		} else {
+			break
+		}
+	}
+	return left, nil
+}
+
+func (p *condParser) parseCompare() (bool, error) {
+	left, err := p.parseValue()
+	if err != nil {
+		return false, err
+	}
+
+	p.skipSpaces()
+
+	// Check for comparison operator
+	op := p.peekOp()
+	if op == "" {
+		// No operator — treat the value as a boolean: non-empty string is true
+		return left != "", nil
+	}
+
+	p.pos += len(op)
+
+	right, err := p.parseValue()
+	if err != nil {
+		return false, err
+	}
+
+	switch op {
+	case "==":
+		return left == right, nil
+	case "!=":
+		return left != right, nil
+	case ">":
+		lf, le := strconv.ParseFloat(left, 64)
+		rf, re := strconv.ParseFloat(right, 64)
+		if le == nil && re == nil {
+			return lf > rf, nil
+		}
+		return left > right, nil
+	case "<":
+		lf, le := strconv.ParseFloat(left, 64)
+		rf, re := strconv.ParseFloat(right, 64)
+		if le == nil && re == nil {
+			return lf < rf, nil
+		}
+		return left < right, nil
+	case "contains":
+		return strings.Contains(left, right), nil
+	case "!contains":
+		return !strings.Contains(left, right), nil
+	default:
+		return false, fmt.Errorf("unknown operator %q", op)
+	}
+}
+
+func (p *condParser) peekOp() string {
+	if p.pos >= len(p.input) {
+		return ""
+	}
+
+	// Two-char operators first
+	if p.pos+1 < len(p.input) {
+		two := p.input[p.pos : p.pos+2]
+		if two == "==" || two == "!=" {
+			return two
+		}
+	}
+
+	// !contains (must check before single char)
+	if p.pos+9 <= len(p.input) && p.input[p.pos:p.pos+9] == "!contains" {
+		// Make sure it's not part of a longer word
+		if p.pos+9 >= len(p.input) || !isWordChar(p.input[p.pos+9]) {
+			return "!contains"
+		}
+	}
+
+	// contains
+	if p.pos+8 <= len(p.input) && p.input[p.pos:p.pos+8] == "contains" {
+		if p.pos+8 >= len(p.input) || !isWordChar(p.input[p.pos+8]) {
+			return "contains"
+		}
+	}
+
+	ch := p.input[p.pos]
+	if ch == '>' || ch == '<' {
+		return string(ch)
+	}
+
+	return ""
+}
+
+func (p *condParser) parseValue() (string, error) {
+	p.skipSpaces()
+
+	if p.pos >= len(p.input) {
+		return "", nil
+	}
+
+	// Parenthesized expression — evaluate and return "true"/"false"
+	if p.input[p.pos] == '(' {
+		p.pos++ // skip '('
+		result, err := p.parseOr()
+		if err != nil {
+			return "", err
+		}
+		p.skipSpaces()
+		if p.pos >= len(p.input) || p.input[p.pos] != ')' {
+			return "", fmt.Errorf("expected ')' at position %d", p.pos)
+		}
+		p.pos++ // skip ')'
+		if result {
+			return "true", nil
+		}
+		return "", nil
+	}
+
+	// Single-quoted string
+	if p.input[p.pos] == '\'' {
+		p.pos++ // skip opening quote
+		start := p.pos
+		for p.pos < len(p.input) && p.input[p.pos] != '\'' {
+			p.pos++
+		}
+		if p.pos >= len(p.input) {
+			return "", fmt.Errorf("unterminated single-quoted string starting at position %d", start-1)
+		}
+		val := p.input[start:p.pos]
+		p.pos++ // skip closing quote
+		return val, nil
+	}
+
+	// Bare word: read until space or operator character
+	start := p.pos
+	for p.pos < len(p.input) {
+		ch := p.input[p.pos]
+		if unicode.IsSpace(rune(ch)) || ch == ')' || ch == '(' || ch == '>' || ch == '<' {
+			break
+		}
+		// Check for two-char operators
+		if p.pos+1 < len(p.input) {
+			two := p.input[p.pos : p.pos+2]
+			if two == "==" || two == "!=" || two == "&&" || two == "||" {
+				break
+			}
+		}
+		p.pos++
+	}
+	return p.input[start:p.pos], nil
+}
+
+func isWordChar(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_'
+}

--- a/worker/condition_test.go
+++ b/worker/condition_test.go
@@ -1,0 +1,345 @@
+package worker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// allVars contains a realistic set of all runtime variable types that
+// conditions can reference. It mirrors what runIfStep builds from
+// exportedVars + buildMetadataParams + resolved secret vars.
+var allVars = map[string]string{
+	// GET_<STEP>_<KEY> — from get step version metadata (version_* params)
+	"GET_APP_BRANCH": "main",
+	"GET_APP_REF":    "abc123def456",
+	"GET_APP_TAG":    "v2.1.0",
+
+	// TASK_<STEP>_<KEY> — from task PIKOCI_OUTPUT exports
+	"TASK_BUILD_VERSION":    "2.1.0",
+	"TASK_BUILD_EXIT_CODE":  "0",
+	"TASK_DETECT_ENV_ENV":   "staging",
+	"TASK_BUILD_TESTS_PASS": "true",
+
+	// BUILD_* — from buildMetadataParams
+	"BUILD_NUMBER":        "42",
+	"BUILD_JOB_NAME":      "deploy",
+	"BUILD_PIPELINE_NAME": "my-pipeline",
+	"BUILD_TEAM_NAME":     "platform",
+
+	// input_<name> — from job input parameters (b.InputValues)
+	"input_env":     "staging",
+	"input_region":  "us-east-1",
+	"input_dry_run": "false",
+	"input_count":   "3",
+}
+
+func TestEvaluateCondition(t *testing.T) {
+	tests := []struct {
+		name      string
+		condition string
+		want      bool
+		wantErr   bool
+	}{
+		// ── Empty / trivial ──
+		{"empty condition is true", "", true, false},
+
+		// ── == (string equality) ──
+		// GET_* vars (resource version metadata)
+		{"eq GET branch match", "$GET_APP_BRANCH == 'main'", true, false},
+		{"eq GET branch no match", "$GET_APP_BRANCH == 'develop'", false, false},
+		{"eq GET ref", "$GET_APP_REF == 'abc123def456'", true, false},
+		{"eq GET tag semver", "$GET_APP_TAG == 'v2.1.0'", true, false},
+		// TASK_* vars (PIKOCI_OUTPUT exports)
+		{"eq TASK version", "$TASK_BUILD_VERSION == '2.1.0'", true, false},
+		{"eq TASK exit code", "$TASK_BUILD_EXIT_CODE == '0'", true, false},
+		{"eq TASK env", "$TASK_DETECT_ENV_ENV == 'staging'", true, false},
+		{"eq TASK boolean-like", "$TASK_BUILD_TESTS_PASS == 'true'", true, false},
+		// BUILD_* vars (build metadata)
+		{"eq BUILD number", "$BUILD_NUMBER == '42'", true, false},
+		{"eq BUILD job name", "$BUILD_JOB_NAME == 'deploy'", true, false},
+		{"eq BUILD pipeline", "$BUILD_PIPELINE_NAME == 'my-pipeline'", true, false},
+		{"eq BUILD team", "$BUILD_TEAM_NAME == 'platform'", true, false},
+		// input_* vars (manual trigger inputs)
+		{"eq input env", "$input_env == 'staging'", true, false},
+		{"eq input region", "$input_region == 'us-east-1'", true, false},
+		{"eq input bool-like", "$input_dry_run == 'false'", true, false},
+		{"eq input numeric", "$input_count == '3'", true, false},
+		// Undefined var expands to empty
+		{"eq undefined var empty", "$UNDEFINED == ''", true, false},
+		{"eq undefined var nonempty", "$UNDEFINED == 'something'", false, false},
+
+		// ── != (not equal) ──
+		{"neq GET match", "$GET_APP_BRANCH != 'develop'", true, false},
+		{"neq GET no match", "$GET_APP_BRANCH != 'main'", false, false},
+		{"neq TASK", "$TASK_BUILD_EXIT_CODE != '1'", true, false},
+		{"neq BUILD", "$BUILD_NUMBER != '99'", true, false},
+		{"neq input", "$input_env != 'production'", true, false},
+		{"neq undefined vs nonempty", "$UNDEFINED != 'something'", true, false},
+		{"neq undefined vs empty", "$UNDEFINED != ''", false, false},
+
+		// ── > (greater than, numeric if parseable) ──
+		{"gt numeric TASK", "$TASK_BUILD_EXIT_CODE > '-1'", true, false},
+		{"gt numeric TASK false", "$TASK_BUILD_EXIT_CODE > '1'", false, false},
+		{"gt numeric BUILD", "$BUILD_NUMBER > '41'", true, false},
+		{"gt numeric BUILD false", "$BUILD_NUMBER > '42'", false, false},
+		{"gt numeric input", "$input_count > '2'", true, false},
+		{"gt numeric input false", "$input_count > '5'", false, false},
+		{"gt string fallback GET", "$GET_APP_BRANCH > 'aaa'", true, false},
+		{"gt string fallback GET false", "$GET_APP_BRANCH > 'zzz'", false, false},
+
+		// ── < (less than, numeric if parseable) ──
+		{"lt numeric BUILD", "$BUILD_NUMBER < '100'", true, false},
+		{"lt numeric BUILD false", "$BUILD_NUMBER < '10'", false, false},
+		{"lt numeric input", "$input_count < '10'", true, false},
+		{"lt numeric input false", "$input_count < '1'", false, false},
+		{"lt string fallback GET", "$GET_APP_BRANCH < 'zzz'", true, false},
+		{"lt string fallback GET false", "$GET_APP_BRANCH < 'aaa'", false, false},
+		{"lt numeric equal", "$BUILD_NUMBER < '42'", false, false},
+		{"gt numeric equal", "$BUILD_NUMBER > '42'", false, false},
+
+		// ── contains (substring match) ──
+		{"contains GET branch prefix", "$GET_APP_BRANCH contains 'mai'", true, false},
+		{"contains GET branch full", "$GET_APP_BRANCH contains 'main'", true, false},
+		{"contains GET ref partial", "$GET_APP_REF contains 'abc123'", true, false},
+		{"contains GET no match", "$GET_APP_BRANCH contains 'dev'", false, false},
+		{"contains TASK version", "$TASK_BUILD_VERSION contains '2.1'", true, false},
+		{"contains BUILD pipeline", "$BUILD_PIPELINE_NAME contains 'pipeline'", true, false},
+		{"contains input region", "$input_region contains 'east'", true, false},
+		{"contains empty in anything", "$GET_APP_BRANCH contains ''", true, false},
+		// When $UNDEFINED expands to empty, "contains ''" becomes a bare word
+		// "contains" followed by trailing text — this is an error, not a match.
+		// Users should quote or compare the empty var differently.
+		{"contains undefined empty is error", "$UNDEFINED contains ''", false, true},
+
+		// ── !contains (negated substring) ──
+		{"!contains GET no match", "$GET_APP_BRANCH !contains 'dev'", true, false},
+		{"!contains GET match", "$GET_APP_BRANCH !contains 'mai'", false, false},
+		{"!contains TASK", "$TASK_DETECT_ENV_ENV !contains 'prod'", true, false},
+		{"!contains BUILD", "$BUILD_TEAM_NAME !contains 'backend'", true, false},
+		{"!contains input", "$input_region !contains 'west'", true, false},
+
+		// ── && (logical AND) ──
+		{"and both true mixed vars", "$GET_APP_BRANCH == 'main' && $input_env == 'staging'", true, false},
+		{"and left false", "$GET_APP_BRANCH == 'develop' && $input_env == 'staging'", false, false},
+		{"and right false", "$GET_APP_BRANCH == 'main' && $input_env == 'production'", false, false},
+		{"and both false", "$GET_APP_BRANCH == 'develop' && $input_env == 'production'", false, false},
+		{"and three terms", "$GET_APP_BRANCH == 'main' && $BUILD_NUMBER == '42' && $input_env == 'staging'", true, false},
+		{"and three terms one false", "$GET_APP_BRANCH == 'main' && $BUILD_NUMBER == '99' && $input_env == 'staging'", false, false},
+		{"and with numeric", "$BUILD_NUMBER > '10' && $input_count < '100'", true, false},
+
+		// ── || (logical OR) ──
+		{"or both false", "$GET_APP_BRANCH == 'develop' || $input_env == 'production'", false, false},
+		{"or left true", "$GET_APP_BRANCH == 'main' || $input_env == 'production'", true, false},
+		{"or right true", "$GET_APP_BRANCH == 'develop' || $input_env == 'staging'", true, false},
+		{"or both true", "$GET_APP_BRANCH == 'main' || $input_env == 'staging'", true, false},
+		{"or three terms", "$GET_APP_BRANCH == 'develop' || $BUILD_NUMBER == '99' || $input_env == 'staging'", true, false},
+		{"or three terms all false", "$GET_APP_BRANCH == 'develop' || $BUILD_NUMBER == '99' || $input_env == 'production'", false, false},
+
+		// ── Parentheses / precedence ──
+		{"parens override precedence", "($GET_APP_BRANCH == 'main' || $GET_APP_BRANCH == 'develop') && $TASK_BUILD_EXIT_CODE == '0'", true, false},
+		{"parens with false inner", "($GET_APP_BRANCH == 'develop' || $GET_APP_BRANCH == 'feature') && $TASK_BUILD_EXIT_CODE == '0'", false, false},
+		{"nested parens", "(($BUILD_NUMBER > '10') && ($input_count < '100'))", true, false},
+		{"or with and precedence no parens", "$GET_APP_BRANCH == 'develop' || $GET_APP_BRANCH == 'main' && $input_env == 'staging'", true, false},
+
+		// ── No-space operators ──
+		{"no space ==", "$GET_APP_BRANCH=='main'", true, false},
+		{"no space !=", "$GET_APP_BRANCH!='develop'", true, false},
+		{"no space >", "$BUILD_NUMBER>'10'", true, false},
+		{"no space <", "$BUILD_NUMBER<'100'", true, false},
+
+		// ── Bare words (unquoted values) ──
+		{"bare word ==", "hello == hello", true, false},
+		{"bare word != ", "hello == world", false, false},
+		{"bare word contains", "hello-world contains hello", true, false},
+
+		// ── Boolean-like (value-as-truthy) ──
+		{"non-empty var is truthy", "$GET_APP_BRANCH", true, false},
+		{"empty/undefined var is falsy", "$UNDEFINED", false, false},
+		{"non-empty TASK var truthy", "$TASK_BUILD_VERSION", true, false},
+		{"non-empty BUILD var truthy", "$BUILD_NUMBER", true, false},
+		{"non-empty input var truthy", "$input_env", true, false},
+
+		// ── Real-world condition patterns ──
+		{"deploy to prod pattern", "$GET_APP_BRANCH == 'main' && $TASK_BUILD_EXIT_CODE == '0' && $input_dry_run == 'false'", true, false},
+		{"deploy to staging pattern", "$TASK_DETECT_ENV_ENV == 'staging' && $input_region contains 'east'", true, false},
+		{"feature branch skip", "$GET_APP_BRANCH != 'main' && $GET_APP_BRANCH != 'develop'", false, false},
+		{"build number threshold", "$BUILD_NUMBER > '10' && $BUILD_NUMBER < '100'", true, false},
+		{"multi-env check", "$input_env == 'production' || $input_env == 'staging'", true, false},
+		{"semver tag check", "$GET_APP_TAG contains 'v2.' && $TASK_BUILD_TESTS_PASS == 'true'", true, false},
+
+		// ── Two vars compared against each other ──
+		{"var vs var eq match", "$GET_APP_BRANCH == $GET_APP_BRANCH", true, false},
+		{"var vs var eq no match", "$GET_APP_BRANCH == $TASK_DETECT_ENV_ENV", false, false},
+		{"var vs var neq", "$GET_APP_BRANCH != $TASK_DETECT_ENV_ENV", true, false},
+		{"var vs var contains", "$BUILD_PIPELINE_NAME contains $input_env", false, false},
+
+		// ── ${VAR} brace syntax (supported by os.Expand) ──
+		{"brace syntax eq", "${GET_APP_BRANCH} == 'main'", true, false},
+		{"brace syntax neq", "${BUILD_NUMBER} != '99'", true, false},
+		{"brace syntax in expression", "${GET_APP_BRANCH} == 'main' && ${input_env} == 'staging'", true, false},
+
+		// ── Numeric edge cases ──
+		{"gt negative number", "$TASK_BUILD_EXIT_CODE > '-1'", true, false},
+		{"lt negative number", "$TASK_BUILD_EXIT_CODE < '-1'", false, false},
+		{"gt float", "$BUILD_NUMBER > '41.5'", true, false},
+		{"lt float", "$BUILD_NUMBER < '42.5'", true, false},
+		{"gt leading zero", "$input_count > '003'", false, false}, // 3 > 3 = false
+		{"eq leading zero", "$input_count == '003'", false, false}, // "3" != "003" string comparison
+		{"gt mixed numeric string left", "$GET_APP_BRANCH > '10'", true, false}, // string fallback: "main" > "10"
+		{"lt mixed numeric string right", "$BUILD_NUMBER < 'abc'", true, false},  // string fallback: "42" < "abc"
+		{"gt equal numeric", "$BUILD_NUMBER > '42'", false, false},
+		{"lt equal numeric", "$BUILD_NUMBER < '42'", false, false},
+		{"gt equal string", "$GET_APP_BRANCH > 'main'", false, false},
+		{"lt equal string", "$GET_APP_BRANCH < 'main'", false, false},
+
+		// ── contains / !contains no-space ──
+		{"contains no space quoted", "$GET_APP_BRANCH contains'mai'", true, false},
+		{"!contains no space quoted", "$GET_APP_BRANCH !contains'dev'", true, false},
+
+		// ── Empty string comparisons ──
+		{"empty eq empty", "'' == ''", true, false},
+		{"empty neq empty", "'' != ''", false, false},
+		{"empty contains empty", "'' contains ''", true, false},
+		{"empty !contains empty", "'' !contains ''", false, false},
+		{"empty lt nonempty", "'' < 'a'", true, false},
+		{"nonempty gt empty", "'a' > ''", true, false},
+
+		// ── Values with operator-like content ──
+		{"value containing equals", "'a==b' == 'a==b'", true, false},
+		{"value containing ampersand", "'a&&b' == 'a&&b'", true, false},
+		{"value containing pipe", "'a||b' == 'a||b'", true, false},
+		{"value containing contains", "'containsX' == 'containsX'", true, false},
+		{"value containing gt", "'a>b' == 'a>b'", true, false},
+
+		// ── && / || mixed precedence (AND binds tighter than OR) ──
+		// false && true || true  →  (false && true) || true  →  false || true  →  true
+		{"and-or precedence left false", "$GET_APP_BRANCH == 'develop' && $BUILD_NUMBER == '42' || $input_env == 'staging'", true, false},
+		// true || false && false  →  true || (false && false)  →  true || false  →  true
+		{"and-or precedence right false", "$GET_APP_BRANCH == 'main' || $BUILD_NUMBER == '99' && $input_env == 'production'", true, false},
+		// false || false && true  →  false || (false && true)  →  false || false  →  false
+		{"and-or precedence all paths false", "$GET_APP_BRANCH == 'develop' || $BUILD_NUMBER == '99' && $input_env == 'staging'", false, false},
+
+		// ── Whitespace edge cases ──
+		{"whitespace only", "   ", false, false},
+		{"extra whitespace around operators", "  $GET_APP_BRANCH   ==   'main'  ", true, false},
+		{"tabs and spaces", "\t$BUILD_NUMBER\t==\t'42'\t", true, false},
+
+		// ── Error cases ──
+		{"unterminated quote", "$GET_APP_BRANCH == 'main", false, true},
+		{"missing closing paren", "($GET_APP_BRANCH == 'main'", false, true},
+		{"trailing text", "$GET_APP_BRANCH == 'main' extratext", false, true},
+		{"extra closing paren", "$GET_APP_BRANCH == 'main')", false, true},
+		{"empty parens", "()", false, false}, // parses inner as empty → "" → falsy
+		{"contains undefined empty is error", "$UNDEFINED contains ''", false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := EvaluateCondition(tt.condition, allVars)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got, "condition: %s", tt.condition)
+		})
+	}
+}
+
+func TestEvaluateCondition_NilVars(t *testing.T) {
+	// Nil vars map should not panic; all vars expand to ""
+	result, err := EvaluateCondition("$FOO == ''", nil)
+	require.NoError(t, err)
+	assert.True(t, result)
+}
+
+func TestEvaluateCondition_EmptyVars(t *testing.T) {
+	result, err := EvaluateCondition("$FOO == ''", map[string]string{})
+	require.NoError(t, err)
+	assert.True(t, result)
+}
+
+func TestEvaluateCondition_SpecialCharValues(t *testing.T) {
+	vars := map[string]string{
+		"GET_APP_BRANCH":     "feature/my-branch",
+		"TASK_BUILD_VERSION": "1.2.3-rc.1",
+		"input_path":         "/opt/deploy/app",
+	}
+
+	tests := []struct {
+		name      string
+		condition string
+		want      bool
+	}{
+		{"slash in branch", "$GET_APP_BRANCH contains 'feature/'", true},
+		{"dot in version", "$TASK_BUILD_VERSION contains '1.2.3'", true},
+		{"dash in version", "$TASK_BUILD_VERSION contains 'rc'", true},
+		{"slash in path", "$input_path contains '/deploy/'", true},
+		{"eq with slash", "$GET_APP_BRANCH == 'feature/my-branch'", true},
+		{"eq with dots and dash", "$TASK_BUILD_VERSION == '1.2.3-rc.1'", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := EvaluateCondition(tt.condition, vars)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestEvaluateCondition_ValuesWithSpaces(t *testing.T) {
+	// When a variable expands to a value with spaces, the bare word parser
+	// reads only until the first space. This means variables containing
+	// spaces produce errors when used unquoted — users should avoid spaces
+	// in PIKOCI_OUTPUT keys and resource metadata values.
+	vars := map[string]string{
+		"TASK_BUILD_MSG": "hello world",
+		"input_label":    "deploy to prod",
+	}
+
+	tests := []struct {
+		name      string
+		condition string
+		want      bool
+		wantErr   bool
+	}{
+		// Space in expanded var causes trailing text errors because the
+		// bare word parser splits on whitespace.
+		{"space value eq is error", "$TASK_BUILD_MSG == 'hello world'", false, true},
+		{"space value contains is error", "$TASK_BUILD_MSG contains 'hello'", false, true},
+		{"space input eq is error", "$input_label == 'deploy to prod'", false, true},
+		// Quoted literal comparison still works fine
+		{"space value eq both quoted", "'hello world' == 'hello world'", true, false},
+		{"space value contains both quoted", "'hello world' contains 'hello'", true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := EvaluateCondition(tt.condition, vars)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got, "condition: %s", tt.condition)
+		})
+	}
+}
+
+func TestEvaluateCondition_SingleQuotesInValues(t *testing.T) {
+	// Single quotes inside values cannot be represented in single-quoted
+	// strings, but they can appear as bare words or in variable values.
+	vars := map[string]string{
+		"TASK_BUILD_MSG": "it's done",
+	}
+
+	// The var expands to: it's done contains 'done'
+	// Bare word reads "it", then the single quote starts a quoted string "'s done contains '"
+	// which is "s done contains ", then "done'" is trailing — this is an error.
+	result, err := EvaluateCondition("$TASK_BUILD_MSG contains 'done'", vars)
+	require.Error(t, err)
+	_ = result
+}

--- a/worker/service.go
+++ b/worker/service.go
@@ -797,6 +797,13 @@ func (w *Worker) runPlan(ctx context.Context, m workitem.Body, b *build.Build, c
 			if w.runInParallelStep(ctx, m, b, cwd, pp, *ps.InParallel, ps, resolvedVersions, exportedVars, secretVals, resolved) {
 				return true, resolved, exportedVars
 			}
+		case job.StepTypeIf:
+			if ps.If == nil {
+				continue
+			}
+			if w.runIfStep(ctx, m, b, cwd, pp, *ps.If, ps, resolvedVersions, exportedVars, secretVals, resolved) {
+				return true, resolved, exportedVars
+			}
 		}
 	}
 	return false, resolved, exportedVars
@@ -1004,6 +1011,192 @@ func (w *Worker) runInParallelStep(
 	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, "", ps.Ensure, "ensure", resolved, exportedVars)
 
 	return anyFailed
+}
+
+// runIfStep evaluates conditional branches and executes the first matching one.
+// Returns true if the selected branch failed.
+func (w *Worker) runIfStep(
+	ctx context.Context, m workitem.Body, b *build.Build,
+	cwd string, pp *pipeline.Pipeline, ifStep job.IfStep,
+	ps job.PlanStep, resolvedVersions map[string]uint32,
+	exportedVars map[string]string, secretVals []string, resolved map[string]string,
+) bool {
+	start := time.Now()
+
+	if len(ifStep.Branches) == 0 {
+		b.Steps = append(b.Steps, build.Step{
+			Type: "if", Status: build.Succeeded, Duration: 0,
+		})
+		w.updateBuild(ctx, m, *b)
+		return false
+	}
+
+	// Build condition vars from exportedVars + build metadata + input values
+	condVars := make(map[string]string)
+	for k, v := range exportedVars {
+		condVars[k] = v
+	}
+	for k, v := range buildMetadataParams(b, m) {
+		condVars[k] = v
+	}
+	for k, v := range resolved {
+		condVars[k] = v
+	}
+
+	// Add parent step placeholder
+	parentIdx := len(b.Steps)
+	label := "if"
+	if len(ifStep.Branches) > 0 && ifStep.Branches[0].Label != "" {
+		label = ifStep.Branches[0].Label
+	}
+	b.Steps = append(b.Steps, build.Step{
+		Type: "if", Name: label, Status: build.Started,
+	})
+	w.updateBuild(ctx, m, *b)
+
+	// Evaluate branches to find the selected one
+	selectedIdx := -1
+	for i, branch := range ifStep.Branches {
+		if branch.Type == "else" {
+			selectedIdx = i
+			break
+		}
+		result, err := EvaluateCondition(branch.Condition, condVars)
+		if err != nil {
+			w.failBuild(ctx, m, *b, fmt.Errorf("condition evaluation error in %s %q: %w", branch.Type, branch.Label, err))
+			return true
+		}
+		if result {
+			selectedIdx = i
+			break
+		}
+	}
+
+	// Build sub-steps for each branch. For the selected branch we use a
+	// local build with SuppressUpdates so inner steps appear nested under the
+	// branch in real-time (same pattern as runInParallelStep).
+	var subSteps []build.Step
+	failed := false
+	for i, branch := range ifStep.Branches {
+		branchName := branch.Label
+		if branchName == "" {
+			branchName = branch.Type
+		}
+
+		if i == selectedIdx {
+			branchStart := time.Now()
+
+			// Initialise the branch sub-step inside the parent so the UI
+			// shows the entered branch immediately.
+			branchIdx := len(subSteps)
+			subSteps = append(subSteps, build.Step{
+				Type: branch.Type, Name: branchName, Status: build.Started,
+			})
+			b.Steps[parentIdx].SubSteps = subSteps
+			w.updateBuild(ctx, m, *b)
+
+			// Local build whose steps sync into the branch's SubSteps on
+			// every updateBuild call, keeping the UI nested in real-time.
+			// Copy InputValues and BuildNumber so buildMetadataParams works.
+			localBuild := &build.Build{
+				SuppressUpdates: true,
+				InputValues:     b.InputValues,
+				BuildNumber:     b.BuildNumber,
+			}
+			localBuild.OnUpdate = func() {
+				subSteps[branchIdx].SubSteps = make([]build.Step, len(localBuild.Steps))
+				copy(subSteps[branchIdx].SubSteps, localBuild.Steps)
+				b.Steps[parentIdx].SubSteps = subSteps
+				w.updateBuild(ctx, m, *b)
+			}
+
+			// Execute inner steps sequentially on the local build.
+			for _, innerPS := range branch.Steps {
+				switch innerPS.Type {
+				case job.StepTypeGet:
+					if innerPS.Get != nil {
+						if w.runGetStep(ctx, m, localBuild, cwd, pp, *innerPS.Get, innerPS, resolvedVersions, exportedVars, secretVals, resolved) {
+							failed = true
+						}
+					}
+				case job.StepTypeTask:
+					if innerPS.Task != nil {
+						if w.runTaskStep(ctx, m, localBuild, cwd, pp, *innerPS.Task, innerPS, exportedVars, secretVals, resolved) {
+							failed = true
+						}
+					}
+				case job.StepTypePut:
+					if innerPS.Put != nil {
+						if w.runPutStep(ctx, m, localBuild, cwd, pp, *innerPS.Put, innerPS, exportedVars, secretVals, resolved) {
+							failed = true
+						}
+					}
+				case job.StepTypeNotify:
+					if innerPS.Notify != nil {
+						if w.runNotifyStep(ctx, m, localBuild, cwd, pp, *innerPS.Notify, innerPS, exportedVars, secretVals, resolved) {
+							failed = true
+						}
+					}
+				case job.StepTypeInParallel:
+					if innerPS.InParallel != nil {
+						if w.runInParallelStep(ctx, m, localBuild, cwd, pp, *innerPS.InParallel, innerPS, resolvedVersions, exportedVars, secretVals, resolved) {
+							failed = true
+						}
+					}
+				case job.StepTypeService:
+					if innerPS.Service != nil {
+						batch := []job.ServiceStep{*innerPS.Service}
+						startedServices := w.startServices(ctx, m, localBuild, cwd, pp, batch, secretVals)
+						if len(startedServices) != len(batch) {
+							failed = true
+						} else if !w.waitForServices(ctx, m, localBuild, cwd, pp, startedServices, secretVals) {
+							failed = true
+						}
+					}
+				}
+				if failed {
+					break
+				}
+			}
+
+			// Final sync of inner steps.
+			subSteps[branchIdx].SubSteps = make([]build.Step, len(localBuild.Steps))
+			copy(subSteps[branchIdx].SubSteps, localBuild.Steps)
+
+			if failed {
+				subSteps[branchIdx].Status = build.Failed
+			} else {
+				subSteps[branchIdx].Status = build.Succeeded
+			}
+			subSteps[branchIdx].Duration = time.Since(branchStart)
+		} else {
+			// Skipped branch
+			subSteps = append(subSteps, build.Step{
+				Type: branch.Type, Name: branchName, Status: build.Skipped,
+			})
+		}
+	}
+
+	// Update parent step
+	status := build.Succeeded
+	if failed {
+		status = build.Failed
+		b.Status = build.Failed
+	}
+	b.Steps[parentIdx].Status = status
+	b.Steps[parentIdx].Duration = time.Since(start)
+	b.Steps[parentIdx].SubSteps = subSteps
+	w.updateBuild(ctx, m, *b)
+
+	// Run if-level hooks
+	if failed {
+		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, "", ps.OnFailure, "on_failure", resolved, exportedVars)
+	} else {
+		w.runHooks(ctx, m, b, &b.Steps, cwd, pp, "", ps.OnSuccess, "on_success", resolved, exportedVars)
+	}
+	w.runHooks(ctx, m, b, &b.Steps, cwd, pp, "", ps.Ensure, "ensure", resolved, exportedVars)
+
+	return failed
 }
 
 // runGetStep runs a single get step (resource pull).

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -10003,3 +10003,292 @@ func TestProcessJob_InputValues_InjectedAsEnvVars(t *testing.T) {
 	assert.Contains(t, taskLogs, "version=v2.0", "input_version env var should be expanded in task logs")
 	assert.Contains(t, taskLogs, "debug=true", "input_debug env var should be expanded in task logs")
 }
+
+func TestProcessJob_IfStep_InputValues_AndBranchSelection(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	svc := mock.NewService(ctrl)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	inputVals := map[string]string{"env": "production", "version": "v3.0"}
+
+	ifJob := job.Job{
+		ID: 1, Name: "deploy",
+		Plan: []job.PlanStep{
+			{
+				Type: job.StepTypeIf,
+				If: &job.IfStep{
+					Branches: []job.IfBranch{
+						{
+							Type:      "if",
+							Label:     "check-prod",
+							Condition: "$input_env == 'production'",
+							Steps: []job.PlanStep{
+								{Type: job.StepTypeTask, Task: &job.TaskStep{
+									Name: "deploy-prod",
+									Run: utils.RunnerCommand{
+										Runner: "exec",
+										Args:   []string{"-ec", "echo PROD version=$input_version"},
+										Params: map[string]string{"path": "/bin/sh"},
+									},
+								}},
+							},
+						},
+						{
+							Type:  "else",
+							Label: "else",
+							Steps: []job.PlanStep{
+								{Type: job.StepTypeTask, Task: &job.TaskStep{
+									Name: "deploy-staging",
+									Run: utils.RunnerCommand{
+										Runner: "exec",
+										Args:   []string{"-ec", "echo STAGING version=$input_version"},
+										Params: map[string]string{"path": "/bin/sh"},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	svc.EXPECT().GetJobBuild(gomock.Any(), "main", "test-pipeline", "deploy", "30").
+		Return(&build.Build{
+			ID: 30, BuildNumber: "30", Status: build.Started,
+			StartedAt: time.Now(), InputValues: inputVals,
+		}, nil).AnyTimes()
+
+	svc.EXPECT().GetPipelineJob(gomock.Any(), "main", "test-pipeline", "deploy").
+		Return(&ifJob, nil)
+
+	svc.EXPECT().NotifySerialGroupPendingBuilds(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	svc.EXPECT().FindBuildGetVersions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	svc.EXPECT().EvaluateDownstreamJobs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	var lastBuild build.Build
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), "main", "test-pipeline", "deploy", "30", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, b build.Build) error {
+			lastBuild = b
+			return nil
+		}).AnyTimes()
+
+	w := &Worker{pikoci: svc, logger: logger}
+	pp := &pipeline.Pipeline{
+		ID: 1, Name: "test-pipeline",
+		Jobs:    []job.Job{ifJob},
+		Runners: []runner.Runner{{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}}},
+	}
+	m := workitem.Body{
+		TeamCanonical: "main", PipelineCanonical: "test-pipeline",
+		JobName: "deploy", BuildID: 30, BuildNumber: "30",
+	}
+
+	w.processJob(context.Background(), m, t.TempDir(), pp)
+
+	// Verify structure: parent "if" step with branch sub-steps
+	require.True(t, len(lastBuild.Steps) > 0, "build should have steps")
+	ifParent := lastBuild.Steps[0]
+	assert.Equal(t, "if", ifParent.Type)
+	assert.Equal(t, build.Succeeded, ifParent.Status)
+	require.Len(t, ifParent.SubSteps, 2, "should have 2 branches (if + else)")
+
+	// First branch (if "check-prod") should be entered because input_env=production
+	assert.Equal(t, "if", ifParent.SubSteps[0].Type)
+	assert.Equal(t, build.Succeeded, ifParent.SubSteps[0].Status)
+	require.Len(t, ifParent.SubSteps[0].SubSteps, 1, "entered branch should have 1 inner step")
+	assert.Equal(t, "deploy-prod", ifParent.SubSteps[0].SubSteps[0].Name)
+
+	// Second branch (else) should be skipped
+	assert.Equal(t, "else", ifParent.SubSteps[1].Type)
+	assert.Equal(t, build.Skipped, ifParent.SubSteps[1].Status)
+
+	// Verify input values are available inside the branch task
+	taskLogs := ifParent.SubSteps[0].SubSteps[0].Logs
+	assert.Contains(t, taskLogs, "PROD version=v3.0", "input_version env var should be expanded inside if branch")
+	assert.NotContains(t, taskLogs, "STAGING", "else branch should not have executed")
+}
+
+func TestProcessJob_IfStep_NoBranchMatches(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	svc := mock.NewService(ctrl)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	inputVals := map[string]string{"env": "development"}
+
+	ifJob := job.Job{
+		ID: 1, Name: "deploy",
+		Plan: []job.PlanStep{
+			{
+				Type: job.StepTypeIf,
+				If: &job.IfStep{
+					Branches: []job.IfBranch{
+						{
+							Type:      "if",
+							Label:     "check-prod",
+							Condition: "$input_env == 'production'",
+							Steps: []job.PlanStep{
+								{Type: job.StepTypeTask, Task: &job.TaskStep{
+									Name: "deploy-prod",
+									Run: utils.RunnerCommand{
+										Runner: "exec",
+										Args:   []string{"-ec", "echo prod"},
+										Params: map[string]string{"path": "/bin/sh"},
+									},
+								}},
+							},
+						},
+						{
+							Type:      "else_if",
+							Label:     "check-staging",
+							Condition: "$input_env == 'staging'",
+							Steps: []job.PlanStep{
+								{Type: job.StepTypeTask, Task: &job.TaskStep{
+									Name: "deploy-staging",
+									Run: utils.RunnerCommand{
+										Runner: "exec",
+										Args:   []string{"-ec", "echo staging"},
+										Params: map[string]string{"path": "/bin/sh"},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	svc.EXPECT().GetJobBuild(gomock.Any(), "main", "test-pipeline", "deploy", "31").
+		Return(&build.Build{
+			ID: 31, BuildNumber: "31", Status: build.Started,
+			StartedAt: time.Now(), InputValues: inputVals,
+		}, nil).AnyTimes()
+
+	svc.EXPECT().GetPipelineJob(gomock.Any(), "main", "test-pipeline", "deploy").
+		Return(&ifJob, nil)
+
+	svc.EXPECT().NotifySerialGroupPendingBuilds(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	svc.EXPECT().FindBuildGetVersions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	svc.EXPECT().EvaluateDownstreamJobs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	var lastBuild build.Build
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), "main", "test-pipeline", "deploy", "31", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, b build.Build) error {
+			lastBuild = b
+			return nil
+		}).AnyTimes()
+
+	w := &Worker{pikoci: svc, logger: logger}
+	pp := &pipeline.Pipeline{
+		ID: 1, Name: "test-pipeline",
+		Jobs:    []job.Job{ifJob},
+		Runners: []runner.Runner{{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}}},
+	}
+	m := workitem.Body{
+		TeamCanonical: "main", PipelineCanonical: "test-pipeline",
+		JobName: "deploy", BuildID: 31, BuildNumber: "31",
+	}
+
+	w.processJob(context.Background(), m, t.TempDir(), pp)
+
+	// No branch matches — all should be skipped, build should succeed
+	assert.Equal(t, build.Succeeded, lastBuild.Status, "build should succeed when no branch matches")
+	require.True(t, len(lastBuild.Steps) > 0)
+	ifParent := lastBuild.Steps[0]
+	assert.Equal(t, "if", ifParent.Type)
+	assert.Equal(t, build.Succeeded, ifParent.Status)
+	require.Len(t, ifParent.SubSteps, 2)
+	assert.Equal(t, build.Skipped, ifParent.SubSteps[0].Status, "if branch should be skipped")
+	assert.Equal(t, build.Skipped, ifParent.SubSteps[1].Status, "else_if branch should be skipped")
+}
+
+func TestProcessJob_IfStep_BranchFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	svc := mock.NewService(ctrl)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	ifJob := job.Job{
+		ID: 1, Name: "deploy",
+		Plan: []job.PlanStep{
+			{
+				Type: job.StepTypeIf,
+				If: &job.IfStep{
+					Branches: []job.IfBranch{
+						{
+							Type:      "if",
+							Label:     "always-true",
+							Condition: "'yes' == 'yes'",
+							Steps: []job.PlanStep{
+								{Type: job.StepTypeTask, Task: &job.TaskStep{
+									Name: "failing-task",
+									Run: utils.RunnerCommand{
+										Runner: "exec",
+										Args:   []string{"-ec", "exit 1"},
+										Params: map[string]string{"path": "/bin/sh"},
+									},
+								}},
+							},
+						},
+						{
+							Type:  "else",
+							Steps: []job.PlanStep{
+								{Type: job.StepTypeTask, Task: &job.TaskStep{
+									Name: "never-reached",
+									Run: utils.RunnerCommand{
+										Runner: "exec",
+										Args:   []string{"-ec", "echo ok"},
+										Params: map[string]string{"path": "/bin/sh"},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	svc.EXPECT().GetJobBuild(gomock.Any(), "main", "test-pipeline", "deploy", "32").
+		Return(&build.Build{
+			ID: 32, BuildNumber: "32", Status: build.Started,
+			StartedAt: time.Now(),
+		}, nil).AnyTimes()
+
+	svc.EXPECT().GetPipelineJob(gomock.Any(), "main", "test-pipeline", "deploy").
+		Return(&ifJob, nil)
+
+	svc.EXPECT().NotifySerialGroupPendingBuilds(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	svc.EXPECT().FindBuildGetVersions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	svc.EXPECT().EvaluateDownstreamJobs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	var lastBuild build.Build
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), "main", "test-pipeline", "deploy", "32", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, b build.Build) error {
+			lastBuild = b
+			return nil
+		}).AnyTimes()
+
+	w := &Worker{pikoci: svc, logger: logger}
+	pp := &pipeline.Pipeline{
+		ID: 1, Name: "test-pipeline",
+		Jobs:    []job.Job{ifJob},
+		Runners: []runner.Runner{{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}}},
+	}
+	m := workitem.Body{
+		TeamCanonical: "main", PipelineCanonical: "test-pipeline",
+		JobName: "deploy", BuildID: 32, BuildNumber: "32",
+	}
+
+	w.processJob(context.Background(), m, t.TempDir(), pp)
+
+	// Build should fail when the selected branch's task fails
+	assert.Equal(t, build.Failed, lastBuild.Status, "build should fail when selected branch fails")
+	require.True(t, len(lastBuild.Steps) > 0)
+	ifParent := lastBuild.Steps[0]
+	assert.Equal(t, "if", ifParent.Type)
+	assert.Equal(t, build.Failed, ifParent.Status, "if parent should be failed")
+	require.Len(t, ifParent.SubSteps, 2)
+	assert.Equal(t, build.Failed, ifParent.SubSteps[0].Status, "entered branch should be failed")
+	assert.Equal(t, build.Skipped, ifParent.SubSteps[1].Status, "else branch should be skipped")
+}


### PR DESCRIPTION
## Summary

- Adds declarative `if`/`else_if`/`else` conditional blocks at the job plan level, enabling branching based on runtime values (`$GET_*`, `$TASK_*`, `$BUILD_*`, `$input_*`)
- Condition evaluator supports `==`, `!=`, `>`, `<`, `contains`, `!contains`, `&&`, `||` with parentheses and `$VAR` expansion
- Skipped branches display with a muted badge in the UI; entered branches show nested steps in real-time

Closes #164