### PR TITLE
refactor: rename $input_ env var prefix to $INPUT_ (#629)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Conditional job execution (`if`/`else_if`/`else`)**: Jobs can use declarative conditional blocks to branch execution based on runtime values (`$GET_*`, `$TASK_*`, `$BUILD_*`, `$input_*`). Supports `==`, `!=`, `>`, `<`, `contains`, `!contains`, `&&`, `||` operators with parentheses. Skipped branches display with a muted badge in the UI ([#164](https://github.com/PikoCI/pikoci/issues/164)).
-- **Parameterized manual triggers**: Jobs can declare `input` blocks to collect parameters on manual trigger, injected as `$input_<name>` env vars. Supports typed fields, defaults, dropdowns, and multi-select ([#467](https://github.com/PikoCI/pikoci/issues/467)).
+- **Conditional job execution (`if`/`else_if`/`else`)**: Jobs can use declarative conditional blocks to branch execution based on runtime values (`$GET_*`, `$TASK_*`, `$BUILD_*`, `$INPUT_*`). Supports `==`, `!=`, `>`, `<`, `contains`, `!contains`, `&&`, `||` operators with parentheses. Skipped branches display with a muted badge in the UI ([#164](https://github.com/PikoCI/pikoci/issues/164)).
+- **Parameterized manual triggers**: Jobs can declare `input` blocks to collect parameters on manual trigger, injected as `$INPUT_<name>` env vars. Supports typed fields, defaults, dropdowns, and multi-select ([#467](https://github.com/PikoCI/pikoci/issues/467)).
 - **`interruptible` on jobs**: When `true`, creating a new build for the job automatically cancels all older running, pending, and waiting-for-approval builds, so only the latest build runs ([#612](https://github.com/PikoCI/pikoci/issues/612)).
 - **`allow_failure` on jobs**: When `true`, a failed build is marked as `warning` (salmon) instead of `failed`, unblocking downstream jobs. Any failed build can also be manually marked as warning via a UI button (requires Maintain role) ([#610](https://github.com/PikoCI/pikoci/issues/610)).
 - **`disable_retry` on jobs**: Prevents build retries via API and hides the retry button in the UI ([#617](https://github.com/PikoCI/pikoci/issues/617)).

--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -305,7 +305,7 @@ Jobs can declare `input` blocks to accept parameters when manually triggered. Ea
 **Trigger behavior:**
 - **Manual trigger (UI/CLI):** A form is shown with one field per input. Required fields (no default) must be filled.
 - **Automatic trigger:** Defaults are used. If no default exists, zero values are used (`""`, `"0"`, `"false"`). Auto-triggers are never blocked by missing inputs.
-- **Local execution (`pikoci run`):** Pass input values via `--var input_<name>=value`.
+- **Local execution (`pikoci run`):** Pass input values via `--var INPUT_<name>=value`.
 - **Retry:** Input values from the original build are automatically copied to the retry.
 
 ```hcl

--- a/docs/Pipeline.md
+++ b/docs/Pipeline.md
@@ -291,7 +291,7 @@ The optional `timeout` attribute limits the total wall-clock time for a build's 
 
 #### input
 
-Jobs can declare `input` blocks to accept parameters when manually triggered. Each input becomes an environment variable `$input_<name>` available to all steps.
+Jobs can declare `input` blocks to accept parameters when manually triggered. Each input becomes an environment variable `$INPUT_<name>` available to all steps.
 
 | Field | Required | Description |
 |-------|----------|-------------|
@@ -330,7 +330,7 @@ job "deploy" {
   task "deploy" {
     run "exec" {
       path = "./deploy.sh"
-      args = ["$input_version", "$input_environment"]
+      args = ["$INPUT_version", "$INPUT_environment"]
     }
   }
 }
@@ -942,7 +942,7 @@ Parentheses are supported for grouping: `($GET_APP_BRANCH == 'main' || $GET_APP_
 - `$GET_<STEP>_<KEY>` — resource version metadata from get steps
 - `$TASK_<STEP>_<KEY>` — values exported via `$PIKOCI_OUTPUT` from task steps
 - `$BUILD_NUMBER`, `$BUILD_JOB_NAME`, `$BUILD_PIPELINE_NAME`, `$BUILD_TEAM_NAME`
-- `$input_<name>` — input parameter values
+- `$INPUT_<name>` — input parameter values
 
 #### Behavior
 

--- a/pikoci/helper.go
+++ b/pikoci/helper.go
@@ -1566,7 +1566,7 @@ func ReadPipeline(ctx context.Context, rpp []byte, vars map[string]interface{}) 
 				inputNames[inp.Name] = true
 				envName := strings.ToLower(inp.Name)
 				if envNames[envName] {
-					return nil, fmt.Errorf("job %q: input %q produces duplicate env var name input_%s", hj.Name, inp.Name, envName)
+					return nil, fmt.Errorf("job %q: input %q produces duplicate env var name INPUT_%s", hj.Name, inp.Name, inp.Name)
 				}
 				envNames[envName] = true
 				if inp.Type != "string" && inp.Type != "number" && inp.Type != "bool" {

--- a/pikoci/job/job.go
+++ b/pikoci/job/job.go
@@ -41,7 +41,7 @@ type HookStep struct {
 }
 
 // Input defines a parameter that can be provided when manually triggering a job.
-// Values are injected as $input_<name> environment variables into all steps.
+// Values are injected as $INPUT_<name> environment variables into all steps.
 type Input struct {
 	Name        string   `json:"name"`
 	Type        string   `json:"type"`              // "string", "number", "bool"

--- a/pikoci/testdata/cron.hcl
+++ b/pikoci/testdata/cron.hcl
@@ -72,21 +72,21 @@ job "deploy-staging" {
   approve "deploy to staging" {}
 
   if "check-dry-run" {
-    condition = "$input_dry_run == 'true'"
+    condition = "$INPUT_dry_run == 'true'"
     task "dry-run" {
       run "exec" {
         path = "/bin/sh"
-        args = ["-ec", "echo '--- DRY RUN ---' && echo version=$input_version env=$input_environment && echo 'would deploy to $input_environment (skipped)' && cat cron-output/timestamp.txt"]
+        args = ["-ec", "echo '--- DRY RUN ---' && echo version=$INPUT_version env=$INPUT_environment && echo 'would deploy to $INPUT_environment (skipped)' && cat cron-output/timestamp.txt"]
       }
     }
   }
 
   else_if "check-production" {
-    condition = "$input_environment == 'production'"
+    condition = "$INPUT_environment == 'production'"
     task "deploy-prod" {
       run "exec" {
         path = "/bin/sh"
-        args = ["-ec", "echo '--- PRODUCTION DEPLOY ---' && echo version=$input_version && cat cron-output/timestamp.txt && echo 'deploying to production...' && sleep 5 && echo 'done'"]
+        args = ["-ec", "echo '--- PRODUCTION DEPLOY ---' && echo version=$INPUT_version && cat cron-output/timestamp.txt && echo 'deploying to production...' && sleep 5 && echo 'done'"]
       }
     }
   }
@@ -95,7 +95,7 @@ job "deploy-staging" {
     task "deploy-staging" {
       run "exec" {
         path = "/bin/sh"
-        args = ["-ec", "echo '--- STAGING DEPLOY ---' && echo version=$input_version && cat cron-output/timestamp.txt && echo 'deploying to staging...' && sleep 5 && echo 'done'"]
+        args = ["-ec", "echo '--- STAGING DEPLOY ---' && echo version=$INPUT_version && cat cron-output/timestamp.txt && echo 'deploying to staging...' && sleep 5 && echo 'done'"]
       }
     }
   }
@@ -236,7 +236,7 @@ job "monitor" {
   task "check" {
     run "exec" {
       path = "/bin/sh"
-      args = ["-ec", "echo '--- monitor ---' && echo target=$input_target verbose=$input_verbose && echo 'cron version: $GET_MY_CRON_DATE' && echo 'done'"]
+      args = ["-ec", "echo '--- monitor ---' && echo target=$INPUT_target verbose=$INPUT_verbose && echo 'cron version: $GET_MY_CRON_DATE' && echo 'done'"]
     }
     on_success "exec" {
       path = "/bin/sh"

--- a/worker/condition_test.go
+++ b/worker/condition_test.go
@@ -178,7 +178,7 @@ func TestEvaluateCondition(t *testing.T) {
 		// ── ${VAR} brace syntax (supported by os.Expand) ──
 		{"brace syntax eq", "${GET_APP_BRANCH} == 'main'", true, false},
 		{"brace syntax neq", "${BUILD_NUMBER} != '99'", true, false},
-		{"brace syntax in expression", "${GET_APP_BRANCH} == 'main' && ${input_env} == 'staging'", true, false},
+		{"brace syntax in expression", "${GET_APP_BRANCH} == 'main' && ${INPUT_env} == 'staging'", true, false},
 
 		// ── Numeric edge cases ──
 		{"gt negative number", "$TASK_BUILD_EXIT_CODE > '-1'", true, false},
@@ -265,7 +265,7 @@ func TestEvaluateCondition_SpecialCharValues(t *testing.T) {
 	vars := map[string]string{
 		"GET_APP_BRANCH":     "feature/my-branch",
 		"TASK_BUILD_VERSION": "1.2.3-rc.1",
-		"input_path":         "/opt/deploy/app",
+		"INPUT_path":         "/opt/deploy/app",
 	}
 
 	tests := []struct {
@@ -297,7 +297,7 @@ func TestEvaluateCondition_ValuesWithSpaces(t *testing.T) {
 	// in PIKOCI_OUTPUT keys and resource metadata values.
 	vars := map[string]string{
 		"TASK_BUILD_MSG": "hello world",
-		"input_label":    "deploy to prod",
+		"INPUT_label":    "deploy to prod",
 	}
 
 	tests := []struct {

--- a/worker/condition_test.go
+++ b/worker/condition_test.go
@@ -28,11 +28,11 @@ var allVars = map[string]string{
 	"BUILD_PIPELINE_NAME": "my-pipeline",
 	"BUILD_TEAM_NAME":     "platform",
 
-	// input_<name> — from job input parameters (b.InputValues)
-	"input_env":     "staging",
-	"input_region":  "us-east-1",
-	"input_dry_run": "false",
-	"input_count":   "3",
+	// INPUT_<name> — from job input parameters (b.InputValues)
+	"INPUT_env":     "staging",
+	"INPUT_region":  "us-east-1",
+	"INPUT_dry_run": "false",
+	"INPUT_count":   "3",
 }
 
 func TestEvaluateCondition(t *testing.T) {
@@ -62,10 +62,10 @@ func TestEvaluateCondition(t *testing.T) {
 		{"eq BUILD pipeline", "$BUILD_PIPELINE_NAME == 'my-pipeline'", true, false},
 		{"eq BUILD team", "$BUILD_TEAM_NAME == 'platform'", true, false},
 		// input_* vars (manual trigger inputs)
-		{"eq input env", "$input_env == 'staging'", true, false},
-		{"eq input region", "$input_region == 'us-east-1'", true, false},
-		{"eq input bool-like", "$input_dry_run == 'false'", true, false},
-		{"eq input numeric", "$input_count == '3'", true, false},
+		{"eq input env", "$INPUT_env == 'staging'", true, false},
+		{"eq input region", "$INPUT_region == 'us-east-1'", true, false},
+		{"eq input bool-like", "$INPUT_dry_run == 'false'", true, false},
+		{"eq input numeric", "$INPUT_count == '3'", true, false},
 		// Undefined var expands to empty
 		{"eq undefined var empty", "$UNDEFINED == ''", true, false},
 		{"eq undefined var nonempty", "$UNDEFINED == 'something'", false, false},
@@ -75,7 +75,7 @@ func TestEvaluateCondition(t *testing.T) {
 		{"neq GET no match", "$GET_APP_BRANCH != 'main'", false, false},
 		{"neq TASK", "$TASK_BUILD_EXIT_CODE != '1'", true, false},
 		{"neq BUILD", "$BUILD_NUMBER != '99'", true, false},
-		{"neq input", "$input_env != 'production'", true, false},
+		{"neq input", "$INPUT_env != 'production'", true, false},
 		{"neq undefined vs nonempty", "$UNDEFINED != 'something'", true, false},
 		{"neq undefined vs empty", "$UNDEFINED != ''", false, false},
 
@@ -84,16 +84,16 @@ func TestEvaluateCondition(t *testing.T) {
 		{"gt numeric TASK false", "$TASK_BUILD_EXIT_CODE > '1'", false, false},
 		{"gt numeric BUILD", "$BUILD_NUMBER > '41'", true, false},
 		{"gt numeric BUILD false", "$BUILD_NUMBER > '42'", false, false},
-		{"gt numeric input", "$input_count > '2'", true, false},
-		{"gt numeric input false", "$input_count > '5'", false, false},
+		{"gt numeric input", "$INPUT_count > '2'", true, false},
+		{"gt numeric input false", "$INPUT_count > '5'", false, false},
 		{"gt string fallback GET", "$GET_APP_BRANCH > 'aaa'", true, false},
 		{"gt string fallback GET false", "$GET_APP_BRANCH > 'zzz'", false, false},
 
 		// ── < (less than, numeric if parseable) ──
 		{"lt numeric BUILD", "$BUILD_NUMBER < '100'", true, false},
 		{"lt numeric BUILD false", "$BUILD_NUMBER < '10'", false, false},
-		{"lt numeric input", "$input_count < '10'", true, false},
-		{"lt numeric input false", "$input_count < '1'", false, false},
+		{"lt numeric input", "$INPUT_count < '10'", true, false},
+		{"lt numeric input false", "$INPUT_count < '1'", false, false},
 		{"lt string fallback GET", "$GET_APP_BRANCH < 'zzz'", true, false},
 		{"lt string fallback GET false", "$GET_APP_BRANCH < 'aaa'", false, false},
 		{"lt numeric equal", "$BUILD_NUMBER < '42'", false, false},
@@ -106,7 +106,7 @@ func TestEvaluateCondition(t *testing.T) {
 		{"contains GET no match", "$GET_APP_BRANCH contains 'dev'", false, false},
 		{"contains TASK version", "$TASK_BUILD_VERSION contains '2.1'", true, false},
 		{"contains BUILD pipeline", "$BUILD_PIPELINE_NAME contains 'pipeline'", true, false},
-		{"contains input region", "$input_region contains 'east'", true, false},
+		{"contains input region", "$INPUT_region contains 'east'", true, false},
 		{"contains empty in anything", "$GET_APP_BRANCH contains ''", true, false},
 		// When $UNDEFINED expands to empty, "contains ''" becomes a bare word
 		// "contains" followed by trailing text — this is an error, not a match.
@@ -118,30 +118,30 @@ func TestEvaluateCondition(t *testing.T) {
 		{"!contains GET match", "$GET_APP_BRANCH !contains 'mai'", false, false},
 		{"!contains TASK", "$TASK_DETECT_ENV_ENV !contains 'prod'", true, false},
 		{"!contains BUILD", "$BUILD_TEAM_NAME !contains 'backend'", true, false},
-		{"!contains input", "$input_region !contains 'west'", true, false},
+		{"!contains input", "$INPUT_region !contains 'west'", true, false},
 
 		// ── && (logical AND) ──
-		{"and both true mixed vars", "$GET_APP_BRANCH == 'main' && $input_env == 'staging'", true, false},
-		{"and left false", "$GET_APP_BRANCH == 'develop' && $input_env == 'staging'", false, false},
-		{"and right false", "$GET_APP_BRANCH == 'main' && $input_env == 'production'", false, false},
-		{"and both false", "$GET_APP_BRANCH == 'develop' && $input_env == 'production'", false, false},
-		{"and three terms", "$GET_APP_BRANCH == 'main' && $BUILD_NUMBER == '42' && $input_env == 'staging'", true, false},
-		{"and three terms one false", "$GET_APP_BRANCH == 'main' && $BUILD_NUMBER == '99' && $input_env == 'staging'", false, false},
-		{"and with numeric", "$BUILD_NUMBER > '10' && $input_count < '100'", true, false},
+		{"and both true mixed vars", "$GET_APP_BRANCH == 'main' && $INPUT_env == 'staging'", true, false},
+		{"and left false", "$GET_APP_BRANCH == 'develop' && $INPUT_env == 'staging'", false, false},
+		{"and right false", "$GET_APP_BRANCH == 'main' && $INPUT_env == 'production'", false, false},
+		{"and both false", "$GET_APP_BRANCH == 'develop' && $INPUT_env == 'production'", false, false},
+		{"and three terms", "$GET_APP_BRANCH == 'main' && $BUILD_NUMBER == '42' && $INPUT_env == 'staging'", true, false},
+		{"and three terms one false", "$GET_APP_BRANCH == 'main' && $BUILD_NUMBER == '99' && $INPUT_env == 'staging'", false, false},
+		{"and with numeric", "$BUILD_NUMBER > '10' && $INPUT_count < '100'", true, false},
 
 		// ── || (logical OR) ──
-		{"or both false", "$GET_APP_BRANCH == 'develop' || $input_env == 'production'", false, false},
-		{"or left true", "$GET_APP_BRANCH == 'main' || $input_env == 'production'", true, false},
-		{"or right true", "$GET_APP_BRANCH == 'develop' || $input_env == 'staging'", true, false},
-		{"or both true", "$GET_APP_BRANCH == 'main' || $input_env == 'staging'", true, false},
-		{"or three terms", "$GET_APP_BRANCH == 'develop' || $BUILD_NUMBER == '99' || $input_env == 'staging'", true, false},
-		{"or three terms all false", "$GET_APP_BRANCH == 'develop' || $BUILD_NUMBER == '99' || $input_env == 'production'", false, false},
+		{"or both false", "$GET_APP_BRANCH == 'develop' || $INPUT_env == 'production'", false, false},
+		{"or left true", "$GET_APP_BRANCH == 'main' || $INPUT_env == 'production'", true, false},
+		{"or right true", "$GET_APP_BRANCH == 'develop' || $INPUT_env == 'staging'", true, false},
+		{"or both true", "$GET_APP_BRANCH == 'main' || $INPUT_env == 'staging'", true, false},
+		{"or three terms", "$GET_APP_BRANCH == 'develop' || $BUILD_NUMBER == '99' || $INPUT_env == 'staging'", true, false},
+		{"or three terms all false", "$GET_APP_BRANCH == 'develop' || $BUILD_NUMBER == '99' || $INPUT_env == 'production'", false, false},
 
 		// ── Parentheses / precedence ──
 		{"parens override precedence", "($GET_APP_BRANCH == 'main' || $GET_APP_BRANCH == 'develop') && $TASK_BUILD_EXIT_CODE == '0'", true, false},
 		{"parens with false inner", "($GET_APP_BRANCH == 'develop' || $GET_APP_BRANCH == 'feature') && $TASK_BUILD_EXIT_CODE == '0'", false, false},
-		{"nested parens", "(($BUILD_NUMBER > '10') && ($input_count < '100'))", true, false},
-		{"or with and precedence no parens", "$GET_APP_BRANCH == 'develop' || $GET_APP_BRANCH == 'main' && $input_env == 'staging'", true, false},
+		{"nested parens", "(($BUILD_NUMBER > '10') && ($INPUT_count < '100'))", true, false},
+		{"or with and precedence no parens", "$GET_APP_BRANCH == 'develop' || $GET_APP_BRANCH == 'main' && $INPUT_env == 'staging'", true, false},
 
 		// ── No-space operators ──
 		{"no space ==", "$GET_APP_BRANCH=='main'", true, false},
@@ -159,21 +159,21 @@ func TestEvaluateCondition(t *testing.T) {
 		{"empty/undefined var is falsy", "$UNDEFINED", false, false},
 		{"non-empty TASK var truthy", "$TASK_BUILD_VERSION", true, false},
 		{"non-empty BUILD var truthy", "$BUILD_NUMBER", true, false},
-		{"non-empty input var truthy", "$input_env", true, false},
+		{"non-empty input var truthy", "$INPUT_env", true, false},
 
 		// ── Real-world condition patterns ──
-		{"deploy to prod pattern", "$GET_APP_BRANCH == 'main' && $TASK_BUILD_EXIT_CODE == '0' && $input_dry_run == 'false'", true, false},
-		{"deploy to staging pattern", "$TASK_DETECT_ENV_ENV == 'staging' && $input_region contains 'east'", true, false},
+		{"deploy to prod pattern", "$GET_APP_BRANCH == 'main' && $TASK_BUILD_EXIT_CODE == '0' && $INPUT_dry_run == 'false'", true, false},
+		{"deploy to staging pattern", "$TASK_DETECT_ENV_ENV == 'staging' && $INPUT_region contains 'east'", true, false},
 		{"feature branch skip", "$GET_APP_BRANCH != 'main' && $GET_APP_BRANCH != 'develop'", false, false},
 		{"build number threshold", "$BUILD_NUMBER > '10' && $BUILD_NUMBER < '100'", true, false},
-		{"multi-env check", "$input_env == 'production' || $input_env == 'staging'", true, false},
+		{"multi-env check", "$INPUT_env == 'production' || $INPUT_env == 'staging'", true, false},
 		{"semver tag check", "$GET_APP_TAG contains 'v2.' && $TASK_BUILD_TESTS_PASS == 'true'", true, false},
 
 		// ── Two vars compared against each other ──
 		{"var vs var eq match", "$GET_APP_BRANCH == $GET_APP_BRANCH", true, false},
 		{"var vs var eq no match", "$GET_APP_BRANCH == $TASK_DETECT_ENV_ENV", false, false},
 		{"var vs var neq", "$GET_APP_BRANCH != $TASK_DETECT_ENV_ENV", true, false},
-		{"var vs var contains", "$BUILD_PIPELINE_NAME contains $input_env", false, false},
+		{"var vs var contains", "$BUILD_PIPELINE_NAME contains $INPUT_env", false, false},
 
 		// ── ${VAR} brace syntax (supported by os.Expand) ──
 		{"brace syntax eq", "${GET_APP_BRANCH} == 'main'", true, false},
@@ -185,8 +185,8 @@ func TestEvaluateCondition(t *testing.T) {
 		{"lt negative number", "$TASK_BUILD_EXIT_CODE < '-1'", false, false},
 		{"gt float", "$BUILD_NUMBER > '41.5'", true, false},
 		{"lt float", "$BUILD_NUMBER < '42.5'", true, false},
-		{"gt leading zero", "$input_count > '003'", false, false}, // 3 > 3 = false
-		{"eq leading zero", "$input_count == '003'", false, false}, // "3" != "003" string comparison
+		{"gt leading zero", "$INPUT_count > '003'", false, false}, // 3 > 3 = false
+		{"eq leading zero", "$INPUT_count == '003'", false, false}, // "3" != "003" string comparison
 		{"gt mixed numeric string left", "$GET_APP_BRANCH > '10'", true, false}, // string fallback: "main" > "10"
 		{"lt mixed numeric string right", "$BUILD_NUMBER < 'abc'", true, false},  // string fallback: "42" < "abc"
 		{"gt equal numeric", "$BUILD_NUMBER > '42'", false, false},
@@ -215,11 +215,11 @@ func TestEvaluateCondition(t *testing.T) {
 
 		// ── && / || mixed precedence (AND binds tighter than OR) ──
 		// false && true || true  →  (false && true) || true  →  false || true  →  true
-		{"and-or precedence left false", "$GET_APP_BRANCH == 'develop' && $BUILD_NUMBER == '42' || $input_env == 'staging'", true, false},
+		{"and-or precedence left false", "$GET_APP_BRANCH == 'develop' && $BUILD_NUMBER == '42' || $INPUT_env == 'staging'", true, false},
 		// true || false && false  →  true || (false && false)  →  true || false  →  true
-		{"and-or precedence right false", "$GET_APP_BRANCH == 'main' || $BUILD_NUMBER == '99' && $input_env == 'production'", true, false},
+		{"and-or precedence right false", "$GET_APP_BRANCH == 'main' || $BUILD_NUMBER == '99' && $INPUT_env == 'production'", true, false},
 		// false || false && true  →  false || (false && true)  →  false || false  →  false
-		{"and-or precedence all paths false", "$GET_APP_BRANCH == 'develop' || $BUILD_NUMBER == '99' && $input_env == 'staging'", false, false},
+		{"and-or precedence all paths false", "$GET_APP_BRANCH == 'develop' || $BUILD_NUMBER == '99' && $INPUT_env == 'staging'", false, false},
 
 		// ── Whitespace edge cases ──
 		{"whitespace only", "   ", false, false},
@@ -276,7 +276,7 @@ func TestEvaluateCondition_SpecialCharValues(t *testing.T) {
 		{"slash in branch", "$GET_APP_BRANCH contains 'feature/'", true},
 		{"dot in version", "$TASK_BUILD_VERSION contains '1.2.3'", true},
 		{"dash in version", "$TASK_BUILD_VERSION contains 'rc'", true},
-		{"slash in path", "$input_path contains '/deploy/'", true},
+		{"slash in path", "$INPUT_path contains '/deploy/'", true},
 		{"eq with slash", "$GET_APP_BRANCH == 'feature/my-branch'", true},
 		{"eq with dots and dash", "$TASK_BUILD_VERSION == '1.2.3-rc.1'", true},
 	}
@@ -310,7 +310,7 @@ func TestEvaluateCondition_ValuesWithSpaces(t *testing.T) {
 		// bare word parser splits on whitespace.
 		{"space value eq is error", "$TASK_BUILD_MSG == 'hello world'", false, true},
 		{"space value contains is error", "$TASK_BUILD_MSG contains 'hello'", false, true},
-		{"space input eq is error", "$input_label == 'deploy to prod'", false, true},
+		{"space input eq is error", "$INPUT_label == 'deploy to prod'", false, true},
 		// Quoted literal comparison still works fine
 		{"space value eq both quoted", "'hello world' == 'hello world'", true, false},
 		{"space value contains both quoted", "'hello world' contains 'hello'", true, false},

--- a/worker/service.go
+++ b/worker/service.go
@@ -2865,7 +2865,7 @@ func buildMetadataParams(b *build.Build, m workitem.Body) map[string]string {
 		"BUILD_TEAM_NAME":     m.TeamCanonical,
 	}
 	for k, v := range b.InputValues {
-		params["input_"+strings.ToLower(k)] = v
+		params["INPUT_"+k] = v
 	}
 	return params
 }

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -9944,7 +9944,7 @@ func TestProcessJob_InputValues_InjectedAsEnvVars(t *testing.T) {
 						Name: "print-env",
 						Run: utils.RunnerCommand{
 							Runner: "exec",
-							Args:   []string{"-ec", "echo version=$input_version debug=$input_debug"},
+							Args:   []string{"-ec", "echo version=$INPUT_version debug=$INPUT_debug"},
 							Params: map[string]string{"path": "/bin/sh"},
 						},
 					},
@@ -9974,7 +9974,7 @@ func TestProcessJob_InputValues_InjectedAsEnvVars(t *testing.T) {
 					Name: "print-env",
 					Run: utils.RunnerCommand{
 						Runner: "exec",
-						Args:   []string{"-ec", "echo version=$input_version debug=$input_debug"},
+						Args:   []string{"-ec", "echo version=$INPUT_version debug=$INPUT_debug"},
 						Params: map[string]string{"path": "/bin/sh"},
 					},
 				}},
@@ -10000,8 +10000,8 @@ func TestProcessJob_InputValues_InjectedAsEnvVars(t *testing.T) {
 			taskLogs = s.Logs
 		}
 	}
-	assert.Contains(t, taskLogs, "version=v2.0", "input_version env var should be expanded in task logs")
-	assert.Contains(t, taskLogs, "debug=true", "input_debug env var should be expanded in task logs")
+	assert.Contains(t, taskLogs, "version=v2.0", "INPUT_version env var should be expanded in task logs")
+	assert.Contains(t, taskLogs, "debug=true", "INPUT_debug env var should be expanded in task logs")
 }
 
 func TestProcessJob_IfStep_InputValues_AndBranchSelection(t *testing.T) {
@@ -10021,13 +10021,13 @@ func TestProcessJob_IfStep_InputValues_AndBranchSelection(t *testing.T) {
 						{
 							Type:      "if",
 							Label:     "check-prod",
-							Condition: "$input_env == 'production'",
+							Condition: "$INPUT_env == 'production'",
 							Steps: []job.PlanStep{
 								{Type: job.StepTypeTask, Task: &job.TaskStep{
 									Name: "deploy-prod",
 									Run: utils.RunnerCommand{
 										Runner: "exec",
-										Args:   []string{"-ec", "echo PROD version=$input_version"},
+										Args:   []string{"-ec", "echo PROD version=$INPUT_version"},
 										Params: map[string]string{"path": "/bin/sh"},
 									},
 								}},
@@ -10041,7 +10041,7 @@ func TestProcessJob_IfStep_InputValues_AndBranchSelection(t *testing.T) {
 									Name: "deploy-staging",
 									Run: utils.RunnerCommand{
 										Runner: "exec",
-										Args:   []string{"-ec", "echo STAGING version=$input_version"},
+										Args:   []string{"-ec", "echo STAGING version=$INPUT_version"},
 										Params: map[string]string{"path": "/bin/sh"},
 									},
 								}},
@@ -10126,7 +10126,7 @@ func TestProcessJob_IfStep_NoBranchMatches(t *testing.T) {
 						{
 							Type:      "if",
 							Label:     "check-prod",
-							Condition: "$input_env == 'production'",
+							Condition: "$INPUT_env == 'production'",
 							Steps: []job.PlanStep{
 								{Type: job.StepTypeTask, Task: &job.TaskStep{
 									Name: "deploy-prod",
@@ -10141,7 +10141,7 @@ func TestProcessJob_IfStep_NoBranchMatches(t *testing.T) {
 						{
 							Type:      "else_if",
 							Label:     "check-staging",
-							Condition: "$input_env == 'staging'",
+							Condition: "$INPUT_env == 'staging'",
 							Steps: []job.PlanStep{
 								{Type: job.StepTypeTask, Task: &job.TaskStep{
 									Name: "deploy-staging",

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -10105,7 +10105,7 @@ func TestProcessJob_IfStep_InputValues_AndBranchSelection(t *testing.T) {
 
 	// Verify input values are available inside the branch task
 	taskLogs := ifParent.SubSteps[0].SubSteps[0].Logs
-	assert.Contains(t, taskLogs, "PROD version=v3.0", "input_version env var should be expanded inside if branch")
+	assert.Contains(t, taskLogs, "PROD version=v3.0", "INPUT_version env var should be expanded inside if branch")
 	assert.NotContains(t, taskLogs, "STAGING", "else branch should not have executed")
 }
 


### PR DESCRIPTION
## Summary

- Renames the `$input_<name>` env var prefix to `$INPUT_<name>` for consistency with `$GET_*`, `$TASK_*`, `$BUILD_*`
- The name after `INPUT_` preserves the original casing from the `input` block label (e.g. `input "version"` → `$INPUT_version`)

Closes #629

## Test plan

- [x] `TestProcessJob_InputValues_InjectedAsEnvVars` passes with new prefix
- [x] `make test-mock` all pass
- [x] `make lint` clean